### PR TITLE
Add missing sitemaps to sitemap index

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -24,4 +24,10 @@
   <sitemap>
     <loc>https://koalagains.com/stocks/past-performance-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/stocks/future-performance-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/stocks/business-and-moat-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Summary
- Added `future-performance-sitemap.xml` and `business-and-moat-sitemap.xml` to the sitemap index
- Both route handlers already existed but were not referenced in `public/sitemap_index.xml`

## Test plan
- [ ] Verify https://koalagains.com/sitemap_index.xml includes both new entries after deploy
- [ ] Verify both sitemap URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)