### PR TITLE
Add priced-in status and expected-price-change fields to ETF scenarios

### DIFF
--- a/insights-ui/prisma/migrations/20260420180000_add_etf_scenario_priced_in_fields/migration.sql
+++ b/insights-ui/prisma/migrations/20260420180000_add_etf_scenario_priced_in_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "etf_scenarios" ADD COLUMN "priced_in_bucket" TEXT NOT NULL DEFAULT 'PARTIALLY_PRICED_IN';
+ALTER TABLE "etf_scenarios" ADD COLUMN "expected_price_change" INTEGER;
+ALTER TABLE "etf_scenarios" ADD COLUMN "expected_price_change_explanation" TEXT;
+ALTER TABLE "etf_scenarios" ADD COLUMN "price_change_timeframe_explanation" TEXT;
+
+-- CreateIndex
+CREATE INDEX "etf_scenarios_space_id_priced_in_bucket_idx" ON "etf_scenarios"("space_id", "priced_in_bucket");

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1720,25 +1720,29 @@ model EtfCachedScore {
 // values can be added without a migration.
 
 model EtfScenario {
-  id                    String   @id @default(uuid())
-  scenarioNumber        Int      @map("scenario_number")
-  title                 String   @map("title")
-  slug                  String   @map("slug")
-  underlyingCause       String   @map("underlying_cause") @db.Text
-  historicalAnalog      String   @map("historical_analog") @db.Text
-  winnersMarkdown       String   @map("winners_markdown") @db.Text
-  losersMarkdown        String   @map("losers_markdown") @db.Text
-  outlookMarkdown       String   @map("outlook_markdown") @db.Text
-  direction             String   @default("DOWNSIDE") @map("direction")
-  timeframe             String   @default("FUTURE") @map("timeframe")
-  probabilityBucket     String   @default("MEDIUM") @map("probability_bucket")
-  probabilityPercentage Int?     @map("probability_percentage")
-  outlookAsOfDate       DateTime @map("outlook_as_of_date") @db.Date
-  metaDescription       String?  @map("meta_description") @db.Text
-  archived              Boolean  @default(false) @map("archived")
-  spaceId               String   @default("koala_gains") @map("space_id")
-  createdAt             DateTime @default(now()) @map("created_at")
-  updatedAt             DateTime @updatedAt @map("updated_at")
+  id                             String   @id @default(uuid())
+  scenarioNumber                 Int      @map("scenario_number")
+  title                          String   @map("title")
+  slug                           String   @map("slug")
+  underlyingCause                String   @map("underlying_cause") @db.Text
+  historicalAnalog               String   @map("historical_analog") @db.Text
+  winnersMarkdown                String   @map("winners_markdown") @db.Text
+  losersMarkdown                 String   @map("losers_markdown") @db.Text
+  outlookMarkdown                String   @map("outlook_markdown") @db.Text
+  direction                      String   @default("DOWNSIDE") @map("direction")
+  timeframe                      String   @default("FUTURE") @map("timeframe")
+  probabilityBucket              String   @default("MEDIUM") @map("probability_bucket")
+  probabilityPercentage          Int?     @map("probability_percentage")
+  pricedInBucket                 String   @default("PARTIALLY_PRICED_IN") @map("priced_in_bucket")
+  expectedPriceChange            Int?     @map("expected_price_change")
+  expectedPriceChangeExplanation String?  @map("expected_price_change_explanation") @db.Text
+  priceChangeTimeframeExplanation String? @map("price_change_timeframe_explanation") @db.Text
+  outlookAsOfDate                DateTime @map("outlook_as_of_date") @db.Date
+  metaDescription                String?  @map("meta_description") @db.Text
+  archived                       Boolean  @default(false) @map("archived")
+  spaceId                        String   @default("koala_gains") @map("space_id")
+  createdAt                      DateTime @default(now()) @map("created_at")
+  updatedAt                      DateTime @updatedAt @map("updated_at")
 
   etfLinks              EtfScenarioEtfLink[]
 
@@ -1748,6 +1752,7 @@ model EtfScenario {
   @@index([spaceId, direction])
   @@index([spaceId, timeframe])
   @@index([spaceId, probabilityBucket])
+  @@index([spaceId, pricedInBucket])
   @@map("etf_scenarios")
 }
 

--- a/insights-ui/src/app/admin-v1/etf-scenarios/UpsertEtfScenarioModal.tsx
+++ b/insights-ui/src/app/admin-v1/etf-scenarios/UpsertEtfScenarioModal.tsx
@@ -7,7 +7,7 @@ import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
 import { usePutData } from '@dodao/web-core/ui/hooks/fetch/usePutData';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { EtfScenario } from '@prisma/client';
-import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { Loader2 } from 'lucide-react';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 
@@ -35,6 +35,14 @@ const PROBABILITY_OPTIONS: Array<{ value: EtfScenarioProbabilityBucket; label: s
   { value: 'LOW', label: 'Low (<20%)' },
 ];
 
+const PRICED_IN_OPTIONS: Array<{ value: EtfScenarioPricedInBucket; label: string }> = [
+  { value: 'NOT_PRICED_IN', label: 'Not priced in (market ignoring)' },
+  { value: 'PARTIALLY_PRICED_IN', label: 'Partially priced in' },
+  { value: 'MOSTLY_PRICED_IN', label: 'Mostly priced in' },
+  { value: 'FULLY_PRICED_IN', label: 'Fully priced in (no edge left)' },
+  { value: 'OVER_PRICED_IN', label: 'Over-priced in (market over-reacted)' },
+];
+
 export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, scenarioId }: UpsertEtfScenarioModalProps): JSX.Element {
   const [scenarioNumber, setScenarioNumber] = useState<number>(1);
   const [title, setTitle] = useState<string>('');
@@ -48,6 +56,10 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
   const [timeframe, setTimeframe] = useState<EtfScenarioTimeframe>('FUTURE');
   const [probabilityBucket, setProbabilityBucket] = useState<EtfScenarioProbabilityBucket>('MEDIUM');
   const [probabilityPercentage, setProbabilityPercentage] = useState<string>('');
+  const [pricedInBucket, setPricedInBucket] = useState<EtfScenarioPricedInBucket>('PARTIALLY_PRICED_IN');
+  const [expectedPriceChange, setExpectedPriceChange] = useState<string>('');
+  const [expectedPriceChangeExplanation, setExpectedPriceChangeExplanation] = useState<string>('');
+  const [priceChangeTimeframeExplanation, setPriceChangeTimeframeExplanation] = useState<string>('');
   const [outlookAsOfDate, setOutlookAsOfDate] = useState<string>(new Date().toISOString().slice(0, 10));
   const [metaDescription, setMetaDescription] = useState<string>('');
   const [archived, setArchived] = useState<boolean>(false);
@@ -83,6 +95,10 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
       setTimeframe('FUTURE');
       setProbabilityBucket('MEDIUM');
       setProbabilityPercentage('');
+      setPricedInBucket('PARTIALLY_PRICED_IN');
+      setExpectedPriceChange('');
+      setExpectedPriceChangeExplanation('');
+      setPriceChangeTimeframeExplanation('');
       setOutlookAsOfDate(new Date().toISOString().slice(0, 10));
       setMetaDescription('');
       setArchived(false);
@@ -110,6 +126,10 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
         setTimeframe(data.timeframe as EtfScenarioTimeframe);
         setProbabilityBucket(data.probabilityBucket as EtfScenarioProbabilityBucket);
         setProbabilityPercentage(typeof data.probabilityPercentage === 'number' ? String(data.probabilityPercentage) : '');
+        setPricedInBucket((data.pricedInBucket as EtfScenarioPricedInBucket) ?? 'PARTIALLY_PRICED_IN');
+        setExpectedPriceChange(typeof data.expectedPriceChange === 'number' ? String(data.expectedPriceChange) : '');
+        setExpectedPriceChangeExplanation(data.expectedPriceChangeExplanation ?? '');
+        setPriceChangeTimeframeExplanation(data.priceChangeTimeframeExplanation ?? '');
         setOutlookAsOfDate(new Date(data.outlookAsOfDate).toISOString().slice(0, 10));
         setMetaDescription(data.metaDescription ?? '');
         setArchived(data.archived);
@@ -139,6 +159,16 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
       probabilityPercentageValue = n;
     }
 
