### PR TITLE
Add ETF category detail pages with reusable components

### DIFF
--- a/insights-ui/prisma/migrations/20260415172756_add_etf_summary_and_final_summary_request/migration.sql
+++ b/insights-ui/prisma/migrations/20260415172756_add_etf_summary_and_final_summary_request/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "etf_generation_requests" ADD COLUMN     "regenerate_final_summary" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "etfs" ADD COLUMN     "summary" TEXT;

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1245,6 +1245,7 @@ model Etf {
   name          String   @map("name")
   exchange      String   @map("exchange")
   inception     String?  @map("inception")
+  summary       String?  @map("summary")
   spaceId       String   @default("koala_gains") @map("space_id")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
@@ -1573,6 +1574,7 @@ model EtfGenerationRequest {
   regeneratePerformanceAndReturns Boolean @default(false) @map("regenerate_performance_and_returns")
   regenerateCostEfficiencyAndTeam Boolean @default(false) @map("regenerate_cost_efficiency_and_team")
   regenerateRiskAnalysis          Boolean @default(false) @map("regenerate_risk_analysis")
+  regenerateFinalSummary          Boolean @default(false) @map("regenerate_final_summary")
 
   status String @default("NotStarted") @map("status")
 

--- a/insights-ui/schemas/etf-analysis/etf-final-summary/etf-final-summary-analysis-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/etf-final-summary/etf-final-summary-analysis-input.schema.yaml
@@ -1,0 +1,59 @@
+$schema: 'http://json-schema.org/draft-07/schema#'
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: string
+    description: 'The full name of the ETF.'
+  symbol:
+    type: string
+    description: 'ETF ticker symbol (e.g., VTI).'
+  exchange:
+    type: string
+    description: 'Exchange code (e.g., NYSEARCA).'
+  inception:
+    type: string
+    description: 'Inception date (string as stored in DB).'
+  categorySummaries:
+    type: array
+    description: 'One short overall summary per ETF analysis category.'
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        categoryKey:
+          type: string
+          description: 'Category key (PerformanceAndReturns, CostEfficiencyAndTeam, RiskAnalysis)'
+        overallSummary:
+          type: string
+          description: '3–5 sentence summary for this category.'
+      required:
+        - categoryKey
+        - overallSummary
+  factorResults:
+    type: array
+    description: 'One-line factor results across categories.'
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        categoryKey:
+          type: string
+        factorAnalysisKey:
+          type: string
+        oneLineExplanation:
+          type: string
+        result:
+          type: string
+          enum: ['Pass', 'Fail']
+      required:
+        - categoryKey
+        - factorAnalysisKey
+        - oneLineExplanation
+        - result
+required:
+  - name
+  - symbol
+  - exchange
+  - categorySummaries
+  - factorResults

--- a/insights-ui/schemas/etf-analysis/etf-final-summary/etf-final-summary-analysis-output.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/etf-final-summary/etf-final-summary-analysis-output.schema.yaml
@@ -1,0 +1,13 @@
+$schema: 'http://json-schema.org/draft-07/schema#'
+type: object
+additionalProperties: false
+properties:
+  summary:
+    type: string
+    description: >-
+      The final ETF summary text. It must be 6–7 short lines, each line a clear sentence.
+      The first line should give the overall verdict (Positive, Negative, or Mixed).
+      The following lines should justify the verdict using the categorySummaries and factorResults.
+      Keep language simple and suitable for retail investors.
+required:
+  - summary

--- a/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
+++ b/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
@@ -12,7 +12,12 @@ import { ArrowPathIcon, PauseIcon, PlayIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 
-const ETF_REGENERATE_FIELDS = ['regeneratePerformanceAndReturns', 'regenerateCostEfficiencyAndTeam', 'regenerateRiskAnalysis'] as const;
+const ETF_REGENERATE_FIELDS = [
+  'regeneratePerformanceAndReturns',
+  'regenerateCostEfficiencyAndTeam',
+  'regenerateRiskAnalysis',
+  'regenerateFinalSummary',
+] as const;
 
 type EtfRegenerateField = (typeof ETF_REGENERATE_FIELDS)[number];
 
@@ -20,12 +25,14 @@ const ETF_FIELD_LABELS: Record<EtfRegenerateField, string> = {
   regeneratePerformanceAndReturns: 'Performance',
   regenerateCostEfficiencyAndTeam: 'Cost & Team',
   regenerateRiskAnalysis: 'Risk',
+  regenerateFinalSummary: 'Final Summary',
 };
 
 const ETF_FIELD_TO_STEP_MAP: Record<EtfRegenerateField, EtfReportType> = {
   regeneratePerformanceAndReturns: EtfReportType.PERFORMANCE_AND_RETURNS,
   regenerateCostEfficiencyAndTeam: EtfReportType.COST_EFFICIENCY_AND_TEAM,
   regenerateRiskAnalysis: EtfReportType.RISK_ANALYSIS,
+  regenerateFinalSummary: EtfReportType.FINAL_SUMMARY,
 };
 
 interface StatusDotProps {

--- a/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
@@ -44,6 +44,7 @@ export default function BulkActionsBar({ selectedEtfs, onClearSelection, onRefre
       regeneratePerformanceAndReturns: allTypes || (options?.performanceAndReturns ?? false),
       regenerateCostEfficiencyAndTeam: allTypes || (options?.costEfficiencyAndTeam ?? false),
       regenerateRiskAnalysis: allTypes || (options?.riskAnalysis ?? false),
+      regenerateFinalSummary: allTypes,
     }));
     await createGenerationRequests(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/generation-requests`, payloads);
     onRefresh();

--- a/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
@@ -13,6 +13,10 @@ function AnalysisPill({ count }: { count: number }): JSX.Element {
   return <span className="px-2 py-1 rounded-full text-xs bg-green-900 text-green-200">{count}</span>;
 }
 
+function SummaryPill({ ok }: { ok: boolean }): JSX.Element {
+  return <span className={`px-2 py-1 rounded-full text-xs ${ok ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'}`}>{ok ? 'Yes' : 'No'}</span>;
+}
+
 export interface EtfReportsTableProps {
   etfs: EtfReportRow[];
   onRefresh: () => void;
@@ -51,6 +55,7 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Performance</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Cost & Team</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Risk</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Summary</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Action</th>
           </tr>
         </thead>
@@ -104,6 +109,9 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
                 <AnalysisPill count={e.riskAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
+                <SummaryPill ok={e.hasSummary} />
+              </td>
+              <td className="px-4 py-3 text-sm text-center">
                 <div className="flex items-center justify-center gap-2">
                   <Link
                     href={`/etfs/${e.exchange}/${e.symbol}/financial-data`}
@@ -121,7 +129,7 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
 
           {etfs.length === 0 && (
             <tr>
-              <td colSpan={11} className="px-4 py-10 text-center text-gray-300">
+              <td colSpan={12} className="px-4 py-10 text-center text-gray-300">
                 No ETFs found.
               </td>
             </tr>

--- a/insights-ui/src/app/admin-v1/etf-reports/EtfRowActionsDropdown.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfRowActionsDropdown.tsx
@@ -48,6 +48,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
     { key: 'generatePastReturns', label: 'Generate Past Returns', disabled: isBusyAll },
     { key: 'generateCostEfficiencyTeam', label: 'Generate Cost, Efficiency & Team', disabled: isBusyAll },
     { key: 'generateRiskAnalysis', label: 'Generate Risk Analysis', disabled: isBusyAll },
+    { key: 'generateFinalSummary', label: 'Generate Final Summary', disabled: isBusyAll },
     { key: 'financial', label: 'Financial Info', disabled: isBusyAll },
     { key: 'morAnalyzer', label: 'Mor Analyzer', disabled: isBusyAll },
     { key: 'morRisk', label: 'Mor Risk', disabled: isBusyAll },
@@ -67,6 +68,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regeneratePerformanceAndReturns: true,
               regenerateCostEfficiencyAndTeam: true,
               regenerateRiskAnalysis: true,
+              regenerateFinalSummary: true,
             },
           ]);
           onDone();
@@ -77,6 +79,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regeneratePerformanceAndReturns: true,
               regenerateCostEfficiencyAndTeam: false,
               regenerateRiskAnalysis: false,
+              regenerateFinalSummary: false,
             },
           ]);
           onDone();
@@ -87,6 +90,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regeneratePerformanceAndReturns: false,
               regenerateCostEfficiencyAndTeam: true,
               regenerateRiskAnalysis: false,
+              regenerateFinalSummary: false,
             },
           ]);
           onDone();
