### PR TITLE
most famous etf comparison - new section

### DIFF
--- a/insights-ui/src/etf-analysis-data/most-famous-etfs-by-group.json
+++ b/insights-ui/src/etf-analysis-data/most-famous-etfs-by-group.json
@@ -1,0 +1,93 @@
+{
+  "description": "Curated list of the most famous 4–5 ETFs under each analysis group defined in etf-analysis-categories.json. Within each group, the selected ETFs intentionally span different Morningstar categories so that peer comparisons cover the breadth of the group rather than a single sub-category. Categories reference the `category` field shown on the KoalaGains ETF financial-data page (e.g. https://koalagains.com/etfs/NYSEARCA/XLY/financial-data).",
+  "groups": [
+    {
+      "key": "broad-equity",
+      "name": "Broad Equity",
+      "etfs": [
+        { "symbol": "SPY", "name": "SPDR S&P 500 ETF Trust", "exchange": "NYSEARCA", "category": "Large Blend" },
+        { "symbol": "IWF", "name": "iShares Russell 1000 Growth ETF", "exchange": "NYSEARCA", "category": "Large Growth" },
+        { "symbol": "IWD", "name": "iShares Russell 1000 Value ETF", "exchange": "NYSEARCA", "category": "Large Value" },
+        { "symbol": "IWM", "name": "iShares Russell 2000 ETF", "exchange": "NYSEARCA", "category": "Small Blend" },
+        { "symbol": "EFA", "name": "iShares MSCI EAFE ETF", "exchange": "NYSEARCA", "category": "Foreign Large Blend" }
+      ]
+    },
+    {
+      "key": "sector-thematic-equity",
+      "name": "Sector & Thematic Equity",
+      "etfs": [
+        { "symbol": "XLK", "name": "Technology Select Sector SPDR Fund", "exchange": "NYSEARCA", "category": "Technology" },
+        { "symbol": "XLV", "name": "Health Care Select Sector SPDR Fund", "exchange": "NYSEARCA", "category": "Health" },
+        { "symbol": "XLF", "name": "Financial Select Sector SPDR Fund", "exchange": "NYSEARCA", "category": "Financial" },
+        { "symbol": "XLE", "name": "Energy Select Sector SPDR Fund", "exchange": "NYSEARCA", "category": "Equity Energy" },
+        { "symbol": "VNQ", "name": "Vanguard Real Estate ETF", "exchange": "NYSEARCA", "category": "Real Estate" }
+      ]
+    },
+    {
+      "key": "leveraged-inverse",
+      "name": "Leveraged & Inverse Trading",
+      "etfs": [
+        { "symbol": "TQQQ", "name": "ProShares UltraPro QQQ", "exchange": "NASDAQ", "category": "Trading--Leveraged Equity" },
+        { "symbol": "SQQQ", "name": "ProShares UltraPro Short QQQ", "exchange": "NASDAQ", "category": "Trading--Inverse Equity" },
+        { "symbol": "TMF", "name": "Direxion Daily 20+ Year Treasury Bull 3X Shares", "exchange": "NYSEARCA", "category": "Trading--Leveraged Debt" },
+        { "symbol": "TBT", "name": "ProShares UltraShort 20+ Year Treasury", "exchange": "NYSEARCA", "category": "Trading--Inverse Debt" },
+        { "symbol": "BOIL", "name": "ProShares Ultra Bloomberg Natural Gas", "exchange": "NYSEARCA", "category": "Trading--Leveraged Commodities" }
+      ]
+    },
+    {
+      "key": "fixed-income-core",
+      "name": "Fixed Income — Core & Government",
+      "etfs": [
+        { "symbol": "AGG", "name": "iShares Core U.S. Aggregate Bond ETF", "exchange": "NYSEARCA", "category": "Intermediate Core Bond" },
+        { "symbol": "TLT", "name": "iShares 20+ Year Treasury Bond ETF", "exchange": "NASDAQ", "category": "Long Government" },
+        { "symbol": "SHY", "name": "iShares 1-3 Year Treasury Bond ETF", "exchange": "NASDAQ", "category": "Short Government" },
+        { "symbol": "TIP", "name": "iShares TIPS Bond ETF", "exchange": "NYSEARCA", "category": "Inflation-Protected Bond" },
+        { "symbol": "BIL", "name": "SPDR Bloomberg 1-3 Month T-Bill ETF", "exchange": "NYSEARCA", "category": "Ultrashort Bond" }
+      ]
+    },
+    {
+      "key": "fixed-income-credit",
+      "name": "Fixed Income — Credit & Income",
+      "etfs": [
+        { "symbol": "HYG", "name": "iShares iBoxx $ High Yield Corporate Bond ETF", "exchange": "NYSEARCA", "category": "High Yield Bond" },
+        { "symbol": "BKLN", "name": "Invesco Senior Loan ETF", "exchange": "NYSEARCA", "category": "Bank Loan" },
+        { "symbol": "PFF", "name": "iShares Preferred and Income Securities ETF", "exchange": "NASDAQ", "category": "Preferred Stock" },
+        { "symbol": "EMB", "name": "iShares J.P. Morgan USD Emerging Markets Bond ETF", "exchange": "NASDAQ", "category": "Emerging Markets Bond" },
+        { "symbol": "CWB", "name": "SPDR Bloomberg Convertible Securities ETF", "exchange": "NYSEARCA", "category": "Convertibles" }
+      ]
+    },
+    {
+      "key": "muni",
+      "name": "Municipal Bonds",
+      "etfs": [
+        { "symbol": "MUB", "name": "iShares National Muni Bond ETF", "exchange": "NYSEARCA", "category": "Muni National Interm" },
+        { "symbol": "SUB", "name": "iShares Short-Term National Muni Bond ETF", "exchange": "NYSEARCA", "category": "Muni National Short" },
+        { "symbol": "MLN", "name": "VanEck Long Muni ETF", "exchange": "NYSEARCA", "category": "Muni National Long" },
+        { "symbol": "HYD", "name": "VanEck High Yield Muni ETF", "exchange": "NYSEARCA", "category": "High Yield Muni" },
+        { "symbol": "CMF", "name": "iShares California Muni Bond ETF", "exchange": "NYSEARCA", "category": "Muni California Long" }
+      ]
+    },
+    {
+      "key": "alt-strategies",
+      "name": "Alternative Strategies",
+      "etfs": [
+        { "symbol": "JEPI", "name": "JPMorgan Equity Premium Income ETF", "exchange": "NYSEARCA", "category": "Derivative Income" },
+        { "symbol": "GLD", "name": "SPDR Gold Shares", "exchange": "NYSEARCA", "category": "Commodities Focused" },
+        { "symbol": "IBIT", "name": "iShares Bitcoin Trust ETF", "exchange": "NASDAQ", "category": "Digital Assets" },
+        { "symbol": "DBC", "name": "Invesco DB Commodity Index Tracking Fund", "exchange": "NYSEARCA", "category": "Commodities Broad Basket" },
+        { "symbol": "DBMF", "name": "iMGP DBi Managed Futures Strategy ETF", "exchange": "NYSEARCA", "category": "Systematic Trend" }
+      ]
+    },
+    {
+      "key": "allocation-target-date",
+      "name": "Allocation & Target-Date",
+      "etfs": [
+        { "symbol": "AOA", "name": "iShares Core Aggressive Allocation ETF", "exchange": "NYSEARCA", "category": "Aggressive Allocation" },
+        { "symbol": "AOR", "name": "iShares Core Growth Allocation ETF", "exchange": "NYSEARCA", "category": "Moderately Aggressive Allocation" },
+        { "symbol": "AOM", "name": "iShares Core Moderate Allocation ETF", "exchange": "NYSEARCA", "category": "Moderately Conservative Allocation" },
+        { "symbol": "AOK", "name": "iShares Core Conservative Allocation ETF", "exchange": "NYSEARCA", "category": "Conservative Allocation" },
+        { "symbol": "GAL", "name": "SPDR SSGA Global Allocation ETF", "exchange": "NYSEARCA", "category": "Global Moderate Allocation" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `insights-ui/src/etf-analysis-data/most-famous-etfs-by-group.json` — a curated list of 4–5 well-known ETFs under each of the 8 groups defined in `etf-analysis-categories.json`.
- For every group the selected ETFs span distinct Morningstar categories (e.g. Broad Equity = Large Blend + Large Growth + Large Value + Small Blend + Foreign Large Blend) so that peer comparisons cover the breadth of the group rather than a single sub-category.
- Each entry captures `symbol`, `name`, `exchange` (matches the `USExchanges` values — mostly `NYSEARCA`, some `NASDAQ`), and `category` (the Morningstar category shown on the KoalaGains financial-data page).

## Notes
- Categories were picked to match those used on pages such as `https://koalagains.com/etfs/NYSEARCA/XLY/financial-data`. A couple of allocation-fund category assignments (AOR / AOM / AOK) can be adjusted if the live KoalaGains values differ from Morningstar's published categorization.

## Test plan
- [ ] `yarn prettier-check` — passes locally
- [ ] `yarn lint` — passes locally
- [ ] `yarn compile` — passes locally
- [ ] Spot-check a few entries against the KoalaGains ETF financial-data page to confirm `category` + `exchange` alignment