### PR TITLE
Fix category creation bug

### DIFF
--- a/src/app/tidbit-collection-categories/edit/[[...tidbitCategoryId]]/page.tsx
+++ b/src/app/tidbit-collection-categories/edit/[[...tidbitCategoryId]]/page.tsx
@@ -13,7 +13,7 @@ function EditTidbitCategorySpace(props: { space: SpaceWithIntegrationsFragment; 
   const { data, loading } = useByteCollectionCategoryWithByteCollectionsQuery({
     variables: {
       spaceId: props.space.id,
-      categoryId: props.params.tidbitCategoryId![0],
+      categoryId: props.params.tidbitCategoryId?.[0] ?? '',
     },
     skip: !props.params.tidbitCategoryId,
   });

--- a/src/app/tidbit-collection-categories/view/[categoryId]/tidbit-collection/page.tsx
+++ b/src/app/tidbit-collection-categories/view/[categoryId]/tidbit-collection/page.tsx
@@ -5,7 +5,7 @@ import getApiResponse from '@/utils/api/getApiResponse';
 import { getSpaceServerSide } from '@/utils/api/getSpaceServerSide';
 import React from 'react';
 
-async function TidbitCollection(props: { params: { categoryId?: any } }) {
+async function TidbitCollection(props: { params: { categoryId?: string } }) {
   const space = (await getSpaceServerSide())!;
 
   const categoryWithByteCollection = await getApiResponse<CategoryWithByteCollection>(space, `byte-collection-categories/${props.params.categoryId}`);


### PR DESCRIPTION
The code breaks when we create a category on `useByteCollectionCategoryWithByteCollectionsQuery` because `props.params.tidbitCategoryId` can be empty. Added a check to see if it is empty