### PR TITLE
Add Is Active filter to admin users page

### DIFF
--- a/insights-ui/src/app/admin-v1/users/page.tsx
+++ b/insights-ui/src/app/admin-v1/users/page.tsx
@@ -54,6 +54,7 @@ export default function Page() {
   const [deleteUserId, setDeleteUserId] = useState<string>('');
   const [roleFilter, setRoleFilter] = useState<string>('All');
   const [isManagerFilter, setIsManagerFilter] = useState<boolean>(false);
+  const [isActiveFilter, setIsActiveFilter] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const pageSize = 100;
 
@@ -63,8 +64,9 @@ export default function Page() {
     params.set('limit', String(pageSize));
     if (roleFilter !== 'All') params.set('role', roleFilter);
     if (isManagerFilter) params.set('isManager', 'true');
+    if (isActiveFilter) params.set('isActive', 'true');
     return `${getBaseUrl()}/api/users?${params.toString()}`;
-  }, [currentPage, roleFilter, isManagerFilter]);
+  }, [currentPage, roleFilter, isManagerFilter, isActiveFilter]);
 
   const { data: usersResponse, loading: loadingUsers, reFetchData: refetchUsers } = useFetchData<UsersResponse>(usersApiUrl, {}, 'Failed to load users');
 
@@ -134,6 +136,11 @@ export default function Page() {
     setCurrentPage(1);
   };
 
+  const handleIsActiveFilterChange = (checked: boolean) => {
+    setIsActiveFilter(checked);
+    setCurrentPage(1);
+  };
+
   return (
     <PageWrapper>
       <AdminNav />
@@ -156,6 +163,7 @@ export default function Page() {
           <StyledSelect label="Role" items={roleFilterItems} selectedItemId={roleFilter} setSelectedItemId={handleRoleFilterChange} />
         </div>
         <Checkbox id="isManagerFilter" labelContent="Is Manager" isChecked={isManagerFilter} onChange={handleIsManagerFilterChange} />
+        <Checkbox id="isActiveFilter" labelContent="Is Active" isChecked={isActiveFilter} onChange={handleIsActiveFilterChange} />
       </div>
 
       {loadingUsers ? (

--- a/insights-ui/src/app/api/users/route.ts
+++ b/insights-ui/src/app/api/users/route.ts
@@ -44,6 +44,7 @@ async function getHandler(req: NextRequest, userContext: KoalaGainsJwtTokenPaylo
   const limit = Math.min(200, Math.max(1, parseInt(searchParams.get('limit') || '100', 10)));
   const roleParam = searchParams.get('role');
   const isManagerParam = searchParams.get('isManager');
+  const isActiveParam = searchParams.get('isActive');
 
   const where: Record<string, unknown> = {
     spaceId: KoalaGainsSpaceId,
@@ -55,6 +56,10 @@ async function getHandler(req: NextRequest, userContext: KoalaGainsJwtTokenPaylo
 
   if (isManagerParam === 'true') {
     where.portfolioManagerProfile = { isNot: null };
+  }
+
+  if (isActiveParam === 'true') {
+    where.OR = [{ favouriteTickers: { some: {} } }, { tickerNotes: { some: {} } }];
   }
 
   const [users, totalCount] = await Promise.all([


### PR DESCRIPTION
## Summary
- Adds an **Is Active** checkbox filter next to **Is Manager** on `/admin-v1/users`.
- "Active" means the user has at least one entry in `favouriteTickers` OR `tickerNotes`.
- Backend: `GET /api/users` accepts `isActive=true` and applies a Prisma `OR` over `favouriteTickers.some({})` and `tickerNotes.some({})`.

## Test plan
- [ ] Open `/admin-v1/users`, verify the new "Is Active" checkbox renders next to "Is Manager".
- [ ] Toggle "Is Active" and confirm the list shows only users with at least one favourite or at least one note.
- [ ] Combine with "Is Manager" and Role filters to confirm they AND together correctly.
- [ ] Pagination resets to page 1 when the filter is toggled.