### PR TITLE
Fix duplicate groupKey in performance-and-returns schema YAML

### DIFF
--- a/insights-ui/schemas/etf-analysis/inputs/performance-and-returns-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/inputs/performance-and-returns-input.schema.yaml
@@ -88,16 +88,6 @@ properties:
     type: string
     description: 'JSON string with expense ratio (explains benchmark tracking drag), inception date (handles young fund evaluation), and style box (detects category/style mismatches).'
 
-  # Resolved group key — identifies which of the 8 ETF groups (broad-equity, sector-thematic-equity, etc.) the fund belongs to; determines factor selection
-  groupKey:
-    type: string
-    description: 'ETF analysis group resolved from fundCategory via etf-analysis-categories.json. One of: broad-equity, sector-thematic-equity, leveraged-inverse, fixed-income-core, fixed-income-credit, muni, alt-strategies, allocation-target-date.'
-
-  # Mor fund category string as stored on EtfStockAnalyzerInfo.category
-  fundCategory:
-    type: [string, 'null']
-    description: 'Fund category (e.g. "Large Blend", "Intermediate Core Bond"). Used to map the fund to an analysis group. May be null for uncategorized funds.'
-
 required:
   - name
   - symbol


### PR DESCRIPTION
## Summary
- Removed duplicate \`groupKey\` and \`fundCategory\` mapping keys from \`insights-ui/schemas/etf-analysis/inputs/performance-and-returns-input.schema.yaml\`.
- The duplicates caused a YAML parse error (\`duplicated mapping key\` at line 92:3) when generating the report for \`regeneratePerformanceAndReturns\`.
- The original definitions earlier in the file already describe the same fields, so the redundant block was deleted.

## Test plan
- [x] YAML parses cleanly (verified with \`yaml.safe_load\`).
- [ ] Re-run \`regeneratePerformanceAndReturns\` and confirm no YAML error.