### PR TITLE
ETF risk-analysis factors: switch to group-based schema with retail-friendly copy

### DIFF
--- a/insights-ui/schemas/etf-analysis/inputs/cost-efficiency-and-team-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/inputs/cost-efficiency-and-team-input.schema.yaml
@@ -38,6 +38,21 @@ properties:
         - factorAnalysisTitle
         - factorAnalysisDescription
 
+  # Asset class identifier — kept for analytical context and prompt framing
+  assetClass:
+    type: string
+    description: 'The ETF asset class (e.g., Equity, Fixed Income, Alternatives, Commodity, Asset Allocation, Currency). Informs analysis tone and thresholds; factor selection itself is driven by groupKey.'
+
+  # Fund category — the Mor category string for this ETF (e.g., Large Blend, High Yield Bond).
+  fundCategory:
+    type: ['string', 'null']
+    description: 'The Mor fund category (e.g., Large Blend, Technology, High Yield Bond). Provides peer-comparison context.'
+
+  # ETF group — derived from fundCategory via etf-analysis-categories.json and drives which factors are selected.
+  groupKey:
+    type: string
+    description: 'The ETF group key (e.g., broad-equity, sector-thematic-equity, fixed-income-core, alt-strategies). Determines which factors from the category config apply to this fund.'
+
   # From EtfFinancialInfo — cost & size data
   financialInfo:
     type: string
@@ -69,6 +84,9 @@ required:
   - exchange
   - categoryKey
   - factorAnalysisArray
+  - assetClass
+  - fundCategory
+  - groupKey
   - financialInfo
   - stockAnalyzerFundInfo
   - morAnalysis

--- a/insights-ui/schemas/etf-analysis/inputs/performance-and-returns-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/inputs/performance-and-returns-input.schema.yaml
@@ -63,10 +63,20 @@ properties:
     type: string
     description: 'JSON string with AUM, beta, 52-week high/low, volume, and holdings count for context.'
 
-  # Asset class identifier — determines which factor set is used and how the model should frame the analysis
+  # Asset class identifier — kept for analytical context and prompt framing
   assetClass:
     type: string
-    description: 'The ETF asset class (e.g., Equity, Fixed Income, Alternatives, Commodity, Asset Allocation, Currency). Determines analysis tone, thresholds, and factor evaluation approach.'
+    description: 'The ETF asset class (e.g., Equity, Fixed Income, Alternatives, Commodity, Asset Allocation, Currency). Informs analysis tone and thresholds; factor selection itself is driven by groupKey.'
+
+  # Fund category — the Mor category string for this ETF (e.g., Large Blend, High Yield Bond).
+  fundCategory:
+    type: ['string', 'null']
+    description: 'The Mor fund category (e.g., Large Blend, Technology, High Yield Bond). Provides peer-comparison context.'
+
+  # ETF group — derived from fundCategory via etf-analysis-categories.json and drives which factors are selected.
+  groupKey:
+    type: string
+    description: 'The ETF group key (e.g., broad-equity, sector-thematic-equity, fixed-income-core, alt-strategies). Determines which factors from the category config apply to this fund.'
 
   # P0 — Yield & income data (critical for bond and income ETFs)
   yieldAndIncome:
@@ -90,3 +100,5 @@ required:
   - morOverview
   - financialSummary
   - assetClass
+  - fundCategory
+  - groupKey

--- a/insights-ui/schemas/etf-analysis/inputs/risk-analysis-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/inputs/risk-analysis-input.schema.yaml
@@ -38,6 +38,21 @@ properties:
         - factorAnalysisTitle
         - factorAnalysisDescription
 
+  # Asset class identifier — kept for analytical context and prompt framing
+  assetClass:
+    type: string
+    description: 'The ETF asset class (e.g., Equity, Fixed Income, Alternatives, Commodity, Asset Allocation, Currency). Informs analysis tone and thresholds; factor selection itself is driven by groupKey.'
+
+  # Fund category — the Mor category string for this ETF (e.g., Large Blend, High Yield Bond).
+  fundCategory:
+    type: ['string', 'null']
+    description: 'The Mor fund category (e.g., Large Blend, Technology, High Yield Bond). Provides peer-comparison context.'
+
+  # ETF group — derived from fundCategory via etf-analysis-categories.json and drives which factors are selected.
+  groupKey:
+    type: string
+    description: 'The ETF group key (e.g., broad-equity, sector-thematic-equity, fixed-income-core, alt-strategies). Determines which factors from the category config apply to this fund.'
+
   # From EtfStockAnalyzerInfo — volatility & risk metrics
   stockAnalyzerRiskMetrics:
     type: string
@@ -64,6 +79,9 @@ required:
   - exchange
   - categoryKey
   - factorAnalysisArray
+  - assetClass
+  - fundCategory
+  - groupKey
   - stockAnalyzerRiskMetrics
   - morRiskPeriods
   - financialRiskContext

