### PR TITLE
Resolve scenario ETF links on detail GET for clickable pills

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
@@ -24,11 +24,11 @@ export interface EtfScenarioDetail extends Omit<EtfScenario, 'outlookAsOfDate' |
   mostExposed: EtfScenarioLinkDto[];
 }
 
-function toLinkDto(link: EtfScenarioEtfLink): EtfScenarioLinkDto {
+function toLinkDto(link: EtfScenarioEtfLink, resolved?: { id: string; exchange: string }): EtfScenarioLinkDto {
   return {
     symbol: link.symbol,
-    exchange: link.exchange,
-    etfId: link.etfId,
+    exchange: link.exchange ?? resolved?.exchange ?? null,
+    etfId: link.etfId ?? resolved?.id ?? null,
     role: link.role as EtfScenarioRole,
     sortOrder: link.sortOrder,
   };
@@ -51,6 +51,21 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const { etfLinks, outlookAsOfDate, createdAt, updatedAt, ...rest } = scenario;
 
+  const unresolvedSymbols = Array.from(new Set(etfLinks.filter((l) => !l.etfId || !l.exchange).map((l) => l.symbol.toUpperCase())));
+  const resolvedBySymbol = new Map<string, { id: string; exchange: string }>();
+  if (unresolvedSymbols.length) {
+    const matches = await prisma.etf.findMany({
+      where: { spaceId, symbol: { in: unresolvedSymbols } },
+      select: { id: true, symbol: true, exchange: true },
+    });
+    for (const etf of matches) {
+      const key = etf.symbol.toUpperCase();
+      if (!resolvedBySymbol.has(key)) resolvedBySymbol.set(key, { id: etf.id, exchange: etf.exchange });
+    }
+  }
+
+  const mapLink = (l: EtfScenarioEtfLink) => toLinkDto(l, resolvedBySymbol.get(l.symbol.toUpperCase()));
+
   return {
     ...rest,
     direction: rest.direction as EtfScenarioDirection,
@@ -59,9 +74,9 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     outlookAsOfDate: outlookAsOfDate.toISOString(),
     createdAt: createdAt.toISOString(),
     updatedAt: updatedAt.toISOString(),
-    winners: etfLinks.filter((l) => l.role === 'WINNER').map(toLinkDto),
-    losers: etfLinks.filter((l) => l.role === 'LOSER').map(toLinkDto),
-    mostExposed: etfLinks.filter((l) => l.role === 'MOST_EXPOSED').map(toLinkDto),
+    winners: etfLinks.filter((l) => l.role === 'WINNER').map(mapLink),
+    losers: etfLinks.filter((l) => l.role === 'LOSER').map(mapLink),
+    mostExposed: etfLinks.filter((l) => l.role === 'MOST_EXPOSED').map(mapLink),
   };
 }
 


### PR DESCRIPTION
## Summary
- Back-fill `exchange` and `etfId` at scenario-detail read time by looking up any link rows with null values against the `Etf` table.
- Makes winners / losers / most-exposed pills clickable on existing scenarios without re-running the import script.
- Keeps stored link rows as the source of truth; the read-time lookup is a fallback when they're missing values.

## Test plan
- [ ] Deploy; load `/etf-scenarios/technology-sector-stagnation-crash` and confirm winners/losers/most-exposed pills are links to `/etfs/<exchange>/<symbol>`.
- [ ] Click a pill (e.g. XLK) and confirm it navigates to the ETF detail page.
- [ ] Symbols that don't match an ETF in the DB still render as plain pills (no link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)