### PR TITLE
Wire ETF scenarios listing cache + admin cache-flush dropdown

### DIFF
--- a/insights-ui/src/app/etf-scenarios/EtfScenariosPageActions.tsx
+++ b/insights-ui/src/app/etf-scenarios/EtfScenariosPageActions.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { revalidateEtfScenariosListingCache } from '@/utils/cache-actions';
+
+export default function EtfScenariosPageActions() {
+  const router = useRouter();
+
+  const actions: EllipsisDropdownItem[] = [
+    { key: 'manage-scenarios', label: 'Manage Scenarios' },
+    { key: 'revalidate-listing-cache', label: 'Revalidate Scenarios Cache' },
+  ];
+
+  return (
+    <PrivateWrapper>
+      <EllipsisDropdown
+        items={actions}
+        className="px-2 py-2"
+        onSelect={async (key) => {
+          if (key === 'manage-scenarios') {
+            router.push('/admin-v1/etf-scenarios');
+            return;
+          }
+
+          if (key === 'revalidate-listing-cache') {
+            await revalidateEtfScenariosListingCache();
+            router.refresh();
+            return;
+          }
+        }}
+      />
+    </PrivateWrapper>
+  );
+}

--- a/insights-ui/src/app/etf-scenarios/page.tsx
+++ b/insights-ui/src/app/etf-scenarios/page.tsx
@@ -1,86 +1,51 @@
+import EtfScenariosPageActions from '@/app/etf-scenarios/EtfScenariosPageActions';
 import EtfScenarioListingGrid from '@/components/etf-scenarios/EtfScenarioListingGrid';
 import EtfScenarioPageLayout from '@/components/etf-scenarios/EtfScenarioPageLayout';
-import { EtfScenarioListingResponse, EtfScenarioListingItem } from '@/app/api/[spaceId]/etf-scenarios/listing/route';
+import { EtfScenarioListingResponse } from '@/app/api/[spaceId]/etf-scenarios/listing/route';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ETF_SCENARIO_LISTING_TAG } from '@/utils/etf-scenario-cache-utils';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import {
   generateEtfScenarioListingMetadata,
   generateEtfScenarioListingJsonLd,
   generateEtfScenarioListingBreadcrumbJsonLd,
   generateEtfScenarioListingItemListJsonLd,
 } from '@/utils/etf-scenario-metadata-generators';
-import { prisma } from '@/prisma';
 
 export const dynamic = 'force-static';
 export const dynamicParams = true;
 export const revalidate = 86400; // 24 hours
 
 const DEFAULT_PAGE_SIZE = 100; // fixed 31-row dataset today; 100 leaves headroom
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
 
 export const metadata = generateEtfScenarioListingMetadata();
 