--- a/insights-ui/src/etf-analysis-data/etf-analysis-factors-cost-efficiency-and-team.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-factors-cost-efficiency-and-team.json
@@ -1,199 +1,87 @@
 {
   "categoryKey": "CostEfficiencyAndTeam",
   "categoryName": "Cost, Efficiency & Team",
-  "categoryDescription": "Evaluates the ETF's cost structure, operational efficiency, fund management quality, and how well the fund delivers value relative to its fees.",
-  "factorsByAssetClass": {
-    "Equity": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its category average and prospectus net expense ratio. For passive equity index ETFs, expense ratios above 0.10% are high — leaders like VOO/IVV charge 0.03%. For active equity ETFs, up to 0.50-0.75% is typical. The expense ratio directly explains benchmark tracking drag — if the ETF trails its index by roughly the expense ratio, that's expected, not a flaw.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. For equity ETFs, larger funds (>$1B AUM) typically have tighter spreads and lower trading friction. Funds under $100M AUM face closure risk. Very high volume (>1M shares/day) indicates institutional adoption. Check if the bid-ask spread is tight relative to the ETF's price — wider spreads erode real returns.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover",
-        "factorAnalysisDescription": "Assesses how frequently the fund trades its holdings. For passive equity index ETFs, turnover should be low (under 10-20%) since they only trade for index reconstitution. For active equity ETFs, turnover of 30-80% is common. Very high turnover (>100%) increases transaction costs and tax drag for taxable accounts, reducing net investor returns.",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates the fund management team's tenure, experience, and the issuer's reputation. For passive equity ETFs, issuer reputation (Vanguard, iShares, SPDR) matters more than individual manager skill. For active equity ETFs, manager tenure is critical — a 10-year track record with the same manager is much more meaningful than a 2-year record. Longer tenure indicates stability and lets investors judge the actual decision-maker's performance.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars (Process, People, Parent, Performance). A Gold/Silver medalist rating indicates strong fund quality across all dimensions. For equity ETFs, the Process and Parent pillars are especially important — they reflect systematic investment discipline and organizational commitment to investors.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ],
-    "Fixed Income": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its category average. For bond ETFs, expense ratios matter even more than for equities because total returns are lower (2-6% annually), so a 0.50% fee can consume 10-25% of the total return. Passive treasury/aggregate bond ETFs should be under 0.10%. High-yield bond ETFs typically charge 0.30-0.50% due to higher trading complexity. The expense ratio is usually the primary explanation for benchmark tracking drag in bond ETFs.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. For bond ETFs, liquidity is critically important because the underlying bonds trade over-the-counter with wide spreads. A bond ETF with low volume (<100K shares/day) or small AUM (<$500M) may trade at persistent premiums or discounts to NAV, directly affecting investor returns. Large bond ETFs (AGG, BND at $100B+) can actually be more liquid than their underlying bonds.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover",
-        "factorAnalysisDescription": "Assesses trading frequency. Bond ETFs inherently have higher turnover than equity ETFs because bonds mature, get called, or are replaced as index composition changes. Turnover of 30-80% is normal for aggregate bond ETFs. Very high turnover (>100%) in a bond ETF increases transaction costs significantly because bond trading costs are much higher than equity trading costs (OTC market with wide bid-ask spreads).",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates fund management and issuer reputation. For bond ETFs, the issuer's fixed-income trading desk quality matters significantly — larger issuers (iShares/BlackRock, Vanguard) have better bond trading infrastructure, leading to tighter tracking and lower transaction costs. For actively managed bond ETFs, manager tenure and the team's credit research capability are critical.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars. For bond ETFs, the Process pillar (index replication methodology, sampling approach) and Price pillar (expense ratio competitiveness) are especially important. A bond ETF with a Gold rating typically combines low fees with excellent index tracking.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ],
-    "Alternatives": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its category average. Alternative strategy ETFs (covered call, managed futures, derivative income) typically charge 0.30-0.80% — higher than passive index funds but justified if the strategy delivers on its income/protection promise. Compare the expense ratio to total return: if the fund charges 0.50% and delivers 8% total return with half the benchmark's volatility, the fee may be well-spent. Also note if the expense ratio is creeping up as the category becomes more competitive.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. For alternative strategy ETFs, liquidity can be a concern because the underlying strategies (options, derivatives) are complex. Very large AUM ($10B+, like JEPI) validates the strategy's scalability. Small alternative ETFs (<$200M) may struggle with options market impact or face closure risk. High daily volume relative to AUM indicates active institutional trading.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover & Strategy Complexity",
-        "factorAnalysisDescription": "Assesses trading frequency and strategy cost. Alternative strategy ETFs often have very high turnover (100-300%+) because they continuously roll options contracts or rebalance derivative positions. This is normal for the strategy type and does not indicate a problem — but it does mean higher hidden trading costs. Compare turnover to category peers: if similar funds have 150% turnover and this fund has 400%, something may be unusual.",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates fund management and issuer reputation. For alternative strategy ETFs, the management team's derivatives expertise is crucial — a covered call strategy's success depends on options pricing and execution skill. Larger issuers (JPMorgan for JEPI, Global X) have dedicated derivatives desks. Manager tenure matters more here than for passive funds because the strategy requires active decision-making on strike selection, roll timing, and position sizing.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars. For alternative strategy ETFs, many are too new to have full analyst coverage. If a rating exists, the Process pillar is most important — it evaluates whether the derivative/options strategy is well-designed and consistently executed. Note that the Derivative Income category is rapidly growing, so ratings may evolve as Mor develops more expertise in this space.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ],
-    "Commodity": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its category average. Commodity ETFs typically charge 0.20-0.50% for broad commodity exposure and 0.40-0.75% for single-commodity or specialized strategies. Physical commodity ETFs (like gold ETFs holding actual bullion) may charge slightly more due to storage costs. The expense ratio plus contango/roll costs are the two main cost drags for commodity ETFs — evaluate both together.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. For commodity ETFs, fund size is important because smaller funds may have difficulty efficiently rolling futures contracts or face higher trading costs in commodity markets. Physical commodity ETFs (gold, silver) benefit from large AUM for secure storage arrangements. ETFs under $200M may face closure risk during commodity bear markets.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover & Roll Costs",
-        "factorAnalysisDescription": "Assesses trading frequency and the impact of futures contract rolling. Futures-based commodity ETFs must regularly roll expiring contracts into the next month, creating implicit costs (contango) or gains (backwardation) not captured by the expense ratio alone. High turnover in commodity ETFs is structural and expected — focus on whether the fund minimizes roll costs through smart contract selection rather than the raw turnover number.",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates fund management and issuer reputation. For commodity ETFs, the issuer's commodity trading infrastructure matters — efficient futures rolling requires experienced execution. Major commodity ETF issuers (Invesco, SPDR, iShares) have dedicated commodity desks. For physical commodity ETFs, the custodian and storage arrangement quality are important safety considerations.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars. For commodity ETFs, the Process pillar evaluates the futures rolling strategy and the Price pillar assesses total cost of ownership (expense ratio + estimated roll costs). A Gold-rated commodity ETF typically has low fees and an efficient rolling methodology that minimizes contango drag.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ],
-    "Asset Allocation": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its allocation category average. Asset allocation ETFs typically charge 0.15-0.50% depending on complexity. Simple target-date or balanced funds should be on the lower end. Multi-asset funds that include alternatives or active management may charge more. Compare against what it would cost to hold the underlying components separately — if a 60/40 fund charges 0.30% but you could replicate it with VTI (0.03%) + BND (0.03%), the convenience premium is 0.27%.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. Asset allocation ETFs may have lower trading volume than pure equity or bond ETFs because they are typically buy-and-hold investments. Lower volume is acceptable if the bid-ask spread remains tight. AUM over $500M provides stability; under $100M may face rebalancing challenges or closure risk.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover & Rebalancing Efficiency",
-        "factorAnalysisDescription": "Assesses trading frequency. Asset allocation ETFs must rebalance between asset classes (stocks, bonds, etc.) periodically, creating some turnover. Turnover of 20-50% is typical for balanced funds. Higher turnover suggests more active tactical allocation shifts. Very low turnover (<10%) may mean the fund is not rebalancing properly. The key question is whether turnover comes from disciplined rebalancing (good) or excessive trading (bad).",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates fund management and issuer reputation. For asset allocation ETFs, the management team's asset allocation skill is the primary value proposition — they decide how much to hold in stocks vs bonds vs other assets. Longer manager tenure allows evaluation of their allocation decisions across different market environments. Major issuers (Vanguard, iShares, BlackRock) with established asset allocation frameworks are preferred.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars. For asset allocation ETFs, the Process pillar is particularly important — it evaluates the asset allocation methodology, rebalancing discipline, and strategic vs tactical approach. The Parent pillar also matters because organizational investment philosophy shapes allocation decisions.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ],
-    "Currency": [
-      {
-        "factorAnalysisKey": "expense_ratio",
-        "factorAnalysisTitle": "Expense Ratio Assessment",
-        "factorAnalysisDescription": "Compares the ETF's expense ratio against its currency category peers. Currency ETFs typically charge 0.30-0.50% due to the costs of rolling currency futures contracts. Since currency returns can be near zero over long periods, even small expense differences matter significantly. The expense ratio plus futures roll costs represent the total cost of maintaining the currency exposure.",
-        "factorAnalysisMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory"
-      },
-      {
-        "factorAnalysisKey": "fund_size_liquidity",
-        "factorAnalysisTitle": "Fund Size & Liquidity",
-        "factorAnalysisDescription": "Evaluates AUM, trading volume, and bid-ask spread. Currency ETFs often have lower AUM and volume than equity ETFs because they are used primarily as hedging or trading instruments. Adequate liquidity (>$100M AUM, >50K shares/day) is important for entering and exiting positions without significant market impact. Wide bid-ask spreads in currency ETFs directly reduce returns on short-term trades.",
-        "factorAnalysisMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol"
-      },
-      {
-        "factorAnalysisKey": "portfolio_turnover",
-        "factorAnalysisTitle": "Portfolio Turnover & Roll Costs",
-        "factorAnalysisDescription": "Assesses trading frequency and currency futures rolling costs. Currency ETFs using futures contracts must roll monthly, creating inherent turnover. The interest rate differential between the two currencies in the pair creates either a positive carry (earning income) or negative carry (paying a cost). This carry is distinct from the expense ratio and is a major component of total return for currency ETFs.",
-        "factorAnalysisMetrics": "overviewTurnover, reportedTurnoverPct"
-      },
-      {
-        "factorAnalysisKey": "management_quality",
-        "factorAnalysisTitle": "Management & Issuer Quality",
-        "factorAnalysisDescription": "Evaluates fund management and issuer reputation. For currency ETFs, the issuer's FX trading desk quality directly affects execution and roll costs. Established currency ETF issuers (Invesco/CurrencyShares, WisdomTree) have the infrastructure for efficient FX futures management. Manager tenure is less critical for passive currency trackers but important for actively managed currency strategy ETFs.",
-        "factorAnalysisMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers"
-      },
-      {
-        "factorAnalysisKey": "mor_assessment",
-        "factorAnalysisTitle": "Mor Analyst Assessment",
-        "factorAnalysisDescription": "Reviews the Mor medalist rating and analyst assessment pillars. Many currency ETFs may lack full analyst coverage due to the niche nature of the category. If a rating exists, the Price pillar (total cost assessment including roll costs) and Process pillar (currency exposure methodology) are most relevant.",
-        "factorAnalysisMetrics": "medalistRating, analysisSections, strategyText"
-      }
-    ]
-  }
+  "categoryDescription": "Evaluates the ETF's fees, size, trading activity, and the people running the fund — the slow-leak factors that quietly decide whether long-term returns are delivered to investors or eaten up by costs. Factors are assigned to one or more ETF groups defined in etf-analysis-categories.json; each group uses exactly 5 factors from this file.",
+  "factors": [
+    {
+      "factorKey": "expense_ratio",
+      "factorTitle": "What You're Paying in Fees",
+      "factorDescription": "Looks at the ETF's expense ratio (annual fee) against what's normal for its category. Rough retail benchmarks: broad index funds should be under 0.10% (VOO is 0.03%), sector and thematic funds 0.10-0.50%, bond funds 0.05-0.30%, muni funds 0.10-0.40%, alternative-strategy funds 0.30-0.80%, leveraged funds 0.80-1.00%, allocation/target-date funds 0.10-0.50%. Fees compound every year — a 0.50% difference over 30 years can quietly erase 15% of your ending balance. The expense ratio also explains most of the tracking gap for passive funds: if the fund trails its index by roughly its expense ratio, that's normal, not a flaw.",
+      "factorMetrics": "expenseRatio, overviewAdjExpenseRatio, overviewProspectusNetExpenseRatio, overviewCategory",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    },
+    {
+      "factorKey": "fund_size_liquidity",
+      "factorTitle": "Fund Size and How Easy It Is to Trade",
+      "factorDescription": "Checks assets under management (AUM), daily volume, and the bid-ask spread (the gap between buy and sell prices). Bigger, more actively traded funds give retail investors tighter spreads and less slippage. Funds under $100-200M AUM carry real closure risk — if the fund shuts down, you're forced to sell at an inconvenient time with possible tax consequences. Very wide spreads silently eat returns on every trade. For bond and alternative-strategy funds, fund size matters even more because the underlying securities trade in less liquid markets.",
+      "factorMetrics": "aum, volume, avgVolume, marketBidAskSpread, dollarVol",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    },
+    {
+      "factorKey": "portfolio_turnover",
+      "factorTitle": "How Often the Fund Trades Its Holdings",
+      "factorDescription": "Portfolio turnover is the percentage of the fund's holdings that are bought and sold each year. Higher turnover means higher hidden trading costs and more taxable events for investors holding the fund in a taxable account. Rough retail benchmarks: passive index funds 0-20% (low is good), active equity funds 30-80% (normal), bond funds 30-80% (bonds mature, so turnover is natural), alternative-strategy funds often 100-300% (options and futures are rolled constantly — expected for the strategy). The red flag is turnover well above category peers, which usually signals undisciplined trading.",
+      "factorMetrics": "overviewTurnover, reportedTurnoverPct",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    },
+    {
+      "factorKey": "management_quality",
+      "factorTitle": "Who Runs the Fund and for How Long",
+      "factorDescription": "For passive index funds, the issuer's reputation and infrastructure matter more than individual managers — Vanguard, iShares (BlackRock), SPDR (State Street), and Schwab run tight, low-cost operations. For active funds and alternative-strategy funds, manager tenure is critical: a 10-year track record with the same manager tells you a lot more than a 2-year record with a brand-new manager. Short tenure means the performance record wasn't really produced by today's decision-maker. High manager turnover is a yellow flag — it suggests internal instability or the fund searching for a strategy.",
+      "factorMetrics": "issuer, numberOfManagers, longestTenure, averageTenure, advisors, currentManagers",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    },
+    {
+      "factorKey": "mor_assessment",
+      "factorTitle": "Mor Analyst Rating",
+      "factorDescription": "Mor's medalist rating (Gold / Silver / Bronze / Neutral / Negative) is a single-letter summary of their full analyst assessment across five pillars: Process, People, Parent, Performance, and Price. Gold-rated funds typically combine low fees, a strong investment process, and a stable team. Retail takeaway: a Gold or Silver rating is a reliable shortcut when picking funds in a category you don't research yourself. Note that many newer alternative-strategy and niche funds lack analyst coverage — absence of a rating is not a negative signal, just a gap.",
+      "factorMetrics": "medalistRating, analysisSections, strategyText",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    }
+  ]
 }

