### PR TITLE
Add ETF scenario analysis with AUTOMATION_SECRET access

### DIFF
--- a/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
@@ -1,12 +1,12 @@
 import { prisma } from '@/prisma';
 import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { slugifyScenarioTitle } from '@/utils/etf-scenario-slug';
+import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
-import { DoDaoJwtTokenPayload } from '@dodao/web-core/types/auth/Session';
 import { EtfScenario } from '@prisma/client';
 import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { NextRequest } from 'next/server';
-import { withLoggedInAdmin } from '../../helpers/withLoggedInAdmin';
+import { withAdminOrToken } from '../../helpers/withAdminOrToken';
 import { z } from 'zod';
 
 const updateEtfScenarioSchema = z.object({
@@ -37,7 +37,11 @@ async function getHandler(_req: NextRequest, { params }: { params: Promise<{ id:
   return prisma.etfScenario.findUnique({ where: { id } });
 }
 
-async function putHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayload, { params }: { params: Promise<{ id: string }> }): Promise<EtfScenario> {
+async function putHandler(
+  request: NextRequest,
+  _userContext: KoalaGainsJwtTokenPayload | null,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<EtfScenario> {
   const { id } = await params;
   const body = updateEtfScenarioSchema.parse(await request.json());
 
@@ -78,7 +82,7 @@ async function putHandler(request: NextRequest, _userContext: DoDaoJwtTokenPaylo
 
 async function deleteHandler(
   _request: NextRequest,
-  _userContext: DoDaoJwtTokenPayload,
+  _userContext: KoalaGainsJwtTokenPayload | null,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<{ success: boolean }> {
   const { id } = await params;
@@ -97,5 +101,5 @@ async function deleteHandler(
 }
 
 export const GET = withErrorHandlingV2<EtfScenario | null>(getHandler);
-export const PUT = withLoggedInAdmin<EtfScenario>(putHandler);
-export const DELETE = withLoggedInAdmin<{ success: boolean }>(deleteHandler);
+export const PUT = withAdminOrToken<EtfScenario>(putHandler);
+export const DELETE = withAdminOrToken<{ success: boolean }>(deleteHandler);

--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -2,12 +2,12 @@ import { prisma } from '@/prisma';
 import { revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { slugifyScenarioTitle } from '@/utils/etf-scenario-slug';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
-import { DoDaoJwtTokenPayload } from '@dodao/web-core/types/auth/Session';
 import { EtfScenario } from '@prisma/client';
 import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { NextRequest } from 'next/server';
-import { withLoggedInAdmin } from '../helpers/withLoggedInAdmin';
+import { withAdminOrToken } from '../helpers/withAdminOrToken';
 import { z } from 'zod';
 
 const createEtfScenarioSchema = z.object({
@@ -47,7 +47,7 @@ async function getHandler(): Promise<EtfScenario[]> {
   });
 }
 
-async function postHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayload): Promise<EtfScenario> {
+async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtTokenPayload | null, _dynamic: { params: Promise<any> }): Promise<EtfScenario> {
   const body = createEtfScenarioSchema.parse(await request.json());
 
   const slug = body.slug?.trim() || slugifyScenarioTitle(body.title);
@@ -96,4 +96,4 @@ async function postHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayl
 }
 
 export const GET = withErrorHandlingV2<EtfScenario[]>(getHandler);
-export const POST = withLoggedInAdmin<EtfScenario>(postHandler);
+export const POST = withAdminOrToken<EtfScenario>(postHandler);


### PR DESCRIPTION
## Summary
- ETF Scenarios feature: multi-dimensional filters (direction, probability bucket/exact %, timeframe), TypeScript-only enums, full admin CRUD.
- POST/PUT/DELETE scenario routes now accept AUTOMATION_SECRET via \`?token=\` or \`x-automation-token\` header for automated scenario ingestion, matching the etfs-v1 pattern.

## Test plan
- [ ] Admin UI: create/edit/delete a scenario; new dimension badges render on listing and detail.
- [ ] Listing page filters: direction, probability range, timeframe dropdowns; search input.
- [ ] Automation call: \`curl -X POST ...?token=$AUTOMATION_SECRET\` creates a scenario; rejected without token; admin session still works.