### PR TITLE
Resolve ETF links on POST scenario route

### DIFF
--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -69,6 +69,18 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
     archived: body.archived ?? false,
   };
 
+  const symbols = Array.from(new Set((body.links ?? []).map((l) => l.symbol.toUpperCase())));
+  const knownEtfs = symbols.length
+    ? await prisma.etf.findMany({
+        where: { spaceId: KoalaGainsSpaceId, symbol: { in: symbols } },
+        select: { id: true, symbol: true, exchange: true },
+      })
+    : [];
+  const knownEtfBySymbol = new Map<string, { id: string; symbol: string; exchange: string }>();
+  for (const etf of knownEtfs) {
+    if (!knownEtfBySymbol.has(etf.symbol)) knownEtfBySymbol.set(etf.symbol, etf);
+  }
+
   const saved = await prisma.$transaction(async (tx) => {
     const scenario = await tx.etfScenario.upsert({
       where: { spaceId_slug: { spaceId: KoalaGainsSpaceId, slug } },
@@ -85,14 +97,19 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
 
     if (body.links?.length) {
       await tx.etfScenarioEtfLink.createMany({
-        data: body.links.map((link, idx) => ({
-          scenarioId: scenario.id,
-          symbol: link.symbol.toUpperCase(),
-          exchange: link.exchange ?? null,
-          role: link.role,
-          sortOrder: link.sortOrder ?? idx,
-          spaceId: KoalaGainsSpaceId,
-        })),
+        data: body.links.map((link, idx) => {
+          const symbol = link.symbol.toUpperCase();
+          const knownEtf = knownEtfBySymbol.get(symbol);
+          return {
+            scenarioId: scenario.id,
+            symbol,
+            exchange: knownEtf?.exchange ?? link.exchange ?? null,
+            etfId: knownEtf?.id ?? null,
+            role: link.role,
+            sortOrder: link.sortOrder ?? idx,
+            spaceId: KoalaGainsSpaceId,
+          };
+        }),
         skipDuplicates: true,
       });
     }


### PR DESCRIPTION
## Problem
On \`/etf-scenarios/<slug>\`, the Winners / Losers / Most-exposed pills (e.g. XLP, XLU, XLK) render as inert \`<span>\`s instead of links to the ETF detail page.

## Root cause
\`EtfScenarioDetailView.LinkPill\` only becomes a \`<Link>\` when both \`exchange\` and \`etfId\` are set on the row. The import script sends \`{symbol, role, sortOrder}\` only, and \`POST /api/etf-scenarios\` was storing those as-is with \`exchange = null\` and \`etfId = null\`. The existing \`/api/etf-scenarios/import\` route already does the ETF lookup; the per-scenario POST route didn't.

## Fix
Mirror the import route's symbol → ETF resolution in \`POST /api/etf-scenarios\`: before upserting, look up all link symbols in the \`Etf\` table (any exchange) and populate \`exchange\` + \`etfId\` on the created link rows. Unknown symbols still persist with null fields and render as plain pills (same fallback as before).

## Next step after merge
\`\`\`bash
cd insights-ui && yarn import:etf-scenarios
\`\`\`
Re-running upserts the 31 scenarios; the POST route now rewrites their link rows with populated exchange+etfId, and the pills on each scenario detail page will start linking to \`/etfs/<exchange>/<symbol>\`.

## Test plan
- [ ] Typecheck / lint / prettier pass locally.
- [ ] After merge + deploy, run the import script and spot-check e.g. \`/etf-scenarios/technology-sector-stagnation-crash\` — XLP / XLU / XLK pills become clickable and navigate to the ETF detail page.