### PR TITLE
Tighten past-returns.md prompt after iter-1 loop review (16 ETFs)

### DIFF
--- a/docs/ai-knowledge/insights-ui/etf-prompts/past-returns.md
+++ b/docs/ai-knowledge/insights-ui/etf-prompts/past-returns.md
@@ -8,11 +8,12 @@ This report covers only returns, consistency, benchmark/category comparison, mom
 ## Scope
 
 - Stay inside this category. Do NOT analyse strategy (→ Strategy report), fees / managers (→ Cost & Team report), or maximum-drawdown severity (→ Risk Analysis report).
-- No forecasts, no price targets, no valuation calls.
+- No forecasts, no price targets, no valuation calls. The summary is a description of what the numbers show, not a recommendation. Do not write "reliable core holding", "highly effective tool", "continues to be", "the fund is a … for investors who …", "delivers precisely on its mandate", "core wealth-building holding", or any variant that tells the reader what to do.
 - Treat the data blocks as the latest snapshot. Never invent numbers.
-- Missing-field rule: if a field/metric is missing, **do not mention it** (do not write “data not provided”, “not available”, “missing”, etc.). Use only what’s present.
-- Every claim must carry at least one numeric anchor from the input. Drop adjectives like "catastrophic", "abysmal", "undeniably" — they add nothing.
-- Do not repeat the same number in more than one paragraph. State it once, then build on it.
+- Missing-field rule: if a field/metric is missing, **do not mention it**. Never write "data not provided", "not available", "missing", "omitted", "not disclosed", "not listed", "technically not provided", "not in the data", "unavailable", or any equivalent — if a metric isn't there, simply leave it out. Use only what's present.
+- Every claim must carry at least one numeric anchor from the input. Drop dramatic adjectives — not just "catastrophic", "abysmal", "undeniably", but also "astronomical", "phenomenal", "incredible", "staggering", "flawlessly", "extraordinary", "massive". Also drop intensifier adverbs that do not change the meaning of the sentence: "entirely", "strictly", "totally", "utterly", "absolutely", "completely", "perfectly", "precisely", "massively", "heavily", "deeply", "severely". If removing the word leaves the sentence unchanged in meaning, remove it.
+- Do not repeat the same number in more than one paragraph. State it once, then build on it. A single metric cited in the summary, cited again in the overall analysis, and cited a third time in a factor block is three violations of this rule, not one.
+- Output is Markdown only. Do not emit raw HTML tags like `<br>` — use blank lines between paragraphs.
 
 ## Factor-metric lookup (only when needed)
 
@@ -38,9 +39,11 @@ Always name the actual index from `indexName` when referring to "the benchmark".
 
 State whether the performance profile is **Strong**, **Mixed**, or **Weak**. Include 3–5 decision-useful numbers (absolute + relative). End with one plain-English takeaway.
 
-## 2. `overallAnalysisDetails` (4 paragraphs, ~900–1300 words total)
+## 2. `overallAnalysisDetails` (4 paragraphs)
 
-Keep paragraphs tight. Do not pad to hit a word count.
+Four tight paragraphs is the target. Aim for substance over length — do not pad. If four
+clean paragraphs fit the data in ~400 words, stop there; do not stretch the section just
+to fill space.
 
 1. **Recent returns snapshot.** `1M`, `3M`, `6M`, `YTD`, `1Y` picture. Is the ETF beating or lagging its category and its named index right now? Is momentum accelerating or cooling? One line on whether the latest move looks broad-based or just noise.
 2. **Longer-term record and peer standing.** `3Y` / `5Y` / `10Y` returns and CAGR where available. Fund vs category vs index gaps in percentage points. Percentile-rank trend across years — cite the actual movement (e.g. `14 → 87 → 18`), not just "volatile". If the peer group is mostly active managers and the fund is passive, say so and adjust the tone (median among active managers is a Pass-grade outcome for a passive fund).

