### PR TITLE
Fix ETF generation pipeline stopping after first step

### DIFF
--- a/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
@@ -74,44 +74,34 @@ export async function triggerEtfGenerationOfAReport(symbol: string, exchange: st
     const inProgressStep = generationRequest.inProgressStep;
     const lastInvocationTime = generationRequest.lastInvocationTime;
 
-    if (!inProgressStep || !lastInvocationTime) {
-      await prisma.etfGenerationRequest.update({
+    if (inProgressStep && lastInvocationTime) {
+      const fiveMinutes = 5 * 60 * 1000;
+      if (Date.now() - lastInvocationTime.getTime() < fiveMinutes) {
+        console.log(`Waiting for ${inProgressStep} of ETF ${symbol} to finish...`);
+        return;
+      }
+
+      const failedSteps = [...generationRequest.failedSteps];
+      if (!failedSteps.includes(inProgressStep)) {
+        failedSteps.push(inProgressStep);
+      }
+
+      Object.entries(etfReportDependencyMap).forEach(([reportType, dependencies]) => {
+        if (dependencies.includes(inProgressStep as EtfReportType) && !failedSteps.includes(reportType as EtfReportType)) {
+          failedSteps.push(reportType as EtfReportType);
+        }
+      });
+
+      generationRequest = await prisma.etfGenerationRequest.update({
         where: { id: generationRequest.id },
         data: {
-          status: EtfGenerationRequestStatus.Failed,
-          completedAt: new Date(),
+          failedSteps: [...new Set(failedSteps)],
+          inProgressStep: null,
           updatedAt: new Date(),
         },
+        include: { etf: true },
       });
-      return;
     }
-
-    const fiveMinutes = 5 * 60 * 1000;
-    if (Date.now() - lastInvocationTime.getTime() < fiveMinutes) {
-      console.log(`Waiting for ${inProgressStep} of ETF ${symbol} to finish...`);
-      return;
-    }
-
-    const failedSteps = [...generationRequest.failedSteps];
-    if (!failedSteps.includes(inProgressStep)) {
-      failedSteps.push(inProgressStep);
-    }
-
-    Object.entries(etfReportDependencyMap).forEach(([reportType, dependencies]) => {
-      if (dependencies.includes(inProgressStep as EtfReportType) && !failedSteps.includes(reportType as EtfReportType)) {
-        failedSteps.push(reportType as EtfReportType);
-      }
-    });
-
-    generationRequest = await prisma.etfGenerationRequest.update({
-      where: { id: generationRequest.id },
-      data: {
-        failedSteps: [...new Set(failedSteps)],
-        inProgressStep: null,
-        updatedAt: new Date(),
-      },
-      include: { etf: true },
-    });
   }
 
   const latestPendingSteps = calculateEtfPendingSteps(generationRequest);


### PR DESCRIPTION
## Summary
- Fixed bug where ETF analysis generation only processed the first category (Performance & Returns) and never moved to Cost Efficiency & Team or Risk Analysis
- Root cause: after the Lambda callback completed step 1, it cleared `inProgressStep` and `lastInvocationTime` to null, then called `triggerEtfGenerationOfAReport()`. That function saw `status=InProgress` with `inProgressStep=null` and immediately marked the request as Failed with a `return`, never processing the remaining steps
- Fix: when `inProgressStep` is null (step just completed via callback), skip the timeout/failure check and fall through to find the next pending step

## Test plan
- [ ] Create a generation request with all 3 categories enabled
- [ ] Verify all 3 steps process sequentially (Performance → Cost & Team → Risk)
- [ ] Verify the generation request status shows Completed (not Failed) after all steps finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)