### PR TITLE
ETF admin screen improvements: bulk actions, flush cache, select missing

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { EtfReportRow } from '@/app/api/[spaceId]/etfs-v1/etf-admin-reports/route';
+
+interface MissingCategory {
+  key: string;
+  label: string;
+  filter: (e: EtfReportRow) => boolean;
+}
+
+const categories: MissingCategory[] = [
+  { key: 'financialInfo', label: 'Financial Info', filter: (e) => !e.hasFinancialInfo },
+  { key: 'stockAnalyzer', label: 'Stock Analyzer', filter: (e) => !e.hasStockAnalyzerInfo },
+  { key: 'morAnalyzer', label: 'MOR Analyzer', filter: (e) => !e.hasMorAnalyzerInfo },
+  { key: 'morRisk', label: 'MOR Risk', filter: (e) => !e.hasMorRiskInfo },
+  { key: 'morPeople', label: 'MOR People', filter: (e) => !e.hasMorPeopleInfo },
+  { key: 'morPortfolio', label: 'MOR Portfolio', filter: (e) => !e.hasMorPortfolioInfo },
+];
+
+export interface SelectMissingBarProps {
+  etfs: EtfReportRow[];
+  onSelectIds: (ids: Set<string>) => void;
+}
+
+export default function SelectMissingBar({ etfs, onSelectIds }: SelectMissingBarProps): JSX.Element | null {
+  const activeCats = categories.filter((cat) => etfs.some(cat.filter));
+
+  if (activeCats.length === 0) return null;
+
+  const buttonClass = 'px-3 py-1.5 text-xs font-medium rounded-md transition-colors bg-gray-700 text-gray-200 hover:bg-gray-600';
+
+  return (
+    <div className="flex items-center gap-3 px-6 py-3 bg-amber-900/30 border-b border-amber-700/40">
+      <span className="text-sm font-medium text-amber-200">Select missing</span>
+      <div className="h-4 w-px bg-amber-700/50" />
+      {activeCats.map((cat) => {
+        const missingEtfs = etfs.filter(cat.filter);
+        return (
+          <button key={cat.key} className={buttonClass} onClick={() => onSelectIds(new Set(missingEtfs.map((e) => e.id)))}>
+            {cat.label} ({missingEtfs.length})
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/insights-ui/src/app/admin-v1/etf-reports/page.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/page.tsx
@@ -7,6 +7,7 @@ import { AllExchanges, EXCHANGES } from '@/utils/countryExchangeUtils';
 import BulkActionsBar from './BulkActionsBar';
 import EtfReportsFilters from './EtfReportsFilters';
 import EtfReportsTable from './EtfReportsTable';
+import SelectMissingBar from './SelectMissingBar';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
@@ -106,6 +107,7 @@ export default function EtfReportsPage(): JSX.Element {
         </div>
       ) : (
         <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 overflow-hidden">
+          <SelectMissingBar etfs={etfs} onSelectIds={setSelectedIds} />
           {selectedEtfs.length > 0 && <BulkActionsBar selectedEtfs={selectedEtfs} onClearSelection={handleClearSelection} onRefresh={reFetchData} />}
 
           <EtfReportsTable


### PR DESCRIPTION
## Summary
- Added checkbox column for multi-row selection with select-all/indeterminate support and a bulk actions bar (Financial Info, Mor Analyzer, Mor Risk, Mor People, Mor Portfolio, Flush Cache)
- Added Flush Cache option to both per-row actions and bulk actions, using a new `revalidateEtfCache` server action
- Added "Select Missing" bar that shows buttons for each data column with counts of ETFs missing that data on the current page, clicking selects those rows for bulk operations

## Test plan
- [ ] Navigate to /admin-v1/etf-reports
- [ ] Verify Select Missing bar appears with correct counts per column
- [ ] Click a Select Missing button and confirm the correct rows are checked
- [ ] Verify bulk actions bar appears and run a bulk action
- [ ] Test Flush Cache on a single row via the ellipsis dropdown
- [ ] Test Flush Cache via bulk actions on multiple selected rows
- [ ] Change page/filter and verify selection clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)