### PR TITLE
fix: display ETFs on /etfs page by querying database directly

### DIFF
--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -1,15 +1,14 @@
 import EtfListingGrid from '@/components/etfs/EtfListingGrid';
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
+import { EtfListingResponse, EtfListingItem } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { getEtfListingTag } from '@/utils/etf-cache-utils';
+import { prisma } from '@/prisma';
 
 export const dynamic = 'force-static';
 export const dynamicParams = true;
 export const revalidate = 86400; // 24 hours
 
-const WEEK = 60 * 60 * 24 * 7;
+const DEFAULT_PAGE_SIZE = 100;
 
 export const metadata = {
   title: 'US ETFs - Exchange Traded Funds Analysis | KoalaGains',
@@ -17,18 +16,49 @@ export const metadata = {
     'Explore US ETFs with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights. Filter by AUM, P/E ratio, payout frequency, and more.',
 };
 
+function toEtfListingItem(etf: any): EtfListingItem {
+  return {
+    id: etf.id,
+    symbol: etf.symbol,
+    name: etf.name,
+    exchange: etf.exchange,
+    aum: etf.financialInfo?.aum ?? null,
+    expenseRatio: etf.financialInfo?.expenseRatio ?? null,
+    pe: etf.financialInfo?.pe ?? null,
+    sharesOut: etf.financialInfo?.sharesOut ?? null,
+    dividendTtm: etf.financialInfo?.dividendTtm ?? null,
+    dividendYield: etf.financialInfo?.dividendYield ?? null,
+    payoutFrequency: etf.financialInfo?.payoutFrequency ?? null,
+    holdings: etf.financialInfo?.holdings ?? null,
+    beta: etf.financialInfo?.beta ?? null,
+  };
+}
+
 export default async function EtfsPage() {
-  const baseUrl = getBaseUrlForServerSidePages();
-  let data: EtfListingResponse = { etfs: [], totalCount: 0, page: 1, pageSize: 100, totalPages: 1, filtersApplied: false };
+  let data: EtfListingResponse = { etfs: [], totalCount: 0, page: 1, pageSize: DEFAULT_PAGE_SIZE, totalPages: 1, filtersApplied: false };
 
   try {
-    const res = await fetch(`${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`, {
-      next: { revalidate: WEEK, tags: [getEtfListingTag()] },
-    });
+    const [etfs, totalCount] = await Promise.all([
+      prisma.etf.findMany({
+        where: { spaceId: KoalaGainsSpaceId },
+        include: { financialInfo: true },
+        orderBy: [{ symbol: 'asc' }],
+        skip: 0,
+        take: DEFAULT_PAGE_SIZE,
+      }),
+      prisma.etf.count({ where: { spaceId: KoalaGainsSpaceId } }),
+    ]);
 
-    if (res.ok) {
-      data = (await res.json()) as EtfListingResponse;
-    }
+    const totalPages = Math.max(1, Math.ceil(totalCount / DEFAULT_PAGE_SIZE));
+
+    data = {
+      etfs: etfs.map(toEtfListingItem),
+      totalCount,
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+      totalPages,
+      filtersApplied: false,
+    };
   } catch (e) {
     console.error('Failed to fetch ETF listing:', e);
   }


### PR DESCRIPTION
## Summary
- The `/etfs` page was showing "No ETFs found" despite 5,078 ETFs existing in the database
- Root cause: the `force-static` page used an HTTP self-fetch to the listing API during build. The initial fetch failed/returned empty, and the empty response was cached for 7 days (`revalidate: WEEK` on fetch), while the page only revalidates every 24 hours — so the stale empty data persisted
- Fix: replaced the HTTP self-fetch with a direct Prisma database query, eliminating the self-referencing fetch problem and the caching mismatch entirely

## Test plan
- [ ] Verify the `/etfs` page displays ETF listings after deployment
- [ ] Confirm pagination info shows correct total count (~5,078 ETFs)
- [ ] Verify ETF cards render with correct financial data (AUM, expense ratio, P/E, etc.)
- [ ] Confirm the `/etfs-filtered` page (force-dynamic) continues to work with filters
- [ ] Verify individual ETF detail pages (`/etfs/[exchange]/[etf]`) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)