--- a/tasks/koala-gains/etf-verification/2026-04-22-past-returns/findings-A-performance-and-returns.md
+++ b/tasks/koala-gains/etf-verification/2026-04-22-past-returns/findings-A-performance-and-returns.md
@@ -1,0 +1,210 @@
+# ETF verification findings — Loop A — PerformanceAndReturns — iter-1
+
+- **Date:** 2026-04-22
+- **Loop:** A (prompt refinement)
+- **Category in scope:** PerformanceAndReturns (`performance-and-returns`)
+- **Prompt file:** `docs/ai-knowledge/insights-ui/etf-prompts/past-returns.md`
+- **Run:** 16 ETFs across all 8 groups, regenerated via
+  `POST /api/koala_gains/etfs-v1/generation-requests`. All 16 completed within ~8 minutes;
+  0 failed.
+- **ETFs reviewed:**
+  - broad-equity: `SPY`, `IWF`
+  - sector-thematic-equity: `XLK`, `XLV`
+  - leveraged-inverse: `TQQQ`, `SQQQ`
+  - fixed-income-core: `AGG`, `TLT`
+  - fixed-income-credit: `HYG`, `BKLN`
+  - muni: `MUB`, `SUB`
+  - alt-strategies: `JEPI`, `GLD`
+  - allocation-target-date: `AOA`, `AOR`
+
+## Overall quality
+
+Reports follow the prompt's structure (3–5-sentence summary, 4-paragraph overall analysis,
+factor Pass/Fail blocks) and get the group-specific calls mostly right — leveraged-inverse
+reports correctly name volatility decay / daily-reset path dependency, muni reports
+correctly give the tax-equivalent-yield framing, and bond reports downplay technicals. The
+problems sit at the language and discipline layer, not the structural layer.
+
+## Per-ETF review
+
+Grouped by the bucket of issue rather than one long block per ETF — each ETF is cited
+where the pattern appeared.
+
+### SPY (broad-equity — Large Blend) — change drivers: #1, #2, #4
+- **Good:** correctly identifies passive tracking, cites percentile ranks against Large
+  Blend peers, gets the short-term-cooling vs. long-term-strong framing right.
+- **Missing / wrong:**
+  - #2: repeats `31.63%` 1Y return in the summary AND paragraph 1 AND the
+    `short_term_returns` factor (the prompt explicitly says not to repeat numbers across
+    paragraphs).
+  - #4: summary ends with "SPY continues to be a highly reliable, core wealth-building
+    holding" — a forward-looking recommendation the prompt explicitly forbids ("No
+    forecasts, no price targets, no valuation calls").
+- **Verdict:** change needed — language discipline, not content.
+
+### IWF (broad-equity — Large Growth) — change drivers: #1
+- **Good:** correctly shows recent-weakness-in-a-multi-year-uptrend; good peer framing
+  against active Large Growth peers.
+- **Missing / wrong:**
+  - Uses raw HTML `<br><br>` separators between paragraphs, not markdown blank lines.
+    Rendering-layer bug but the prompt already says "Markdown" — worth a tightening.
+- **Verdict:** change needed — enforce markdown only.
+
+### XLK (sector-thematic-equity — Technology) — change drivers: #1
+- **Good:** solid sector framing and technical-trend Fail justification.
+- **Missing / wrong:**
+  - Heavy intensifier soup: "phenomenal", "staggering", "incredible", "undeniably",
+    "unequivocally", "massive long-term wealth creation".
+- **Verdict:** change needed — adjective discipline.
+
+### XLV (sector-thematic-equity — Health) — change drivers: #1
+- **Good:** correctly highlights low-beta defensive posture and top-quartile 5-year rank
+  despite trailing 1-year.
+- **Missing / wrong:** mild adjective inflation ("sharply deteriorated", "severely",
+  "precariously") but the facts are right.
+- **Verdict:** change needed — adjective discipline.
+
+### TQQQ (leveraged-inverse — Trading--Leveraged Equity) — change drivers: #1, #3
+- **Good:** explicitly names daily-reset mechanics, path dependency, volatility decay —
+  exactly the group-specific angle the prompt asks for.
+- **Missing / wrong:**
+  - Uses "catastrophic" — the prompt explicitly bans this adjective by name on line 14.
+  - `category_peer_standing` factor contains "exact percentile rankings are omitted for
+    this specialized peer group" — violates the missing-field rule (the prompt says
+    "do not write 'data not provided', 'not available', 'missing', etc."; "omitted" is
+    the same family).
+- **Verdict:** change needed — named banned word slipped through; missing-field rule needs
+  wider coverage.
+
+### SQQQ (leveraged-inverse — Trading--Inverse Equity) — change drivers: #1
+- **Good:** correctly explains "near-absolute certainty of long-term capital loss due to
+  volatility drag"; correctly frames it as a tactical instrument, not an investment.
+- **Missing / wrong:** adjectives lean heavy ("staggering", "inescapable", "guaranteed
+  outcome") but facts are right.
+- **Verdict:** change needed — adjective discipline.
+
+### AGG (fixed-income-core — Intermediate Core Bond) — change drivers: #1, #2
+- **Good:** cleanly separates NAV-return-tracking (pass) from absolute-return-volatility
+  (fail in `returns_consistency`). Good use of SEC yield as the "income-first headline"
+  the prompt wants for income funds.
+- **Missing / wrong:**
+  - #2: `-13.06%` 2022 loss repeated across summary, paragraph, strengths section,
+    `rate_environment_resilience` factor, and `returns_consistency` factor.
+  - Adjective inflation: "flawlessly", "perfectly", "near-flawless".
+- **Verdict:** change needed — repetition + adjectives.
+
+### TLT (fixed-income-core — Long Government) — change drivers: #1, #2, #5
+- **Good:** correctly Fails `benchmark_tracking` on the `1.12 pp` 3-year lag vs. the index
+  (passes the narrow-threshold rule for bonds correctly).
+- **Missing / wrong:**
+  - #2: `-31.41%` 2022 loss and `-51.83%` distance-from-ATH are each repeated 3+ times.
+  - #5: `category_peer_standing` correctly ranks it bottom-quartile but doesn't note
+    whether the peer group is mostly active managers — the prompt (Section 3) says a
+    passive fund near the median in an active peer group should still be Pass; for TLT
+    the reverse (bottom-quartile) applies so Fail is right, but the rationale should
+    mention the passive-vs-active setup.
+- **Verdict:** change needed — repetition, plus a minor sharpening of the passive-vs-active
+  rationale (factor-description responsibility, noted but not the prompt's top priority).
+
+### HYG (fixed-income-credit — High Yield Bond) — change drivers: #1
+- **Good:** correctly uses the `1.0 pp` narrow threshold for high-yield tracking; correctly
+  frames yield as the income engine.
+- **Missing / wrong:** intensifier soup ("strictly", "deeply", "precisely"); otherwise
+  solid.
+- **Verdict:** change needed — adjective discipline.
+
+### BKLN (fixed-income-credit — Bank Loan) — change drivers: #1, #2
+- **Good:** correctly separates capital-preservation from yield-harvesting; surfaces
+  floating-rate advantage vs. 2022 rate shock.
+- **Missing / wrong:**
+  - #2: `7.03%` dividend yield and `-8.97%` 10-year price drop each repeat 3+ times.
+- **Verdict:** change needed — repetition.
+
+### MUB (muni — Muni National Interm) — change drivers: none material
+- **Good:** includes the tax-equivalent-yield line with the 32% bracket (`~5.0% TEY`) as
+  the prompt explicitly requires. Correctly pegs performance to the passive mandate.
+- **Missing / wrong:** minor adjective inflation but within tolerance.
+- **Verdict:** no individual change needed — good example of prompt compliance.
+
+### SUB (muni — Muni National Short) — change drivers: none material
+- **Good:** includes `~3.65% TEY` at 32% bracket as required; frames it correctly as a
+  cash-alternative with capital-preservation focus.
+- **Missing / wrong:** mild adjective inflation.
+- **Verdict:** no individual change needed.
+
+### JEPI (alt-strategies — Derivative Income) — change drivers: #1, #3, #4 (worst offender)
+- **Good:** correctly labels the mandate (defensive / covered-call), correctly cites low
+  beta and `-3.53%` 2022 drawdown vs. benchmark's `-19.43%`.
+- **Missing / wrong:** **severe** prose quality issues:
+  - `benchmark_comparison` factor: 7 intensifier adverbs in one sentence — "entirely",
+    "strictly", "totally", "staggering", "massive", "deeply chronic", "completely Fail".
+  - `long_term_cagr` factor: "standard 10-year, 15-year, and 20-year data points are
+    technically not provided" — direct violation of the missing-field rule; should have
+    omitted the reference entirely.
+  - `price_trend_momentum` factor: "entirely current technical momentum posture of the
+    massive ETF heavily reflects absolutely clear short-term directional weakness and a
+    complete lack of broad buying momentum" — maximum adverb stacking.
+  - Summary ends with "the fund is a highly effective tool for retail investors" — an
+    investment recommendation the prompt forbids.
+- **Verdict:** change needed — JEPI is the clearest single signal that the prompt's
+  discipline rules aren't being enforced strongly enough.
+
+### GLD (alt-strategies — Commodities Focused) — change drivers: #1, #4
+- **Good:** correctly calls out zero-yield / price-only return driver; correctly highlights
+  low-equity-correlation as the diversification value.
+- **Missing / wrong:**
+  - #1: "highly attractive", "flawlessly", "strictly", "extraordinarily", "remarkably".
+  - #4: summary ends with "this ETF delivers precisely on its core mandate" — borderline
+    recommendation.
+- **Verdict:** change needed — adjective discipline.
+
+### AOA (allocation-target-date — Global Moderately Aggressive) — change drivers: #1, #4
+- **Good:** correctly frames 80/20 mandate, names the benchmark (S&P Target Risk
+  Aggressive), cites peer group correctly.
+- **Missing / wrong:**
+  - #4: "the fund is a highly efficient 80/20 global portfolio that captures equity
+    upside" — recommendation language.
+- **Verdict:** change needed — recommendation language.
+
+### AOR (allocation-target-date — Global Moderate) — change drivers: #1, #4
+- **Good:** clean peer-standing framing, correctly Fails `downside_protection` on the
+  2022 category underperformance.
+- **Missing / wrong:**
+  - #4: "this is a highly reliable core holding that strictly and successfully executes
+    its moderate risk mandate" — recommendation.
+- **Verdict:** change needed — recommendation language.
+
+## Group-level summary
+
+- **Broad-equity, sector-thematic-equity, alt-strategies:** adjective / intensifier
+  inflation is the dominant problem. Content is solid.
+- **Leveraged-inverse:** one banned word ("catastrophic") slipped through; "omitted"
+  phrasing in factor text violates the missing-field rule.
+- **Fixed-income-core, fixed-income-credit:** number repetition is the dominant problem.
+  Content is solid.
+- **Muni:** clean. TEY rule works.
+- **Allocation-target-date:** recommendation phrasing in summaries.
+
+## Final changes
+
+- **`docs/ai-knowledge/insights-ui/etf-prompts/past-returns.md`** — apply four targeted
+  tightenings:
+  1. **Expand the banned-adjective list** to include the intensifier adverbs that showed
+     up repeatedly: "entirely", "strictly", "totally", "utterly", "absolutely",
+     "completely", "perfectly", "flawlessly", "precisely", "massively", "staggering",
+     "phenomenal", "incredible". These don't add information.
+  2. **Broaden the missing-field rule** to explicitly ban "omitted", "not disclosed",
+     "not listed", "technically not provided", "not in the data", "unavailable" —
+     "missing" alone isn't catching variants.
+  3. **Ban recommendation phrasing in the summary**. Add one sentence: "The summary
+     is a description of what the numbers show, not a recommendation. Do not write
+     'reliable core holding', 'highly effective tool', 'continues to be', 'the fund is
+     a … for investors who …' or any variant that tells the reader what to do."
+  4. **Drop the 900–1300-word target** on `overallAnalysisDetails`. Actual good outputs
+     are ~400–500 words and the word floor creates a padding incentive. Replace with
+     "Aim for substance over length; four tight paragraphs is the target."
+- **No factor JSON changes in this pass.** The factor file
+  `etf-analysis-factors-performance-and-returns.json` looks appropriate — the failures
+  were language-level, not taxonomy-level.
+- **No changes to the other three category prompts** — they weren't in scope for this
+  test run.


### PR DESCRIPTION
## Summary

Ran the ETF verification loop end-to-end against the **Past Returns / Performance & Returns** prompt for 16 ETFs (2 per group across all 8 groups). Findings doc and targeted prompt edits included in this PR.

**What I ran:**
- \`yarn etf-verify:sample --per-group 2\` → 16 ETFs across: broad-equity, sector-thematic-equity, leveraged-inverse, fixed-income-core, fixed-income-credit, muni, alt-strategies, allocation-target-date
- \`yarn etf-verify:trigger --categories performance-and-returns\` → 16 generation requests enqueued
- Polled \`GET /api/koala_gains/etfs-v1/generation-requests\` until all settled (~8 minutes, 0 failures)
- \`yarn etf-verify:fetch\` → pulled \`GET /api/koala_gains/etfs-v1/exchange/{EX}/{SYM}/analysis\` for each ETF and rendered one markdown per ETF
- Reviewed each ETF's Performance & Returns section against the prompt's scope rules

## Findings

Full per-ETF review in \`tasks/koala-gains/etf-verification/2026-04-22-past-returns/findings-A-performance-and-returns.md\`. Short version:

- **Structure** of every output follows the prompt correctly (3–5-sentence summary, 4-paragraph overall analysis, factor Pass/Fail blocks). Group-specific calls are mostly right — leveraged-inverse correctly discusses volatility decay, muni correctly gives tax-equivalent yield framing at 32% federal, bond funds correctly downplay technicals.
- **Language discipline** is where every failure clusters:
  - Intensifier-adverb soup across the board (\"entirely\", \"strictly\", \"totally\", \"flawlessly\", \"perfectly\", etc.). JEPI's output is the worst single example.
  - Number repetition — same figure cited in summary + paragraph + factor block, violating the \"don't repeat\" rule.
  - Missing-field-rule violations using variants the prompt didn't explicitly name: \"omitted\", \"technically not provided\" (TQQQ, JEPI).
  - Recommendation phrasing in summaries (\"highly reliable core holding\", \"highly effective tool\", \"continues to be\") — the prompt bans forecasts but not clearly enough.
  - IWF output used raw \`<br>\` HTML tags instead of markdown paragraph breaks.
  - One banned adjective (\"catastrophic\") slipped through despite being named in the prompt.
  - The 900–1300-word target on \`overallAnalysisDetails\` is unrealistic — actual good outputs are ~400 words; the floor just encourages padding.

## Prompt changes

Four targeted edits to \`docs/ai-knowledge/insights-ui/etf-prompts/past-returns.md\`:

1. Expanded banned-adjective list (dramatic adjectives + intensifier adverbs with removal test: \"if the sentence reads the same without the word, remove it\").
2. Broadened missing-field rule with a specific list of banned phrases (\"omitted\", \"not disclosed\", etc.).
3. Explicit ban on recommendation phrasing in the summary with concrete examples.
4. Dropped the 900–1300-word target; replaced with \"Four tight paragraphs is the target. Aim for substance over length.\"
5. Banned raw HTML output (e.g. \`<br>\` between paragraphs).

No changes to \`etf-analysis-factors-performance-and-returns.json\` — failures were language-level, not taxonomy-level.

## Test plan

- [ ] Once merged, re-run the loop on the same 16 ETFs and confirm the intensifier-adverb count, number-repetition count, and recommendation-phrase count all drop.
- [ ] If iter-2 output still has material discipline gaps, add a \"reduce adjective density by N%\" instruction to the prompt.

## Dependency note

This PR depends on the automation tooling in PR #1345 (yarn etf-verify:* scripts + by-ids endpoint). The findings doc and prompt change are independent artifacts — the prompt change will take effect on the next generation regardless of #1345's merge order, but reproducing the review loop locally requires the scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)