### PR TITLE
Add per-ETF rationale and expected-price-change to scenario links

### DIFF
--- a/insights-ui/prisma/migrations/20260421120000_add_etf_scenario_link_rationale_and_price_change/migration.sql
+++ b/insights-ui/prisma/migrations/20260421120000_add_etf_scenario_link_rationale_and_price_change/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "etf_scenario_etf_links" ADD COLUMN "role_explanation" TEXT;
+ALTER TABLE "etf_scenario_etf_links" ADD COLUMN "expected_price_change" INTEGER;
+ALTER TABLE "etf_scenario_etf_links" ADD COLUMN "expected_price_change_explanation" TEXT;

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1757,16 +1757,19 @@ model EtfScenario {
 }
 
 model EtfScenarioEtfLink {
-  id          String   @id @default(uuid())
-  scenarioId  String   @map("scenario_id")
-  etfId       String?  @map("etf_id")
-  symbol      String   @map("symbol")
-  exchange    String?  @map("exchange")
-  role        String   @map("role")
-  sortOrder   Int      @default(0) @map("sort_order")
-  spaceId     String   @default("koala_gains") @map("space_id")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  id                             String   @id @default(uuid())
+  scenarioId                     String   @map("scenario_id")
+  etfId                          String?  @map("etf_id")
+  symbol                         String   @map("symbol")
+  exchange                       String?  @map("exchange")
+  role                           String   @map("role")
+  sortOrder                      Int      @default(0) @map("sort_order")
+  roleExplanation                String?  @map("role_explanation") @db.Text
+  expectedPriceChange            Int?     @map("expected_price_change")
+  expectedPriceChangeExplanation String?  @map("expected_price_change_explanation") @db.Text
+  spaceId                        String   @default("koala_gains") @map("space_id")
+  createdAt                      DateTime @default(now()) @map("created_at")
+  updatedAt                      DateTime @updatedAt @map("updated_at")
 
   scenario    EtfScenario @relation(fields: [scenarioId], references: [id], onDelete: Cascade)
 

--- a/insights-ui/src/app/admin-v1/etf-scenarios/ManageLinksModal.tsx
+++ b/insights-ui/src/app/admin-v1/etf-scenarios/ManageLinksModal.tsx
@@ -3,6 +3,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import Button from '@dodao/web-core/components/core/buttons/Button';
 import Input from '@dodao/web-core/components/core/input/Input';
 import SingleSectionModal from '@dodao/web-core/components/core/modals/SingleSectionModal';
+import TextareaAutosize from '@dodao/web-core/components/core/textarea/TextareaAutosize';
 import { useDeleteData } from '@dodao/web-core/ui/hooks/fetch/useDeleteData';
 import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
@@ -23,6 +24,9 @@ interface AddLinkFormState {
   symbol: string;
   exchange: string;
   role: EtfScenarioRole;
+  roleExplanation: string;
+  expectedPriceChange: string;
+  expectedPriceChangeExplanation: string;
 }
 
 const ROLES: EtfScenarioRole[] = ['WINNER', 'LOSER', 'MOST_EXPOSED'];
@@ -34,7 +38,14 @@ function fetchDetailBySlug(slug: string): Promise<EtfScenarioDetail | null> {
 export default function ManageLinksModal({ isOpen, onClose, onSuccess, scenarioId, scenarioTitle }: ManageLinksModalProps): JSX.Element {
   const [detail, setDetail] = useState<EtfScenarioDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState<boolean>(false);
-  const [form, setForm] = useState<AddLinkFormState>({ symbol: '', exchange: '', role: 'WINNER' });
+  const [form, setForm] = useState<AddLinkFormState>({
+    symbol: '',
+    exchange: '',
+    role: 'WINNER',
+    roleExplanation: '',
+    expectedPriceChange: '',
+    expectedPriceChangeExplanation: '',
+  });
   const [formError, setFormError] = useState<string>('');
 
   const { postData, loading: adding } = usePostData<EtfScenarioEtfLink, unknown>({
@@ -77,13 +88,33 @@ export default function ManageLinksModal({ isOpen, onClose, onSuccess, scenarioI
       return;
     }
 
+    let expectedPriceChangeValue: number | null = null;
+    if (form.expectedPriceChange.trim() !== '') {
+      const n = parseInt(form.expectedPriceChange, 10);
+      if (isNaN(n) || n < -100 || n > 100) {
+        setFormError('Expected price change must be an integer between -100 and 100.');
+        return;
+      }
+      expectedPriceChangeValue = n;
+    }
+
     try {
       await postData(`/api/etf-scenarios/${scenarioId}/links`, {
         symbol,
         exchange: form.exchange.trim() || null,
         role: form.role,
+        roleExplanation: form.roleExplanation.trim() || null,
+        expectedPriceChange: expectedPriceChangeValue,
+        expectedPriceChangeExplanation: form.expectedPriceChangeExplanation.trim() || null,
       });
-      setForm({ symbol: '', exchange: '', role: form.role });
+      setForm({
+        symbol: '',
+        exchange: '',
+        role: form.role,
+        roleExplanation: '',
+        expectedPriceChange: '',
+        expectedPriceChangeExplanation: '',
+      });
       await refreshDetail();
     } catch {
       setFormError('Failed to add link');
@@ -148,6 +179,34 @@ export default function ManageLinksModal({ isOpen, onClose, onSuccess, scenarioI
                   Add
                 </Button>
               </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <TextareaAutosize
+                  label="Role explanation (why this ETF is a winner / loser / most-exposed — markdown)"
+                  modelValue={form.roleExplanation}
+                  onUpdate={(v: unknown): void => {
+                    if (typeof v === 'string') setForm((f) => ({ ...f, roleExplanation: v }));
+                  }}
+                />
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-gray-300">Expected price change % (-100 to 100)</span>
+                  <input
+                    type="number"
+                    min={-100}
+                    max={100}
+                    className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+                    value={form.expectedPriceChange}
+                    onChange={(e) => setForm((f) => ({ ...f, expectedPriceChange: e.target.value }))}
+                    placeholder="e.g. -25"
+                  />
+                </label>
+              </div>
+              <TextareaAutosize
+                label="Expected price change explanation (size of the move and over what timeframe — markdown)"
+                modelValue={form.expectedPriceChangeExplanation}
+                onUpdate={(v: unknown): void => {
+                  if (typeof v === 'string') setForm((f) => ({ ...f, expectedPriceChangeExplanation: v }));
+                }}
+              />
               {formError && <p className="text-red-500 text-sm">{formError}</p>}
             </div>
 
@@ -161,22 +220,31 @@ export default function ManageLinksModal({ isOpen, onClose, onSuccess, scenarioI
                 ) : (
                   <ul className="space-y-1">
                     {group.items.map((link) => (
-                      <li
-                        key={`${link.symbol}-${link.role}`}
-                        className="flex items-center justify-between bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm"
-                      >
-                        <span>
-                          <span className="font-semibold text-white">{link.symbol}</span>
-                          {link.exchange && <span className="text-gray-400"> · {link.exchange}</span>}
-                          {link.etfId ? (
-                            <span className="ml-2 text-xs text-emerald-400">resolved</span>
-                          ) : (
-                            <span className="ml-2 text-xs text-gray-500">unresolved</span>
-                          )}
-                        </span>
-                        <Button variant="outlined" onClick={() => handleRemove(link)} disabled={removing}>
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
+                      <li key={`${link.symbol}-${link.role}`} className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm">
+                        <div className="flex items-center justify-between">
+                          <span>
+                            <span className="font-semibold text-white">{link.symbol}</span>
+                            {link.exchange && <span className="text-gray-400"> · {link.exchange}</span>}
+                            {link.etfId ? (
+                              <span className="ml-2 text-xs text-emerald-400">resolved</span>
+                            ) : (
+                              <span className="ml-2 text-xs text-gray-500">unresolved</span>
+                            )}
+                            {link.expectedPriceChange !== null && (
+                              <span className={`ml-2 text-xs ${link.expectedPriceChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                                {link.expectedPriceChange > 0 ? '+' : ''}
+                                {link.expectedPriceChange}%
+                              </span>
+                            )}
+                          </span>
+                          <Button variant="outlined" onClick={() => handleRemove(link)} disabled={removing}>
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                        {link.roleExplanation && <p className="mt-1 text-xs text-gray-300 whitespace-pre-wrap">{link.roleExplanation}</p>}
+                        {link.expectedPriceChangeExplanation && (
+                          <p className="mt-1 text-xs text-gray-400 whitespace-pre-wrap">{link.expectedPriceChangeExplanation}</p>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts
@@ -10,6 +10,9 @@ export interface EtfScenarioLinkDto {
   etfId: string | null;
   role: EtfScenarioRole;
   sortOrder: number;
+  roleExplanation: string | null;
+  expectedPriceChange: number | null;
+  expectedPriceChangeExplanation: string | null;
 }
 
 export interface EtfScenarioDetail
@@ -33,6 +36,9 @@ function toLinkDto(link: EtfScenarioEtfLink, resolved?: { id: string; exchange: 
     etfId: link.etfId ?? resolved?.id ?? null,
     role: link.role as EtfScenarioRole,
     sortOrder: link.sortOrder,
+    roleExplanation: link.roleExplanation,
+    expectedPriceChange: link.expectedPriceChange,
+    expectedPriceChangeExplanation: link.expectedPriceChangeExplanation,
   };
 }
 

--- a/insights-ui/src/app/api/etf-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/[id]/links/route.ts
@@ -14,6 +14,9 @@ const addLinkSchema = z.object({
   etfId: z.string().nullable().optional(),
   role: z.nativeEnum(EtfScenarioRole),
   sortOrder: z.number().int().nonnegative().optional(),
+  roleExplanation: z.string().nullable().optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
 });
 
 export type AddEtfScenarioLinkRequest = z.infer<typeof addLinkSchema>;
@@ -44,12 +47,18 @@ async function postHandler(
       etfId: body.etfId ?? null,
       role: body.role,
       sortOrder: body.sortOrder ?? 0,
+      roleExplanation: body.roleExplanation ?? null,
+      expectedPriceChange: body.expectedPriceChange ?? null,
+      expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
       spaceId: KoalaGainsSpaceId,
     },
     update: {
       exchange: body.exchange ?? null,
       etfId: body.etfId ?? null,
       sortOrder: body.sortOrder ?? 0,
+      roleExplanation: body.roleExplanation ?? null,
+      expectedPriceChange: body.expectedPriceChange ?? null,
+      expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
     },
   });
 

--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -37,6 +37,9 @@ const createEtfScenarioSchema = z.object({
         exchange: z.string().nullable().optional(),
         role: z.nativeEnum(EtfScenarioRole),
         sortOrder: z.number().int().nonnegative().optional(),
+        roleExplanation: z.string().nullable().optional(),
+        expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+        expectedPriceChangeExplanation: z.string().nullable().optional(),
       })
     )
     .optional(),
@@ -115,6 +118,9 @@ async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtToke
             etfId: knownEtf?.id ?? null,
             role: link.role,
             sortOrder: link.sortOrder ?? idx,
+            roleExplanation: link.roleExplanation ?? null,
+            expectedPriceChange: link.expectedPriceChange ?? null,
+            expectedPriceChangeExplanation: link.expectedPriceChangeExplanation ?? null,
             spaceId: KoalaGainsSpaceId,
           };
         }),

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
@@ -27,12 +27,57 @@ function LinkPill({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
   return inner;
 }
 
+function formatExpectedPriceChange(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}%`;
+}
+
+function LinkCard({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
+  const hasDetails = link.roleExplanation || link.expectedPriceChange !== null || link.expectedPriceChangeExplanation;
+  const changeColor = link.expectedPriceChange === null ? '' : link.expectedPriceChange >= 0 ? 'text-emerald-300' : 'text-red-300';
+
+  return (
+    <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <LinkPill link={link} />
+        {link.expectedPriceChange !== null && (
+          <span className={`text-xs font-semibold ${changeColor}`}>{formatExpectedPriceChange(link.expectedPriceChange)}</span>
+        )}
+      </div>
+      {hasDetails && (
+        <div className="space-y-1 mt-1">
+          {link.roleExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-300"
+              dangerouslySetInnerHTML={renderMarkdown(link.roleExplanation)}
+            />
+          )}
+          {link.expectedPriceChangeExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-400"
+              dangerouslySetInnerHTML={renderMarkdown(link.expectedPriceChangeExplanation)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function LinkList({ title, links, emptyLabel }: { title: string; links: EtfScenarioLinkDto[]; emptyLabel?: string }): JSX.Element {
+  const anyDetailed = links.some((l) => l.roleExplanation || l.expectedPriceChange !== null || l.expectedPriceChangeExplanation);
   return (
     <div>
       <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300 mb-2">{title}</h3>
       {links.length === 0 ? (
         <p className="text-xs text-gray-500">{emptyLabel ?? '—'}</p>
+      ) : anyDetailed ? (
+        <div className="flex flex-col gap-2">
+          {links.map((l) => (
+            <LinkCard key={`${l.symbol}-${l.role}`} link={l} />
+          ))}
+        </div>
       ) : (
         <div className="flex flex-wrap gap-1.5">
           {links.map((l) => (
@@ -42,12 +87,6 @@ function LinkList({ title, links, emptyLabel }: { title: string; links: EtfScena
       )}
     </div>
   );
-}
-
-function formatExpectedPriceChange(value: number | null | undefined): string {
-  if (value === null || value === undefined) return '—';
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value}%`;
 }
 
 export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScenarioDetail }): JSX.Element {


### PR DESCRIPTION
## Summary

Each winner / loser / most-exposed pill can now explain itself rather than relying on the scenario-level markdown blobs. Adds three optional columns to `EtfScenarioEtfLink`:

- `roleExplanation` — markdown, why this specific ETF is a winner / loser / most-exposed
- `expectedPriceChange` — signed int (−100..100), expected per-ETF % move
- `expectedPriceChangeExplanation` — markdown, size of the move and over what timeframe

**Wired through:**
- Prisma schema + new migration `20260421120000_add_etf_scenario_link_rationale_and_price_change`
- POST `/api/etf-scenarios` bulk links zod schema and link-row insertion
- POST `/api/etf-scenarios/[id]/links` (both create and update branches of the upsert)
- Detail GET `EtfScenarioLinkDto` now exposes all three fields
- Admin `ManageLinksModal`: the "Add link" form grew three inputs (markdown + signed int + markdown); existing link rows render the role explanation, the change %, and the price-change explanation inline
- Public `EtfScenarioDetailView`: `LinkList` switches to a richer `LinkCard` layout when any link in the group has detail populated (falls back to the compact pill grid for legacy links, so existing scenarios look the same until detail is added)

Legacy links render unchanged (all three fields are nullable; UI checks `!== null` / truthy before rendering).

## Test plan

- [ ] Apply migration; verify existing rows have NULL for all three columns and nothing breaks.
- [ ] Open admin Manage Links modal on an existing scenario — confirm the three new inputs show on the add form and that existing rows display the empty state cleanly.
- [ ] Add a link via the modal with all three new fields populated; reopen and confirm the card shows the rationale + colored ± % + price-change explanation.
- [ ] POST a full scenario via `/api/etf-scenarios` with link-level `roleExplanation` / `expectedPriceChange` / `expectedPriceChangeExplanation`; GET the scenario and confirm all fields round-trip.
- [ ] Visit a public detail page on a scenario with detailed links — verify the "Winners (tagged) / Losers (tagged) / Most exposed" section renders as cards with rationale + signed % + explanation.
- [ ] Visit a public detail page on a scenario with only legacy links (no detail) — verify it still renders the compact pill layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)