### PR TITLE
Add 6 new ETF filters and compact filter UI

### DIFF
--- a/insights-ui/src/components/etfs/EtfFiltersButton.tsx
+++ b/insights-ui/src/components/etfs/EtfFiltersButton.tsx
@@ -10,11 +10,17 @@ import {
   ETF_EXPENSE_RATIO_OPTIONS,
   ETF_PE_RATIO_OPTIONS,
   ETF_DIVIDEND_TTM_OPTIONS,
+  ETF_DIVIDEND_YIELD_OPTIONS,
   ETF_PAYOUT_FREQUENCY_OPTIONS,
   ETF_SHARES_OUT_OPTIONS,
   ETF_HOLDINGS_OPTIONS,
   ETF_SHARPE_RATIO_OPTIONS,
   ETF_SORTINO_RATIO_OPTIONS,
+  ETF_BETA_OPTIONS,
+  ETF_RSI_OPTIONS,
+  ETF_DIVIDEND_YEARS_OPTIONS,
+  ETF_ASSET_CLASS_OPTIONS,
+  ETF_ISSUER_OPTIONS,
   MOR_ADVANCED_FILTERS,
   getAppliedEtfFilters,
   buildInitialEtfSelected,
@@ -43,8 +49,8 @@ export default function EtfFiltersButton(): JSX.Element {
         {currentFilters.length > 0 && <span className="bg-blue-500 px-2 py-0.5 font-bold rounded-full text-xs animate-pulse">{currentFilters.length}</span>}
       </button>
       {isModalOpen && (
-        <FullPageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Filter ETFs" fullWidth={false} className="max-w-5xl">
-          <div className="px-6 py-2">
+        <FullPageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Filter ETFs" fullWidth={false} className="max-w-6xl">
+          <div className="px-4 py-2">
             <EtfFilterModalContent key={modalKey} initialSelected={buildInitialEtfSelected(currentFilters)} onClose={() => setIsModalOpen(false)} />
           </div>
         </FullPageModal>
@@ -62,16 +68,17 @@ interface FilterDropdownProps {
 }
 
 function FilterDropdown({ id, label, value, options, onChange }: FilterDropdownProps): JSX.Element {
+  const isActive = value !== '';
   return (
-    <div className="bg-[#374151] rounded-lg p-4">
-      <label htmlFor={id} className="block text-white mb-2 text-sm">
+    <div className={`rounded p-2 ${isActive ? 'bg-[#3B4252] ring-1 ring-[#F59E0B]' : 'bg-[#374151]'}`}>
+      <label htmlFor={id} className="block text-gray-300 mb-1 text-xs truncate" title={label}>
         {label}
       </label>
       <select
         id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full bg-[#4B5563] text-white border border-[#6B7280] rounded-lg px-2 py-1 text-sm focus:ring-2 focus:ring-[#4F46E5] focus:border-transparent"
+        className="w-full bg-[#4B5563] text-white border border-[#6B7280] rounded px-1.5 py-1 text-xs focus:ring-1 focus:ring-[#4F46E5] focus:border-transparent"
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
@@ -133,15 +140,14 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Basic Filters */}
       <div>
-        <h3 className="text-white font-semibold text-sm mb-3">Basic Filters</h3>
-        <p className="text-[#9CA3AF] text-xs mb-4">Filter ETFs by financial metrics</p>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <h3 className="text-white font-semibold text-xs mb-2">Basic Filters</h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
           <FilterDropdown
             id="aum"
-            label="Assets Under Management (AUM)"
+            label="AUM"
             value={selectedFilters[EtfFilterParamKey.AUM] || ''}
             options={ETF_AUM_OPTIONS}
             onChange={(v) => handleChange(EtfFilterParamKey.AUM, v)}
@@ -168,6 +174,13 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
             onChange={(v) => handleChange(EtfFilterParamKey.DIVIDEND_TTM, v)}
           />
           <FilterDropdown
+            id="dividendYield"
+            label="Dividend Yield"
+            value={selectedFilters[EtfFilterParamKey.DIVIDEND_YIELD] || ''}
+            options={ETF_DIVIDEND_YIELD_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.DIVIDEND_YIELD, v)}
+          />
+          <FilterDropdown
             id="payoutFrequency"
             label="Payout Frequency"
             value={selectedFilters[EtfFilterParamKey.PAYOUT_FREQUENCY] || ''}
@@ -183,10 +196,24 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
           />
           <FilterDropdown
             id="holdings"
-            label="Number of Holdings"
+            label="Holdings"
             value={selectedFilters[EtfFilterParamKey.HOLDINGS] || ''}
             options={ETF_HOLDINGS_OPTIONS}
             onChange={(v) => handleChange(EtfFilterParamKey.HOLDINGS, v)}
+          />
+          <FilterDropdown
+            id="beta"
+            label="Beta (1Y)"
+            value={selectedFilters[EtfFilterParamKey.BETA] || ''}
+            options={ETF_BETA_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.BETA, v)}
+          />
+          <FilterDropdown
+            id="rsi"
+            label="RSI"
+            value={selectedFilters[EtfFilterParamKey.RSI] || ''}
+            options={ETF_RSI_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.RSI, v)}
           />
           <FilterDropdown
             id="sharpeRatio"
@@ -202,18 +229,39 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
             options={ETF_SORTINO_RATIO_OPTIONS}
             onChange={(v) => handleChange(EtfFilterParamKey.SORTINO_RATIO, v)}
           />
+          <FilterDropdown
+            id="dividendYears"
+            label="Dividend Years"
+            value={selectedFilters[EtfFilterParamKey.DIVIDEND_YEARS] || ''}
+            options={ETF_DIVIDEND_YEARS_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.DIVIDEND_YEARS, v)}
+          />
+          <FilterDropdown
+            id="assetClass"
+            label="Asset Class"
+            value={selectedFilters[EtfFilterParamKey.ASSET_CLASS] || ''}
+            options={ETF_ASSET_CLASS_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.ASSET_CLASS, v)}
+          />
+          <FilterDropdown
+            id="issuer"
+            label="Issuer"
+            value={selectedFilters[EtfFilterParamKey.ISSUER] || ''}
+            options={ETF_ISSUER_OPTIONS}
+            onChange={(v) => handleChange(EtfFilterParamKey.ISSUER, v)}
+          />
         </div>
       </div>
 
       {/* Advanced (Morningstar) Filters */}
       <div>
-        <h3 className="text-white font-semibold text-sm mb-1">Advanced Filters</h3>
-        <p className="text-[#9CA3AF] text-xs mb-4">Morningstar risk data — only ETFs with Morningstar data will be shown when these filters are active</p>
+        <h3 className="text-white font-semibold text-xs mb-1">Advanced Filters (Morningstar)</h3>
+        <p className="text-[#9CA3AF] text-[10px] mb-2">Only ETFs with Morningstar data shown when active</p>
 
         {morFiltersByPeriod.map(({ period, filters: periodFilters }) => (
-          <div key={period} className="mb-4">
-            <h4 className="text-gray-300 text-xs font-medium mb-2 uppercase tracking-wider">{period}</h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div key={period} className="mb-3">
+            <h4 className="text-gray-300 text-[10px] font-medium mb-1.5 uppercase tracking-wider">{period}</h4>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
               {periodFilters.map((def) => (
                 <FilterDropdown
                   key={def.paramKey}
@@ -230,18 +278,18 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
       </div>
 
       {/* Actions */}
-      <div className="flex justify-between items-center pt-4 border-t border-[#374151]">
-        <button onClick={handleClearAll} className="text-[#E5E7EB] hover:text-white text-sm underline" type="button">
+      <div className="flex justify-between items-center pt-3 border-t border-[#374151]">
+        <button onClick={handleClearAll} className="text-[#E5E7EB] hover:text-white text-xs underline" type="button">
           Clear all filters
         </button>
 
         <div className="flex gap-3">
-          <button onClick={onClose} className="bg-[#374151] hover:bg-[#4B5563] text-white font-medium rounded-lg px-6 py-2.5 text-sm" type="button">
+          <button onClick={onClose} className="bg-[#374151] hover:bg-[#4B5563] text-white font-medium rounded-lg px-5 py-2 text-xs" type="button">
             Cancel
           </button>
           <button
             onClick={handleApply}
-            className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium rounded-lg px-6 py-2.5 text-sm transition-all duration-200"
+            className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium rounded-lg px-5 py-2 text-xs transition-all duration-200"
             type="button"
           >
             Apply Filters

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -9,11 +9,17 @@ export enum EtfFilterType {
   EXPENSE_RATIO = 'expenseRatio',
   PE_RATIO = 'peRatio',
   DIVIDEND_TTM = 'dividendTtm',
+  DIVIDEND_YIELD = 'dividendYield',
   PAYOUT_FREQUENCY = 'payoutFrequency',
   SHARES_OUT = 'sharesOut',
   HOLDINGS = 'holdings',
   SHARPE_RATIO = 'sharpeRatio',
   SORTINO_RATIO = 'sortinoRatio',
+  BETA = 'beta',
+  RSI = 'rsi',
+  DIVIDEND_YEARS = 'dividendYears',
+  ASSET_CLASS = 'assetClass',
+  ISSUER = 'issuer',
   SEARCH = 'search',
   // Advanced (Morningstar) filters — per period
   MOR_UPSIDE_3YR = 'morUpside3yr',
@@ -32,11 +38,17 @@ export enum EtfFilterParamKey {
   EXPENSE_RATIO = 'expenseRatio',
   PE_RATIO = 'peRatio',
   DIVIDEND_TTM = 'dividendTtm',
+  DIVIDEND_YIELD = 'dividendYield',
   PAYOUT_FREQUENCY = 'payoutFrequency',
   SHARES_OUT = 'sharesOut',
   HOLDINGS = 'holdings',
   SHARPE_RATIO = 'sharpeRatio',
   SORTINO_RATIO = 'sortinoRatio',
+  BETA = 'beta',
+  RSI = 'rsi',
+  DIVIDEND_YEARS = 'dividendYears',
+  ASSET_CLASS = 'assetClass',
+  ISSUER = 'issuer',
   SEARCH = 'search',
   // Advanced (Morningstar) filters — per period
   MOR_UPSIDE_3YR = 'morUpside3yr',
@@ -68,10 +80,14 @@ type RangeFilterType =
   | EtfFilterType.EXPENSE_RATIO
   | EtfFilterType.PE_RATIO
   | EtfFilterType.DIVIDEND_TTM
+  | EtfFilterType.DIVIDEND_YIELD
   | EtfFilterType.SHARES_OUT
   | EtfFilterType.HOLDINGS
   | EtfFilterType.SHARPE_RATIO
   | EtfFilterType.SORTINO_RATIO
+  | EtfFilterType.BETA
+  | EtfFilterType.RSI
+  | EtfFilterType.DIVIDEND_YEARS
   | EtfFilterType.MOR_UPSIDE_3YR
   | EtfFilterType.MOR_UPSIDE_5YR
   | EtfFilterType.MOR_UPSIDE_10YR
@@ -79,7 +95,13 @@ type RangeFilterType =
   | EtfFilterType.MOR_DOWNSIDE_5YR
   | EtfFilterType.MOR_DOWNSIDE_10YR;
 
-type SelectFilterType = EtfFilterType.PAYOUT_FREQUENCY | EtfFilterType.MOR_RISK_3YR | EtfFilterType.MOR_RISK_5YR | EtfFilterType.MOR_RISK_10YR;
+type SelectFilterType =
+  | EtfFilterType.PAYOUT_FREQUENCY
+  | EtfFilterType.ASSET_CLASS
+  | EtfFilterType.ISSUER
+  | EtfFilterType.MOR_RISK_3YR
+  | EtfFilterType.MOR_RISK_5YR
+  | EtfFilterType.MOR_RISK_10YR;
 
 export interface AppliedEtfRangeFilter extends AppliedEtfFilterBase {
   type: RangeFilterType;
@@ -187,6 +209,75 @@ export const ETF_SORTINO_RATIO_OPTIONS: ReadonlyArray<ThresholdOption> = [
   { label: 'Excellent (> 3)', value: '3-' },
 ] as const;
 
+export const ETF_BETA_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Negative (< 0)', value: 'negative' },
+  { label: 'Low (0 - 0.5)', value: '0-0.5' },
+  { label: 'Below Market (0.5 - 0.8)', value: '0.5-0.8' },
+  { label: 'Market (0.8 - 1.2)', value: '0.8-1.2' },
+  { label: 'Above Market (1.2 - 1.5)', value: '1.2-1.5' },
+  { label: 'High (> 1.5)', value: '1.5-' },
+] as const;
+
+export const ETF_RSI_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Oversold (< 30)', value: '0-30' },
+  { label: 'Weak (30 - 40)', value: '30-40' },
+  { label: 'Neutral (40 - 60)', value: '40-60' },
+  { label: 'Strong (60 - 70)', value: '60-70' },
+  { label: 'Overbought (> 70)', value: '70-' },
+] as const;
+
+export const ETF_DIVIDEND_YIELD_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'None (< 0.5%)', value: '0-0.5' },
+  { label: 'Low (0.5% - 2%)', value: '0.5-2' },
+  { label: 'Moderate (2% - 4%)', value: '2-4' },
+  { label: 'High (4% - 6%)', value: '4-6' },
+  { label: 'Very High (> 6%)', value: '6-' },
+] as const;
+
+export const ETF_DIVIDEND_YEARS_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'None (0)', value: '0-0' },
+  { label: 'New (1 - 3)', value: '1-3' },
+  { label: 'Established (3 - 10)', value: '3-10' },
+  { label: 'Long (10 - 20)', value: '10-20' },
+  { label: 'Aristocrat (20+)', value: '20-' },
+] as const;
+
+export const ETF_ASSET_CLASS_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'Equity', value: 'Equity' },
+  { label: 'Fixed Income', value: 'Fixed Income' },
+  { label: 'Commodity', value: 'Commodity' },
+  { label: 'Alternatives', value: 'Alternatives' },
+  { label: 'Multi-Asset', value: 'Multi-Asset' },
+  { label: 'Currency', value: 'Currency' },
+] as const;
+
+export const ETF_ISSUER_OPTIONS: ReadonlyArray<ThresholdOption> = [
+  { label: 'Any', value: '' },
+  { label: 'BlackRock', value: 'BlackRock' },
+  { label: 'Vanguard', value: 'Vanguard' },
+  { label: 'State Street', value: 'State Street' },
+  { label: 'Invesco', value: 'Invesco' },
+  { label: 'Schwab', value: 'Schwab' },
+  { label: 'First Trust', value: 'First Trust' },
+  { label: 'ProShares', value: 'ProShares' },
+  { label: 'WisdomTree', value: 'WisdomTree' },
+  { label: 'Goldman Sachs', value: 'Goldman Sachs' },
+  { label: 'JPMorgan', value: 'JPMorgan' },
+  { label: 'Fidelity', value: 'Fidelity' },
+  { label: 'Direxion', value: 'Direxion' },
+  { label: 'Global X', value: 'Global X' },
+  { label: 'PIMCO', value: 'PIMCO' },
+  { label: 'Innovator', value: 'Innovator' },
+  { label: 'VanEck', value: 'VanEck' },
+  { label: 'ARK', value: 'ARK' },
+  { label: 'Dimensional', value: 'Dimensional' },
+] as const;
+
 export const ETF_MOR_UPSIDE_CAPTURE_OPTIONS: ReadonlyArray<ThresholdOption> = [
   { label: 'Any', value: '' },
   { label: 'Low (< 85)', value: '0-85' },
@@ -219,11 +310,17 @@ const ALL_ETF_PARAM_KEYS: EtfFilterParamKey[] = [
   EtfFilterParamKey.EXPENSE_RATIO,
   EtfFilterParamKey.PE_RATIO,
   EtfFilterParamKey.DIVIDEND_TTM,
+  EtfFilterParamKey.DIVIDEND_YIELD,
   EtfFilterParamKey.PAYOUT_FREQUENCY,
   EtfFilterParamKey.SHARES_OUT,
   EtfFilterParamKey.HOLDINGS,
   EtfFilterParamKey.SHARPE_RATIO,
   EtfFilterParamKey.SORTINO_RATIO,
+  EtfFilterParamKey.BETA,
+  EtfFilterParamKey.RSI,
+  EtfFilterParamKey.DIVIDEND_YEARS,
+  EtfFilterParamKey.ASSET_CLASS,
+  EtfFilterParamKey.ISSUER,
   EtfFilterParamKey.SEARCH,
   EtfFilterParamKey.MOR_UPSIDE_3YR,
   EtfFilterParamKey.MOR_UPSIDE_5YR,
@@ -336,6 +433,8 @@ export const MOR_ADVANCED_FILTERS: MorAdvancedFilterDef[] = [
 
 const SELECT_FILTER_TYPES: Set<string> = new Set([
   EtfFilterType.PAYOUT_FREQUENCY,
+  EtfFilterType.ASSET_CLASS,
+  EtfFilterType.ISSUER,
   EtfFilterType.MOR_RISK_3YR,
   EtfFilterType.MOR_RISK_5YR,
   EtfFilterType.MOR_RISK_10YR,
@@ -414,6 +513,13 @@ export function getAppliedEtfFilters(searchParams: ReadonlyURLSearchParams): App
     if (f) filters.push(f);
   }
 
+  // Dividend Yield
+  const dyRaw = searchParams.get(EtfFilterParamKey.DIVIDEND_YIELD);
+  if (dyRaw) {
+    const f = parseRangeFilter(dyRaw, EtfFilterType.DIVIDEND_YIELD, EtfFilterParamKey.DIVIDEND_YIELD, ETF_DIVIDEND_YIELD_OPTIONS, 'Dividend Yield');
+    if (f) filters.push(f);
+  }
+
   // Payout Frequency
   const pfRaw = searchParams.get(EtfFilterParamKey.PAYOUT_FREQUENCY);
   if (pfRaw && pfRaw.trim()) {
@@ -452,6 +558,51 @@ export function getAppliedEtfFilters(searchParams: ReadonlyURLSearchParams): App
   if (sortinoRaw) {
     const f = parseRangeFilter(sortinoRaw, EtfFilterType.SORTINO_RATIO, EtfFilterParamKey.SORTINO_RATIO, ETF_SORTINO_RATIO_OPTIONS, 'Sortino Ratio');
     if (f) filters.push(f);
+  }
+
+  // Beta
+  const betaRaw = searchParams.get(EtfFilterParamKey.BETA);
+  if (betaRaw) {
+    const f = parseRangeFilter(betaRaw, EtfFilterType.BETA, EtfFilterParamKey.BETA, ETF_BETA_OPTIONS, 'Beta');
+    if (f) filters.push(f);
+  }
+
+  // RSI
+  const rsiRaw = searchParams.get(EtfFilterParamKey.RSI);
+  if (rsiRaw) {
+    const f = parseRangeFilter(rsiRaw, EtfFilterType.RSI, EtfFilterParamKey.RSI, ETF_RSI_OPTIONS, 'RSI');
+    if (f) filters.push(f);
+  }
+
+  // Dividend Years
+  const divYearsRaw = searchParams.get(EtfFilterParamKey.DIVIDEND_YEARS);
+  if (divYearsRaw) {
+    const f = parseRangeFilter(divYearsRaw, EtfFilterType.DIVIDEND_YEARS, EtfFilterParamKey.DIVIDEND_YEARS, ETF_DIVIDEND_YEARS_OPTIONS, 'Dividend Years');
+    if (f) filters.push(f);
+  }
+
+  // Asset Class
+  const acRaw = searchParams.get(EtfFilterParamKey.ASSET_CLASS);
+  if (acRaw && acRaw.trim()) {
+    const matchingOption = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value === acRaw);
+    filters.push({
+      type: EtfFilterType.ASSET_CLASS,
+      paramKey: EtfFilterParamKey.ASSET_CLASS,
+      selectedValue: acRaw,
+      label: matchingOption ? `Asset Class: ${matchingOption.label}` : `Asset Class: ${acRaw}`,
+    });
+  }
+
+  // Issuer
+  const issuerRaw = searchParams.get(EtfFilterParamKey.ISSUER);
+  if (issuerRaw && issuerRaw.trim()) {
+    const matchingOption = ETF_ISSUER_OPTIONS.find((o) => o.value === issuerRaw);
+    filters.push({
+      type: EtfFilterType.ISSUER,
+      paramKey: EtfFilterParamKey.ISSUER,
+      selectedValue: issuerRaw,
+      label: matchingOption ? `Issuer: ${matchingOption.label}` : `Issuer: ${issuerRaw}`,
+    });
   }
 
   // Morningstar advanced filters (per-period)
@@ -638,6 +789,14 @@ export function createEtfFinancialFilter(filters: EtfFilterParams): Prisma.EtfFi
     where.holdings = holdingsFilter;
   }
 
+  const dyRange = parseRangeParam(filters[EtfFilterParamKey.DIVIDEND_YIELD]);
+  if (dyRange) {
+    const dyFilter: Prisma.FloatNullableFilter = {};
+    if (dyRange.min !== undefined) dyFilter.gte = dyRange.min;
+    if (dyRange.max !== undefined) dyFilter.lte = dyRange.max;
+    where.dividendYield = dyFilter;
+  }
+
   return where;
 }
 
@@ -672,6 +831,47 @@ export function createEtfStockAnalyzerFilter(filters: EtfFilterParams): Prisma.E
         where.sortino = sortinoFilter;
       }
     }
+  }
+
+  const betaParam = filters[EtfFilterParamKey.BETA]?.trim();
+  if (betaParam) {
+    if (betaParam === 'negative') {
+      where.beta1y = { lt: 0 };
+    } else {
+      const betaRange = parseRangeParam(betaParam);
+      if (betaRange) {
+        const betaFilter: Prisma.FloatNullableFilter = {};
+        if (betaRange.min !== undefined) betaFilter.gte = betaRange.min;
+        if (betaRange.max !== undefined) betaFilter.lte = betaRange.max;
+        where.beta1y = betaFilter;
+      }
+    }
+  }
+
+  const rsiRange = parseRangeParam(filters[EtfFilterParamKey.RSI]);
+  if (rsiRange) {
+    const rsiFilter: Prisma.FloatNullableFilter = {};
+    if (rsiRange.min !== undefined) rsiFilter.gte = rsiRange.min;
+    if (rsiRange.max !== undefined) rsiFilter.lte = rsiRange.max;
+    where.rsi = rsiFilter;
+  }
+
+  const divYearsRange = parseRangeParam(filters[EtfFilterParamKey.DIVIDEND_YEARS]);
+  if (divYearsRange) {
+    const divYearsFilter: Prisma.IntNullableFilter = {};
+    if (divYearsRange.min !== undefined) divYearsFilter.gte = divYearsRange.min;
+    if (divYearsRange.max !== undefined) divYearsFilter.lte = divYearsRange.max;
+    where.divYears = divYearsFilter;
+  }
+
+  const assetClass = filters[EtfFilterParamKey.ASSET_CLASS]?.trim();
+  if (assetClass) {
+    where.assetClass = { equals: assetClass, mode: 'insensitive' };
+  }
+
+  const issuer = filters[EtfFilterParamKey.ISSUER]?.trim();
+  if (issuer) {
+    where.issuer = { contains: issuer, mode: 'insensitive' };
   }
 
   return where;


### PR DESCRIPTION
## Summary
- Added 6 new Basic Filters: Beta (1Y), RSI, Dividend Yield, Dividend Years, Asset Class, and Issuer
- Beta/RSI/Sharpe/Sortino use DB-level filtering on EtfStockAnalyzerInfo; Dividend Yield uses EtfFinancialInfo
- Asset Class is a select dropdown (Equity/Fixed Income/Commodity/Alternatives/Multi-Asset/Currency)
- Issuer is a select dropdown with top 18 ETF issuers (BlackRock, Vanguard, State Street, etc.)
- Filter UI compacted: 5-column grid, smaller padding/fonts, active filters highlighted with ring indicator — now supports 30-40 filters comfortably

## Test plan
- [ ] Open filter modal — verify all 15 Basic Filters and 9 Morningstar filters are visible
- [ ] Test Beta filter with each option (Negative, Low, Below Market, Market, Above Market, High)
- [ ] Test RSI filter (Oversold, Weak, Neutral, Strong, Overbought)
- [ ] Test Dividend Yield filter ranges
- [ ] Test Dividend Years filter
- [ ] Test Asset Class dropdown (Equity, Fixed Income, etc.)
- [ ] Test Issuer dropdown (BlackRock, Vanguard, etc.)
- [ ] Verify applied filter chips appear/remove correctly for all new filters
- [ ] Verify compact layout renders well on mobile, tablet, and desktop
- [ ] Combine multiple new filters with existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)