@@ -97,6 +101,18 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regeneratePerformanceAndReturns: false,
               regenerateCostEfficiencyAndTeam: false,
               regenerateRiskAnalysis: true,
+              regenerateFinalSummary: false,
+            },
+          ]);
+          onDone();
+        } else if (key === 'generateFinalSummary') {
+          await createGenerationRequest(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/generation-requests`, [
+            {
+              etf: { symbol: etf.symbol, exchange: etf.exchange },
+              regeneratePerformanceAndReturns: false,
+              regenerateCostEfficiencyAndTeam: false,
+              regenerateRiskAnalysis: false,
+              regenerateFinalSummary: true,
             },
           ]);
           onDone();

--- a/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
@@ -15,6 +15,7 @@ const categories: MissingCategory[] = [
   { key: 'morRisk', label: 'MOR Risk', filter: (e) => !e.hasMorRiskInfo },
   { key: 'morPeople', label: 'MOR People', filter: (e) => !e.hasMorPeopleInfo },
   { key: 'morPortfolio', label: 'MOR Portfolio', filter: (e) => !e.hasMorPortfolioInfo },
+  { key: 'summary', label: 'Missing Summary', filter: (e) => !e.hasSummary },
   {
     key: 'analysis',
     label: 'Missing Analysis',

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
@@ -15,6 +15,7 @@ export interface EtfReportRow {
   hasMorRiskInfo: boolean;
   hasMorPeopleInfo: boolean;
   hasMorPortfolioInfo: boolean;
+  hasSummary: boolean;
   performanceAnalysisCount: number;
   costEfficiencyAnalysisCount: number;
   riskAnalysisCount: number;
@@ -112,6 +113,7 @@ const getHandler = async (
         symbol: true,
         name: true,
         exchange: true,
+        summary: true,
         financialInfo: { select: { id: true } },
         stockAnalyzerInfo: { select: { id: true } },
         morAnalyzerInfo: { select: { id: true } },
@@ -152,6 +154,7 @@ const getHandler = async (
         hasMorRiskInfo: !!e.morRiskInfo,
         hasMorPeopleInfo: !!e.morPeopleInfo,
         hasMorPortfolioInfo: !!e.morPortfolioInfo,
+        hasSummary: Boolean(e.summary && e.summary.trim()),
         performanceAnalysisCount: factorResults.filter((r) => r.categoryKey === 'PerformanceAndReturns').length,
         costEfficiencyAnalysisCount: factorResults.filter((r) => r.categoryKey === 'CostEfficiencyAndTeam').length,
         riskAnalysisCount: factorResults.filter((r) => r.categoryKey === 'RiskAnalysis').length,

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
@@ -43,7 +43,11 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
       },
     });
 
-    await triggerEtfGenerationOfAReport(etf, exchange, generationRequestId);
+    try {
+      await triggerEtfGenerationOfAReport(etf, exchange, generationRequestId);
+    } catch (triggerError) {
+      console.error('Error triggering next ETF report step (will be retried by cron):', triggerError);
+    }
   }
 
   return { success: true };

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
@@ -43,11 +43,7 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
       },
     });
 
-    try {
-      await triggerEtfGenerationOfAReport(etf, exchange, generationRequestId);
-    } catch (triggerError) {
-      console.error('Error triggering next ETF report step (will be retried by cron):', triggerError);
-    }
+    await triggerEtfGenerationOfAReport(etf, exchange, generationRequestId);
   }
 
   return { success: true };

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/save-report-callback/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { EtfReportType, ETF_REPORT_TYPE_TO_CATEGORY } from '@/types/etf/etf-analysis-types';
 import { triggerEtfGenerationOfAReport } from '@/utils/etf-analysis-reports/etf-generation-report-utils';
-import { saveEtfFactorAnalysisResponse } from '@/utils/etf-analysis-reports/save-etf-report-utils';
+import { saveEtfFactorAnalysisResponse, saveEtfFinalSummaryResponse } from '@/utils/etf-analysis-reports/save-etf-report-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
@@ -13,12 +13,16 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
 
   console.log('ETF save-report-callback received:', { reportType, generationRequestId, exchange, etf });
 
-  const categoryKey = ETF_REPORT_TYPE_TO_CATEGORY[reportType];
-  if (!categoryKey) {
-    throw new Error(`Unsupported ETF report type: ${reportType}`);
-  }
+  if (reportType === EtfReportType.FINAL_SUMMARY) {
+    await saveEtfFinalSummaryResponse(etf, exchange, llmResponse);
+  } else {
+    const categoryKey = ETF_REPORT_TYPE_TO_CATEGORY[reportType];
+    if (!categoryKey) {
+      throw new Error(`Unsupported ETF report type: ${reportType}`);
+    }
 
-  await saveEtfFactorAnalysisResponse(etf, exchange, llmResponse, categoryKey);
+    await saveEtfFactorAnalysisResponse(etf, exchange, llmResponse, categoryKey);
+  }
 
   if (generationRequestId) {
     const generationRequest = await prisma.etfGenerationRequest.findUniqueOrThrow({

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/generate-etf-v1-request/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/generate-etf-v1-request/route.ts
@@ -69,10 +69,7 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<{ spac
 
   for (const request of [...inProgressRequests, ...notStartedRequests]) {
     try {
-      const pending = calculateEtfPendingSteps(request);
-      console.log(
-        `ETF cron: processing request ${request.id} for ${request.etf.symbol} | status=${request.status} | inProgressStep=${request.inProgressStep} | completed=[${request.completedSteps}] | failed=[${request.failedSteps}] | pending=[${pending}]`
-      );
+      console.log(`Processing ETF request ${request.id} for ${request.etf.symbol} on ${request.etf.exchange}`);
       await triggerEtfGenerationOfAReport(request.etf.symbol, request.etf.exchange, request.id);
       processedCount++;
     } catch (error) {

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/generate-etf-v1-request/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/generate-etf-v1-request/route.ts
@@ -69,7 +69,10 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<{ spac
 
   for (const request of [...inProgressRequests, ...notStartedRequests]) {
     try {
-      console.log(`Processing ETF request ${request.id} for ${request.etf.symbol} on ${request.etf.exchange}`);
+      const pending = calculateEtfPendingSteps(request);
+      console.log(
+        `ETF cron: processing request ${request.id} for ${request.etf.symbol} | status=${request.status} | inProgressStep=${request.inProgressStep} | completed=[${request.completedSteps}] | failed=[${request.failedSteps}] | pending=[${pending}]`
+      );
       await triggerEtfGenerationOfAReport(request.etf.symbol, request.etf.exchange, request.id);
       processedCount++;
     } catch (error) {

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/generation-requests/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/generation-requests/route.ts
@@ -16,6 +16,7 @@ export interface EtfGenerationRequestPayload {
   regeneratePerformanceAndReturns: boolean;
   regenerateCostEfficiencyAndTeam: boolean;
   regenerateRiskAnalysis: boolean;
+  regenerateFinalSummary?: boolean;
 }
 
 export interface EtfGenerationRequestWithEtf extends EtfGenerationRequest {
@@ -164,6 +165,7 @@ async function postHandler(
           regeneratePerformanceAndReturns: regenerateOptions.regeneratePerformanceAndReturns || existingRequest.regeneratePerformanceAndReturns,
           regenerateCostEfficiencyAndTeam: regenerateOptions.regenerateCostEfficiencyAndTeam || existingRequest.regenerateCostEfficiencyAndTeam,
           regenerateRiskAnalysis: regenerateOptions.regenerateRiskAnalysis || existingRequest.regenerateRiskAnalysis,
+          regenerateFinalSummary: regenerateOptions.regenerateFinalSummary || existingRequest.regenerateFinalSummary,
           updatedAt: new Date(),
         },
       });
@@ -175,6 +177,7 @@ async function postHandler(
           regeneratePerformanceAndReturns: regenerateOptions.regeneratePerformanceAndReturns,
           regenerateCostEfficiencyAndTeam: regenerateOptions.regenerateCostEfficiencyAndTeam,
           regenerateRiskAnalysis: regenerateOptions.regenerateRiskAnalysis,
+          regenerateFinalSummary: regenerateOptions.regenerateFinalSummary ?? true,
         },
       });
     }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -4,11 +4,7 @@ import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryRe
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
-import {
-  generateEtfCategoryMetadata,
-  generateEtfCategoryArticleJsonLd,
-  generateEtfCategoryBreadcrumbJsonLd,
-} from '@/utils/etf-metadata-generators';
+import { generateEtfCategoryMetadata, generateEtfCategoryArticleJsonLd, generateEtfCategoryBreadcrumbJsonLd } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -95,8 +91,22 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
   const publishedDate = etfData.createdAt?.toISOString?.() || now;
   const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
 
-  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
-  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+  const articleSchema = generateEtfCategoryArticleJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    publishedDate,
+    modifiedDate,
+  });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+  });
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'US ETFs', href: '/etfs', current: false },

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -1,0 +1,123 @@
+import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
+import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import {
+  generateEtfCategoryMetadata,
+  generateEtfCategoryArticleJsonLd,
+  generateEtfCategoryBreadcrumbJsonLd,
+} from '@/utils/etf-metadata-generators';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+const CATEGORY_KEY = EtfAnalysisCategory.CostEfficiencyAndTeam;
+const CATEGORY_NAME = 'Cost, Efficiency & Team';
+const CATEGORY_SLUG = 'cost-efficiency-team';
+const BADGE_CLASS = 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ exchange: string; etf: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+async function fetchEtf(exchange: string, etf: string): Promise<EtfFastResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}?allowNull=true`;
+  const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+  if (!res.ok) return null;
+  return (await res.json()) as EtfFastResponse | null;
+}
+
+async function fetchAnalysis(exchange: string, etf: string): Promise<EtfAnalysisResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}/analysis`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) return { categories: [] };
+    return (await res.json()) as EtfAnalysisResponse;
+  } catch {
+    return { categories: [] };
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  let etfName = symbol;
+  let createdTime: string | undefined;
+  let updatedTime: string | undefined;
+
+  try {
+    const data = await fetchEtf(exchange, symbol);
+    if (data) {
+      etfName = data.name ?? etfName;
+      createdTime = data.createdAt?.toISOString();
+      updatedTime = data.updatedAt?.toISOString();
+    }
+  } catch {
+    /* keep generic */
+  }
+
+  return generateEtfCategoryMetadata({
+    etfName,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    description: `${CATEGORY_NAME} analysis for ${etfName} (${symbol}) ETF — expense ratio, fund size, liquidity, portfolio turnover, management quality, and Mor assessment.`,
+    keywords: [`${etfName} expense ratio`, `${symbol} ETF cost`, `${symbol} management`, 'ETF cost analysis', 'ETF efficiency', 'KoalaGains'],
+    createdTime,
+    updatedTime,
+  });
+}
+
+export default async function CostEfficiencyTeamPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  const [etfData, analysisData] = await Promise.all([fetchEtf(exchange, symbol), fetchAnalysis(exchange, symbol)]);
+  if (!etfData) notFound();
+
+  const categoryResult = analysisData.categories.find((c) => c.categoryKey === CATEGORY_KEY);
+  if (!categoryResult) notFound();
+
+  const now = new Date().toISOString();
+  const publishedDate = etfData.createdAt?.toISOString?.() || now;
+  const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
+
+  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+
+  const breadcrumbs: BreadcrumbsOjbect[] = [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: `${etfData.name} (${symbol})`, href: `/etfs/${exchange}/${symbol}`, current: false },
+    { name: CATEGORY_NAME, href: `/etfs/${exchange}/${symbol}/${CATEGORY_SLUG}`, current: true },
+  ];
+
+  return (
+    <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <EtfCategoryReport
+        etfName={etfData.name}
+        symbol={symbol}
+        exchange={exchange}
+        categoryResult={categoryResult}
+        analysisTitle={`${etfData.name} (${symbol}) ${CATEGORY_NAME} Analysis`}
+        categoryBadgeText={CATEGORY_NAME}
+        categoryBadgeClassName={BADGE_CLASS}
+        updatedAt={modifiedDate}
+      />
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -263,7 +263,15 @@ function EtfArticleFooter({ modifiedDate, formattedModifiedDate }: { modifiedDat
   );
 }
 
-function EtfAnalysisSection({ analysisPromise, exchange, symbol }: { analysisPromise: Promise<EtfAnalysisResponse>; exchange: string; symbol: string }): JSX.Element | null {
+function EtfAnalysisSection({
+  analysisPromise,
+  exchange,
+  symbol,
+}: {
+  analysisPromise: Promise<EtfAnalysisResponse>;
+  exchange: string;
+  symbol: string;
+}): JSX.Element | null {
   const analysis: EtfAnalysisResponse = use(analysisPromise);
   return <EtfAnalysisSections data={analysis} exchange={exchange} symbol={symbol} />;
 }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -12,6 +12,7 @@ import { getCountryByExchange, SupportedCountries, formatExchangeWithCountry, to
 import { generateEtfDetailMetadata, generateEtfDetailArticleJsonLd, generateEtfDetailBreadcrumbJsonLd } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { parseMarkdown } from '@/util/parse-markdown';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
@@ -192,6 +193,13 @@ function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Eleme
         <div className="mb-4">
           <span className="text-sm text-gray-400">Inception Date: </span>
           <span className="text-sm font-medium">{d.inception}</span>
+        </div>
+      )}
+
+      {/* Summary (if available) */}
+      {d.summary && d.summary.trim() && (
+        <div className="mb-2" itemProp="description">
+          <div className="markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(d.summary) }} />
         </div>
       )}
     </section>

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -263,9 +263,9 @@ function EtfArticleFooter({ modifiedDate, formattedModifiedDate }: { modifiedDat
   );
 }
 
-function EtfAnalysisSection({ analysisPromise }: { analysisPromise: Promise<EtfAnalysisResponse> }): JSX.Element | null {
+function EtfAnalysisSection({ analysisPromise, exchange, symbol }: { analysisPromise: Promise<EtfAnalysisResponse>; exchange: string; symbol: string }): JSX.Element | null {
   const analysis: EtfAnalysisResponse = use(analysisPromise);
-  return <EtfAnalysisSections data={analysis} />;
+  return <EtfAnalysisSections data={analysis} exchange={exchange} symbol={symbol} />;
 }
 
 /** PAGE */
@@ -350,7 +350,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
         </Suspense>
 
         <Suspense fallback={null}>
-          <EtfAnalysisSection analysisPromise={analysisPromise} />
+          <EtfAnalysisSection analysisPromise={analysisPromise} exchange={exchange} symbol={etf} />
         </Suspense>
 
         <EtfArticleFooter modifiedDate={modifiedDate} formattedModifiedDate={formattedModifiedDate} />

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -1,0 +1,123 @@
+import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
+import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import {
+  generateEtfCategoryMetadata,
+  generateEtfCategoryArticleJsonLd,
+  generateEtfCategoryBreadcrumbJsonLd,
+} from '@/utils/etf-metadata-generators';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+const CATEGORY_KEY = EtfAnalysisCategory.PerformanceAndReturns;
+const CATEGORY_NAME = 'Performance & Returns';
+const CATEGORY_SLUG = 'performance-returns';
+const BADGE_CLASS = 'bg-emerald-100 dark:bg-emerald-900 text-emerald-800 dark:text-emerald-300';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ exchange: string; etf: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+async function fetchEtf(exchange: string, etf: string): Promise<EtfFastResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}?allowNull=true`;
+  const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+  if (!res.ok) return null;
+  return (await res.json()) as EtfFastResponse | null;
+}
+
+async function fetchAnalysis(exchange: string, etf: string): Promise<EtfAnalysisResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}/analysis`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) return { categories: [] };
+    return (await res.json()) as EtfAnalysisResponse;
+  } catch {
+    return { categories: [] };
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  let etfName = symbol;
+  let createdTime: string | undefined;
+  let updatedTime: string | undefined;
+
+  try {
+    const data = await fetchEtf(exchange, symbol);
+    if (data) {
+      etfName = data.name ?? etfName;
+      createdTime = data.createdAt?.toISOString();
+      updatedTime = data.updatedAt?.toISOString();
+    }
+  } catch {
+    /* keep generic */
+  }
+
+  return generateEtfCategoryMetadata({
+    etfName,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    description: `${CATEGORY_NAME} analysis for ${etfName} (${symbol}) ETF — long-term CAGR, short-term returns, consistency, benchmark comparison, and price momentum.`,
+    keywords: [`${etfName} performance`, `${symbol} ETF returns`, `${symbol} CAGR`, 'ETF performance analysis', 'ETF returns', 'KoalaGains'],
+    createdTime,
+    updatedTime,
+  });
+}
+
+export default async function PerformanceReturnsPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  const [etfData, analysisData] = await Promise.all([fetchEtf(exchange, symbol), fetchAnalysis(exchange, symbol)]);
+  if (!etfData) notFound();
+
+  const categoryResult = analysisData.categories.find((c) => c.categoryKey === CATEGORY_KEY);
+  if (!categoryResult) notFound();
+
+  const now = new Date().toISOString();
+  const publishedDate = etfData.createdAt?.toISOString?.() || now;
+  const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
+
+  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+
+  const breadcrumbs: BreadcrumbsOjbect[] = [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: `${etfData.name} (${symbol})`, href: `/etfs/${exchange}/${symbol}`, current: false },
+    { name: CATEGORY_NAME, href: `/etfs/${exchange}/${symbol}/${CATEGORY_SLUG}`, current: true },
+  ];
+
+  return (
+    <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <EtfCategoryReport
+        etfName={etfData.name}
+        symbol={symbol}
+        exchange={exchange}
+        categoryResult={categoryResult}
+        analysisTitle={`${etfData.name} (${symbol}) ${CATEGORY_NAME} Analysis`}
+        categoryBadgeText={CATEGORY_NAME}
+        categoryBadgeClassName={BADGE_CLASS}
+        updatedAt={modifiedDate}
+      />
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -4,11 +4,7 @@ import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryRe
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
-import {
-  generateEtfCategoryMetadata,
-  generateEtfCategoryArticleJsonLd,
-  generateEtfCategoryBreadcrumbJsonLd,
-} from '@/utils/etf-metadata-generators';
+import { generateEtfCategoryMetadata, generateEtfCategoryArticleJsonLd, generateEtfCategoryBreadcrumbJsonLd } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -95,8 +91,22 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
   const publishedDate = etfData.createdAt?.toISOString?.() || now;
   const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
 
-  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
-  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+  const articleSchema = generateEtfCategoryArticleJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    publishedDate,
+    modifiedDate,
+  });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+  });
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'US ETFs', href: '/etfs', current: false },

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -1,0 +1,123 @@
+import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
+import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import {
+  generateEtfCategoryMetadata,
+  generateEtfCategoryArticleJsonLd,
+  generateEtfCategoryBreadcrumbJsonLd,
+} from '@/utils/etf-metadata-generators';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+const CATEGORY_KEY = EtfAnalysisCategory.RiskAnalysis;
+const CATEGORY_NAME = 'Risk Analysis';
+const CATEGORY_SLUG = 'risk-analysis';
+const BADGE_CLASS = 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-300';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ exchange: string; etf: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+async function fetchEtf(exchange: string, etf: string): Promise<EtfFastResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}?allowNull=true`;
+  const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+  if (!res.ok) return null;
+  return (await res.json()) as EtfFastResponse | null;
+}
+
+async function fetchAnalysis(exchange: string, etf: string): Promise<EtfAnalysisResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}/analysis`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) return { categories: [] };
+    return (await res.json()) as EtfAnalysisResponse;
+  } catch {
+    return { categories: [] };
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  let etfName = symbol;
+  let createdTime: string | undefined;
+  let updatedTime: string | undefined;
+
+  try {
+    const data = await fetchEtf(exchange, symbol);
+    if (data) {
+      etfName = data.name ?? etfName;
+      createdTime = data.createdAt?.toISOString();
+      updatedTime = data.updatedAt?.toISOString();
+    }
+  } catch {
+    /* keep generic */
+  }
+
+  return generateEtfCategoryMetadata({
+    etfName,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    description: `${CATEGORY_NAME} for ${etfName} (${symbol}) ETF — volatility, Sharpe/Sortino ratios, maximum drawdown, capture ratios, and risk scores vs category peers.`,
+    keywords: [`${etfName} risk`, `${symbol} ETF volatility`, `${symbol} Sharpe ratio`, 'ETF risk analysis', 'ETF drawdown', 'KoalaGains'],
+    createdTime,
+    updatedTime,
+  });
+}
+
+export default async function RiskAnalysisPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  const [etfData, analysisData] = await Promise.all([fetchEtf(exchange, symbol), fetchAnalysis(exchange, symbol)]);
+  if (!etfData) notFound();
+
+  const categoryResult = analysisData.categories.find((c) => c.categoryKey === CATEGORY_KEY);
+  if (!categoryResult) notFound();
+
+  const now = new Date().toISOString();
+  const publishedDate = etfData.createdAt?.toISOString?.() || now;
+  const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
+
+  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+
+  const breadcrumbs: BreadcrumbsOjbect[] = [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: `${etfData.name} (${symbol})`, href: `/etfs/${exchange}/${symbol}`, current: false },
+    { name: CATEGORY_NAME, href: `/etfs/${exchange}/${symbol}/${CATEGORY_SLUG}`, current: true },
+  ];
+
+  return (
+    <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <EtfCategoryReport
+        etfName={etfData.name}
+        symbol={symbol}
+        exchange={exchange}
+        categoryResult={categoryResult}
+        analysisTitle={`${etfData.name} (${symbol}) ${CATEGORY_NAME}`}
+        categoryBadgeText={CATEGORY_NAME}
+        categoryBadgeClassName={BADGE_CLASS}
+        updatedAt={modifiedDate}
+      />
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -4,11 +4,7 @@ import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryRe
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
-import {
-  generateEtfCategoryMetadata,
-  generateEtfCategoryArticleJsonLd,
-  generateEtfCategoryBreadcrumbJsonLd,
-} from '@/utils/etf-metadata-generators';
+import { generateEtfCategoryMetadata, generateEtfCategoryArticleJsonLd, generateEtfCategoryBreadcrumbJsonLd } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -95,8 +91,22 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
   const publishedDate = etfData.createdAt?.toISOString?.() || now;
   const modifiedDate = etfData.updatedAt?.toISOString?.() || now;
 
-  const articleSchema = generateEtfCategoryArticleJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG, publishedDate, modifiedDate });
-  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({ etfName: etfData.name, symbol, exchange, categoryName: CATEGORY_NAME, categorySlug: CATEGORY_SLUG });
+  const articleSchema = generateEtfCategoryArticleJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+    publishedDate,
+    modifiedDate,
+  });
+  const breadcrumbSchema = generateEtfCategoryBreadcrumbJsonLd({
+    etfName: etfData.name,
+    symbol,
+    exchange,
+    categoryName: CATEGORY_NAME,
+    categorySlug: CATEGORY_SLUG,
+  });
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'US ETFs', href: '/etfs', current: false },

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
@@ -1,43 +1,58 @@
 'use client';
 
-import { EtfAnalysisResponse, EtfCategoryAnalysisResultResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
+import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
-import etfAnalysisFactorsConfig from '@/etf-analysis-data/etf-analysis-factors.json';
 import { parseMarkdown } from '@/util/parse-markdown';
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
+import Link from 'next/link';
 
-const CATEGORY_NAMES: Record<string, string> = {
-  [EtfAnalysisCategory.PerformanceAndReturns]: 'Performance & Returns',
-  [EtfAnalysisCategory.CostEfficiencyAndTeam]: 'Cost, Efficiency & Team',
-  [EtfAnalysisCategory.RiskAnalysis]: 'Risk Analysis',
+const CATEGORY_DISPLAY: Record<string, { name: string; order: number; slug: string }> = {
+  [EtfAnalysisCategory.PerformanceAndReturns]: { name: 'Performance & Returns', order: 1, slug: 'performance-returns' },
+  [EtfAnalysisCategory.CostEfficiencyAndTeam]: { name: 'Cost, Efficiency & Team', order: 2, slug: 'cost-efficiency-team' },
+  [EtfAnalysisCategory.RiskAnalysis]: { name: 'Risk Analysis', order: 3, slug: 'risk-analysis' },
 };
 
 const CATEGORY_ORDER = [EtfAnalysisCategory.PerformanceAndReturns, EtfAnalysisCategory.CostEfficiencyAndTeam, EtfAnalysisCategory.RiskAnalysis];
 
-function getFactorTitle(categoryKey: string, factorKey: string): string {
-  const cat = etfAnalysisFactorsConfig.categories.find((c) => c.categoryKey === categoryKey);
-  const factor = cat?.factors.find((f) => f.factorAnalysisKey === factorKey);
-  return factor?.factorAnalysisTitle || factorKey;
+interface EtfAnalysisSectionsProps {
+  data: EtfAnalysisResponse;
+  exchange: string;
+  symbol: string;
 }
 
-function EtfSummaryAnalysis({ data }: { data: EtfAnalysisResponse }): JSX.Element {
+export default function EtfAnalysisSections({ data, exchange, symbol }: EtfAnalysisSectionsProps): JSX.Element | null {
+  if (!data.categories || data.categories.length === 0) {
+    return null;
+  }
+
   return (
     <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-8 sm:py-6" itemProp="abstract">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700 px-4">Summary Analysis</h2>
       <div className="space-y-4 px-4">
         {CATEGORY_ORDER.map((categoryKey) => {
           const categoryResult = data.categories.find((r) => r.categoryKey === categoryKey);
+          const display = CATEGORY_DISPLAY[categoryKey] || { name: categoryKey, order: 99, slug: '' };
           return (
             <div key={categoryKey} className="bg-gray-900 p-4 rounded-md shadow-sm">
               <div className="flex items-center gap-2 mb-2">
-                <h3 className="text-lg font-semibold">{CATEGORY_NAMES[categoryKey] || categoryKey}</h3>
-                {categoryResult && (
-                  <div
-                    className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
-                    style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
+                <div className="flex items-center gap-2">
+                  <h3 className="text-lg font-semibold">{display.name}</h3>
+                  {categoryResult && (
+                    <div
+                      className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
+                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
+                    >
+                      {categoryResult.factorResults?.filter((fr) => fr.result === 'Pass').length || 0}/{categoryResult.factorResults?.length || 0}
+                    </div>
+                  )}
+                </div>
+                {categoryResult && display.slug && (
+                  <Link
+                    href={`/etfs/${exchange}/${symbol}/${display.slug}`}
+                    className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                    style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
                   >
-                    {categoryResult.factorResults?.filter((fr) => fr.result === 'Pass').length || 0}/{categoryResult.factorResults?.length || 0}
-                  </div>
+                    View Detailed Analysis →
+                  </Link>
                 )}
               </div>
               <div
@@ -49,81 +64,5 @@ function EtfSummaryAnalysis({ data }: { data: EtfAnalysisResponse }): JSX.Elemen
         })}
       </div>
     </section>
-  );
-}
-
-function EtfDetailedAnalysis({ data }: { data: EtfAnalysisResponse }): JSX.Element {
-  return (
-    <section id="detailed-analysis" className="mb-8" itemProp="articleBody">
-      <h2 className="text-2xl font-bold mb-6">Detailed Analysis</h2>
-
-      {CATEGORY_ORDER.map((categoryKey) => {
-        const categoryResult = data.categories.find((r) => r.categoryKey === categoryKey);
-        if (!categoryResult) return null;
-
-        return (
-          <div key={`detail-${categoryKey}`} id={`detailed-${categoryKey}`} className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-8">
-            <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
-              <h3 className="text-xl font-bold">{CATEGORY_NAMES[categoryKey] || categoryKey}</h3>
-              <div
-                className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
-                style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
-              >
-                {categoryResult.factorResults?.filter((fr) => fr.result === 'Pass').length || 0}/{categoryResult.factorResults?.length || 0}
-              </div>
-            </div>
-
-            {categoryResult.summary && (
-              <div className="mb-4">
-                <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult.summary) }} />
-              </div>
-            )}
-
-            {categoryResult.factorResults?.length ? (
-              <ul className="space-y-3">
-                {categoryResult.factorResults.map((factor) => (
-                  <li key={factor.factorKey} className="bg-gray-800 px-2 py-4 sm:p-4 rounded-md">
-                    <div className="flex flex-col gap-y-2">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          {factor.result === 'Pass' ? (
-                            <CheckCircleIcon className="h-6 w-6 text-green-500 flex-shrink-0" />
-                          ) : (
-                            <XCircleIcon className="h-6 w-6 text-red-500 flex-shrink-0" />
-                          )}
-                          <h4 className="font-semibold">{getFactorTitle(categoryKey, factor.factorKey)}</h4>
-                        </div>
-                        <span
-                          className={`px-2 py-1 rounded-full text-sm font-medium ${
-                            factor.result === 'Pass' ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'
-                          }`}
-                        >
-                          {factor.result}
-                        </span>
-                      </div>
-                      <p className="text-sm text-gray-400">{factor.oneLineExplanation}</p>
-                      <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(factor.detailedExplanation) }} />
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </div>
-        );
-      })}
-    </section>
-  );
-}
-
-export default function EtfAnalysisSections({ data }: { data: EtfAnalysisResponse }): JSX.Element | null {
-  if (!data.categories || data.categories.length === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      <EtfSummaryAnalysis data={data} />
-      <EtfDetailedAnalysis data={data} />
-    </>
   );
 }

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -1,0 +1,160 @@
+import { EtfCategoryAnalysisResultResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
+import etfAnalysisFactorsConfig from '@/etf-analysis-data/etf-analysis-factors.json';
+import { parseMarkdown } from '@/util/parse-markdown';
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
+import Link from 'next/link';
+
+const PASS_RESULT = 'Pass';
+
+function getFactorTitle(categoryKey: string, factorKey: string): string {
+  const cat = etfAnalysisFactorsConfig.categories.find((c) => c.categoryKey === categoryKey);
+  const factor = cat?.factors.find((f) => f.factorAnalysisKey === factorKey);
+  return factor?.factorAnalysisTitle || factorKey;
+}
+
+export interface EtfCategoryReportProps {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  categoryResult: EtfCategoryAnalysisResultResponse;
+  analysisTitle: string;
+  categoryBadgeText: string;
+  categoryBadgeClassName: string;
+  updatedAt?: string;
+}
+
+export default function EtfCategoryReport({
+  etfName,
+  symbol,
+  exchange,
+  categoryResult,
+  analysisTitle,
+  categoryBadgeText,
+  categoryBadgeClassName,
+  updatedAt,
+}: EtfCategoryReportProps): JSX.Element | null {
+  if (!categoryResult) return null;
+
+  const modifiedDate = new Date(updatedAt || new Date());
+  const formattedModifiedDate = modifiedDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  const passCount = categoryResult.factorResults?.filter((fr) => fr.result === PASS_RESULT).length || 0;
+  const totalCount = categoryResult.factorResults?.length || 0;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+        <header className="mb-6 pb-4 border-b border-color">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+            <div className="flex-1">
+              <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-color mb-2" itemProp="headline">
+                {etfName} <span className="text-muted-foreground">({symbol})</span>
+              </h1>
+              <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
+                <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+                  {exchange}
+                </span>
+                <span className="text-muted-foreground">•</span>
+                <div
+                  className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
+                  style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
+                >
+                  {passCount}/{totalCount}
+                </div>
+                <span className="text-muted-foreground">•</span>
+                <time dateTime={modifiedDate.toISOString()} className="text-muted-foreground text-sm" itemProp="dateModified">
+                  {formattedModifiedDate}
+                </time>
+              </div>
+            </div>
+            <Link href={`/etfs/${exchange}/${symbol}`} className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1">
+              View Full Report →
+            </Link>
+          </div>
+        </header>
+
+        <div className="prose prose-invert max-w-none">
+          <section className="mb-6">
+            <h2 className="text-xl font-semibold text-color mb-3">Analysis Title</h2>
+            <p className="text-color" itemProp="description">
+              {analysisTitle}
+            </p>
+          </section>
+
+          <section className="mb-6">
+            <h2 className="text-xl font-semibold text-color mb-3">Executive Summary</h2>
+            {categoryResult.summary ? (
+              <div className="text-color leading-relaxed" itemProp="abstract" dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult.summary) }} />
+            ) : (
+              <p className="text-color leading-relaxed" itemProp="abstract" />
+            )}
+          </section>
+
+          {categoryResult.overallAnalysisDetails && (
+            <section className="mb-6" itemProp="articleBody">
+              <h2 className="text-xl font-semibold text-color mb-3">Comprehensive Analysis</h2>
+              <div
+                className="markdown markdown-body prose-headings:text-color prose-p:text-color prose-strong:text-color prose-code:text-color prose-a:text-primary hover:prose-a:text-primary/80"
+                dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult.overallAnalysisDetails) }}
+              />
+            </section>
+          )}
+
+          {categoryResult.factorResults && categoryResult.factorResults.length > 0 && (
+            <section className="mb-6">
+              <h2 className="text-xl font-semibold text-color mb-3">Factor Analysis</h2>
+              <ul className="space-y-3 mt-2">
+                {categoryResult.factorResults.map((factor) => (
+                  <li key={factor.factorKey} className="bg-gray-800 px-2 py-4 sm:p-4 rounded-md">
+                    <div className="flex flex-col gap-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          {factor.result === PASS_RESULT ? (
+                            <CheckCircleIcon className="h-6 w-6 text-green-500 flex-shrink-0" />
+                          ) : (
+                            <XCircleIcon className="h-6 w-6 text-red-500 flex-shrink-0" />
+                          )}
+                          <h3 className="font-semibold">{getFactorTitle(categoryResult.categoryKey, factor.factorKey)}</h3>
+                        </div>
+                        <span
+                          className={`px-2 py-1 rounded-full text-sm font-medium ${
+                            factor.result === PASS_RESULT ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'
+                          }`}
+                        >
+                          {factor.result}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-400">{factor.oneLineExplanation}</p>
+                      <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(factor.detailedExplanation) }} />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+
+        <footer className="mt-8 pt-6 border-t border-color">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="text-sm text-muted-foreground">
+              <span>Last updated by </span>
+              <span itemProp="author" itemScope itemType="https://schema.org/Organization">
+                <span itemProp="name">KoalaGains</span>
+              </span>
+              <span> on </span>
+              <time dateTime={modifiedDate.toISOString()} itemProp="dateModified">
+                {formattedModifiedDate}
+              </time>
+            </div>
+            <div className="flex gap-2">
+              <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+                ETF Analysis
+              </span>
+              <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${categoryBadgeClassName}`}>{categoryBadgeText}</span>
+            </div>
+          </div>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/insights-ui/src/components/visualizations/RadarChart.tsx
+++ b/insights-ui/src/components/visualizations/RadarChart.tsx
@@ -44,6 +44,13 @@ const RadarChart: React.FC<RadarChartProps> = ({ data, scorePercentage }) => {
   const itemKeys = Object.keys(data);
   const SCORE_OFFSET = 0.5; // Adds padding ONLY for zero scores
 
+  const shouldShowFactorDetails = (): boolean => {
+    const keys = Object.keys(data);
+    const v1Keys = ['BusinessAndMoat', 'FinancialStatementAnalysis', 'PastPerformance', 'FutureGrowth', 'FairValue'];
+    const etfKeys = ['PerformanceAndReturns', 'CostEfficiencyAndTeam', 'RiskAnalysis'];
+    return keys.some((key) => v1Keys.includes(key) || etfKeys.includes(key));
+  };
+
   const scores: number[] = itemKeys.map((category) => {
     const rawScore = data[category].scores.reduce((acc, item) => acc + item.score, 0);
     return rawScore === 0 ? SCORE_OFFSET : rawScore;
@@ -182,13 +189,8 @@ const RadarChart: React.FC<RadarChartProps> = ({ data, scorePercentage }) => {
               return 'No data available';
             }
 
-            // Check if this is V1 data (has V1 category keys) - if so, skip showing summary
-            const isV1Data = Object.keys(data).some((key) =>
-              ['BusinessAndMoat', 'FinancialStatementAnalysis', 'PastPerformance', 'FutureGrowth', 'FairValue'].includes(key)
-            );
-
-            if (isV1Data) {
-              return ''; // Don't show summary for V1 data
+            if (shouldShowFactorDetails()) {
+              return ''; // Don't show summary when we show factor breakdown
             }
 
             const summary = data[categoryKey].summary;
@@ -208,27 +210,19 @@ const RadarChart: React.FC<RadarChartProps> = ({ data, scorePercentage }) => {
             const totalChecks = categoryData.length;
             const totalOnes = categoryData.filter((item) => item.score === 1).length;
 
-            // Check if this is V1 data (has V1 category keys)
-            const isV1Data = Object.keys(data).some((key) =>
-              ['BusinessAndMoat', 'FinancialStatementAnalysis', 'PastPerformance', 'FutureGrowth', 'FairValue'].includes(key)
-            );
-
-            if (isV1Data) {
-              // For V1 data, show detailed factor breakdown in footer (normal text)
+            if (shouldShowFactorDetails()) {
               const factorDetails = categoryData
                 .map((item) => {
                   const icon = item.score === 1 ? '✅' : '❌';
-                  // Extract factor name from comment (before the colon)
                   const factorName = item.comment.split(':')[0] || 'Unknown Factor';
                   return `${icon} ${factorName}`;
                 })
                 .join('\n');
-              return factorDetails;
-            } else {
-              // For original data, show the compact version
-              const analysisChecks = categoryData.map((item) => (item.score === 1 ? '✅' : '❌')).join('');
-              return `Analysis Checks ${totalOnes}/${totalChecks}\n${analysisChecks}`;
+              return factorDetails || 'No analysis available';
             }
+
+            const analysisChecks = categoryData.map((item) => (item.score === 1 ? '✅' : '❌')).join('');
+            return `Analysis Checks ${totalOnes}/${totalChecks}\n${analysisChecks}`;
           },
         },
       },

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -8,6 +8,7 @@ export enum EtfReportType {
   PERFORMANCE_AND_RETURNS = 'performance-and-returns',
   COST_EFFICIENCY_AND_TEAM = 'cost-efficiency-and-team',
   RISK_ANALYSIS = 'risk-analysis',
+  FINAL_SUMMARY = 'final-summary',
 }
 
 export enum EtfGenerationRequestStatus {
@@ -21,13 +22,21 @@ export const ETF_REPORT_TYPE_TO_CATEGORY: Record<EtfReportType, EtfAnalysisCateg
   [EtfReportType.PERFORMANCE_AND_RETURNS]: EtfAnalysisCategory.PerformanceAndReturns,
   [EtfReportType.COST_EFFICIENCY_AND_TEAM]: EtfAnalysisCategory.CostEfficiencyAndTeam,
   [EtfReportType.RISK_ANALYSIS]: EtfAnalysisCategory.RiskAnalysis,
+  // FINAL_SUMMARY is saved directly on the ETF record (not a category analysis).
+  // We still provide a placeholder mapping to satisfy the Record<> type; it is not used.
+  [EtfReportType.FINAL_SUMMARY]: EtfAnalysisCategory.PerformanceAndReturns,
 };
 
 export const ETF_PROMPT_KEYS: Record<EtfReportType, string> = {
   [EtfReportType.PERFORMANCE_AND_RETURNS]: 'US/etfs/performance-returns',
   [EtfReportType.COST_EFFICIENCY_AND_TEAM]: 'US/etfs/cost-efficiency-team',
   [EtfReportType.RISK_ANALYSIS]: 'US/etfs/risk-analysis',
+  [EtfReportType.FINAL_SUMMARY]: 'US/etfs/final-summary',
 };
+
+export interface EtfFinalSummaryResponse {
+  summary: string;
+}
 
 export interface EtfAnalysisFactorDefinition {
   factorAnalysisKey: string;

--- a/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
@@ -117,16 +117,25 @@ export async function triggerEtfGenerationOfAReport(symbol: string, exchange: st
     return;
   }
 
+  console.log(`ETF trigger: starting step ${nextStep} for ${symbol} (request: ${generationRequest.id})`);
   await markEtfRequestAsInProgress(generationRequest, nextStep);
 
   try {
     await generateEtfCategoryAnalysis(spaceId, etfRecord, generationRequest.id, nextStep);
+    console.log(`ETF trigger: Lambda invoked for step ${nextStep} of ${symbol} — waiting for callback`);
   } catch (error) {
     console.error(`Error generating ETF ${nextStep} for ${symbol}:`, error);
+    const currentRequest = await prisma.etfGenerationRequest.findUniqueOrThrow({
+      where: { id: generationRequest.id },
+    });
+    const updatedFailedSteps = [...currentRequest.failedSteps];
+    if (!updatedFailedSteps.includes(nextStep)) {
+      updatedFailedSteps.push(nextStep);
+    }
     await prisma.etfGenerationRequest.update({
       where: { id: generationRequest.id },
       data: {
-        failedSteps: [...generationRequest.failedSteps, nextStep],
+        failedSteps: updatedFailedSteps,
         inProgressStep: null,
         updatedAt: new Date(),
       },

--- a/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
@@ -4,6 +4,7 @@ import { EtfAnalysisCategory, EtfGenerationRequestStatus, EtfReportType, ETF_PRO
 import { fetchEtfWithAllData, EtfWithAllData } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
 import {
   prepareCostEfficiencyAndTeamInputJson,
+  prepareEtfFinalSummaryInputJson,
   preparePerformanceAndReturnsInputJson,
   prepareRiskAnalysisInputJson,
 } from '@/utils/etf-analysis-reports/etf-report-input-json-utils';
@@ -15,12 +16,14 @@ export const etfReportDependencyMap: Record<EtfReportType, EtfReportType[]> = {
   [EtfReportType.PERFORMANCE_AND_RETURNS]: [],
   [EtfReportType.COST_EFFICIENCY_AND_TEAM]: [],
   [EtfReportType.RISK_ANALYSIS]: [],
+  [EtfReportType.FINAL_SUMMARY]: [EtfReportType.PERFORMANCE_AND_RETURNS, EtfReportType.COST_EFFICIENCY_AND_TEAM, EtfReportType.RISK_ANALYSIS],
 };
 
 export const etfDependencyBasedReportOrder: EtfReportType[] = [
   EtfReportType.PERFORMANCE_AND_RETURNS,
   EtfReportType.COST_EFFICIENCY_AND_TEAM,
   EtfReportType.RISK_ANALYSIS,
+  EtfReportType.FINAL_SUMMARY,
 ];
 
 function prepareInputJsonForReportType(etf: EtfWithAllData, reportType: EtfReportType) {
@@ -31,6 +34,8 @@ function prepareInputJsonForReportType(etf: EtfWithAllData, reportType: EtfRepor
       return prepareCostEfficiencyAndTeamInputJson(etf);
     case EtfReportType.RISK_ANALYSIS:
       return prepareRiskAnalysisInputJson(etf);
+    case EtfReportType.FINAL_SUMMARY:
+      return prepareEtfFinalSummaryInputJson(etf);
   }
 }
 

--- a/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-generation-report-utils.ts
@@ -117,25 +117,16 @@ export async function triggerEtfGenerationOfAReport(symbol: string, exchange: st
     return;
   }
 
-  console.log(`ETF trigger: starting step ${nextStep} for ${symbol} (request: ${generationRequest.id})`);
   await markEtfRequestAsInProgress(generationRequest, nextStep);
 
   try {
     await generateEtfCategoryAnalysis(spaceId, etfRecord, generationRequest.id, nextStep);
-    console.log(`ETF trigger: Lambda invoked for step ${nextStep} of ${symbol} — waiting for callback`);
   } catch (error) {
     console.error(`Error generating ETF ${nextStep} for ${symbol}:`, error);
-    const currentRequest = await prisma.etfGenerationRequest.findUniqueOrThrow({
-      where: { id: generationRequest.id },
-    });
-    const updatedFailedSteps = [...currentRequest.failedSteps];
-    if (!updatedFailedSteps.includes(nextStep)) {
-      updatedFailedSteps.push(nextStep);
-    }
     await prisma.etfGenerationRequest.update({
       where: { id: generationRequest.id },
       data: {
-        failedSteps: updatedFailedSteps,
+        failedSteps: [...generationRequest.failedSteps, nextStep],
         inProgressStep: null,
         updatedAt: new Date(),
       },

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -226,3 +226,26 @@ export function prepareRiskAnalysisInputJson(etf: EtfWithAllData) {
     }),
   };
 }
+
+export function prepareEtfFinalSummaryInputJson(etf: EtfWithAllData) {
+  const categorySummaries = (etf.categoryAnalysisResults || []).map((c) => ({
+    categoryKey: c.categoryKey,
+    overallSummary: c.summary,
+  }));
+
+  const factorResults = (etf.analysisCategoryFactorResults || []).map((f) => ({
+    categoryKey: f.categoryKey,
+    factorAnalysisKey: f.factorKey,
+    oneLineExplanation: f.oneLineExplanation,
+    result: f.result,
+  }));
+
+  return {
+    name: etf.name,
+    symbol: etf.symbol,
+    exchange: etf.exchange,
+    inception: etf.inception || '',
+    categorySummaries,
+    factorResults,
+  };
+}

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-steps-statuses.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-steps-statuses.ts
@@ -28,5 +28,13 @@ export function calculateEtfPendingSteps(request: EtfGenerationRequest): EtfRepo
     pendingSteps.push(EtfReportType.RISK_ANALYSIS);
   }
 
+  if (
+    request.regenerateFinalSummary &&
+    !request.completedSteps.includes(EtfReportType.FINAL_SUMMARY) &&
+    !request.failedSteps.includes(EtfReportType.FINAL_SUMMARY)
+  ) {
+    pendingSteps.push(EtfReportType.FINAL_SUMMARY);
+  }
+
   return pendingSteps;
 }

--- a/insights-ui/src/utils/etf-analysis-reports/get-etf-report-data-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/get-etf-report-data-utils.ts
@@ -1,6 +1,16 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { Etf, EtfFinancialInfo, EtfMorAnalyzerInfo, EtfMorPeopleInfo, EtfMorPortfolioInfo, EtfMorRiskInfo, EtfStockAnalyzerInfo } from '@prisma/client';
+import {
+  Etf,
+  EtfAnalysisCategoryFactorResult,
+  EtfCategoryAnalysisResult,
+  EtfFinancialInfo,
+  EtfMorAnalyzerInfo,
+  EtfMorPeopleInfo,
+  EtfMorPortfolioInfo,
+  EtfMorRiskInfo,
+  EtfStockAnalyzerInfo,
+} from '@prisma/client';
 
 export interface EtfWithAllData extends Etf {
   financialInfo: EtfFinancialInfo | null;
@@ -9,6 +19,8 @@ export interface EtfWithAllData extends Etf {
   morRiskInfo: EtfMorRiskInfo | null;
   morPeopleInfo: EtfMorPeopleInfo | null;
   morPortfolioInfo: EtfMorPortfolioInfo | null;
+  categoryAnalysisResults: (EtfCategoryAnalysisResult & { factorResults: EtfAnalysisCategoryFactorResult[] })[];
+  analysisCategoryFactorResults: EtfAnalysisCategoryFactorResult[];
 }
 
 export async function fetchEtfBySymbolAndExchange(symbol: string, exchange: string): Promise<Etf> {
@@ -35,6 +47,12 @@ export async function fetchEtfWithAllData(symbol: string, exchange: string): Pro
       morRiskInfo: true,
       morPeopleInfo: true,
       morPortfolioInfo: true,
+      categoryAnalysisResults: {
+        include: {
+          factorResults: true,
+        },
+      },
+      analysisCategoryFactorResults: true,
     },
   });
 }

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { EtfAnalysisCategory, EtfCategoryAnalysisResponse } from '@/types/etf/etf-analysis-types';
+import { EtfAnalysisCategory, EtfCategoryAnalysisResponse, EtfFinalSummaryResponse } from '@/types/etf/etf-analysis-types';
 import { getEtfAnalysisFactorsForCategory } from '@/utils/etf-analysis-reports/etf-report-input-json-utils';
 import { fetchEtfBySymbolAndExchange } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
@@ -73,6 +73,20 @@ export async function saveEtfFactorAnalysisResponse(
 
   const score = response.factors.filter((f) => f.result && f.result.toLowerCase().includes('pass')).length;
   await updateEtfCachedScore(etfRecord.id, categoryKey, score);
+
+  revalidateEtfAndExchangeTag(symbol, exchange);
+}
+
+export async function saveEtfFinalSummaryResponse(symbol: string, exchange: string, response: EtfFinalSummaryResponse): Promise<void> {
+  const etfRecord = await fetchEtfBySymbolAndExchange(symbol, exchange);
+
+  await prisma.etf.update({
+    where: { id: etfRecord.id },
+    data: {
+      summary: response.summary,
+      updatedAt: new Date(),
+    },
+  });
 
   revalidateEtfAndExchangeTag(symbol, exchange);
 }

--- a/insights-ui/src/utils/etf-metadata-generators.ts
+++ b/insights-ui/src/utils/etf-metadata-generators.ts
@@ -95,7 +95,7 @@ export function generateEtfDetailMetadata({ etfName, symbol, exchange, createdTi
   const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}`;
 
   const description = truncateForMeta(
-    `${etfName} (${symbol}) ETF analysis — performance returns, risk assessment, cost efficiency, expense ratio, and portfolio insights on ${exchange}.`
+    `${etfName} (${symbol}) analysis — performance returns, risk assessment, cost efficiency, expense ratio, and portfolio insights on ${exchange}.`
   );
 
   const keywords = [

--- a/insights-ui/src/utils/etf-metadata-generators.ts
+++ b/insights-ui/src/utils/etf-metadata-generators.ts
@@ -192,3 +192,93 @@ export function generateEtfDetailBreadcrumbJsonLd({ etfName, symbol, exchange }:
     ],
   };
 }
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ETF Category Detail Pages (/etfs/[exchange]/[etf]/[category])
+// ────────────────────────────────────────────────────────────────────────────────
+
+interface EtfCategoryMetadataInput {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  categoryName: string;
+  categorySlug: string;
+  description: string;
+  keywords: string[];
+  createdTime?: string;
+  updatedTime?: string;
+}
+
+export function generateEtfCategoryMetadata(input: EtfCategoryMetadataInput): Metadata {
+  const { etfName, symbol, exchange, categoryName, categorySlug, description, keywords, createdTime, updatedTime } = input;
+  const year = new Date().getFullYear();
+  const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}/${categorySlug}`;
+  const shortDesc = truncateForMeta(description);
+
+  return {
+    title: `${etfName} (${symbol}) ${categoryName} Analysis (${year}) | ${SITE_NAME}`,
+    description: shortDesc,
+    alternates: { canonical: canonicalUrl },
+    keywords,
+    openGraph: {
+      title: `${etfName} (${symbol}) ${categoryName} Analysis | ${SITE_NAME}`,
+      description: shortDesc,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      type: 'article',
+      publishedTime: createdTime,
+      modifiedTime: updatedTime,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${etfName} (${symbol}) ${categoryName} Analysis | ${SITE_NAME}`,
+      description: shortDesc,
+    },
+  };
+}
+
+export function generateEtfCategoryArticleJsonLd(input: {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  categoryName: string;
+  categorySlug: string;
+  publishedDate: string;
+  modifiedDate: string;
+}) {
+  const { etfName, symbol, exchange, categoryName, categorySlug, publishedDate, modifiedDate } = input;
+  const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}/${categorySlug}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${etfName} (${symbol}) ${categoryName} Analysis`,
+    description: `${categoryName} analysis for ${etfName} (${symbol}) ETF on ${exchange}.`,
+    image: [LOGO_URL],
+    datePublished: publishedDate,
+    dateModified: modifiedDate,
+    author: { '@type': 'Organization', name: SITE_NAME, url: BASE_URL },
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: BASE_URL,
+      logo: { '@type': 'ImageObject', url: LOGO_URL, width: 600, height: 60 },
+    },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
+    articleSection: 'ETF Analysis',
+  };
+}
+
+export function generateEtfCategoryBreadcrumbJsonLd(input: { etfName: string; symbol: string; exchange: string; categoryName: string; categorySlug: string }) {
+  const { etfName, symbol, exchange, categoryName, categorySlug } = input;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: BASE_URL },
+      { '@type': 'ListItem', position: 2, name: 'US ETFs', item: `${BASE_URL}/etfs` },
+      { '@type': 'ListItem', position: 3, name: `${etfName} (${symbol})`, item: `${BASE_URL}/etfs/${exchange}/${symbol}` },
+      { '@type': 'ListItem', position: 4, name: categoryName, item: `${BASE_URL}/etfs/${exchange}/${symbol}/${categorySlug}` },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Created 3 ETF category detail pages: `/etfs/[exchange]/[etf]/performance-returns`, `/cost-efficiency-team`, `/risk-analysis`
- Each page has category-specific metadata, JSON-LD Article + BreadcrumbList schemas, and breadcrumbs
- Created reusable `EtfCategoryReport` component (mirrors stock's `TickerCategoryReport` layout)
- Updated main ETF page to show only summary analysis with "View Detailed Analysis →" links to category pages
- Added `generateEtfCategoryMetadata`, `generateEtfCategoryArticleJsonLd`, `generateEtfCategoryBreadcrumbJsonLd` to metadata generators

## Test plan
- [ ] Visit /etfs/nysearca/spy — verify summary analysis shows with "View Detailed Analysis" links
- [ ] Click each link → verify category page renders with full factor analysis
- [ ] Check breadcrumbs: US ETFs > ETF Name > Category Name
- [ ] Verify metadata and JSON-LD in page source
- [ ] Test on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)