### PR TITLE
fix: Resolve failing PR #1281 build - handle ETF listing fetch error during prerender

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -1,0 +1,160 @@
+import { prisma } from '@/prisma';
+import {
+  createEtfFinancialFilter,
+  createEtfSearchFilter,
+  hasEtfFiltersAppliedServer,
+  parseEtfFilterParams,
+  parseNumericStringValue,
+  EtfFilterParamKey,
+} from '@/utils/etf-filter-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export interface EtfListingItem {
+  id: string;
+  symbol: string;
+  name: string;
+  exchange: string;
+  aum: string | null;
+  expenseRatio: number | null;
+  pe: number | null;
+  sharesOut: string | null;
+  dividendTtm: number | null;
+  dividendYield: number | null;
+  payoutFrequency: string | null;
+  holdings: number | null;
+  beta: number | null;
+}
+
+export interface EtfListingResponse {
+  etfs: EtfListingItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  filtersApplied: boolean;
+}
+
+function parseRangeParam(param: string | undefined): { min?: number; max?: number } | null {
+  if (!param || !param.trim()) return null;
+  const [minStr, maxStr] = param.split('-');
+  const min = minStr ? parseFloat(minStr) : undefined;
+  const max = maxStr ? parseFloat(maxStr) : undefined;
+  if (min === undefined && max === undefined) return null;
+  return { min, max };
+}
+
+function isInRange(value: number | null, min?: number, max?: number): boolean {
+  if (value === null) return false;
+  if (min !== undefined && value < min) return false;
+  if (max !== undefined && value > max) return false;
+  return true;
+}
+
+function toEtfListingItem(etf: any): EtfListingItem {
+  return {
+    id: etf.id,
+    symbol: etf.symbol,
+    name: etf.name,
+    exchange: etf.exchange,
+    aum: etf.financialInfo?.aum ?? null,
+    expenseRatio: etf.financialInfo?.expenseRatio ?? null,
+    pe: etf.financialInfo?.pe ?? null,
+    sharesOut: etf.financialInfo?.sharesOut ?? null,
+    dividendTtm: etf.financialInfo?.dividendTtm ?? null,
+    dividendYield: etf.financialInfo?.dividendYield ?? null,
+    payoutFrequency: etf.financialInfo?.payoutFrequency ?? null,
+    holdings: etf.financialInfo?.holdings ?? null,
+    beta: etf.financialInfo?.beta ?? null,
+  };
+}
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<EtfListingResponse> {
+  const { spaceId } = await context.params;
+  const { searchParams } = new URL(req.url);
+
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+  const pageSize = Math.min(200, Math.max(1, parseInt(searchParams.get('pageSize') || String(DEFAULT_PAGE_SIZE), 10)));
+
+  const filters = parseEtfFilterParams(req);
+  const filtersApplied = hasEtfFiltersAppliedServer(filters);
+
+  // Build Prisma where clause for Etf (search)
+  const etfWhere = createEtfSearchFilter(spaceId, filters);
+
+  // Build Prisma where clause for EtfFinancialInfo (float fields)
+  const financialFilter = createEtfFinancialFilter(filters);
+  const hasFinancialFilter = Object.keys(financialFilter).length > 0;
+
+  if (hasFinancialFilter) {
+    etfWhere.financialInfo = { is: financialFilter };
+  }
+
+  // Check if we need application-level post-filtering (string numeric fields)
+  const aumRange = parseRangeParam(filters[EtfFilterParamKey.AUM]);
+  const sharesOutRange = parseRangeParam(filters[EtfFilterParamKey.SHARES_OUT]);
+  const needsPostFilter = aumRange !== null || sharesOutRange !== null;
+
+  if (needsPostFilter) {
+    // When post-filtering is needed, fetch all DB-matching records,
+    // apply string-field filters in memory, then paginate the result.
+    const allEtfs = await prisma.etf.findMany({
+      where: etfWhere,
+      include: { financialInfo: true },
+      orderBy: [{ symbol: 'asc' }],
+    });
+
+    const filtered = allEtfs.filter((etf) => {
+      if (aumRange) {
+        const aumValue = parseNumericStringValue(etf.financialInfo?.aum);
+        if (!isInRange(aumValue, aumRange.min, aumRange.max)) return false;
+      }
+      if (sharesOutRange) {
+        const soValue = parseNumericStringValue(etf.financialInfo?.sharesOut);
+        if (!isInRange(soValue, sharesOutRange.min, sharesOutRange.max)) return false;
+      }
+      return true;
+    });
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const start = (page - 1) * pageSize;
+    const pageSlice = filtered.slice(start, start + pageSize);
+
+    return {
+      etfs: pageSlice.map(toEtfListingItem),
+      totalCount,
+      page,
+      pageSize,
+      totalPages,
+      filtersApplied,
+    };
+  }
+
+  // Fast path: all filters are DB-level, use Prisma skip/take + count
+  const [etfs, totalCount] = await Promise.all([
+    prisma.etf.findMany({
+      where: etfWhere,
+      include: { financialInfo: true },
+      orderBy: [{ symbol: 'asc' }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.etf.count({ where: etfWhere }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  return {
+    etfs: etfs.map(toEtfListingItem),
+    totalCount,
+    page,
+    pageSize,
+    totalPages,
+    filtersApplied,
+  };
+}
+
+export const GET = withErrorHandlingV2<EtfListingResponse>(getHandler);

--- a/insights-ui/src/app/etfs-filtered/page.tsx
+++ b/insights-ui/src/app/etfs-filtered/page.tsx
@@ -1,0 +1,34 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'US ETFs - Filtered Results | KoalaGains',
+  description:
+    'Explore US ETFs with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights. Filter by AUM, P/E ratio, payout frequency, and more.',
+};
+
+type PageProps = {
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export default async function EtfsFilteredPage({ searchParams: searchParamsPromise }: PageProps) {
+  const searchParams = await searchParamsPromise;
+
+  const dataPromise = (async () => {
+    return fetchEtfListingData(searchParams);
+  })();
+
+  return (
+    <EtfPageLayout
+      title="US ETFs"
+      description="Explore US exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights."
+      showAppliedFilters={true}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -1,0 +1,36 @@
+import EtfListingGrid from '@/components/etfs/EtfListingGrid';
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getEtfListingTag } from '@/utils/etf-cache-utils';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = 86400; // 24 hours
+
+const WEEK = 60 * 60 * 24 * 7;
+
+export const metadata = {
+  title: 'US ETFs - Exchange Traded Funds Analysis | KoalaGains',
+  description:
+    'Explore US ETFs with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights. Filter by AUM, P/E ratio, payout frequency, and more.',
+};
+
+export default async function EtfsPage() {
+  const baseUrl = getBaseUrlForServerSidePages();
+  const res = await fetch(`${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`, {
+    next: { revalidate: WEEK, tags: [getEtfListingTag()] },
+  });
+
+  const data = (await res.json()) as EtfListingResponse;
+
+  return (
+    <EtfPageLayout
+      title="US ETFs"
+      description="Explore US exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights."
+    >
+      <EtfListingGrid data={data} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -19,11 +19,19 @@ export const metadata = {
 
 export default async function EtfsPage() {
   const baseUrl = getBaseUrlForServerSidePages();
-  const res = await fetch(`${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`, {
-    next: { revalidate: WEEK, tags: [getEtfListingTag()] },
-  });
+  let data: EtfListingResponse = { etfs: [], totalCount: 0, page: 1, pageSize: 100, totalPages: 1, filtersApplied: false };
 
-  const data = (await res.json()) as EtfListingResponse;
+  try {
+    const res = await fetch(`${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`, {
+      next: { revalidate: WEEK, tags: [getEtfListingTag()] },
+    });
+
+    if (res.ok) {
+      data = (await res.json()) as EtfListingResponse;
+    }
+  } catch (e) {
+    console.error('Failed to fetch ETF listing:', e);
+  }
 
   return (
     <EtfPageLayout

--- a/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
@@ -105,9 +105,13 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
   const r = (Array.isArray(rows) ? rows : []) as Array<{ label: string; values: Record<string, string> }>;
   if (!r.length) {
     return (
-      <div className="bg-purple-950/20 border border-purple-800/30 rounded-lg p-4 mt-4">
-        <h4 className="text-sm font-medium text-purple-200 mb-2">{title}</h4>
-        <p className="text-sm text-purple-300/70">No {title.toLowerCase()} data available.</p>
+      <div className="mt-4 rounded-lg border border-gray-700 bg-gray-900/60 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-700">
+          <h4 className="text-sm font-medium text-gray-200">{title}</h4>
+        </div>
+        <div className="px-4 py-4">
+          <p className="text-sm text-gray-400">No {title.toLowerCase()} data available.</p>
+        </div>
       </div>
     );
   }
@@ -120,37 +124,41 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
 
   return (
     <div className="mt-4">
-      <h4 className="text-sm font-medium text-gray-200 mb-3">{title}</h4>
-      <div className="overflow-x-auto rounded-lg border border-purple-800/30 bg-purple-950/20">
-        <table className="min-w-full">
-          <thead className="bg-purple-900/40">
-            <tr>
-              {columns.map((c) => (
-                <th key={c} className="px-4 py-3 text-left text-xs font-medium text-purple-200 uppercase tracking-wider whitespace-nowrap">
-                  {c}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-purple-800/20">
-            {tableRows.map((r, idx) => (
-              <tr key={idx} className={idx % 2 === 0 ? 'bg-purple-950/10' : 'bg-purple-950/25'}>
-                {columns.map((c) => {
-                  const cellValue = (r as any)[c];
-                  return (
-                    <td key={c} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap">
-                      {cellValue === null || cellValue === undefined || String(cellValue).trim() === '' ? (
-                        <span className="text-gray-500">—</span>
-                      ) : (
-                        String(cellValue)
-                      )}
-                    </td>
-                  );
-                })}
+      <div className="rounded-lg border border-gray-700 bg-gray-900 shadow-sm overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-700 sm:px-6">
+          <h4 className="text-sm font-medium text-gray-100">{title}</h4>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-800">
+              <tr>
+                {columns.map((c) => (
+                  <th key={c} className="px-4 py-3 text-left text-xs font-medium text-white uppercase tracking-wider whitespace-nowrap sm:px-6">
+                    {c}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-gray-800">
+              {tableRows.map((r, idx) => (
+                <tr key={idx} className="hover:bg-gray-700">
+                  {columns.map((c) => {
+                    const cellValue = (r as any)[c];
+                    return (
+                      <td key={c} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap sm:px-6">
+                        {cellValue === null || cellValue === undefined || String(cellValue).trim() === '' ? (
+                          <span className="text-gray-500">—</span>
+                        ) : (
+                          String(cellValue)
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );
@@ -159,8 +167,8 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
 function MorAnalysis({ analysis }: { analysis: EtfMorAnalysis | null }): JSX.Element {
   if (!analysis || !analysis.available) {
     return (
-      <div className="bg-orange-950/20 border border-orange-800/30 rounded-lg p-4 mt-4">
-        <p className="text-sm text-orange-300/70">No analysis available.</p>
+      <div className="border border-gray-700/50 rounded-lg p-4 mt-4">
+        <p className="text-sm">No analysis available.</p>
       </div>
     );
   }
@@ -211,7 +219,7 @@ function MorHoldings({ holdings }: { holdings: EtfMorHoldings | null }): JSX.Ele
     { label: 'Equity Holdings', value: holdings.equityHoldings },
     { label: 'Bond Holdings', value: holdings.bondHoldings },
     { label: 'Other Holdings', value: holdings.otherHoldings },
-    { label: '% Assets in Top 10', value: holdings.pctAssetsInTop10, accent: true },
+    { label: '% Assets in Top 10', value: holdings.pctAssetsInTop10 },
   ];
 
   const top = Array.isArray(holdings.topHoldings) ? holdings.topHoldings : [];
@@ -270,7 +278,7 @@ function MorRisk({ riskPeriods }: { riskPeriods: EtfMorRiskPeriods | null }): JS
 
             <MetricGrid
               items={[
-                { label: 'Risk Score', value: score.riskScore, accent: true },
+                { label: 'Risk Score', value: score.riskScore },
                 { label: 'Risk Level', value: score.riskLevel },
                 { label: 'Risk vs Category', value: rr.riskVsCategory },
                 { label: 'Return vs Category', value: rr.returnVsCategory },
@@ -332,11 +340,11 @@ export default function EtfMorInfo({ data }: { data: EtfMorInfoOptionalWrapper }
 
   return (
     <section id="etf-mor-info" className="bg-gray-900 rounded-lg shadow-sm px-3 py-4 sm:p-6 mt-6">
-      <SectionHeading title="Mor Analyzer Data" subtitle={updatedLabel} />
+      <SectionHeading title="Detailed Financial Data" subtitle={updatedLabel} />
 
       {!hasAny ? (
         <div className="mt-6 bg-slate-800/30 border border-slate-700/50 rounded-lg p-6 text-center">
-          <p className="text-gray-400">No Mor Analyzer data saved yet.</p>
+          <p className="text-gray-400">No detailed financial data saved yet.</p>
           <p className="text-sm text-gray-500 mt-1">Use the admin panel to trigger data collection.</p>
         </div>
       ) : (
@@ -346,8 +354,8 @@ export default function EtfMorInfo({ data }: { data: EtfMorInfoOptionalWrapper }
             <h3 className="text-lg font-medium text-gray-100 mb-4">Overview</h3>
             <MetricGrid
               items={[
-                { label: 'NAV', value: analyzer?.overviewNav, accent: true },
-                { label: '1-Day Return', value: analyzer?.overviewOneDayReturn, accent: true },
+                { label: 'NAV', value: analyzer?.overviewNav },
+                { label: '1-Day Return', value: analyzer?.overviewOneDayReturn },
                 { label: 'Total Assets', value: analyzer?.overviewTotalAssets },
                 { label: 'Adj. Expense Ratio', value: analyzer?.overviewAdjExpenseRatio },
                 { label: 'Prospectus Net Expense Ratio', value: analyzer?.overviewProspectusNetExpenseRatio },
@@ -399,7 +407,7 @@ export default function EtfMorInfo({ data }: { data: EtfMorInfoOptionalWrapper }
             <MetricGrid
               items={[
                 { label: 'Inception Date', value: people?.inceptionDate },
-                { label: 'Number of Managers', value: people?.numberOfManagers, accent: true },
+                { label: 'Number of Managers', value: people?.numberOfManagers },
                 { label: 'Longest Tenure', value: people?.longestTenure },
                 { label: 'Advisors', value: people?.advisors },
                 { label: 'Average Tenure', value: people?.averageTenure },

--- a/insights-ui/src/components/etfs/EtfAppliedFilterChips.tsx
+++ b/insights-ui/src/components/etfs/EtfAppliedFilterChips.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { useRouter, useSearchParams, usePathname, ReadonlyURLSearchParams } from 'next/navigation';
+import { XMarkIcon } from '@heroicons/react/20/solid';
+
+import { getAppliedEtfFilters, removeEtfFilterFromParams, clearAllEtfFilterParams, type AppliedEtfFilter } from '@/utils/etf-filter-utils';
+
+interface EtfAppliedFilterChipsProps {
+  className?: string;
+  showClearAll?: boolean;
+}
+
+export default function EtfAppliedFilterChips({ className = '', showClearAll = true }: EtfAppliedFilterChipsProps): JSX.Element | null {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const currentFilters: AppliedEtfFilter[] = useMemo(() => getAppliedEtfFilters(searchParams), [searchParams]);
+
+  if (currentFilters.length === 0) return null;
+
+  const handleRemove = (filter: AppliedEtfFilter): void => {
+    const nextParams = removeEtfFilterFromParams(searchParams, filter);
+    const remainingFilters = getAppliedEtfFilters(nextParams as ReadonlyURLSearchParams);
+
+    if (remainingFilters.length === 0 && pathname.includes('/etfs-filtered')) {
+      const staticPath = pathname.replace('/etfs-filtered', '/etfs');
+      router.push(staticPath);
+    } else {
+      router.push(`${pathname}?${nextParams.toString()}`);
+    }
+  };
+
+  const handleClearAll = (): void => {
+    if (pathname.includes('/etfs-filtered')) {
+      const staticPath = pathname.replace('/etfs-filtered', '/etfs');
+      router.push(staticPath);
+    } else {
+      const nextParams = clearAllEtfFilterParams(searchParams);
+      router.push(`?${nextParams.toString()}`);
+    }
+  };
+
+  return (
+    <div className={['flex flex-wrap items-center gap-3 mb-6', className].join(' ')}>
+      {currentFilters.map((filter, idx) => (
+        <div
+          key={`${filter.type}-${idx}`}
+          className="inline-flex items-center gap-2 text-black px-3 py-1.5 rounded-full text-sm bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B]"
+        >
+          <span>{filter.label}</span>
+          <button
+            onClick={() => handleRemove(filter)}
+            className="hover:bg-white hover:bg-opacity-20 rounded-full p-0.5"
+            aria-label={`Remove ${filter.label}`}
+            type="button"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+
+      {showClearAll && currentFilters.length > 1 && (
+        <button onClick={handleClearAll} className="text-[#E5E7EB] hover:text-white text-sm underline" type="button">
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfFiltersButton.tsx
+++ b/insights-ui/src/components/etfs/EtfFiltersButton.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import FullPageModal from '@dodao/web-core/components/core/modals/FullPageModal';
+import { AdjustmentsHorizontalIcon } from '@heroicons/react/20/solid';
+
+import {
+  ETF_AUM_OPTIONS,
+  ETF_EXPENSE_RATIO_OPTIONS,
+  ETF_PE_RATIO_OPTIONS,
+  ETF_DIVIDEND_TTM_OPTIONS,
+  ETF_PAYOUT_FREQUENCY_OPTIONS,
+  ETF_SHARES_OUT_OPTIONS,
+  getAppliedEtfFilters,
+  buildInitialEtfSelected,
+  applySelectedEtfFiltersToParams,
+  EtfFilterParamKey,
+  type AppliedEtfFilter,
+  type EtfSelectedFiltersMap,
+  type ThresholdOption,
+} from '@/utils/etf-filter-utils';
+
+export default function EtfFiltersButton(): JSX.Element {
+  const searchParams = useSearchParams();
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const currentFilters: AppliedEtfFilter[] = getAppliedEtfFilters(searchParams);
+  const modalKey: string = JSON.stringify({ f: currentFilters, open: isModalOpen });
+
+  return (
+    <>
+      <button
+        onClick={() => setIsModalOpen(true)}
+        className="inline-flex items-center gap-2 bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium rounded-lg px-4 py-2.5 text-sm shadow-md"
+      >
+        <AdjustmentsHorizontalIcon className="h-5 w-5" />
+        Filters
+        {currentFilters.length > 0 && <span className="bg-blue-500 px-2 py-0.5 font-bold rounded-full text-xs animate-pulse">{currentFilters.length}</span>}
+      </button>
+      {isModalOpen && (
+        <FullPageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Filter ETFs" fullWidth={false} className="max-w-5xl">
+          <div className="px-6 py-2">
+            <EtfFilterModalContent key={modalKey} initialSelected={buildInitialEtfSelected(currentFilters)} onClose={() => setIsModalOpen(false)} />
+          </div>
+        </FullPageModal>
+      )}
+    </>
+  );
+}
+
+interface FilterDropdownProps {
+  id: string;
+  label: string;
+  value: string;
+  options: ReadonlyArray<ThresholdOption>;
+  onChange: (value: string) => void;
+}
+
+function FilterDropdown({ id, label, value, options, onChange }: FilterDropdownProps): JSX.Element {
+  return (
+    <div className="bg-[#374151] rounded-lg p-4">
+      <label htmlFor={id} className="block text-white mb-2 text-sm">
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full bg-[#4B5563] text-white border border-[#6B7280] rounded-lg px-2 py-1 text-sm focus:ring-2 focus:ring-[#4F46E5] focus:border-transparent"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+interface EtfFilterModalContentProps {
+  initialSelected: EtfSelectedFiltersMap;
+  onClose: () => void;
+}
+
+function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalContentProps): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const [selectedFilters, setSelectedFilters] = useState<EtfSelectedFiltersMap>(() => ({ ...initialSelected }));
+
+  const handleChange = (paramKey: EtfFilterParamKey, value: string): void => {
+    setSelectedFilters((prev) => {
+      if (!value) {
+        const { [paramKey]: _, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [paramKey]: value };
+    });
+  };
+
+  const handleClearAll = (): void => {
+    setSelectedFilters({});
+  };
+
+  const handleApply = (): void => {
+    const nextParams = applySelectedEtfFiltersToParams(searchParams, selectedFilters);
+    const hasFilters = Object.values(selectedFilters).some((v) => v && v.length > 0);
+
+    if (hasFilters) {
+      let filteredPath = pathname;
+      if (!pathname.includes('/etfs-filtered')) {
+        filteredPath = pathname.replace('/etfs', '/etfs-filtered');
+      }
+      router.push(`${filteredPath}?${nextParams.toString()}`);
+    } else {
+      router.push(`${pathname}?${nextParams.toString()}`);
+    }
+
+    onClose();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-[#E5E7EB] text-sm mb-4">Filter ETFs by financial metrics</p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <FilterDropdown
+            id="aum"
+            label="Assets Under Management (AUM)"
+            value={selectedFilters[EtfFilterParamKey.AUM] || ''}
+            options={ETF_AUM_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.AUM, v)}
+          />
+          <FilterDropdown
+            id="expenseRatio"
+            label="Expense Ratio"
+            value={selectedFilters[EtfFilterParamKey.EXPENSE_RATIO] || ''}
+            options={ETF_EXPENSE_RATIO_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.EXPENSE_RATIO, v)}
+          />
+          <FilterDropdown
+            id="peRatio"
+            label="P/E Ratio"
+            value={selectedFilters[EtfFilterParamKey.PE_RATIO] || ''}
+            options={ETF_PE_RATIO_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.PE_RATIO, v)}
+          />
+          <FilterDropdown
+            id="dividendTtm"
+            label="Dividend TTM"
+            value={selectedFilters[EtfFilterParamKey.DIVIDEND_TTM] || ''}
+            options={ETF_DIVIDEND_TTM_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.DIVIDEND_TTM, v)}
+          />
+          <FilterDropdown
+            id="payoutFrequency"
+            label="Payout Frequency"
+            value={selectedFilters[EtfFilterParamKey.PAYOUT_FREQUENCY] || ''}
+            options={ETF_PAYOUT_FREQUENCY_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.PAYOUT_FREQUENCY, v)}
+          />
+          <FilterDropdown
+            id="sharesOut"
+            label="Shares Outstanding"
+            value={selectedFilters[EtfFilterParamKey.SHARES_OUT] || ''}
+            options={ETF_SHARES_OUT_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.SHARES_OUT, v)}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between items-center pt-4 border-t border-[#374151]">
+        <button onClick={handleClearAll} className="text-[#E5E7EB] hover:text-white text-sm underline" type="button">
+          Clear all filters
+        </button>
+
+        <div className="flex gap-3">
+          <button onClick={onClose} className="bg-[#374151] hover:bg-[#4B5563] text-white font-medium rounded-lg px-6 py-2.5 text-sm" type="button">
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium rounded-lg px-6 py-2.5 text-sm transition-all duration-200"
+            type="button"
+          >
+            Apply Filters
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfListingGrid.tsx
@@ -1,0 +1,121 @@
+import { EtfListingResponse, EtfListingItem } from '@/app/api/[spaceId]/etfs-v1/listing/route';
+import Link from 'next/link';
+import React, { use } from 'react';
+import EtfPagination from './EtfPagination';
+
+function parseNumericString(value: string | null): number | null {
+  if (!value) return null;
+  const raw = value.trim();
+  if (!raw) return null;
+  const cleaned = raw.replace(/,/g, '').replace(/^\$/, '').trim();
+  const match = cleaned.match(/^([+-]?\d+(?:\.\d+)?)\s*([KMBT])?$/i);
+  if (!match) return null;
+  const num = Number(match[1]);
+  if (!Number.isFinite(num)) return null;
+  const suffix = (match[2] || '').toUpperCase();
+  const mult = suffix === 'K' ? 1_000 : suffix === 'M' ? 1_000_000 : suffix === 'B' ? 1_000_000_000 : suffix === 'T' ? 1_000_000_000_000 : 1;
+  return num * mult;
+}
+
+function formatCompactAmount(value: string | null): string {
+  const n = parseNumericString(value);
+  if (n === null) return 'N/A';
+  if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(2)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+function formatNumber(value: number | null): string {
+  if (value === null || value === undefined) return 'N/A';
+  return value.toLocaleString('en-US', { maximumFractionDigits: 2 });
+}
+
+function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
+  return (
+    <Link
+      href={`/etfs/${etf.exchange}/${etf.symbol}`}
+      className="block bg-[#1F2937] border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">{etf.symbol}</span>
+          <span className="text-xs text-gray-400">{etf.exchange}</span>
+        </div>
+        {etf.payoutFrequency && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
+      </div>
+
+      <h3 className="text-white text-sm font-medium mb-3 line-clamp-2 min-h-[2.5rem]">{etf.name}</h3>
+
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <div>
+          <span className="text-gray-400">AUM</span>
+          <p className="text-white font-medium">{formatCompactAmount(etf.aum)}</p>
+        </div>
+        <div>
+          <span className="text-gray-400">Expense Ratio</span>
+          <p className="text-white font-medium">{etf.expenseRatio !== null ? `${etf.expenseRatio}%` : 'N/A'}</p>
+        </div>
+        <div>
+          <span className="text-gray-400">P/E Ratio</span>
+          <p className="text-white font-medium">{formatNumber(etf.pe)}</p>
+        </div>
+        <div>
+          <span className="text-gray-400">Dividend TTM</span>
+          <p className="text-white font-medium">{etf.dividendTtm !== null && etf.dividendTtm !== 0 ? `$${formatNumber(etf.dividendTtm)}` : '--'}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default function EtfListingGrid({
+  data,
+  dataPromise,
+}: {
+  data?: EtfListingResponse | null;
+  dataPromise?: Promise<EtfListingResponse> | null;
+}): JSX.Element | null {
+  const resolvedData = dataPromise ? use(dataPromise) : data;
+
+  if (!resolvedData) return null;
+
+  if (resolvedData.etfs.length === 0) {
+    return (
+      <div className="text-center py-12">
+        {resolvedData.filtersApplied ? (
+          <>
+            <p className="text-[#E5E7EB] text-lg">No ETFs match the current filters.</p>
+            <p className="text-[#E5E7EB] text-sm mt-2">Try adjusting your filter criteria to see more results.</p>
+          </>
+        ) : (
+          <>
+            <p className="text-[#E5E7EB] text-lg">No ETFs found.</p>
+            <p className="text-[#E5E7EB] text-sm mt-2">Please try again later.</p>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  const { page, totalCount, totalPages } = resolvedData;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm text-gray-400">
+          Showing {resolvedData.etfs.length} of {totalCount.toLocaleString()} ETF{totalCount !== 1 ? 's' : ''}
+          {totalPages > 1 && ` (Page ${page} of ${totalPages})`}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {resolvedData.etfs.map((etf) => (
+          <EtfCard key={etf.id} etf={etf} />
+        ))}
+      </div>
+
+      {totalPages > 1 && <EtfPagination currentPage={page} totalPages={totalPages} />}
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfListingLoadingSkeleton.tsx
+++ b/insights-ui/src/components/etfs/EtfListingLoadingSkeleton.tsx
@@ -1,0 +1,27 @@
+export default function EtfListingLoadingSkeleton(): JSX.Element {
+  return (
+    <div className="space-y-4">
+      <div className="h-5 w-32 bg-gray-800 rounded animate-pulse" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div key={i} className="bg-[#1F2937] border border-[#374151] rounded-lg p-4 animate-pulse">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="h-5 w-14 bg-gray-700 rounded" />
+              <div className="h-4 w-12 bg-gray-800 rounded" />
+            </div>
+            <div className="h-4 w-3/4 bg-gray-700 rounded mb-1" />
+            <div className="h-4 w-1/2 bg-gray-700 rounded mb-3" />
+            <div className="grid grid-cols-2 gap-2">
+              {Array.from({ length: 4 }).map((_, j) => (
+                <div key={j}>
+                  <div className="h-3 w-12 bg-gray-800 rounded mb-1" />
+                  <div className="h-4 w-16 bg-gray-700 rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfPageLayout.tsx
+++ b/insights-ui/src/components/etfs/EtfPageLayout.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import EtfFiltersButton from '@/components/etfs/EtfFiltersButton';
+import EtfAppliedFilterChips from '@/components/etfs/EtfAppliedFilterChips';
+
+interface EtfPageLayoutProps {
+  title: string;
+  description: string;
+  showAppliedFilters?: boolean;
+  children: ReactNode;
+}
+
+function buildBreadcrumbs(): BreadcrumbsOjbect[] {
+  return [{ name: 'US ETFs', href: '/etfs', current: true }];
+}
+
+export default function EtfPageLayout({ title, description, showAppliedFilters = false, children }: EtfPageLayoutProps) {
+  const breadcrumbs = buildBreadcrumbs();
+
+  return (
+    <PageWrapper>
+      <div className="overflow-x-auto">
+        <Breadcrumbs
+          breadcrumbs={breadcrumbs}
+          rightButton={
+            <div className="flex">
+              <EtfFiltersButton />
+            </div>
+          }
+        />
+      </div>
+
+      {showAppliedFilters && <EtfAppliedFilterChips showClearAll={true} />}
+
+      <div className="w-full mb-8">
+        <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
+        <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
+      </div>
+
+      {children}
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfPagination.tsx
+++ b/insights-ui/src/components/etfs/EtfPagination.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/20/solid';
+
+interface EtfPaginationProps {
+  currentPage: number;
+  totalPages: number;
+}
+
+export default function EtfPagination({ currentPage, totalPages }: EtfPaginationProps): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const navigateToPage = (page: number): void => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (page <= 1) {
+      params.delete('page');
+    } else {
+      params.set('page', String(page));
+    }
+
+    // If going to page 1 with no other filters, navigate to static page
+    const hasFilters = Array.from(params.keys()).some((k) => k !== 'page');
+    const targetPage = page <= 1 ? 1 : page;
+
+    if (targetPage === 1 && !hasFilters && pathname.includes('/etfs-filtered')) {
+      router.push('/etfs');
+    } else {
+      const filteredPath = pathname.includes('/etfs-filtered') ? pathname : '/etfs-filtered';
+      const qs = params.toString();
+      router.push(qs ? `${filteredPath}?${qs}` : filteredPath);
+    }
+  };
+
+  // Build visible page numbers: show first, last, current +/- 2, with ellipses
+  const pages: (number | 'ellipsis')[] = [];
+  const addPage = (p: number) => {
+    if (p >= 1 && p <= totalPages && !pages.includes(p)) pages.push(p);
+  };
+
+  addPage(1);
+  if (currentPage - 2 > 2) pages.push('ellipsis');
+  for (let i = Math.max(2, currentPage - 2); i <= Math.min(totalPages - 1, currentPage + 2); i++) {
+    addPage(i);
+  }
+  if (currentPage + 2 < totalPages - 1) pages.push('ellipsis');
+  if (totalPages > 1) addPage(totalPages);
+
+  return (
+    <nav className="flex items-center justify-center gap-1 mt-8" aria-label="Pagination">
+      <button
+        onClick={() => navigateToPage(currentPage - 1)}
+        disabled={currentPage <= 1}
+        className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-[#374151] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Previous page"
+      >
+        <ChevronLeftIcon className="h-5 w-5" />
+      </button>
+
+      {pages.map((item, idx) =>
+        item === 'ellipsis' ? (
+          <span key={`ellipsis-${idx}`} className="px-2 text-gray-500">
+            ...
+          </span>
+        ) : (
+          <button
+            key={item}
+            onClick={() => navigateToPage(item)}
+            className={`min-w-[2.25rem] h-9 rounded-lg text-sm font-medium transition-colors ${
+              item === currentPage ? 'bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black' : 'text-gray-400 hover:text-white hover:bg-[#374151]'
+            }`}
+          >
+            {item}
+          </button>
+        )
+      )}
+
+      <button
+        onClick={() => navigateToPage(currentPage + 1)}
+        disabled={currentPage >= totalPages}
+        className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-[#374151] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Next page"
+      >
+        <ChevronRightIcon className="h-5 w-5" />
+      </button>
+    </nav>
+  );
+}

--- a/insights-ui/src/components/etfs/WithSuspenseEtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/WithSuspenseEtfListingGrid.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react';
+import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
+import EtfListingGrid from './EtfListingGrid';
+import EtfListingLoadingSkeleton from './EtfListingLoadingSkeleton';
+
+interface WithSuspenseEtfListingGridProps {
+  dataPromise: Promise<EtfListingResponse>;
+}
+
+export default function WithSuspenseEtfListingGrid({ dataPromise }: WithSuspenseEtfListingGridProps) {
+  return (
+    <Suspense fallback={<EtfListingLoadingSkeleton />}>
+      <EtfListingGrid dataPromise={dataPromise} />
+    </Suspense>
+  );
+}

--- a/insights-ui/src/utils/etf-cache-utils.ts
+++ b/insights-ui/src/utils/etf-cache-utils.ts
@@ -7,3 +7,10 @@ export const etfAndExchangeTag = (symbol: string, exchange: string): `${typeof E
   `${ETF_EXCHANGE_TAG_PREFIX}_${symbol.toUpperCase()}_${exchange.toUpperCase()}`;
 
 export const revalidateEtfAndExchangeTag = (symbol: string, exchange: string) => revalidateTag(etfAndExchangeTag(symbol, exchange));
+
+/** Cache tag for the ETF listing page */
+export const ETF_LISTING_TAG = 'etf_listing' as const;
+
+export const getEtfListingTag = (): string => ETF_LISTING_TAG;
+
+export const revalidateEtfListingTag = () => revalidateTag(ETF_LISTING_TAG);

--- a/insights-ui/src/utils/etf-data-utils.ts
+++ b/insights-ui/src/utils/etf-data-utils.ts
@@ -1,0 +1,25 @@
+import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { hasEtfFiltersApplied, etfToSortedQueryString, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfListingTag } from '@/utils/etf-cache-utils';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+
+export async function fetchEtfListingData(searchParams?: EtfSearchParams): Promise<EtfListingResponse> {
+  const baseUrl = getBaseUrl();
+  const filters = hasEtfFiltersApplied(searchParams);
+  const hasPageOrFilters = filters || (searchParams?.page && searchParams.page !== '1');
+
+  const baseUrlPath = `${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`;
+  const url = hasPageOrFilters && searchParams ? `${baseUrlPath}?${etfToSortedQueryString(searchParams)}` : baseUrlPath;
+  const tags = hasPageOrFilters ? [] : [getEtfListingTag()];
+
+  try {
+    const res = await fetch(url, { next: { tags } });
+    if (!res.ok) return { etfs: [], totalCount: 0, page: 1, pageSize: 100, totalPages: 1, filtersApplied: filters };
+
+    return (await res.json()) as EtfListingResponse;
+  } catch (e) {
+    console.error('Failed to fetch ETF listing:', e);
+    return { etfs: [], totalCount: 0, page: 1, pageSize: 100, totalPages: 1, filtersApplied: filters };
+  }
+}

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -1,0 +1,426 @@
+import { Prisma } from '@prisma/client';
+import { NextRequest } from 'next/server';
+import { ReadonlyURLSearchParams } from 'next/navigation';
+
+/** ----- Types and Enums ----- */
+
+export enum EtfFilterType {
+  AUM = 'aum',
+  EXPENSE_RATIO = 'expenseRatio',
+  PE_RATIO = 'peRatio',
+  DIVIDEND_TTM = 'dividendTtm',
+  PAYOUT_FREQUENCY = 'payoutFrequency',
+  SHARES_OUT = 'sharesOut',
+  SEARCH = 'search',
+}
+
+export enum EtfFilterParamKey {
+  AUM = 'aum',
+  EXPENSE_RATIO = 'expenseRatio',
+  PE_RATIO = 'peRatio',
+  DIVIDEND_TTM = 'dividendTtm',
+  PAYOUT_FREQUENCY = 'payoutFrequency',
+  SHARES_OUT = 'sharesOut',
+  SEARCH = 'search',
+}
+
+export type EtfSearchParams = { [key: string]: string | string[] | undefined };
+
+export interface ThresholdOption {
+  label: string;
+  value: string;
+}
+
+export interface AppliedEtfFilterBase {
+  type: EtfFilterType;
+  label: string;
+  paramKey: EtfFilterParamKey;
+}
+
+export interface AppliedEtfRangeFilter extends AppliedEtfFilterBase {
+  type: EtfFilterType.AUM | EtfFilterType.EXPENSE_RATIO | EtfFilterType.PE_RATIO | EtfFilterType.DIVIDEND_TTM | EtfFilterType.SHARES_OUT;
+  minValue?: number;
+  maxValue?: number;
+}
+
+export interface AppliedEtfSelectFilter extends AppliedEtfFilterBase {
+  type: EtfFilterType.PAYOUT_FREQUENCY;
+  selectedValue: string;
+}
+
+export interface AppliedEtfSearchFilter extends AppliedEtfFilterBase {
+  type: EtfFilterType.SEARCH;
+  searchQuery: string;
+}
+
+export type AppliedEtfFilter = AppliedEtfRangeFilter | AppliedEtfSelectFilter | AppliedEtfSearchFilter;
+
+export type EtfSelectedFiltersMap = Record<string, string>;
+
+export interface EtfFilterParams {
+  [EtfFilterParamKey.AUM]?: string;
+  [EtfFilterParamKey.EXPENSE_RATIO]?: string;
+  [EtfFilterParamKey.PE_RATIO]?: string;
+  [EtfFilterParamKey.DIVIDEND_TTM]?: string;
+  [EtfFilterParamKey.PAYOUT_FREQUENCY]?: string;
+  [EtfFilterParamKey.SHARES_OUT]?: string;
+  [EtfFilterParamKey.SEARCH]?: string;
+}
+
+/** ----- Constants ----- */
+
+export const ETF_AUM_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Micro (< $100M)', value: '0-100000000' },
+  { label: 'Small ($100M - $500M)', value: '100000000-500000000' },
+  { label: 'Medium ($500M - $2B)', value: '500000000-2000000000' },
+  { label: 'Large ($2B - $10B)', value: '2000000000-10000000000' },
+  { label: 'Very Large (> $10B)', value: '10000000000-' },
+] as const;
+
+export const ETF_EXPENSE_RATIO_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Ultra Low (< 0.1%)', value: '0-0.1' },
+  { label: 'Low (0.1% - 0.3%)', value: '0.1-0.3' },
+  { label: 'Moderate (0.3% - 0.75%)', value: '0.3-0.75' },
+  { label: 'High (0.75% - 1%)', value: '0.75-1' },
+  { label: 'Very High (> 1%)', value: '1-' },
+] as const;
+
+export const ETF_PE_RATIO_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Low (< 15)', value: '0-15' },
+  { label: 'Moderate (15 - 25)', value: '15-25' },
+  { label: 'High (25 - 50)', value: '25-50' },
+  { label: 'Very High (> 50)', value: '50-' },
+  { label: 'Negative / N/A', value: 'negative' },
+] as const;
+
+export const ETF_DIVIDEND_TTM_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'None / Very Low (< $0.5)', value: '0-0.5' },
+  { label: 'Low ($0.5 - $2)', value: '0.5-2' },
+  { label: 'Moderate ($2 - $5)', value: '2-5' },
+  { label: 'High ($5 - $10)', value: '5-10' },
+  { label: 'Very High (> $10)', value: '10-' },
+] as const;
+
+export const ETF_PAYOUT_FREQUENCY_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Monthly', value: 'Monthly' },
+  { label: 'Quarterly', value: 'Quarterly' },
+  { label: 'Semi-Annual', value: 'Semi-Annual' },
+  { label: 'Annual', value: 'Annual' },
+  { label: 'Weekly', value: 'Weekly' },
+] as const;
+
+export const ETF_SHARES_OUT_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Small (< 10M)', value: '0-10000000' },
+  { label: 'Medium (10M - 50M)', value: '10000000-50000000' },
+  { label: 'Large (50M - 200M)', value: '50000000-200000000' },
+  { label: 'Very Large (> 200M)', value: '200000000-' },
+] as const;
+
+const ALL_ETF_PARAM_KEYS: EtfFilterParamKey[] = [
+  EtfFilterParamKey.AUM,
+  EtfFilterParamKey.EXPENSE_RATIO,
+  EtfFilterParamKey.PE_RATIO,
+  EtfFilterParamKey.DIVIDEND_TTM,
+  EtfFilterParamKey.PAYOUT_FREQUENCY,
+  EtfFilterParamKey.SHARES_OUT,
+  EtfFilterParamKey.SEARCH,
+];
+
+/** ----- Client-side Helpers ----- */
+
+function parseRangeFilter(
+  raw: string,
+  type: EtfFilterType.AUM | EtfFilterType.EXPENSE_RATIO | EtfFilterType.PE_RATIO | EtfFilterType.DIVIDEND_TTM | EtfFilterType.SHARES_OUT,
+  paramKey: EtfFilterParamKey,
+  options: ReadonlyArray<ThresholdOption>,
+  defaultLabel: string
+): AppliedEtfRangeFilter | null {
+  if (!raw || !raw.trim()) return null;
+
+  if (raw === 'negative') {
+    return {
+      type,
+      paramKey,
+      label: options.find((o) => o.value === 'negative')?.label || `${defaultLabel}: Negative / N/A`,
+    };
+  }
+
+  const [minStr, maxStr] = raw.split('-');
+  const minValue = minStr ? parseFloat(minStr) : undefined;
+  const maxValue = maxStr ? parseFloat(maxStr) : undefined;
+
+  const matchingOption = options.find((opt) => opt.value === raw);
+  const label = matchingOption ? matchingOption.label : `${defaultLabel}: ${formatRange(minValue, maxValue)}`;
+
+  return { type, paramKey, minValue, maxValue, label };
+}
+
+function formatRange(min?: number, max?: number): string {
+  const fmt = (v: number): string => {
+    if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
+    if (v >= 1e6) return `$${(v / 1e6).toFixed(1)}M`;
+    if (v >= 1e3) return `$${(v / 1e3).toFixed(1)}K`;
+    return `${v}`;
+  };
+  if (min !== undefined && max !== undefined) return `${fmt(min)} - ${fmt(max)}`;
+  if (min !== undefined) return `> ${fmt(min)}`;
+  if (max !== undefined) return `< ${fmt(max)}`;
+  return 'Any';
+}
+
+export function getAppliedEtfFilters(searchParams: ReadonlyURLSearchParams): AppliedEtfFilter[] {
+  const filters: AppliedEtfFilter[] = [];
+
+  // AUM
+  const aumRaw = searchParams.get(EtfFilterParamKey.AUM);
+  if (aumRaw) {
+    const f = parseRangeFilter(aumRaw, EtfFilterType.AUM, EtfFilterParamKey.AUM, ETF_AUM_OPTIONS, 'AUM');
+    if (f) filters.push(f);
+  }
+
+  // Expense Ratio
+  const erRaw = searchParams.get(EtfFilterParamKey.EXPENSE_RATIO);
+  if (erRaw) {
+    const f = parseRangeFilter(erRaw, EtfFilterType.EXPENSE_RATIO, EtfFilterParamKey.EXPENSE_RATIO, ETF_EXPENSE_RATIO_OPTIONS, 'Expense Ratio');
+    if (f) filters.push(f);
+  }
+
+  // PE Ratio
+  const peRaw = searchParams.get(EtfFilterParamKey.PE_RATIO);
+  if (peRaw) {
+    const f = parseRangeFilter(peRaw, EtfFilterType.PE_RATIO, EtfFilterParamKey.PE_RATIO, ETF_PE_RATIO_OPTIONS, 'P/E Ratio');
+    if (f) filters.push(f);
+  }
+
+  // Dividend TTM
+  const divRaw = searchParams.get(EtfFilterParamKey.DIVIDEND_TTM);
+  if (divRaw) {
+    const f = parseRangeFilter(divRaw, EtfFilterType.DIVIDEND_TTM, EtfFilterParamKey.DIVIDEND_TTM, ETF_DIVIDEND_TTM_OPTIONS, 'Dividend TTM');
+    if (f) filters.push(f);
+  }
+
+  // Payout Frequency
+  const pfRaw = searchParams.get(EtfFilterParamKey.PAYOUT_FREQUENCY);
+  if (pfRaw && pfRaw.trim()) {
+    const matchingOption = ETF_PAYOUT_FREQUENCY_OPTIONS.find((o) => o.value === pfRaw);
+    filters.push({
+      type: EtfFilterType.PAYOUT_FREQUENCY,
+      paramKey: EtfFilterParamKey.PAYOUT_FREQUENCY,
+      selectedValue: pfRaw,
+      label: matchingOption ? `Payout: ${matchingOption.label}` : `Payout: ${pfRaw}`,
+    });
+  }
+
+  // Shares Outstanding
+  const soRaw = searchParams.get(EtfFilterParamKey.SHARES_OUT);
+  if (soRaw) {
+    const f = parseRangeFilter(soRaw, EtfFilterType.SHARES_OUT, EtfFilterParamKey.SHARES_OUT, ETF_SHARES_OUT_OPTIONS, 'Shares Out');
+    if (f) filters.push(f);
+  }
+
+  // Search
+  const searchRaw = searchParams.get(EtfFilterParamKey.SEARCH);
+  if (searchRaw && searchRaw.trim()) {
+    filters.push({
+      type: EtfFilterType.SEARCH,
+      paramKey: EtfFilterParamKey.SEARCH,
+      searchQuery: searchRaw.trim(),
+      label: `Search: ${searchRaw.trim()}`,
+    });
+  }
+
+  return filters;
+}
+
+export function buildInitialEtfSelected(filters: ReadonlyArray<AppliedEtfFilter>): EtfSelectedFiltersMap {
+  const initial: EtfSelectedFiltersMap = {};
+  for (const filter of filters) {
+    if (filter.type === EtfFilterType.SEARCH) {
+      initial[EtfFilterParamKey.SEARCH] = (filter as AppliedEtfSearchFilter).searchQuery;
+    } else if (filter.type === EtfFilterType.PAYOUT_FREQUENCY) {
+      initial[EtfFilterParamKey.PAYOUT_FREQUENCY] = (filter as AppliedEtfSelectFilter).selectedValue;
+    } else {
+      const rangeFilter = filter as AppliedEtfRangeFilter;
+      if (filter.label.includes('Negative')) {
+        initial[filter.paramKey] = 'negative';
+      } else {
+        const min = rangeFilter.minValue !== undefined ? rangeFilter.minValue : '';
+        const max = rangeFilter.maxValue !== undefined ? rangeFilter.maxValue : '';
+        initial[filter.paramKey] = `${min}-${max}`;
+      }
+    }
+  }
+  return initial;
+}
+
+export function clearAllEtfFilterParams(searchParams: ReadonlyURLSearchParams): URLSearchParams {
+  const params = new URLSearchParams(searchParams.toString());
+  for (const key of ALL_ETF_PARAM_KEYS) {
+    params.delete(key);
+  }
+  // Reset to page 1 when clearing filters
+  params.delete('page');
+  return params;
+}
+
+export function removeEtfFilterFromParams(searchParams: ReadonlyURLSearchParams, filterToRemove: AppliedEtfFilter): URLSearchParams {
+  const params = new URLSearchParams(searchParams.toString());
+  params.delete(filterToRemove.paramKey);
+  // Reset to page 1 when removing a filter
+  params.delete('page');
+  return params;
+}
+
+export function applySelectedEtfFiltersToParams(searchParams: ReadonlyURLSearchParams, newSelected: EtfSelectedFiltersMap): URLSearchParams {
+  const params = clearAllEtfFilterParams(searchParams);
+  for (const [k, v] of Object.entries(newSelected)) {
+    if (v && v.length > 0) {
+      params.set(k, v);
+    }
+  }
+  // Reset to page 1 when applying new filters
+  params.delete('page');
+  return params;
+}
+
+const toScalar = (v: string | string[] | undefined): string | undefined => (Array.isArray(v) ? v.join(',') : v);
+
+export const etfToSortedQueryString = (sp: EtfSearchParams): string => {
+  const usp = new URLSearchParams();
+  Object.keys(sp)
+    .sort()
+    .forEach((k) => {
+      const v = toScalar(sp[k]);
+      if (v) usp.set(k, v);
+    });
+  return usp.toString();
+};
+
+export const hasEtfFiltersApplied = (sp?: EtfSearchParams): boolean => {
+  if (!sp) return false;
+  return ALL_ETF_PARAM_KEYS.some((key) => Boolean(toScalar(sp[key])));
+};
+
+/** ----- Server-side Helpers ----- */
+
+export function parseEtfFilterParams(req: NextRequest): EtfFilterParams {
+  const { searchParams } = new URL(req.url);
+  return {
+    [EtfFilterParamKey.AUM]: searchParams.get(EtfFilterParamKey.AUM) || undefined,
+    [EtfFilterParamKey.EXPENSE_RATIO]: searchParams.get(EtfFilterParamKey.EXPENSE_RATIO) || undefined,
+    [EtfFilterParamKey.PE_RATIO]: searchParams.get(EtfFilterParamKey.PE_RATIO) || undefined,
+    [EtfFilterParamKey.DIVIDEND_TTM]: searchParams.get(EtfFilterParamKey.DIVIDEND_TTM) || undefined,
+    [EtfFilterParamKey.PAYOUT_FREQUENCY]: searchParams.get(EtfFilterParamKey.PAYOUT_FREQUENCY) || undefined,
+    [EtfFilterParamKey.SHARES_OUT]: searchParams.get(EtfFilterParamKey.SHARES_OUT) || undefined,
+    [EtfFilterParamKey.SEARCH]: searchParams.get(EtfFilterParamKey.SEARCH) || undefined,
+  };
+}
+
+/**
+ * Parse a numeric string value. Supports raw numbers ("478850977"),
+ * formatted strings ("$190.08M", "1.13M"), and comma-separated numbers.
+ */
+export function parseNumericStringValue(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  const cleaned = raw.replace(/,/g, '').replace(/^\$/, '').trim();
+  const match = cleaned.match(/^([+-]?\d+(?:\.\d+)?)\s*([KMBT])?$/i);
+  if (!match) return null;
+
+  const num = Number(match[1]);
+  if (!Number.isFinite(num)) return null;
+
+  const suffix = (match[2] || '').toUpperCase();
+  const mult = suffix === 'K' ? 1_000 : suffix === 'M' ? 1_000_000 : suffix === 'B' ? 1_000_000_000 : suffix === 'T' ? 1_000_000_000_000 : 1;
+  return num * mult;
+}
+
+function parseRangeParam(param: string | undefined): { min?: number; max?: number } | null {
+  if (!param || !param.trim()) return null;
+  const [minStr, maxStr] = param.split('-');
+  const min = minStr ? parseFloat(minStr) : undefined;
+  const max = maxStr ? parseFloat(maxStr) : undefined;
+  if (min === undefined && max === undefined) return null;
+  return { min, max };
+}
+
+/**
+ * Build Prisma where clause for EtfFinancialInfo float fields.
+ */
+export function createEtfFinancialFilter(filters: EtfFilterParams): Prisma.EtfFinancialInfoWhereInput {
+  const where: Prisma.EtfFinancialInfoWhereInput = {};
+
+  // Expense Ratio
+  const erRange = parseRangeParam(filters[EtfFilterParamKey.EXPENSE_RATIO]);
+  if (erRange) {
+    const erFilter: Prisma.FloatNullableFilter = {};
+    if (erRange.min !== undefined) erFilter.gte = erRange.min;
+    if (erRange.max !== undefined) erFilter.lte = erRange.max;
+    where.expenseRatio = erFilter;
+  }
+
+  // PE Ratio
+  const peParam = filters[EtfFilterParamKey.PE_RATIO];
+  if (peParam && peParam.trim()) {
+    if (peParam === 'negative') {
+      where.OR = [{ pe: { lt: 0 } }, { pe: null }];
+    } else {
+      const peRange = parseRangeParam(peParam);
+      if (peRange) {
+        const peFilter: Prisma.FloatNullableFilter = {};
+        if (peRange.min !== undefined) peFilter.gte = peRange.min;
+        if (peRange.max !== undefined) peFilter.lte = peRange.max;
+        where.pe = peFilter;
+      }
+    }
+  }
+
+  // Dividend TTM
+  const divRange = parseRangeParam(filters[EtfFilterParamKey.DIVIDEND_TTM]);
+  if (divRange) {
+    const divFilter: Prisma.FloatNullableFilter = {};
+    if (divRange.min !== undefined) divFilter.gte = divRange.min;
+    if (divRange.max !== undefined) divFilter.lte = divRange.max;
+    where.dividendTtm = divFilter;
+  }
+
+  // Payout Frequency
+  const pf = filters[EtfFilterParamKey.PAYOUT_FREQUENCY];
+  if (pf && pf.trim()) {
+    where.payoutFrequency = { equals: pf, mode: 'insensitive' };
+  }
+
+  return where;
+}
+
+/**
+ * Build Prisma where clause for Etf with search filter.
+ */
+export function createEtfSearchFilter(spaceId: string, filters: EtfFilterParams): Prisma.EtfWhereInput {
+  const etfWhere: Prisma.EtfWhereInput = { spaceId };
+
+  const searchTerm = filters[EtfFilterParamKey.SEARCH]?.trim();
+  if (searchTerm) {
+    etfWhere.OR = [
+      { symbol: { equals: searchTerm.toUpperCase(), mode: 'insensitive' } },
+      { symbol: { startsWith: searchTerm.toUpperCase(), mode: 'insensitive' } },
+      { name: { startsWith: searchTerm, mode: 'insensitive' } },
+      { symbol: { contains: searchTerm, mode: 'insensitive' } },
+      { name: { contains: searchTerm, mode: 'insensitive' } },
+    ];
+  }
+
+  return etfWhere;
+}
+
+export function hasEtfFiltersAppliedServer(filters: EtfFilterParams): boolean {
+  return ALL_ETF_PARAM_KEYS.some((key) => !!filters[key]?.trim());
+}


### PR DESCRIPTION
## Summary
- Fixes the build failure in PR #1281 where prerendering `/etfs` page failed with `SyntaxError: Unexpected token '<'`
- Root cause: the `/etfs` page uses `force-static` and fetches from its own API route during build. Since the ETF listing API route is new and not yet deployed to production (`koalagains.com`), the fetch returns an HTML 404 page instead of JSON
- Added try/catch with `res.ok` check and fallback empty response, consistent with the existing pattern in `etf-data-utils.ts`

## Files Changed
- `insights-ui/src/app/etfs/page.tsx` — added error handling for fetch during static prerender

## Test plan
- [x] Verified build gets past `/etfs` prerender (previously failed here)
- [x] Lint passes
- [x] Prettier passes
- [ ] CI build should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)