### PR TITLE
Simplify ETF pagination routing logic

### DIFF
--- a/insights-ui/src/components/etfs/EtfPagination.tsx
+++ b/insights-ui/src/components/etfs/EtfPagination.tsx
@@ -21,18 +21,14 @@ export default function EtfPagination({ currentPage, totalPages }: EtfPagination
       params.set('page', String(page));
     }
 
-    // If going to page 1 with no other filters, navigate to static page
     const hasFilters = Array.from(params.keys()).some((k) => k !== 'page');
     const targetPage = page <= 1 ? 1 : page;
 
     if (targetPage === 1 && !hasFilters) {
       router.push('/etfs');
-    } else if (hasFilters) {
-      const qs = params.toString();
-      router.push(`/etfs-filtered?${qs}`);
     } else {
       const qs = params.toString();
-      router.push(qs ? `/etfs?${qs}` : '/etfs');
+      router.push(`/etfs-filtered?${qs}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Simplified the `navigateToPage` function in `EtfPagination.tsx` by removing redundant routing branches
- All non-default page navigations now consistently route through `/etfs-filtered`, while page 1 without filters routes to clean `/etfs` path
- Reduces code complexity by removing a separate branch that handled pages without filters differently

## Test plan
- [ ] Navigate to page 2+ on ETF listing — should route to `/etfs-filtered?page=N`
- [ ] Navigate back to page 1 with no filters — should route to `/etfs`
- [ ] Apply filters and paginate — should route to `/etfs-filtered?filter=...&page=N`
- [ ] Verify pagination UI renders correctly with ellipses for large page counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)