--- a/insights-ui/src/etf-analysis-data/etf-analysis-factors-risk-analysis.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-factors-risk-analysis.json
@@ -1,21 +1,38 @@
 {
   "categoryKey": "RiskAnalysis",
   "categoryName": "Risk Analysis",
-  "categoryDescription": "Evaluates the ETF's risk profile — how bumpy the ride is, how bad the worst losses have been, and whether the fund is taking on the kind of risk a retail investor should expect for this type of ETF. Factors are assigned to one or more ETF groups defined in etf-analysis-categories.json; each group uses exactly 4 factors from this file.",
+  "categoryDescription": "Evaluates the ETF's risk profile — how bumpy the ride is, how bad the worst losses have been, and whether the fund is taking on the kind of risk a retail investor should expect for this type of ETF. Factors are assigned to one or more ETF groups defined in etf-analysis-categories.json; each group uses exactly 5 factors from this file.",
   "factors": [
     {
       "factorKey": "overall_volatility",
       "factorTitle": "How Bumpy Is the Ride",
       "factorDescription": "Measures how much the ETF's price jumps around day-to-day and month-to-month. Uses beta (how it moves compared to the broad market) and standard deviation (size of typical swings). A beta of 1.0 means it moves roughly with the market; above 1.2 means bigger swings in both directions; below 0.8 means calmer moves. Check whether the volatility matches what the ETF is supposed to deliver — a 'low-volatility' fund with a high beta is not doing its job.",
       "factorMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures",
-      "groups": ["broad-equity", "sector-thematic-equity", "leveraged-inverse", "alt-strategies", "allocation-target-date"]
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
     },
     {
       "factorKey": "risk_adjusted_return",
       "factorTitle": "Are You Paid Fairly for the Risk",
       "factorDescription": "Looks at the Sharpe ratio, which shows how much return you got for every unit of risk taken. Higher is better. For equity ETFs, a Sharpe above 0.5 is decent and above 1.0 is very good. Bond ETFs and low-return funds naturally have lower Sharpe numbers, so compare against peers in the same category rather than to a fixed threshold. Two funds with identical returns but different Sharpe ratios — the one with the higher Sharpe delivered those returns with less stress along the way.",
       "factorMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn",
-      "groups": ["broad-equity", "fixed-income-core", "fixed-income-credit", "muni", "alt-strategies", "allocation-target-date"]
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "muni",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
     },
     {
       "factorKey": "worst_drawdown",
@@ -28,6 +45,7 @@
         "leveraged-inverse",
         "fixed-income-core",
         "fixed-income-credit",
+        "muni",
         "alt-strategies",
         "allocation-target-date"
       ]
@@ -37,7 +55,14 @@
       "factorTitle": "Is It Riskier Than Similar Funds",
       "factorDescription": "Compares the ETF's overall risk score against other funds in the same Mor category. A fund with above-average risk vs its peers should be delivering above-average returns to justify that extra risk — if not, investors are taking on more volatility for nothing. Below-average risk with similar returns is a positive sign of good risk management.",
       "factorMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods",
-      "groups": ["broad-equity", "sector-thematic-equity", "leveraged-inverse", "fixed-income-core", "fixed-income-credit", "muni"]
+      "groups": ["broad-equity", "sector-thematic-equity", "leveraged-inverse", "fixed-income-core", "fixed-income-credit", "muni", "allocation-target-date"]
+    },
+    {
+      "factorKey": "capture_ratios",
+      "factorTitle": "How Much of Market Ups and Downs It Catches",
+      "factorDescription": "Looks at upside capture (what percentage of the benchmark's gains the fund catches) and downside capture (what percentage of the benchmark's losses it absorbs). The ideal pattern is high upside capture and low downside capture — the fund grabs most of the gains but avoids most of the losses. For broad equity index funds both should be near 100%. For alternative strategies like covered call funds, something like 70% upside / 50% downside means the strategy is delivering the protection it promises.",
+      "factorMetrics": "captureRatios, riskVsCategory, returnVsCategory",
+      "groups": ["broad-equity", "alt-strategies"]
     },
     {
       "factorKey": "interest_rate_sensitivity",

--- a/insights-ui/src/etf-analysis-data/etf-analysis-factors-risk-analysis.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-factors-risk-analysis.json
@@ -1,199 +1,78 @@
 {
   "categoryKey": "RiskAnalysis",
   "categoryName": "Risk Analysis",
-  "categoryDescription": "Evaluates the ETF's risk profile including volatility, drawdowns, risk-adjusted returns, and downside protection across multiple time periods.",
-  "factorsByAssetClass": {
-    "Equity": [
-      {
-        "factorAnalysisKey": "volatility_measures",
-        "factorAnalysisTitle": "Volatility & Standard Deviation",
-        "factorAnalysisDescription": "Measures the fund's price volatility using beta, standard deviation, and ATR. For equity ETFs, beta near 1.0 is expected for broad market funds. Beta significantly above 1.0 (like growth ETFs at 1.2+) means amplified swings — higher highs and lower lows. Beta below 0.7 (like high-dividend or low-volatility ETFs) means dampened moves. Evaluate whether the observed volatility matches what the strategy promises.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios which measure return per unit of risk. For equity ETFs, a Sharpe ratio above 0.5 is decent, above 1.0 is very good. Sortino ratio is more useful because it only penalizes downside volatility, not upside. Compare to the category average — an equity ETF with higher Sharpe than its category is delivering better risk-adjusted value. High-beta growth ETFs naturally have lower Sharpe ratios than low-volatility ETFs.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Maximum Drawdown & Recovery",
-        "factorAnalysisDescription": "Analyzes the worst peak-to-trough declines and recovery time. For broad equity ETFs, drawdowns of -20% to -35% happen roughly once a decade (2008, 2020, 2022). Growth ETFs may drop -30% to -40%. The key question is recovery speed — did the fund recover within 1-2 years? A fund that draws down more than its category average AND recovers slower is a genuine concern. Contextualize ATH distance: being -5% to -10% from ATH is normal for equities.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "capture_ratios",
-        "factorAnalysisTitle": "Upside/Downside Capture Ratios",
-        "factorAnalysisDescription": "Measures how much of the market's upside the fund captures vs how much of the downside it absorbs. For equity ETFs, the ideal is upside capture > downside capture. A passive S&P 500 ETF should have both near 100%. A defensive equity ETF (high-dividend, low-volatility) might show 70% upside / 50% downside — capturing less of the gains but much less of the losses. Active ETFs that show 90% upside / 110% downside are destroying value through poor stock selection.",
-        "factorAnalysisMetrics": "captureRatios, riskVsCategory, returnVsCategory"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's overall Mor risk score and risk level against its category peers across 3-year, 5-year, and 10-year periods. For equity ETFs, consistently below-average risk vs category is favorable. A passive index ETF should show average risk for its category. An actively managed equity ETF with above-average risk should be delivering above-average returns to justify it.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ],
-    "Fixed Income": [
-      {
-        "factorAnalysisKey": "interest_rate_sensitivity",
-        "factorAnalysisTitle": "Interest Rate Sensitivity & Duration Risk",
-        "factorAnalysisDescription": "For bond ETFs, interest rate risk (measured by duration) is the primary risk factor. Beta relative to equities is less meaningful — a bond ETF's beta near 0 simply means it doesn't move with stocks, not that it's low-risk. Instead, evaluate using the annual return pattern: how badly did the fund get hit in 2022 (rising rates) vs how well it did in 2019/2020 (falling rates)? Long-duration bond ETFs (like TLT) can lose -30% in a rising rate year despite being 'safe' government bonds. The magnitude of rate-driven losses should be compared to category peers, not to equities.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, riskAndVolatilityMeasures, riskPeriods"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios for bond ETFs. Bond ETFs typically have lower Sharpe ratios than equity ETFs because their returns are lower. A Sharpe above 0.3 is decent for a bond fund. Compare to category average rather than absolute benchmarks. Sortino is particularly useful for bond ETFs because the 2022 rate shock created extreme downside that distorts symmetric volatility measures. A bond ETF that maintained a positive Sortino through 2022-2024 is demonstrating good risk-adjusted performance.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Maximum Drawdown & Recovery",
-        "factorAnalysisDescription": "Analyzes worst declines for bond ETFs. The 2022 rate hike cycle caused historically unprecedented bond losses (AGG -13%, TLT -31%). For bond ETFs, the key question is: was the drawdown in line with the category and duration profile, or did the fund lose more than expected? A bond ETF that lost -15% when its category lost -13% has a problem. A bond ETF that lost -13% in line with its category was simply exposed to the asset class. ATH distance is less meaningful for bond ETFs — ATHs were often set during the 2020 zero-rate era and are not realistic reference points.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "credit_and_default_risk",
-        "factorAnalysisTitle": "Credit & Default Risk Exposure",
-        "factorAnalysisDescription": "Evaluates the credit risk profile of the bond ETF. Treasury bond ETFs have essentially zero credit risk. Investment-grade corporate bond ETFs have moderate credit risk. High-yield (junk) bond ETFs carry significant credit risk that manifests during economic stress. Compare the fund's worst calendar year to its category — if a high-yield ETF lost significantly more than peers during 2020 or 2022, it may have had excessive exposure to lower-rated credits. Use the Mor risk score relative to category to gauge credit positioning.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's Mor risk score against its bond category peers across multiple periods. For bond ETFs, below-average risk vs category means the fund is taking less interest rate or credit risk than peers — which usually means lower returns too. The right question is whether the risk/return trade-off is fair: is the fund taking proportionally less risk for proportionally less return? A fund with below-average risk but average returns is well-managed.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ],
-    "Alternatives": [
-      {
-        "factorAnalysisKey": "volatility_vs_underlying",
-        "factorAnalysisTitle": "Volatility Relative to Underlying Market",
-        "factorAnalysisDescription": "For alternative strategy ETFs (covered call, derivative income), the core value proposition is lower volatility than their underlying market. A covered call ETF on the S&P 500 should have significantly lower volatility than the S&P 500 itself. Beta well below 1.0 (e.g., JEPI at 0.59) confirms the strategy is working. If an alternatives ETF has beta near 1.0 or higher, it's not providing the volatility reduction investors expect. Compare ATR and beta to what the underlying index would deliver.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios. For alternative strategy ETFs, risk-adjusted returns should be the headline metric — these funds explicitly trade absolute return for better risk efficiency. A covered call ETF that delivers Sharpe of 0.8 vs the S&P 500's Sharpe of 0.6 is doing its job, even if the absolute return is lower. Sortino is especially important here because downside protection is the explicit promise. Compare Sharpe/Sortino to both the category average and the underlying benchmark.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Drawdown & Downside Protection",
-        "factorAnalysisDescription": "Analyzes maximum drawdown relative to the reference benchmark. This is the most important risk factor for alternative strategy ETFs — outperforming during drawdowns is their core promise. JEPI losing -3.53% in 2022 while the S&P lost -19.43% is a success story. A fund that promises downside protection but draws down as much as the benchmark is failing at its stated objective. Calculate the protection ratio: fund drawdown / benchmark drawdown. A ratio under 0.50 is excellent, under 0.75 is good, above 0.90 means minimal protection.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "capture_ratios",
-        "factorAnalysisTitle": "Upside/Downside Capture Ratios",
-        "factorAnalysisDescription": "Measures upside vs downside capture relative to the benchmark. For alternative strategy ETFs, the expected pattern is: upside capture 50-80% (giving up some gains) and downside capture 30-60% (protecting against losses). The key metric is the capture ratio spread: (upside capture - downside capture). A positive spread means the fund captures more upside than downside — that's the ideal. JEPI's beta of 0.59 suggests roughly 59% capture of both, but the covered call premium should improve the downside capture.",
-        "factorAnalysisMetrics": "captureRatios, riskVsCategory, returnVsCategory"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's risk score against other alternative strategy ETFs. The Derivative Income category is growing rapidly (279 funds as of 2025), so category comparison is increasingly meaningful. A fund with below-average risk vs category means it's more conservative than peers — which may mean less income but better protection. Note that risk metrics for new alternative ETFs may be based on limited history and could change significantly as the fund matures.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ],
-    "Commodity": [
-      {
-        "factorAnalysisKey": "volatility_measures",
-        "factorAnalysisTitle": "Volatility & Cyclicality",
-        "factorAnalysisDescription": "Measures the fund's volatility in the context of commodity cycle behavior. Commodity ETFs are inherently more volatile than equity or bond ETFs. A commodity ETF with high ATR and wide price ranges is normal — the question is whether the volatility is in line with the specific commodity's historical behavior. Gold ETFs are relatively low-volatility commodities; oil and natural gas ETFs are extremely volatile. Beta relative to equities shows correlation — commodities ideally have low equity beta (diversification benefit).",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios for commodity ETFs. Commodities often have low or negative Sharpe ratios over extended periods because returns are cyclical and can be near zero long-term. A Sharpe above 0 is acceptable for many commodity ETFs. Compare to category peers rather than equity benchmarks. Gold ETFs tend to have better Sharpe ratios than energy or agricultural commodity ETFs due to lower volatility.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Maximum Drawdown & Cycle Recovery",
-        "factorAnalysisDescription": "Analyzes worst declines in the context of commodity super-cycles. Commodity ETFs can experience drawdowns of -40% to -70% during cycle downturns (oil in 2014-2016, 2020). The critical question is recovery: did the commodity recover to prior levels, and how long did it take? Commodities that haven't recovered from cycle lows after 5+ years may face structural demand decline. Compare drawdown severity and recovery speed to the commodity's historical cycle pattern.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "diversification_benefit",
-        "factorAnalysisTitle": "Portfolio Diversification Benefit",
-        "factorAnalysisDescription": "Evaluates how the commodity ETF behaves relative to stocks and bonds. The primary risk benefit of commodities in a portfolio is low or negative correlation with equities. Beta near 0 or negative indicates strong diversification benefit. If the commodity ETF moves in lockstep with equities (high beta), it provides less portfolio protection. Gold ETFs typically show negative equity correlation during crises (strong diversifier); energy ETFs may have higher equity correlation.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, captureRatios"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's Mor risk score against commodity category peers. For commodity ETFs, above-average risk vs category may mean higher leverage, more concentrated commodity exposure, or less efficient futures rolling. Below-average risk with comparable returns indicates superior risk management.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ],
-    "Asset Allocation": [
-      {
-        "factorAnalysisKey": "volatility_vs_components",
-        "factorAnalysisTitle": "Volatility Relative to Pure Components",
-        "factorAnalysisDescription": "Measures whether the asset allocation fund delivers smoother returns than its individual components. A 60/40 fund should have lower volatility than a pure equity fund and lower drawdowns than pure bonds in rate-shock years. Beta should be between the equity beta (~1.0) and bond beta (~0), weighted by allocation. If a balanced fund has equity-level volatility, the allocation may be more aggressive than stated or the bond component isn't providing the expected diversification.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios. Asset allocation funds should ideally have BETTER Sharpe ratios than pure equity or pure bond funds because diversification improves risk-adjusted returns. If a balanced fund's Sharpe ratio is lower than both its equity and bond benchmarks, the allocation isn't adding value. Compare to category average (other balanced/allocation funds) for the most relevant benchmark.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Maximum Drawdown & Protection",
-        "factorAnalysisDescription": "Analyzes worst declines relative to pure equity benchmarks. The primary value of asset allocation is shallower drawdowns. A 60/40 fund that lost -20% in 2022 when equities lost -20% and bonds lost -13% failed at its mandate — it should have lost somewhere in between. Evaluate the 'drawdown reduction ratio': how much less did this fund lose compared to a pure equity fund? Also assess 2022 specifically, when both stocks and bonds fell simultaneously — this was a stress test for all allocation strategies.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "capture_ratios",
-        "factorAnalysisTitle": "Upside/Downside Capture Ratios",
-        "factorAnalysisDescription": "Measures upside vs downside capture relative to the equity benchmark. A well-managed balanced fund should capture 60-80% of equity upside (proportional to equity allocation) but significantly less than 60-80% of equity downside (because bonds dampen losses). If downside capture exceeds upside capture proportional to the equity weight, the allocation is not working as intended.",
-        "factorAnalysisMetrics": "captureRatios, riskVsCategory, returnVsCategory"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's risk score against allocation category peers. For asset allocation ETFs, risk consistency is more important than absolute risk level — the fund should maintain similar risk positioning over time, reflecting a disciplined allocation approach. Sudden changes in risk score may indicate drift in the allocation or undisciplined rebalancing.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ],
-    "Currency": [
-      {
-        "factorAnalysisKey": "volatility_measures",
-        "factorAnalysisTitle": "Currency Volatility",
-        "factorAnalysisDescription": "Measures the fund's volatility in the context of currency market behavior. Major currency pairs (EUR/USD, GBP/USD) typically have lower volatility than emerging market currencies. ATR relative to price shows daily movement expectations. Beta relative to equities indicates how much the currency position correlates with stock markets — low equity beta is expected and desirable for currency ETFs used as hedging tools.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures"
-      },
-      {
-        "factorAnalysisKey": "risk_adjusted_returns",
-        "factorAnalysisTitle": "Risk-Adjusted Returns",
-        "factorAnalysisDescription": "Evaluates Sharpe and Sortino ratios for currency ETFs. Currency returns tend to be mean-reverting with high volatility, leading to low Sharpe ratios over long periods. A Sharpe near 0 is common. Compare to category peers rather than absolute thresholds. Positive carry currencies (higher interest rate currencies) may show better risk-adjusted returns but with more downside tail risk.",
-        "factorAnalysisMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn"
-      },
-      {
-        "factorAnalysisKey": "drawdown_analysis",
-        "factorAnalysisTitle": "Maximum Drawdown & Recovery",
-        "factorAnalysisDescription": "Analyzes worst declines for currency ETFs. Currencies can experience sharp, sudden moves (10-20% in months) driven by central bank policy changes, political events, or economic crises. The key risk question is: does the currency pair have a history of mean-reversion (recovers to prior levels) or structural depreciation (persistent one-way decline)? Emerging market currency ETFs carry higher drawdown risk than major currency pair ETFs.",
-        "factorAnalysisMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate"
-      },
-      {
-        "factorAnalysisKey": "correlation_profile",
-        "factorAnalysisTitle": "Correlation & Hedging Effectiveness",
-        "factorAnalysisDescription": "Evaluates how the currency ETF's returns correlate with equities and other asset classes. Currency ETFs are often held for hedging or diversification. Low or negative beta to equities suggests the currency position provides portfolio protection during equity selloffs. Safe-haven currencies (USD, JPY, CHF) tend to strengthen during equity crises. Risk-on currencies (AUD, emerging markets) may fall alongside equities, reducing their diversification value.",
-        "factorAnalysisMetrics": "beta, beta1y, beta2y, beta5y, captureRatios"
-      },
-      {
-        "factorAnalysisKey": "risk_vs_category",
-        "factorAnalysisTitle": "Risk Score vs Category",
-        "factorAnalysisDescription": "Compares the fund's risk score against currency category peers. For currency ETFs, above-average risk vs category may indicate exposure to more volatile currency pairs or use of leverage. Below-average risk with comparable returns indicates a less volatile currency pair or better risk management in the futures rolling process.",
-        "factorAnalysisMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods"
-      }
-    ]
-  }
+  "categoryDescription": "Evaluates the ETF's risk profile — how bumpy the ride is, how bad the worst losses have been, and whether the fund is taking on the kind of risk a retail investor should expect for this type of ETF. Factors are assigned to one or more ETF groups defined in etf-analysis-categories.json; each group uses exactly 4 factors from this file.",
+  "factors": [
+    {
+      "factorKey": "overall_volatility",
+      "factorTitle": "How Bumpy Is the Ride",
+      "factorDescription": "Measures how much the ETF's price jumps around day-to-day and month-to-month. Uses beta (how it moves compared to the broad market) and standard deviation (size of typical swings). A beta of 1.0 means it moves roughly with the market; above 1.2 means bigger swings in both directions; below 0.8 means calmer moves. Check whether the volatility matches what the ETF is supposed to deliver — a 'low-volatility' fund with a high beta is not doing its job.",
+      "factorMetrics": "beta, beta1y, beta2y, beta5y, atr, riskAndVolatilityMeasures",
+      "groups": ["broad-equity", "sector-thematic-equity", "leveraged-inverse", "alt-strategies", "allocation-target-date"]
+    },
+    {
+      "factorKey": "risk_adjusted_return",
+      "factorTitle": "Are You Paid Fairly for the Risk",
+      "factorDescription": "Looks at the Sharpe ratio, which shows how much return you got for every unit of risk taken. Higher is better. For equity ETFs, a Sharpe above 0.5 is decent and above 1.0 is very good. Bond ETFs and low-return funds naturally have lower Sharpe numbers, so compare against peers in the same category rather than to a fixed threshold. Two funds with identical returns but different Sharpe ratios — the one with the higher Sharpe delivered those returns with less stress along the way.",
+      "factorMetrics": "sharpe, sortino, portfolioRiskScore, morAnalyzerRiskReturn",
+      "groups": ["broad-equity", "fixed-income-core", "fixed-income-credit", "muni", "alt-strategies", "allocation-target-date"]
+    },
+    {
+      "factorKey": "worst_drawdown",
+      "factorTitle": "Worst Drop and How Long It Took to Recover",
+      "factorDescription": "Shows the biggest peak-to-trough fall the ETF has had, and how long it took to get back to the previous high. For broad equity ETFs, drops of -20% to -35% happen roughly once a decade. Bond ETFs were hit by -10% to -30% drops in 2022. The key question for retail investors: could I emotionally hold this fund through that kind of drop? A fund that fell harder AND recovered slower than its category peers is a bigger concern than the drawdown number alone.",
+      "factorMetrics": "drawdown, drawdownDates, athChgPercent, athDate, atlChgPercent, atlDate",
+      "groups": [
+        "broad-equity",
+        "sector-thematic-equity",
+        "leveraged-inverse",
+        "fixed-income-core",
+        "fixed-income-credit",
+        "alt-strategies",
+        "allocation-target-date"
+      ]
+    },
+    {
+      "factorKey": "risk_vs_peers",
+      "factorTitle": "Is It Riskier Than Similar Funds",
+      "factorDescription": "Compares the ETF's overall risk score against other funds in the same Mor category. A fund with above-average risk vs its peers should be delivering above-average returns to justify that extra risk — if not, investors are taking on more volatility for nothing. Below-average risk with similar returns is a positive sign of good risk management.",
+      "factorMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods",
+      "groups": ["broad-equity", "sector-thematic-equity", "leveraged-inverse", "fixed-income-core", "fixed-income-credit", "muni"]
+    },
+    {
+      "factorKey": "interest_rate_sensitivity",
+      "factorTitle": "How Much Rate Changes Hurt This Fund",
+      "factorDescription": "For bond and muni ETFs, the main risk is that when interest rates rise, bond prices fall — and the longer the duration (the bond's time to maturity), the worse the hit. Long-duration government bond ETFs like TLT lost around -31% in 2022 when rates spiked. The retail takeaway: look at how badly this fund did in rising-rate years vs falling-rate years. If the 2022 loss was roughly in line with category peers, it's an asset-class issue, not a fund-specific flaw.",
+      "factorMetrics": "beta, beta1y, beta2y, beta5y, riskAndVolatilityMeasures, riskPeriods",
+      "groups": ["fixed-income-core", "muni"]
+    },
+    {
+      "factorKey": "credit_risk",
+      "factorTitle": "Risk That Bonds in the Fund Default",
+      "factorDescription": "Looks at the credit quality of bonds in the ETF. Treasury funds essentially have zero default risk. Investment-grade corporate funds carry mild credit risk. High-yield (junk) bond funds carry real default risk — during recessions they can lose 15-25% as weaker companies default. Muni funds depend on the financial health of state and local issuers. Check if the fund held up similarly to its credit-peer category during stress periods (2020, 2022) — losses far worse than peers suggest excessive exposure to lower-rated credits.",
+      "factorMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, riskPeriods",
+      "groups": ["fixed-income-credit", "muni"]
+    },
+    {
+      "factorKey": "leverage_decay",
+      "factorTitle": "Daily-Reset Decay Warning",
+      "factorDescription": "Leveraged and inverse ETFs reset every day, which means their long-term returns are almost never the leverage factor (2x, 3x, -1x) times the underlying's long-term return. In flat or choppy markets, daily compounding eats away at the value — this is called 'decay.' A 3x S&P 500 ETF can actually lose money over a year even if the S&P went up over that year, if the path was volatile. Retail takeaway: these are short-term trading tools, not long-term holdings. Never hold them through volatile sideways markets.",
+      "factorMetrics": "return1m, return3m, return1y, return3y, returnsAnnual, beta, beta1y",
+      "groups": ["leveraged-inverse"]
+    },
+    {
+      "factorKey": "downside_protection",
+      "factorTitle": "How Well It Holds Up in Market Crashes",
+      "factorDescription": "This is the main value proposition for alternative strategy funds (covered call, managed futures) and allocation funds (60/40, target-date). Measures how much of the benchmark's drop the fund actually absorbed. A covered call ETF that lost only -3% while the S&P lost -19% in 2022 delivered real downside protection. A '60/40' fund that lost -20% when stocks lost -20% failed at its job. The protection ratio (fund drawdown ÷ benchmark drawdown) under 0.50 is excellent, under 0.75 is good, above 0.90 means you're not getting much protection for the fees.",
+      "factorMetrics": "returnsAnnual, captureRatios, drawdown, riskVsCategory, returnVsCategory",
+      "groups": ["alt-strategies", "allocation-target-date"]
+    },
+    {
+      "factorKey": "concentration_risk",
+      "factorTitle": "Risk of Being All-In on One Theme",
+      "factorDescription": "Sector and thematic ETFs put all their eggs in one basket — a single sector (tech, energy, healthcare) or theme. When that sector has a bad year, there's no diversification to cushion the fall. Tech funds dropped around -30% in 2022; energy funds dropped more than -50% in 2020. Check the top-10 holdings weight: if the top 10 make up more than 60% of the fund, the fund's fate is tied to just a handful of names. Retail takeaway: these belong as small slices of a portfolio, not the whole thing.",
+      "factorMetrics": "riskScore, riskLevel, riskVsCategory, returnVsCategory, drawdown",
+      "groups": ["sector-thematic-equity"]
+    }
+  ]
 }

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -45,12 +45,10 @@ export interface EtfAnalysisFactorDefinition {
   factorAnalysisMetrics?: string;
 }
 
-export type EtfAssetClass = 'Equity' | 'Fixed Income' | 'Alternatives' | 'Commodity' | 'Asset Allocation' | 'Currency';
-
 /**
- * Group-based factor definition used by the new performance-and-returns config.
- * Each factor declares the ETF groups it applies to; the pipeline selects factors
- * by intersecting the fund's group (derived from EtfStockAnalyzerInfo.category) with these.
+ * Group-based factor definition. Each factor declares the ETF groups it applies
+ * to; the pipeline selects factors by intersecting the fund's group (derived
+ * from EtfStockAnalyzerInfo.category via etf-analysis-categories.json) with these.
  */
 export interface EtfGroupFactorDefinition {
   factorKey: string;
@@ -65,13 +63,6 @@ export interface EtfGroupBasedFactorsConfig {
   categoryName: string;
   categoryDescription: string;
   factors: EtfGroupFactorDefinition[];
-}
-
-export interface EtfAssetClassBasedFactorsConfig {
-  categoryKey: EtfAnalysisCategory;
-  categoryName: string;
-  categoryDescription: string;
-  factorsByAssetClass: Record<EtfAssetClass, EtfAnalysisFactorDefinition[]>;
 }
 
 export interface EtfGroup {

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -23,7 +23,7 @@ function isEtfAssetClass(value: string): value is EtfAssetClass {
 const categoriesConfig = etfCategoriesRaw as EtfCategoriesConfig;
 const performanceAndReturnsConfig = performanceAndReturnsRaw as EtfGroupBasedFactorsConfig;
 const costEfficiencyAndTeamConfig = costEfficiencyAndTeamRaw as EtfAssetClassBasedFactorsConfig;
-const riskAnalysisConfig = riskAnalysisRaw as EtfAssetClassBasedFactorsConfig;
+const riskAnalysisConfig = riskAnalysisRaw as EtfGroupBasedFactorsConfig;
 
 function normalizeGroupFactor(f: EtfGroupFactorDefinition): EtfAnalysisFactorDefinition {
   return {
@@ -50,17 +50,17 @@ function getFactorsForAssetClass(config: EtfAssetClassBasedFactorsConfig, assetC
   return config.factorsByAssetClass[resolved] || config.factorsByAssetClass['Equity'] || [];
 }
 
-function getPerformanceFactorsForGroup(groupKey: string): EtfAnalysisFactorDefinition[] {
-  return performanceAndReturnsConfig.factors.filter((f) => f.groups.includes(groupKey)).map(normalizeGroupFactor);
+function getGroupFactors(config: EtfGroupBasedFactorsConfig, groupKey: string): EtfAnalysisFactorDefinition[] {
+  return config.factors.filter((f) => f.groups.includes(groupKey)).map(normalizeGroupFactor);
 }
 
 /**
  * Get analysis factors for a given category.
  *
- * - PerformanceAndReturns uses group-based selection: the fund's EtfStockAnalyzerInfo.category
- *   is mapped to a group (via etf-analysis-categories.json), then factors whose `groups`
- *   includes that group are selected.
- * - CostEfficiencyAndTeam and RiskAnalysis still use asset-class-based selection.
+ * - PerformanceAndReturns and RiskAnalysis use group-based selection: the fund's
+ *   EtfStockAnalyzerInfo.category is mapped to a group (via etf-analysis-categories.json),
+ *   then factors whose `groups` includes that group are selected.
+ * - CostEfficiencyAndTeam still uses asset-class-based selection.
  */
 export function getEtfAnalysisFactorsForCategory(
   categoryKey: EtfAnalysisCategory,
@@ -69,20 +69,24 @@ export function getEtfAnalysisFactorsForCategory(
   switch (categoryKey) {
     case EtfAnalysisCategory.PerformanceAndReturns: {
       const groupKey = getEtfGroupKeyForCategory(params.fundCategory) || DEFAULT_GROUP_KEY;
-      const factors = getPerformanceFactorsForGroup(groupKey);
+      const factors = getGroupFactors(performanceAndReturnsConfig, groupKey);
       if (factors.length > 0) return factors;
-      return getPerformanceFactorsForGroup(DEFAULT_GROUP_KEY);
+      return getGroupFactors(performanceAndReturnsConfig, DEFAULT_GROUP_KEY);
     }
     case EtfAnalysisCategory.CostEfficiencyAndTeam:
       return getFactorsForAssetClass(costEfficiencyAndTeamConfig, params.assetClass);
-    case EtfAnalysisCategory.RiskAnalysis:
-      return getFactorsForAssetClass(riskAnalysisConfig, params.assetClass);
+    case EtfAnalysisCategory.RiskAnalysis: {
+      const groupKey = getEtfGroupKeyForCategory(params.fundCategory) || DEFAULT_GROUP_KEY;
+      const factors = getGroupFactors(riskAnalysisConfig, groupKey);
+      if (factors.length > 0) return factors;
+      return getGroupFactors(riskAnalysisConfig, DEFAULT_GROUP_KEY);
+    }
   }
 }
 
 /**
  * Find a factor definition by key for a given category. Searches across every
- * group (PerformanceAndReturns) or every asset class (Cost/Risk).
+ * group (PerformanceAndReturns, RiskAnalysis) or every asset class (CostEfficiencyAndTeam).
  */
 export function findFactorDefinition(categoryKey: EtfAnalysisCategory, factorKey: string): EtfAnalysisFactorDefinition | undefined {
   if (categoryKey === EtfAnalysisCategory.PerformanceAndReturns) {
@@ -90,9 +94,13 @@ export function findFactorDefinition(categoryKey: EtfAnalysisCategory, factorKey
     return found ? normalizeGroupFactor(found) : undefined;
   }
 
-  const config = categoryKey === EtfAnalysisCategory.CostEfficiencyAndTeam ? costEfficiencyAndTeamConfig : riskAnalysisConfig;
+  if (categoryKey === EtfAnalysisCategory.RiskAnalysis) {
+    const found = riskAnalysisConfig.factors.find((f) => f.factorKey === factorKey);
+    return found ? normalizeGroupFactor(found) : undefined;
+  }
+
   for (const assetClass of VALID_ASSET_CLASSES) {
-    const factors = config.factorsByAssetClass[assetClass];
+    const factors = costEfficiencyAndTeamConfig.factorsByAssetClass[assetClass];
     if (!factors) continue;
     const found = factors.find((f) => f.factorAnalysisKey === factorKey);
     if (found) return found;
@@ -278,7 +286,9 @@ export function prepareRiskAnalysisInputJson(etf: EtfWithAllData) {
   const fin = etf.financialInfo;
   const risk = etf.morRiskInfo;
   const assetClass = sa?.assetClass || 'Equity';
-  const factors = getEtfAnalysisFactorsForCategory(EtfAnalysisCategory.RiskAnalysis, { assetClass });
+  const fundCategory = sa?.category || null;
+  const groupKey = getEtfGroupKeyForCategory(fundCategory) || DEFAULT_GROUP_KEY;
+  const factors = getEtfAnalysisFactorsForCategory(EtfAnalysisCategory.RiskAnalysis, { fundCategory: fundCategory ?? undefined });
 
   return {
     name: etf.name,
@@ -286,6 +296,8 @@ export function prepareRiskAnalysisInputJson(etf: EtfWithAllData) {
     exchange: etf.exchange,
     categoryKey: EtfAnalysisCategory.RiskAnalysis,
     assetClass,
+    fundCategory,
+    groupKey,
     factorAnalysisArray: prepareFactorAnalysisArray(factors),
     stockAnalyzerRiskMetrics: JSON.stringify({
       beta: fin?.beta,

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -1,8 +1,6 @@
 import {
   EtfAnalysisCategory,
   EtfAnalysisFactorDefinition,
-  EtfAssetClass,
-  EtfAssetClassBasedFactorsConfig,
   EtfCategoriesConfig,
   EtfGroupBasedFactorsConfig,
   EtfGroupFactorDefinition,
@@ -13,17 +11,18 @@ import costEfficiencyAndTeamRaw from '@/etf-analysis-data/etf-analysis-factors-c
 import riskAnalysisRaw from '@/etf-analysis-data/etf-analysis-factors-risk-analysis.json';
 import { EtfWithAllData } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
 
-const VALID_ASSET_CLASSES: EtfAssetClass[] = ['Equity', 'Fixed Income', 'Alternatives', 'Commodity', 'Asset Allocation', 'Currency'];
 const DEFAULT_GROUP_KEY = 'broad-equity';
-
-function isEtfAssetClass(value: string): value is EtfAssetClass {
-  return (VALID_ASSET_CLASSES as string[]).includes(value);
-}
 
 const categoriesConfig = etfCategoriesRaw as EtfCategoriesConfig;
 const performanceAndReturnsConfig = performanceAndReturnsRaw as EtfGroupBasedFactorsConfig;
-const costEfficiencyAndTeamConfig = costEfficiencyAndTeamRaw as EtfAssetClassBasedFactorsConfig;
+const costEfficiencyAndTeamConfig = costEfficiencyAndTeamRaw as EtfGroupBasedFactorsConfig;
 const riskAnalysisConfig = riskAnalysisRaw as EtfGroupBasedFactorsConfig;
+
+const CATEGORY_CONFIGS: Record<EtfAnalysisCategory, EtfGroupBasedFactorsConfig> = {
+  [EtfAnalysisCategory.PerformanceAndReturns]: performanceAndReturnsConfig,
+  [EtfAnalysisCategory.CostEfficiencyAndTeam]: costEfficiencyAndTeamConfig,
+  [EtfAnalysisCategory.RiskAnalysis]: riskAnalysisConfig,
+};
 
 function normalizeGroupFactor(f: EtfGroupFactorDefinition): EtfAnalysisFactorDefinition {
   return {
@@ -45,67 +44,32 @@ export function getEtfGroupKeyForCategory(category: string | null | undefined): 
   return match?.group;
 }
 
-function getFactorsForAssetClass(config: EtfAssetClassBasedFactorsConfig, assetClass?: string): EtfAnalysisFactorDefinition[] {
-  const resolved: EtfAssetClass = assetClass && isEtfAssetClass(assetClass) ? assetClass : 'Equity';
-  return config.factorsByAssetClass[resolved] || config.factorsByAssetClass['Equity'] || [];
-}
-
 function getGroupFactors(config: EtfGroupBasedFactorsConfig, groupKey: string): EtfAnalysisFactorDefinition[] {
   return config.factors.filter((f) => f.groups.includes(groupKey)).map(normalizeGroupFactor);
 }
 
 /**
- * Get analysis factors for a given category.
- *
- * - PerformanceAndReturns and RiskAnalysis use group-based selection: the fund's
- *   EtfStockAnalyzerInfo.category is mapped to a group (via etf-analysis-categories.json),
- *   then factors whose `groups` includes that group are selected.
- * - CostEfficiencyAndTeam still uses asset-class-based selection.
+ * Get analysis factors for a given category. All three categories now use
+ * group-based selection: the fund's EtfStockAnalyzerInfo.category is mapped
+ * to a group (via etf-analysis-categories.json), then factors whose `groups`
+ * includes that group are selected.
  */
-export function getEtfAnalysisFactorsForCategory(
-  categoryKey: EtfAnalysisCategory,
-  params: { assetClass?: string; fundCategory?: string } = {}
-): EtfAnalysisFactorDefinition[] {
-  switch (categoryKey) {
-    case EtfAnalysisCategory.PerformanceAndReturns: {
-      const groupKey = getEtfGroupKeyForCategory(params.fundCategory) || DEFAULT_GROUP_KEY;
-      const factors = getGroupFactors(performanceAndReturnsConfig, groupKey);
-      if (factors.length > 0) return factors;
-      return getGroupFactors(performanceAndReturnsConfig, DEFAULT_GROUP_KEY);
-    }
-    case EtfAnalysisCategory.CostEfficiencyAndTeam:
-      return getFactorsForAssetClass(costEfficiencyAndTeamConfig, params.assetClass);
-    case EtfAnalysisCategory.RiskAnalysis: {
-      const groupKey = getEtfGroupKeyForCategory(params.fundCategory) || DEFAULT_GROUP_KEY;
-      const factors = getGroupFactors(riskAnalysisConfig, groupKey);
-      if (factors.length > 0) return factors;
-      return getGroupFactors(riskAnalysisConfig, DEFAULT_GROUP_KEY);
-    }
-  }
+export function getEtfAnalysisFactorsForCategory(categoryKey: EtfAnalysisCategory, params: { fundCategory?: string } = {}): EtfAnalysisFactorDefinition[] {
+  const config = CATEGORY_CONFIGS[categoryKey];
+  const groupKey = getEtfGroupKeyForCategory(params.fundCategory) || DEFAULT_GROUP_KEY;
+  const factors = getGroupFactors(config, groupKey);
+  if (factors.length > 0) return factors;
+  return getGroupFactors(config, DEFAULT_GROUP_KEY);
 }
 
 /**
  * Find a factor definition by key for a given category. Searches across every
- * group (PerformanceAndReturns, RiskAnalysis) or every asset class (CostEfficiencyAndTeam).
+ * group definition in that category.
  */
 export function findFactorDefinition(categoryKey: EtfAnalysisCategory, factorKey: string): EtfAnalysisFactorDefinition | undefined {
-  if (categoryKey === EtfAnalysisCategory.PerformanceAndReturns) {
-    const found = performanceAndReturnsConfig.factors.find((f) => f.factorKey === factorKey);
-    return found ? normalizeGroupFactor(found) : undefined;
-  }
-
-  if (categoryKey === EtfAnalysisCategory.RiskAnalysis) {
-    const found = riskAnalysisConfig.factors.find((f) => f.factorKey === factorKey);
-    return found ? normalizeGroupFactor(found) : undefined;
-  }
-
-  for (const assetClass of VALID_ASSET_CLASSES) {
-    const factors = costEfficiencyAndTeamConfig.factorsByAssetClass[assetClass];
-    if (!factors) continue;
-    const found = factors.find((f) => f.factorAnalysisKey === factorKey);
-    if (found) return found;
-  }
-  return undefined;
+  const config = CATEGORY_CONFIGS[categoryKey];
+  const found = config.factors.find((f) => f.factorKey === factorKey);
+  return found ? normalizeGroupFactor(found) : undefined;
 }
 
 function prepareFactorAnalysisArray(factors: EtfAnalysisFactorDefinition[]) {
@@ -228,7 +192,9 @@ export function prepareCostEfficiencyAndTeamInputJson(etf: EtfWithAllData) {
   const people = etf.morPeopleInfo;
   const portfolio = etf.morPortfolioInfo;
   const assetClass = sa?.assetClass || 'Equity';
-  const factors = getEtfAnalysisFactorsForCategory(EtfAnalysisCategory.CostEfficiencyAndTeam, { assetClass });
+  const fundCategory = sa?.category || null;
+  const groupKey = getEtfGroupKeyForCategory(fundCategory) || DEFAULT_GROUP_KEY;
+  const factors = getEtfAnalysisFactorsForCategory(EtfAnalysisCategory.CostEfficiencyAndTeam, { fundCategory: fundCategory ?? undefined });
 
   return {
     name: etf.name,
@@ -236,6 +202,8 @@ export function prepareCostEfficiencyAndTeamInputJson(etf: EtfWithAllData) {
     exchange: etf.exchange,
     categoryKey: EtfAnalysisCategory.CostEfficiencyAndTeam,
     assetClass,
+    fundCategory,
+    groupKey,
     factorAnalysisArray: prepareFactorAnalysisArray(factors),
     financialInfo: JSON.stringify({
       expenseRatio: fin?.expenseRatio,


### PR DESCRIPTION
## Summary

Migrates `etf-analysis-factors-risk-analysis.json` from the old `factorsByAssetClass` schema to the group-based schema already used by `etf-analysis-factors-performance-and-returns.json`. Each of the 8 ETF groups defined in `etf-analysis-categories.json` now maps to **exactly 4 factors**, selected via the fund's category-to-group mapping rather than its asset class.

Factor copy was rewritten in plain language so retail investors can understand what each check means.

## What changed

- `src/etf-analysis-data/etf-analysis-factors-risk-analysis.json` — rewritten to use `factors[]` with `groups[]` tags instead of `factorsByAssetClass`. Nine distinct factors introduced:
  - `overall_volatility`, `risk_adjusted_return`, `worst_drawdown`, `risk_vs_peers`
  - `interest_rate_sensitivity`, `credit_risk`, `leverage_decay`
  - `downside_protection`, `concentration_risk`
- `src/utils/etf-analysis-reports/etf-report-input-json-utils.ts`:
  - `riskAnalysisConfig` now typed as `EtfGroupBasedFactorsConfig`.
  - Extracted a shared `getGroupFactors()` helper used by both PerformanceAndReturns and RiskAnalysis.
  - `findFactorDefinition` routes RiskAnalysis through the group-based lookup.
  - `prepareRiskAnalysisInputJson` now passes `fundCategory` (not `assetClass`) to the factor resolver and includes `groupKey` in the prompt payload (mirrors PerformanceAndReturns).

## Per-group factor mapping (4 each)

| Group | Factors |
|---|---|
| `broad-equity` | overall_volatility, risk_adjusted_return, worst_drawdown, risk_vs_peers |
| `sector-thematic-equity` | overall_volatility, worst_drawdown, risk_vs_peers, concentration_risk |
| `leveraged-inverse` | overall_volatility, worst_drawdown, risk_vs_peers, leverage_decay |
| `fixed-income-core` | interest_rate_sensitivity, risk_adjusted_return, worst_drawdown, risk_vs_peers |
| `fixed-income-credit` | credit_risk, risk_adjusted_return, worst_drawdown, risk_vs_peers |
| `muni` | interest_rate_sensitivity, credit_risk, risk_adjusted_return, risk_vs_peers |
| `alt-strategies` | downside_protection, overall_volatility, risk_adjusted_return, worst_drawdown |
| `allocation-target-date` | downside_protection, overall_volatility, risk_adjusted_return, worst_drawdown |

## What is **not** changed

- `etf-analysis-factors-cost-efficiency-and-team.json` is still on the asset-class-based schema. `EtfAssetClassBasedFactorsConfig` and the `getFactorsForAssetClass` helper remain in place for that one category. Happy to migrate it in a follow-up PR when you want.

## Test plan

- [x] `yarn lint` passes.
- [x] `yarn prettier-check` passes.
- [x] `yarn compile` (prisma generate + tsc) passes.
- [ ] `yarn build` — webpack compile + typecheck pass, but static page collection fails on an unrelated env-var issue (`KOALA_AWS_ACCESS_KEY_ID` required by `industry-tariff-report/sitemap.xml`). This failure reproduces on `main` and is unrelated to this PR's changes.
- [ ] Next generation run for a risk-analysis report writes prompt input containing the new `groupKey`, `fundCategory`, and the 4 group-selected factors.
- [ ] Existing `EtfAnalysisCategoryFactorResult` rows with old factor keys (e.g. `volatility_measures`, `interest_rate_sensitivity`, `drawdown_analysis`, `capture_ratios`, `credit_and_default_risk`, etc.) will become orphaned — decide whether to regenerate affected ETFs or leave the stale rows until they're rewritten on the next generation cycle.