### PR TITLE
Add 2s delay between bulk ETF admin operations

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
@@ -36,6 +36,10 @@ export default function BulkActionsBar({ selectedEtfs, onClearSelection, onRefre
     setProgress({ done: 0, total });
 
     for (let i = 0; i < total; i++) {
+      if (i > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+
       const etf = selectedEtfs[i];
       const base = `${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${etf.exchange}/${etf.symbol}`;
 


### PR DESCRIPTION
## Summary
- Adds a 2-second client-side delay between sequential requests in the ETF admin bulk actions bar
- Prevents concurrent requests to Morningstar and StockAnalysis APIs during bulk operations
- The delay is applied between iterations (not before the first request), so there's no unnecessary initial wait

## Test plan
- [ ] Select multiple ETFs and trigger a bulk action (e.g., Mor Analyzer)
- [ ] Verify requests are spaced ~2 seconds apart in browser network tab
- [ ] Verify progress counter still updates correctly after each request completes