### PR TITLE
ETF scenarios: upsert POST by slug + import script

### DIFF
--- a/insights-ui/package.json
+++ b/insights-ui/package.json
@@ -12,7 +12,8 @@
     "prettier-fix": "prettier --config .prettierrc 'src/**/*.{js,ts,tsx,json}' --write",
     "prettier-check": "prettier --check 'src/**/*.{js,ts,tsx,json}'",
     "generate:tariff": "tsx src/scripts/run-tariff-report.ts",
-    "generate:meta-descriptions": "tsx src/scripts/generate-meta-descriptions.ts"
+    "generate:meta-descriptions": "tsx src/scripts/generate-meta-descriptions.ts",
+    "import:etf-scenarios": "tsx src/scripts/import-etf-scenarios.ts"
   },
   "engines": {
     "node": ">=23.11.0"

--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/prisma';
-import { revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
+import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { slugifyScenarioTitle } from '@/utils/etf-scenario-slug';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
@@ -52,27 +52,36 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
 
   const slug = body.slug?.trim() || slugifyScenarioTitle(body.title);
 
-  const created = await prisma.$transaction(async (tx) => {
-    const scenario = await tx.etfScenario.create({
-      data: {
-        scenarioNumber: body.scenarioNumber,
-        title: body.title,
+  const commonData = {
+    scenarioNumber: body.scenarioNumber,
+    title: body.title,
+    underlyingCause: body.underlyingCause,
+    historicalAnalog: body.historicalAnalog,
+    winnersMarkdown: body.winnersMarkdown,
+    losersMarkdown: body.losersMarkdown,
+    outlookMarkdown: body.outlookMarkdown,
+    direction: body.direction,
+    timeframe: body.timeframe,
+    probabilityBucket: body.probabilityBucket,
+    probabilityPercentage: body.probabilityPercentage ?? null,
+    outlookAsOfDate: new Date(body.outlookAsOfDate),
+    metaDescription: body.metaDescription ?? null,
+    archived: body.archived ?? false,
+  };
+
+  const saved = await prisma.$transaction(async (tx) => {
+    const scenario = await tx.etfScenario.upsert({
+      where: { spaceId_slug: { spaceId: KoalaGainsSpaceId, slug } },
+      create: {
+        id: slug,
         slug,
-        underlyingCause: body.underlyingCause,
-        historicalAnalog: body.historicalAnalog,
-        winnersMarkdown: body.winnersMarkdown,
-        losersMarkdown: body.losersMarkdown,
-        outlookMarkdown: body.outlookMarkdown,
-        direction: body.direction,
-        timeframe: body.timeframe,
-        probabilityBucket: body.probabilityBucket,
-        probabilityPercentage: body.probabilityPercentage ?? null,
-        outlookAsOfDate: new Date(body.outlookAsOfDate),
-        metaDescription: body.metaDescription ?? null,
-        archived: body.archived ?? false,
         spaceId: KoalaGainsSpaceId,
+        ...commonData,
       },
+      update: commonData,
     });
+
+    await tx.etfScenarioEtfLink.deleteMany({ where: { scenarioId: scenario.id } });
 
     if (body.links?.length) {
       await tx.etfScenarioEtfLink.createMany({
@@ -92,7 +101,8 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
   });
 
   revalidateEtfScenarioListingTag();
-  return created;
+  revalidateEtfScenarioBySlugTag(saved.slug);
+  return saved;
 }
 
 export const GET = withErrorHandlingV2<EtfScenario[]>(getHandler);

--- a/insights-ui/src/scripts/import-etf-scenarios.ts
+++ b/insights-ui/src/scripts/import-etf-scenarios.ts
@@ -1,0 +1,87 @@
+import 'dotenv/config';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parseScenariosMarkdown, ParsedScenario } from '@/utils/etf-scenario-markdown-parser';
+
+const DEFAULT_MARKDOWN_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../docs/ai-knowledge/insights-ui/etf-analysis/etf-market-scenarios.md'
+);
+
+const API_BASE = (process.env.SCENARIOS_API_BASE ?? 'https://koalagains.com').replace(/\/+$/, '');
+const AUTOMATION_SECRET = process.env.AUTOMATION_SECRET ?? '';
+const MARKDOWN_PATH = process.env.SCENARIOS_MD_PATH ?? DEFAULT_MARKDOWN_PATH;
+const FALLBACK_DATE = new Date(process.env.SCENARIOS_FALLBACK_DATE ?? '2026-04-19');
+
+function toRequestBody(s: ParsedScenario) {
+  return {
+    scenarioNumber: s.scenarioNumber,
+    title: s.title,
+    slug: s.slug,
+    underlyingCause: s.underlyingCause,
+    historicalAnalog: s.historicalAnalog,
+    winnersMarkdown: s.winnersMarkdown,
+    losersMarkdown: s.losersMarkdown,
+    outlookMarkdown: s.outlookMarkdown,
+    direction: s.direction,
+    timeframe: s.timeframe,
+    probabilityBucket: s.probabilityBucket,
+    probabilityPercentage: s.probabilityPercentage,
+    outlookAsOfDate: s.outlookAsOfDate.toISOString(),
+    links: s.links.map((l) => ({ symbol: l.symbol, role: l.role, sortOrder: l.sortOrder })),
+  };
+}
+
+async function main() {
+  if (!AUTOMATION_SECRET) {
+    throw new Error('AUTOMATION_SECRET is not set — export it or source the discord-claude-bot/.env before running.');
+  }
+
+  console.log(`📄 Reading scenarios from: ${MARKDOWN_PATH}`);
+  const markdown = await readFile(MARKDOWN_PATH, 'utf-8');
+  const scenarios = parseScenariosMarkdown(markdown, FALLBACK_DATE);
+  console.log(`✅ Parsed ${scenarios.length} scenarios`);
+
+  if (scenarios.length === 0) {
+    throw new Error('No scenarios parsed — check the markdown file and heading format.');
+  }
+
+  const endpoint = `${API_BASE}/api/etf-scenarios?token=${encodeURIComponent(AUTOMATION_SECRET)}`;
+  console.log(`🎯 Target: ${API_BASE}/api/etf-scenarios (token elided)`);
+
+  let ok = 0;
+  let fail = 0;
+  for (const scenario of scenarios) {
+    const body = toRequestBody(scenario);
+    const label = `#${scenario.scenarioNumber} ${scenario.title}`;
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        fail++;
+        console.error(`❌ ${label} — HTTP ${res.status}: ${text.slice(0, 400)}`);
+        break;
+      }
+      const json = (await res.json()) as { id?: string; slug?: string };
+      ok++;
+      console.log(`✅ ${label} → id=${json.id ?? '?'} slug=${json.slug ?? '?'}`);
+    } catch (err) {
+      fail++;
+      console.error(`❌ ${label} — ${(err as Error).message}`);
+      break;
+    }
+  }
+
+  console.log(`\nDone — ${ok} succeeded, ${fail} failed, ${scenarios.length - ok - fail} skipped.`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- \`POST /api/etf-scenarios\` now upserts on \`(spaceId, slug)\` and sets Prisma \`id = slug\` on create, so repeated ingestion calls are idempotent and scenario ids match their slugs.
- Link rows are replaced on every upsert so they reflect the incoming payload exactly.
- New \`yarn import:etf-scenarios\` script (\`src/scripts/import-etf-scenarios.ts\`) parses \`docs/ai-knowledge/insights-ui/etf-analysis/etf-market-scenarios.md\` with \`parseScenariosMarkdown\` and POSTs each scenario to the route one-by-one, using \`AUTOMATION_SECRET\` as the \`?token=\` query param.

## How to run
\`\`\`bash
# secret is stored in discord-claude-bot/.env
export AUTOMATION_SECRET=<from discord-claude-bot/.env>
export SCENARIOS_API_BASE=https://koalagains.com   # default
cd insights-ui && yarn import:etf-scenarios
\`\`\`
Running again is safe — each POST upserts by slug.

## Test plan
- [ ] Typecheck / lint / prettier pass locally.
- [ ] Script parses 31 scenarios from the markdown file (verified: \`✅ Parsed 31 scenarios\`).
- [ ] First POST to prod returns 200 and a scenario row whose \`id\` equals its \`slug\`; second POST of the same scenario is a no-op update (no duplicate row).
- [ ] Listing page on prod shows all 31 scenarios with correct direction / probability / timeframe badges.