+    let expectedPriceChangeValue: number | null = null;
+    if (expectedPriceChange.trim() !== '') {
+      const n = parseInt(expectedPriceChange, 10);
+      if (isNaN(n) || n < -100 || n > 100) {
+        setFormError('Expected price change must be an integer between -100 and 100.');
+        return;
+      }
+      expectedPriceChangeValue = n;
+    }
+
     const payload = {
       scenarioNumber,
       title,
@@ -152,6 +182,10 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
       timeframe,
       probabilityBucket,
       probabilityPercentage: probabilityPercentageValue,
+      pricedInBucket,
+      expectedPriceChange: expectedPriceChangeValue,
+      expectedPriceChangeExplanation: expectedPriceChangeExplanation || null,
+      priceChangeTimeframeExplanation: priceChangeTimeframeExplanation || null,
       outlookAsOfDate: new Date(outlookAsOfDate).toISOString(),
       metaDescription: metaDescription || null,
       archived,
@@ -271,6 +305,51 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
             />
           </label>
         </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Priced in</span>
+            <select
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={pricedInBucket}
+              onChange={(e) => setPricedInBucket(e.target.value as EtfScenarioPricedInBucket)}
+            >
+              {PRICED_IN_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Expected price change % (average still to move, -100 to 100)</span>
+            <input
+              type="number"
+              min={-100}
+              max={100}
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={expectedPriceChange}
+              onChange={(e) => setExpectedPriceChange(e.target.value)}
+              placeholder="e.g. -15"
+            />
+          </label>
+        </div>
+
+        <TextareaAutosize
+          label="Expected price change explanation (markdown; describe the range and the reasoning)"
+          modelValue={expectedPriceChangeExplanation}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setExpectedPriceChangeExplanation(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Price change timeframe explanation (markdown; describe start and end of the move in words)"
+          modelValue={priceChangeTimeframeExplanation}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setPriceChangeTimeframeExplanation(v);
+          }}
+        />
 
         <TextareaAutosize
           label="Underlying cause (markdown)"

--- a/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { EtfScenario, EtfScenarioEtfLink } from '@prisma/client';
-import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { NextRequest } from 'next/server';
 
 export interface EtfScenarioLinkDto {
@@ -12,10 +12,12 @@ export interface EtfScenarioLinkDto {
   sortOrder: number;
 }
 
-export interface EtfScenarioDetail extends Omit<EtfScenario, 'outlookAsOfDate' | 'createdAt' | 'updatedAt' | 'direction' | 'timeframe' | 'probabilityBucket'> {
+export interface EtfScenarioDetail
+  extends Omit<EtfScenario, 'outlookAsOfDate' | 'createdAt' | 'updatedAt' | 'direction' | 'timeframe' | 'probabilityBucket' | 'pricedInBucket'> {
   direction: EtfScenarioDirection;
   timeframe: EtfScenarioTimeframe;
   probabilityBucket: EtfScenarioProbabilityBucket;
+  pricedInBucket: EtfScenarioPricedInBucket;
   outlookAsOfDate: string;
   createdAt: string;
   updatedAt: string;
@@ -71,6 +73,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     direction: rest.direction as EtfScenarioDirection,
     timeframe: rest.timeframe as EtfScenarioTimeframe,
     probabilityBucket: rest.probabilityBucket as EtfScenarioProbabilityBucket,
+    pricedInBucket: rest.pricedInBucket as EtfScenarioPricedInBucket,
     outlookAsOfDate: outlookAsOfDate.toISOString(),
     createdAt: createdAt.toISOString(),
     updatedAt: updatedAt.toISOString(),

--- a/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
@@ -24,11 +24,11 @@ export interface EtfScenarioDetail extends Omit<EtfScenario, 'outlookAsOfDate' |
   mostExposed: EtfScenarioLinkDto[];
 }
 
-function toLinkDto(link: EtfScenarioEtfLink): EtfScenarioLinkDto {
+function toLinkDto(link: EtfScenarioEtfLink, resolved?: { id: string; exchange: string }): EtfScenarioLinkDto {
   return {
     symbol: link.symbol,
-    exchange: link.exchange,
-    etfId: link.etfId,
+    exchange: link.exchange ?? resolved?.exchange ?? null,
+    etfId: link.etfId ?? resolved?.id ?? null,
     role: link.role as EtfScenarioRole,
     sortOrder: link.sortOrder,
   };
@@ -51,6 +51,21 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const { etfLinks, outlookAsOfDate, createdAt, updatedAt, ...rest } = scenario;
 
+  const unresolvedSymbols = Array.from(new Set(etfLinks.filter((l) => !l.etfId || !l.exchange).map((l) => l.symbol.toUpperCase())));
+  const resolvedBySymbol = new Map<string, { id: string; exchange: string }>();
+  if (unresolvedSymbols.length) {
+    const matches = await prisma.etf.findMany({
+      where: { spaceId, symbol: { in: unresolvedSymbols } },
+      select: { id: true, symbol: true, exchange: true },
+    });
+    for (const etf of matches) {
+      const key = etf.symbol.toUpperCase();
+      if (!resolvedBySymbol.has(key)) resolvedBySymbol.set(key, { id: etf.id, exchange: etf.exchange });
+    }
+  }
+
+  const mapLink = (l: EtfScenarioEtfLink) => toLinkDto(l, resolvedBySymbol.get(l.symbol.toUpperCase()));
+
   return {
     ...rest,
     direction: rest.direction as EtfScenarioDirection,
@@ -59,9 +74,9 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     outlookAsOfDate: outlookAsOfDate.toISOString(),
     createdAt: createdAt.toISOString(),
     updatedAt: updatedAt.toISOString(),
-    winners: etfLinks.filter((l) => l.role === 'WINNER').map(toLinkDto),
-    losers: etfLinks.filter((l) => l.role === 'LOSER').map(toLinkDto),
-    mostExposed: etfLinks.filter((l) => l.role === 'MOST_EXPOSED').map(toLinkDto),
+    winners: etfLinks.filter((l) => l.role === 'WINNER').map(mapLink),
+    losers: etfLinks.filter((l) => l.role === 'LOSER').map(mapLink),
+    mostExposed: etfLinks.filter((l) => l.role === 'MOST_EXPOSED').map(mapLink),
   };
 }
 

--- a/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
@@ -4,7 +4,7 @@ import { slugifyScenarioTitle } from '@/utils/etf-scenario-slug';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { EtfScenario } from '@prisma/client';
-import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { NextRequest } from 'next/server';
 import { withAdminOrToken } from '../../helpers/withAdminOrToken';
 import { z } from 'zod';
@@ -22,6 +22,10 @@ const updateEtfScenarioSchema = z.object({
   timeframe: z.nativeEnum(EtfScenarioTimeframe).optional(),
   probabilityBucket: z.nativeEnum(EtfScenarioProbabilityBucket).optional(),
   probabilityPercentage: z.number().int().min(0).max(100).nullable().optional(),
+  pricedInBucket: z.nativeEnum(EtfScenarioPricedInBucket).optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
+  priceChangeTimeframeExplanation: z.string().nullable().optional(),
   outlookAsOfDate: z
     .string()
     .refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date')
@@ -65,6 +69,10 @@ async function putHandler(
       ...(body.timeframe !== undefined && { timeframe: body.timeframe }),
       ...(body.probabilityBucket !== undefined && { probabilityBucket: body.probabilityBucket }),
       ...(body.probabilityPercentage !== undefined && { probabilityPercentage: body.probabilityPercentage }),
+      ...(body.pricedInBucket !== undefined && { pricedInBucket: body.pricedInBucket }),
+      ...(body.expectedPriceChange !== undefined && { expectedPriceChange: body.expectedPriceChange }),
+      ...(body.expectedPriceChangeExplanation !== undefined && { expectedPriceChangeExplanation: body.expectedPriceChangeExplanation }),
+      ...(body.priceChangeTimeframeExplanation !== undefined && { priceChangeTimeframeExplanation: body.priceChangeTimeframeExplanation }),
       ...(body.outlookAsOfDate !== undefined && { outlookAsOfDate: new Date(body.outlookAsOfDate) }),
       ...(body.metaDescription !== undefined && { metaDescription: body.metaDescription }),
       ...(body.archived !== undefined && { archived: body.archived }),

--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -5,7 +5,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { EtfScenario } from '@prisma/client';
-import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
 import { NextRequest } from 'next/server';
 import { withAdminOrToken } from '../helpers/withAdminOrToken';
 import { z } from 'zod';
@@ -23,6 +23,10 @@ const createEtfScenarioSchema = z.object({
   timeframe: z.nativeEnum(EtfScenarioTimeframe),
   probabilityBucket: z.nativeEnum(EtfScenarioProbabilityBucket),
   probabilityPercentage: z.number().int().min(0).max(100).nullable().optional(),
+  pricedInBucket: z.nativeEnum(EtfScenarioPricedInBucket).optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
+  priceChangeTimeframeExplanation: z.string().nullable().optional(),
   outlookAsOfDate: z.string().refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date'),
   metaDescription: z.string().nullable().optional(),
   archived: z.boolean().optional(),
@@ -64,6 +68,10 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
     timeframe: body.timeframe,
     probabilityBucket: body.probabilityBucket,
     probabilityPercentage: body.probabilityPercentage ?? null,
+    pricedInBucket: body.pricedInBucket ?? EtfScenarioPricedInBucket.PARTIALLY_PRICED_IN,
+    expectedPriceChange: body.expectedPriceChange ?? null,
+    expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
+    priceChangeTimeframeExplanation: body.priceChangeTimeframeExplanation ?? null,
     outlookAsOfDate: new Date(body.outlookAsOfDate),
     metaDescription: body.metaDescription ?? null,
     archived: body.archived ?? false,

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { EtfScenarioDetail, EtfScenarioLinkDto } from '@/app/api/[spaceId]/etf-scenarios/[slug]/route';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { EtfScenarioDirectionBadge, EtfScenarioProbabilityBadge, EtfScenarioTimeframeBadge } from './EtfScenarioOutlookBadge';
-import { directionLabel, probabilityBucketLabel, timeframeLabel } from '@/utils/etf-scenario-metadata-generators';
+import { directionLabel, pricedInBucketLabel, probabilityBucketLabel, timeframeLabel } from '@/utils/etf-scenario-metadata-generators';
 
 function renderMarkdown(md: string) {
   return { __html: parseMarkdown(md) as string };
@@ -44,8 +44,16 @@ function LinkList({ title, links, emptyLabel }: { title: string; links: EtfScena
   );
 }
 
+function formatExpectedPriceChange(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}%`;
+}
+
 export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScenarioDetail }): JSX.Element {
   const asOf = scenario.outlookAsOfDate.slice(0, 10);
+  const hasPricingContext =
+    scenario.pricedInBucket || scenario.expectedPriceChange !== null || scenario.expectedPriceChangeExplanation || scenario.priceChangeTimeframeExplanation;
 
   return (
     <article className="text-[#E5E7EB]">
@@ -73,6 +81,34 @@ export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScena
         <h2 className="text-lg font-semibold text-white mb-2">Historical analog</h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.historicalAnalog)} />
       </section>
+
+      {hasPricingContext && (
+        <section className="mb-6 bg-[#1F2937] border border-[#374151] rounded-lg p-4">
+          <h2 className="text-lg font-semibold text-white mb-3">Priced-in status & expected move</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">How much is already priced in</p>
+              <p className="text-sm text-white font-semibold">{pricedInBucketLabel(scenario.pricedInBucket)}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Expected average price change (still to move)</p>
+              <p className="text-sm text-white font-semibold">{formatExpectedPriceChange(scenario.expectedPriceChange)}</p>
+            </div>
+          </div>
+          {scenario.expectedPriceChangeExplanation && (
+            <div className="mb-3">
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Range & reasoning</p>
+              <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.expectedPriceChangeExplanation)} />
+            </div>
+          )}
+          {scenario.priceChangeTimeframeExplanation && (
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">When the move plays out</p>
+              <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.priceChangeTimeframeExplanation)} />
+            </div>
+          )}
+        </section>
+      )}
 
       <section className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>

--- a/insights-ui/src/types/etfScenarioEnums.ts
+++ b/insights-ui/src/types/etfScenarioEnums.ts
@@ -23,6 +23,19 @@ export const EtfScenarioProbabilityBucket = {
 } as const;
 export type EtfScenarioProbabilityBucket = (typeof EtfScenarioProbabilityBucket)[keyof typeof EtfScenarioProbabilityBucket];
 
+// How much of the scenario is already reflected in current ETF prices.
+// Pairs with probabilityPercentage to signal remaining edge: a 50%-probability
+// scenario that is FULLY_PRICED_IN has no actionable edge; a 20%-probability
+// scenario that is NOT_PRICED_IN can still be a strong trade.
+export const EtfScenarioPricedInBucket = {
+  NOT_PRICED_IN: 'NOT_PRICED_IN',
+  PARTIALLY_PRICED_IN: 'PARTIALLY_PRICED_IN',
+  MOSTLY_PRICED_IN: 'MOSTLY_PRICED_IN',
+  FULLY_PRICED_IN: 'FULLY_PRICED_IN',
+  OVER_PRICED_IN: 'OVER_PRICED_IN',
+} as const;
+export type EtfScenarioPricedInBucket = (typeof EtfScenarioPricedInBucket)[keyof typeof EtfScenarioPricedInBucket];
+
 export const EtfScenarioRole = {
   WINNER: 'WINNER',
   LOSER: 'LOSER',

--- a/insights-ui/src/utils/etf-scenario-metadata-generators.ts
+++ b/insights-ui/src/utils/etf-scenario-metadata-generators.ts
@@ -230,3 +230,20 @@ export function timeframeLabel(timeframe: string): string {
       return timeframe;
   }
 }
+
+export function pricedInBucketLabel(bucket: string): string {
+  switch (bucket) {
+    case 'NOT_PRICED_IN':
+      return 'Not priced in';
+    case 'PARTIALLY_PRICED_IN':
+      return 'Partially priced in';
+    case 'MOSTLY_PRICED_IN':
+      return 'Mostly priced in';
+    case 'FULLY_PRICED_IN':
+      return 'Fully priced in';
+    case 'OVER_PRICED_IN':
+      return 'Over-priced in';
+    default:
+      return bucket;
+  }
+}


### PR DESCRIPTION
## Summary

Adds four new fields to `EtfScenario` so scenarios can express **how much is already baked into current ETF prices** and **how much move is still expected** — the single most important dimension that was previously missing (a 50%-probability scenario already fully priced in has no actionable edge; a 20%-probability scenario not priced in at all can still be a strong trade).

**New fields:**
- `pricedInBucket` — enum: `NOT_PRICED_IN` / `PARTIALLY_PRICED_IN` / `MOSTLY_PRICED_IN` / `FULLY_PRICED_IN` / `OVER_PRICED_IN` (default `PARTIALLY_PRICED_IN`, indexed on `(space_id, priced_in_bucket)`).
- `expectedPriceChange` — signed int (−100..100), the average % still to move.
- `expectedPriceChangeExplanation` — markdown text describing the expected range and the reasoning.
- `priceChangeTimeframeExplanation` — markdown text describing the start and end of the move (narrative form; dedicated start/end date columns deferred for now).

**Wired through:**
- Prisma schema + new migration `20260420180000_add_etf_scenario_priced_in_fields`
- `EtfScenarioPricedInBucket` TS enum in `src/types/etfScenarioEnums.ts`
- POST `/api/etf-scenarios` + PUT `/api/etf-scenarios/[id]` Zod schemas and data mapping
- Public GET DTO `EtfScenarioDetail` at `/api/[spaceId]/etf-scenarios/[slug]`
- Admin `UpsertEtfScenarioModal` — new "Priced in" select, "Expected price change %" number input, and two markdown textareas
- Public detail view — new "Priced-in status & expected move" section between Historical analog and Winners/Losers

Import route + markdown parser + listing route not updated: imported scenarios pick up the DB default (`PARTIALLY_PRICED_IN`) and the listing item doesn't need these fields yet.

## Test plan

- [ ] Apply migration against a dev DB; verify existing scenarios default to `PARTIALLY_PRICED_IN` and NULL for the three optional columns.
- [ ] Open admin upsert modal on an existing scenario — confirm the four new controls load values and save correctly.
- [ ] Create/update a scenario via POST/PUT with the new fields in the payload; GET the scenario and confirm the fields round-trip.
- [ ] Visit the public detail page on a scenario with values populated — verify the new "Priced-in status & expected move" section renders with bucket label, signed percentage, and both markdown blocks.
- [ ] Visit the public detail page on a scenario with only default values — verify section still renders the bucket label and `—` for the change, with no broken layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)