### PR TITLE
fix(etfs): serialize BigInt fields in future-outlook lambda input

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route.ts
@@ -7,7 +7,7 @@ export interface EtfScoresResponse {
   performanceAndReturnsScore: number;
   costEfficiencyAndTeamScore: number;
   riskAnalysisScore: number;
-  futurePerformanceOutlookScore: number;
+  futurePerformanceOutlookScore: number | null;
   finalScore: number;
 }
 

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -5,6 +5,7 @@ import {
   EtfGroupBasedFactorsConfig,
   EtfGroupFactorDefinition,
 } from '@/types/etf/etf-analysis-types';
+import { serializeBigIntFields } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
 import etfCategoriesRaw from '@/etf-analysis-data/etf-analysis-categories.json';
 import performanceAndReturnsRaw from '@/etf-analysis-data/etf-analysis-factors-performance-and-returns.json';
 import costEfficiencyAndTeamRaw from '@/etf-analysis-data/etf-analysis-factors-cost-efficiency-and-team.json';
@@ -335,13 +336,15 @@ export function prepareFuturePerformanceOutlookInputJson(etf: EtfWithAllData) {
     factorAnalysisArray: prepareFactorAnalysisArray(factors),
 
     // Broad blocks: the forward-looking category is explicitly synthesis-heavy,
-    // and upstream data availability varies a lot by ETF type.
-    etfFinancialInfo: fin ? JSON.stringify(fin) : null,
-    etfStockAnalyzerInfo: sa ? JSON.stringify(sa) : null,
-    etfMorAnalyzerInfo: mor ? JSON.stringify(mor) : null,
-    etfMorRiskInfo: risk ? JSON.stringify(risk) : null,
-    etfMorPeopleInfo: people ? JSON.stringify(people) : null,
-    etfMorPortfolioInfo: portfolio ? JSON.stringify(portfolio) : null,
+    // and upstream data availability varies a lot by ETF type. Route through
+    // serializeBigIntFields so BigInt columns (stockAnalyzerInfo.avgVolume,
+    // dollarVol, preVolume) don't break JSON.stringify.
+    etfFinancialInfo: fin ? JSON.stringify(serializeBigIntFields(fin)) : null,
+    etfStockAnalyzerInfo: sa ? JSON.stringify(serializeBigIntFields(sa)) : null,
+    etfMorAnalyzerInfo: mor ? JSON.stringify(serializeBigIntFields(mor)) : null,
+    etfMorRiskInfo: risk ? JSON.stringify(serializeBigIntFields(risk)) : null,
+    etfMorPeopleInfo: people ? JSON.stringify(serializeBigIntFields(people)) : null,
+    etfMorPortfolioInfo: portfolio ? JSON.stringify(serializeBigIntFields(portfolio)) : null,
   };
 }
 


### PR DESCRIPTION
## Summary
- `prepareFuturePerformanceOutlookInputJson` was calling `JSON.stringify` directly on `etf.stockAnalyzerInfo`, which contains BigInt columns (`avgVolume`, `dollarVol`, `preVolume`).
- That raised `TypeError: Do not know how to serialize a BigInt` and failed the future-performance-outlook step when the cron picked up the ETF (e.g. QQQI).
- Fix: route each sub-object through the existing `serializeBigIntFields` helper before stringify, matching how the other ETF API routes handle it.

## Test plan
- [x] yarn lint
- [x] yarn prettier-check
- [x] yarn compile
- [ ] Trigger Future Outlook generation for QQQI and confirm the lambda is invoked (no BigInt error in the cron log) and `etf_cached_scores.future_performance_outlook_score` is written on callback.