### PR TITLE
fix(etf-scores): allow nullable futurePerformanceOutlookScore in API response

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route.ts
@@ -7,7 +7,7 @@ export interface EtfScoresResponse {
   performanceAndReturnsScore: number;
   costEfficiencyAndTeamScore: number;
   riskAnalysisScore: number;
-  futurePerformanceOutlookScore: number;
+  futurePerformanceOutlookScore: number | null;
   finalScore: number;
 }
 


### PR DESCRIPTION
## Summary
The `EtfCachedScore.futurePerformanceOutlookScore` schema field was changed to optional (`Int?`) in PR #1342, which caused a TypeScript build error in the scores API route:

`Type 'number | null' is not assignable to type 'number'`

This PR updates the `EtfScoresResponse` interface so `futurePerformanceOutlookScore` is typed as `number | null`, matching the new Prisma type.

## Test plan
- [x] `yarn lint`
- [x] `yarn prettier-check`
- [x] `yarn compile`