-export default async function EtfScenariosPage() {
-  let data: EtfScenarioListingResponse = {
-    scenarios: [],
-    totalCount: 0,
-    page: 1,
-    pageSize: DEFAULT_PAGE_SIZE,
-    totalPages: 1,
-    filtersApplied: false,
-  };
-
+async function fetchScenarioListing(): Promise<EtfScenarioListingResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etf-scenarios/listing?pageSize=${DEFAULT_PAGE_SIZE}`;
   try {
-    const [rows, totalCount] = await Promise.all([
-      prisma.etfScenario.findMany({
-        where: { spaceId: KoalaGainsSpaceId, archived: false },
-        orderBy: [{ scenarioNumber: 'asc' }],
-        take: DEFAULT_PAGE_SIZE,
-        select: {
-          id: true,
-          scenarioNumber: true,
-          title: true,
-          slug: true,
-          direction: true,
-          timeframe: true,
-          probabilityBucket: true,
-          probabilityPercentage: true,
-          outlookAsOfDate: true,
-          underlyingCause: true,
-          archived: true,
-        },
-      }),
-      prisma.etfScenario.count({ where: { spaceId: KoalaGainsSpaceId, archived: false } }),
-    ]);
-
-    const scenarios: EtfScenarioListingItem[] = rows.map((s) => ({
-      id: s.id,
-      scenarioNumber: s.scenarioNumber,
-      title: s.title,
-      slug: s.slug,
-      direction: s.direction as EtfScenarioListingItem['direction'],
-      timeframe: s.timeframe as EtfScenarioListingItem['timeframe'],
-      probabilityBucket: s.probabilityBucket as EtfScenarioListingItem['probabilityBucket'],
-      probabilityPercentage: s.probabilityPercentage,
-      outlookAsOfDate: s.outlookAsOfDate.toISOString(),
-      underlyingCause: s.underlyingCause,
-      archived: s.archived,
-    }));
-
-    data = {
-      scenarios,
-      totalCount,
-      page: 1,
-      pageSize: DEFAULT_PAGE_SIZE,
-      totalPages: Math.max(1, Math.ceil(totalCount / DEFAULT_PAGE_SIZE)),
-      filtersApplied: false,
-    };
+    const res = await fetch(url, {
+      next: { revalidate: WEEK_IN_SECONDS, tags: [ETF_SCENARIO_LISTING_TAG] },
+    });
+    if (!res.ok) {
+      console.error(`Failed to fetch ETF scenarios listing: HTTP ${res.status}`);
+      return { scenarios: [], totalCount: 0, page: 1, pageSize: DEFAULT_PAGE_SIZE, totalPages: 1, filtersApplied: false };
+    }
+    return (await res.json()) as EtfScenarioListingResponse;
   } catch (e) {
     console.error('Failed to fetch ETF scenarios listing:', e);
+    return { scenarios: [], totalCount: 0, page: 1, pageSize: DEFAULT_PAGE_SIZE, totalPages: 1, filtersApplied: false };
   }
+}
+
+export default async function EtfScenariosPage() {
+  const data = await fetchScenarioListing();
 
   return (
     <EtfScenarioPageLayout
       title="ETF Market Scenarios"
       description="A dated playbook of recurring market scenarios that meaningfully move specific ETF categories — with winners, losers, historical analogs, and a qualitative probability outlook."
+      rightButton={<EtfScenariosPageActions />}
     >
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfScenarioListingJsonLd()) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfScenarioListingBreadcrumbJsonLd()) }} />

--- a/insights-ui/src/utils/cache-actions.ts
+++ b/insights-ui/src/utils/cache-actions.ts
@@ -8,6 +8,7 @@ import {
   revalidateTickerAndExchangeTag,
 } from '@/utils/ticker-v1-cache-utils';
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { PortfolioManagerType } from '@/types/portfolio-manager';
 import { prisma } from '@/prisma';
@@ -51,4 +52,14 @@ export async function revalidateTickerCache(ticker: string, exchange: string) {
 export async function revalidateEtfCache(symbol: string, exchange: string) {
   revalidateEtfAndExchangeTag(symbol, exchange);
   return { success: true, message: `Cache invalidated for ETF ${exchange.toUpperCase()}:${symbol.toUpperCase()}` };
+}
+
+export async function revalidateEtfScenariosListingCache() {
+  revalidateEtfScenarioListingTag();
+  return { success: true, message: 'Revalidated ETF scenarios listing cache' };
+}
+
+export async function revalidateEtfScenarioCache(slug: string) {
+  revalidateEtfScenarioBySlugTag(slug);
+  return { success: true, message: `Revalidated ETF scenario cache for ${slug}` };
 }


### PR DESCRIPTION
## Why you weren't seeing scenarios on /etf-scenarios
\`/etf-scenarios\` was statically rendered with \`force-static\` + \`revalidate = 86400\` using direct Prisma queries. The POST route calls \`revalidateEtfScenarioListingTag()\`, but that tag wasn't attached to anything on the listing page — so the already-built static HTML kept serving its empty-at-build-time payload. The 31 rows are in Postgres (confirmed via \`GET /api/etf-scenarios\`), they just weren't reaching the static page.

## Summary
- Listing page now fetches \`/api/[spaceId]/etf-scenarios/listing\` with \`next.tags = [ETF_SCENARIO_LISTING_TAG]\`, mirroring how \`/stocks\` consumes its API. Every upsert via POST /api/etf-scenarios will now invalidate this tag and regenerate the page on next request.
- Added \`EtfScenariosPageActions\` — admin-only three-dots dropdown on \`/etf-scenarios\`, matching \`StocksGridPageActions\`. Items: "Manage Scenarios" (→ \`/admin-v1/etf-scenarios\`) and "Revalidate Scenarios Cache".
- Added server actions \`revalidateEtfScenariosListingCache\` and \`revalidateEtfScenarioCache(slug)\` in \`cache-actions.ts\`.

## Test plan
- [ ] After deploy, open \`/etf-scenarios\` — all 31 scenarios render.
- [ ] As an admin, the three-dots menu is visible; clicking "Revalidate Scenarios Cache" forces a fresh fetch.
- [ ] Typecheck / lint / prettier all pass locally.