### PR TITLE
feat(etfs): add Similar ETFs section to ETF report page

### DIFF
--- a/docs/ai-knowledge/insights-ui/etf-prompts/intro-strategy.md
+++ b/docs/ai-knowledge/insights-ui/etf-prompts/intro-strategy.md
@@ -56,3 +56,14 @@ Style rules
 - Neutral and factual — no buy/sell/hold opinions and no return forecasts. Naming specific competitor ETFs (by name or ticker) is fine when it sharpens a comparison, but do not rank them or recommend one over another.
 - Be concrete and specific: prefer "tracks the S&P 500, a market-cap-weighted index of roughly 500 large U.S. companies" over "tracks a popular U.S. equity index."
 - Preserve the four-paragraph structure with a single blank line between paragraphs, followed by the "Red Flags & Risks" bulleted list as the final section. Bullets are allowed only inside that final section; the four paragraphs themselves stay as plain prose with no headings, no bullets, and no markdown.
+
+Similar ETFs (structured output field `similarEtfs`)
+
+In addition to the prose above, return a `similarEtfs` array with **at least 6** ETFs that are genuine substitutes for the analyzed fund — funds tracking the same (or a very close) underlying index, in the same category, with comparable exposure mechanics (weighting, replication, tilts). Do **not** just list the biggest or most famous ETFs in the asset class; prioritize true peers a retail investor would realistically choose between. If the fund is a plain-vanilla index tracker, its closest siblings from other issuers tracking the same/equivalent index must appear.
+
+Constraints for each entry:
+- `exchange` must be one of: `BATS`, `NASDAQ`, `NYSE`, `NYSEARCA` (we only cover US-listed ETFs on these exchanges).
+- `symbol` and `exchange` must be uppercase.
+- `reason` must be a single short sentence (≤ 25 words) explaining the substitutability (e.g. "Tracks the same S&P 500 index with identical market-cap weighting.").
+- Do not include the analyzed ETF itself.
+- Do not invent tickers — only include ETFs you can verify exist on one of the listed exchanges.

--- a/docs/ai-knowledge/insights-ui/etf-prompts/intro-strategy.md
+++ b/docs/ai-knowledge/insights-ui/etf-prompts/intro-strategy.md
@@ -64,6 +64,5 @@ In addition to the prose above, return a `similarEtfs` array with **at least 6**
 Constraints for each entry:
 - `exchange` must be one of: `BATS`, `NASDAQ`, `NYSE`, `NYSEARCA` (we only cover US-listed ETFs on these exchanges).
 - `symbol` and `exchange` must be uppercase.
-- `reason` must be a single short sentence (≤ 25 words) explaining the substitutability (e.g. "Tracks the same S&P 500 index with identical market-cap weighting.").
 - Do not include the analyzed ETF itself.
 - Do not invent tickers — only include ETFs you can verify exist on one of the listed exchanges.

--- a/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
+++ b/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
@@ -5,7 +5,6 @@ CREATE TABLE "etf_similar_etfs" (
     "symbol" TEXT NOT NULL,
     "exchange" TEXT NOT NULL,
     "name" TEXT,
-    "reason" TEXT,
     "sort_order" INTEGER NOT NULL DEFAULT 0,
     "matched_etf_id" TEXT,
     "space_id" TEXT NOT NULL DEFAULT 'koala_gains',

--- a/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
+++ b/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "etf_similar_etfs" (
+    "id" TEXT NOT NULL,
+    "source_etf_id" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "exchange" TEXT NOT NULL,
+    "name" TEXT,
+    "reason" TEXT,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "matched_etf_id" TEXT,
+    "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "etf_similar_etfs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "etf_similar_etfs_source_etf_id_idx" ON "etf_similar_etfs"("source_etf_id");
+
+-- CreateIndex
+CREATE INDEX "etf_similar_etfs_matched_etf_id_idx" ON "etf_similar_etfs"("matched_etf_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "etf_similar_etfs_source_etf_id_symbol_exchange_key" ON "etf_similar_etfs"("source_etf_id", "symbol", "exchange");
+
+-- AddForeignKey
+ALTER TABLE "etf_similar_etfs" ADD CONSTRAINT "etf_similar_etfs_source_etf_id_fkey" FOREIGN KEY ("source_etf_id") REFERENCES "etfs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "etf_similar_etfs" ADD CONSTRAINT "etf_similar_etfs_matched_etf_id_fkey" FOREIGN KEY ("matched_etf_id") REFERENCES "etfs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
+++ b/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
@@ -6,7 +6,6 @@ CREATE TABLE "etf_similar_etfs" (
     "exchange" TEXT NOT NULL,
     "name" TEXT,
     "sort_order" INTEGER NOT NULL DEFAULT 0,
-    "matched_etf_id" TEXT,
     "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
@@ -18,13 +17,7 @@ CREATE TABLE "etf_similar_etfs" (
 CREATE INDEX "etf_similar_etfs_source_etf_id_idx" ON "etf_similar_etfs"("source_etf_id");
 
 -- CreateIndex
-CREATE INDEX "etf_similar_etfs_matched_etf_id_idx" ON "etf_similar_etfs"("matched_etf_id");
-
--- CreateIndex
 CREATE UNIQUE INDEX "etf_similar_etfs_source_etf_id_symbol_exchange_key" ON "etf_similar_etfs"("source_etf_id", "symbol", "exchange");
 
 -- AddForeignKey
 ALTER TABLE "etf_similar_etfs" ADD CONSTRAINT "etf_similar_etfs_source_etf_id_fkey" FOREIGN KEY ("source_etf_id") REFERENCES "etfs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "etf_similar_etfs" ADD CONSTRAINT "etf_similar_etfs_matched_etf_id_fkey" FOREIGN KEY ("matched_etf_id") REFERENCES "etfs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
+++ b/insights-ui/prisma/migrations/20260422120000_add_etf_similar_etfs/migration.sql
@@ -4,7 +4,6 @@ CREATE TABLE "etf_similar_etfs" (
     "source_etf_id" TEXT NOT NULL,
     "symbol" TEXT NOT NULL,
     "exchange" TEXT NOT NULL,
-    "name" TEXT,
     "sort_order" INTEGER NOT NULL DEFAULT 0,
     "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1729,7 +1729,6 @@ model EtfSimilarEtf {
   symbol       String  @map("symbol")
   exchange     String  @map("exchange")
   name         String? @map("name")
-  reason       String? @map("reason") @db.Text
   sortOrder    Int     @default(0) @map("sort_order")
   matchedEtfId String? @map("matched_etf_id")
   spaceId      String  @default("koala_gains") @map("space_id")

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1723,13 +1723,12 @@ model EtfCachedScore {
 // Per source-ETF list of similar/peer ETFs produced by the INDEX_STRATEGY LLM step.
 // Symbol + exchange are sufficient to link the card to the peer's report page.
 model EtfSimilarEtf {
-  id          String  @id @default(uuid())
-  sourceEtfId String  @map("source_etf_id")
-  symbol      String  @map("symbol")
-  exchange    String  @map("exchange")
-  name        String? @map("name")
-  sortOrder   Int     @default(0) @map("sort_order")
-  spaceId     String  @default("koala_gains") @map("space_id")
+  id          String @id @default(uuid())
+  sourceEtfId String @map("source_etf_id")
+  symbol      String @map("symbol")
+  exchange    String @map("exchange")
+  sortOrder   Int    @default(0) @map("sort_order")
+  spaceId     String @default("koala_gains") @map("space_id")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1291,6 +1291,8 @@ model Etf {
   analysisCategoryFactorResults EtfAnalysisCategoryFactorResult[]
   cachedScore                 EtfCachedScore?
   priceHistory                EtfPriceHistory?
+  similarEtfs                 EtfSimilarEtf[] @relation("EtfSimilarEtfSource")
+  similarToEtfs               EtfSimilarEtf[] @relation("EtfSimilarEtfMatched")
 
   @@unique([spaceId, symbol, exchange])
   @@index([symbol])
@@ -1714,6 +1716,34 @@ model EtfCachedScore {
   @@unique([etfId])
   @@index([etfId])
   @@map("etf_cached_scores")
+}
+
+// --------------------------
+// ETF Similar ETFs
+// --------------------------
+// Per source-ETF list of similar/peer ETFs produced by the INDEX_STRATEGY LLM step.
+// `matchedEtfId` is set when the (symbol, exchange, spaceId) pair exists in our `etfs` table.
+model EtfSimilarEtf {
+  id           String  @id @default(uuid())
+  sourceEtfId  String  @map("source_etf_id")
+  symbol       String  @map("symbol")
+  exchange     String  @map("exchange")
+  name         String? @map("name")
+  reason       String? @map("reason") @db.Text
+  sortOrder    Int     @default(0) @map("sort_order")
+  matchedEtfId String? @map("matched_etf_id")
+  spaceId      String  @default("koala_gains") @map("space_id")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  sourceEtf  Etf  @relation("EtfSimilarEtfSource", fields: [sourceEtfId], references: [id], onDelete: Cascade)
+  matchedEtf Etf? @relation("EtfSimilarEtfMatched", fields: [matchedEtfId], references: [id], onDelete: SetNull)
+
+  @@unique([sourceEtfId, symbol, exchange])
+  @@index([sourceEtfId])
+  @@index([matchedEtfId])
+  @@map("etf_similar_etfs")
 }
 
 // --------------------------

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1292,7 +1292,6 @@ model Etf {
   cachedScore                 EtfCachedScore?
   priceHistory                EtfPriceHistory?
   similarEtfs                 EtfSimilarEtf[] @relation("EtfSimilarEtfSource")
-  similarToEtfs               EtfSimilarEtf[] @relation("EtfSimilarEtfMatched")
 
   @@unique([spaceId, symbol, exchange])
   @@index([symbol])
@@ -1722,26 +1721,23 @@ model EtfCachedScore {
 // ETF Similar ETFs
 // --------------------------
 // Per source-ETF list of similar/peer ETFs produced by the INDEX_STRATEGY LLM step.
-// `matchedEtfId` is set when the (symbol, exchange, spaceId) pair exists in our `etfs` table.
+// Symbol + exchange are sufficient to link the card to the peer's report page.
 model EtfSimilarEtf {
-  id           String  @id @default(uuid())
-  sourceEtfId  String  @map("source_etf_id")
-  symbol       String  @map("symbol")
-  exchange     String  @map("exchange")
-  name         String? @map("name")
-  sortOrder    Int     @default(0) @map("sort_order")
-  matchedEtfId String? @map("matched_etf_id")
-  spaceId      String  @default("koala_gains") @map("space_id")
+  id          String  @id @default(uuid())
+  sourceEtfId String  @map("source_etf_id")
+  symbol      String  @map("symbol")
+  exchange    String  @map("exchange")
+  name        String? @map("name")
+  sortOrder   Int     @default(0) @map("sort_order")
+  spaceId     String  @default("koala_gains") @map("space_id")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  sourceEtf  Etf  @relation("EtfSimilarEtfSource", fields: [sourceEtfId], references: [id], onDelete: Cascade)
-  matchedEtf Etf? @relation("EtfSimilarEtfMatched", fields: [matchedEtfId], references: [id], onDelete: SetNull)
+  sourceEtf Etf @relation("EtfSimilarEtfSource", fields: [sourceEtfId], references: [id], onDelete: Cascade)
 
   @@unique([sourceEtfId, symbol, exchange])
   @@index([sourceEtfId])
-  @@index([matchedEtfId])
   @@map("etf_similar_etfs")
 }
 

--- a/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
@@ -23,14 +23,10 @@ properties:
         name:
           type: string
           description: 'Full name of the similar ETF (e.g., Vanguard S&P 500 ETF).'
-        reason:
-          type: string
-          description: 'One short sentence (≤ 25 words) on why this ETF is a true substitute (e.g., tracks the same index, same category and weighting scheme).'
       required:
         - symbol
         - exchange
         - name
-        - reason
 required:
   - indexStrategy
   - similarEtfs

--- a/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
@@ -5,5 +5,32 @@ properties:
   indexStrategy:
     type: string
     description: 'A concise description of the ETF’s underlying index and strategy (what it tracks, how it is constructed, and any notable methodology/tilts).'
+  similarEtfs:
+    type: array
+    minItems: 6
+    description: 'At least 6 ETFs that are genuine substitutes for the analyzed ETF — same/very-similar underlying index, same category, same broad exposure mechanics. Not just famous or popular peers. All entries must be US-listed on BATS, NASDAQ, NYSE, or NYSEARCA.'
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        symbol:
+          type: string
+          description: 'Ticker symbol of the similar ETF in uppercase (e.g., VOO, IVV).'
+        exchange:
+          type: string
+          enum: ['BATS', 'NASDAQ', 'NYSE', 'NYSEARCA']
+          description: 'Exchange code in uppercase. Must be one of: BATS, NASDAQ, NYSE, NYSEARCA.'
+        name:
+          type: string
+          description: 'Full name of the similar ETF (e.g., Vanguard S&P 500 ETF).'
+        reason:
+          type: string
+          description: 'One short sentence (≤ 25 words) on why this ETF is a true substitute (e.g., tracks the same index, same category and weighting scheme).'
+      required:
+        - symbol
+        - exchange
+        - name
+        - reason
 required:
   - indexStrategy
+  - similarEtfs

--- a/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/outputs/index-strategy-output.schema.yaml
@@ -20,13 +20,9 @@ properties:
           type: string
           enum: ['BATS', 'NASDAQ', 'NYSE', 'NYSEARCA']
           description: 'Exchange code in uppercase. Must be one of: BATS, NASDAQ, NYSE, NYSEARCA.'
-        name:
-          type: string
-          description: 'Full name of the similar ETF (e.g., Vanguard S&P 500 ETF).'
       required:
         - symbol
         - exchange
-        - name
 required:
   - indexStrategy
   - similarEtfs

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -1,8 +1,6 @@
 import { getEtfWhereClause } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
 import { prisma } from '@/prisma';
-import { parseNumericStringValue } from '@/utils/etf-filter-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
-import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 
 export interface SimilarEtf {
@@ -10,76 +8,61 @@ export interface SimilarEtf {
   name: string;
   symbol: string;
   exchange: string;
+  reason: string | null;
   aum: string | null;
   category: string | null;
   assetClass: string | null;
   cachedScore: { finalScore: number } | null;
+  inDb: boolean;
 }
 
 const MAX_RESULTS = 6;
-const CANDIDATE_LIMIT = 100;
 
 async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }): Promise<SimilarEtf[]> {
   const { spaceId, exchange, etf } = await context.params;
   const where = getEtfWhereClause({ spaceId, exchange, etf });
 
-  const etfRecord = await prisma.etf.findFirst({
+  const sourceEtf = await prisma.etf.findFirst({
     where,
+    select: { id: true },
+  });
+  if (!sourceEtf) return [];
+
+  const stored = await prisma.etfSimilarEtf.findMany({
+    where: { sourceEtfId: sourceEtf.id },
+    orderBy: { sortOrder: 'asc' },
     include: {
-      financialInfo: true,
-      stockAnalyzerInfo: true,
+      matchedEtf: {
+        include: {
+          financialInfo: true,
+          stockAnalyzerInfo: true,
+          cachedScore: true,
+        },
+      },
     },
   });
-  if (!etfRecord) return [];
 
-  const category: string | null = etfRecord.stockAnalyzerInfo?.category?.trim() || null;
-  const assetClass: string | null = etfRecord.stockAnalyzerInfo?.assetClass?.trim() || null;
-
-  // Use category if present, fallback to assetClass.
-  const stockAnalyzerInfoFilter: Prisma.EtfStockAnalyzerInfoWhereInput | null = category
-    ? { category: { equals: category, mode: 'insensitive' } }
-    : assetClass
-    ? { assetClass: { equals: assetClass, mode: 'insensitive' } }
-    : null;
-
-  if (!stockAnalyzerInfoFilter) return [];
-
-  const candidates = await prisma.etf.findMany({
-    where: {
-      spaceId: where.spaceId,
-      id: { not: etfRecord.id },
-      stockAnalyzerInfo: { is: stockAnalyzerInfoFilter },
-    },
-    include: {
-      financialInfo: true,
-      stockAnalyzerInfo: true,
-      cachedScore: true,
-    },
-    take: CANDIDATE_LIMIT,
-  });
-
-  const currentAum: number | null = parseNumericStringValue(etfRecord.financialInfo?.aum);
-
-  // Rank by AUM proximity when both sides have a parseable AUM; otherwise push to the end.
-  const ranked = candidates
-    .map((c) => {
-      const aumNum: number | null = parseNumericStringValue(c.financialInfo?.aum);
-      const distance: number = currentAum !== null && aumNum !== null ? Math.abs(aumNum - currentAum) : Number.POSITIVE_INFINITY;
-      return { etf: c, distance };
-    })
-    .sort((a, b) => a.distance - b.distance)
-    .slice(0, MAX_RESULTS);
-
-  return ranked.map((r) => ({
-    id: r.etf.id,
-    name: r.etf.name,
-    symbol: r.etf.symbol,
-    exchange: r.etf.exchange,
-    aum: r.etf.financialInfo?.aum ?? null,
-    category: r.etf.stockAnalyzerInfo?.category ?? null,
-    assetClass: r.etf.stockAnalyzerInfo?.assetClass ?? null,
-    cachedScore: r.etf.cachedScore ? { finalScore: r.etf.cachedScore.finalScore } : null,
-  }));
+  // Show only ETFs that exist in our DB so the cards link to a real page
+  // and can display score / AUM. The LLM is asked for at least 6, so most
+  // should resolve.
+  return stored
+    .filter((s) => s.matchedEtf !== null)
+    .slice(0, MAX_RESULTS)
+    .map((s) => {
+      const matched = s.matchedEtf!;
+      return {
+        id: matched.id,
+        name: matched.name || s.name || s.symbol,
+        symbol: matched.symbol,
+        exchange: matched.exchange,
+        reason: s.reason,
+        aum: matched.financialInfo?.aum ?? null,
+        category: matched.stockAnalyzerInfo?.category ?? null,
+        assetClass: matched.stockAnalyzerInfo?.assetClass ?? null,
+        cachedScore: matched.cachedScore ? { finalScore: matched.cachedScore.finalScore } : null,
+        inDb: true,
+      };
+    });
 }
 
 export const GET = withErrorHandlingV2<SimilarEtf[]>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -18,7 +18,7 @@ async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceI
 
   const sourceEtf = await prisma.etf.findFirst({
     where,
-    select: { id: true },
+    select: { id: true, spaceId: true },
   });
   if (!sourceEtf) return [];
 
@@ -27,12 +27,23 @@ async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceI
     orderBy: { sortOrder: 'asc' },
     take: MAX_RESULTS,
   });
+  if (stored.length === 0) return [];
+
+  // Name lives on the main Etf row — look it up by (symbol, exchange).
+  const etfs = await prisma.etf.findMany({
+    where: {
+      spaceId: sourceEtf.spaceId,
+      OR: stored.map((s) => ({ symbol: s.symbol, exchange: s.exchange })),
+    },
+    select: { symbol: true, exchange: true, name: true },
+  });
+  const nameByKey: Map<string, string> = new Map<string, string>(etfs.map((e) => [`${e.symbol}|${e.exchange}`, e.name]));
 
   return stored.map((s) => ({
     id: s.id,
     symbol: s.symbol,
     exchange: s.exchange,
-    name: s.name || s.symbol,
+    name: nameByKey.get(`${s.symbol}|${s.exchange}`) ?? s.symbol,
   }));
 }
 

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -1,0 +1,85 @@
+import { getEtfWhereClause } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
+import { prisma } from '@/prisma';
+import { parseNumericStringValue } from '@/utils/etf-filter-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { Prisma } from '@prisma/client';
+import { NextRequest } from 'next/server';
+
+export interface SimilarEtf {
+  id: string;
+  name: string;
+  symbol: string;
+  exchange: string;
+  aum: string | null;
+  category: string | null;
+  assetClass: string | null;
+  cachedScore: { finalScore: number } | null;
+}
+
+const MAX_RESULTS = 6;
+const CANDIDATE_LIMIT = 100;
+
+async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }): Promise<SimilarEtf[]> {
+  const { spaceId, exchange, etf } = await context.params;
+  const where = getEtfWhereClause({ spaceId, exchange, etf });
+
+  const etfRecord = await prisma.etf.findFirst({
+    where,
+    include: {
+      financialInfo: true,
+      stockAnalyzerInfo: true,
+    },
+  });
+  if (!etfRecord) return [];
+
+  const category: string | null = etfRecord.stockAnalyzerInfo?.category?.trim() || null;
+  const assetClass: string | null = etfRecord.stockAnalyzerInfo?.assetClass?.trim() || null;
+
+  // Use category if present, fallback to assetClass.
+  const stockAnalyzerInfoFilter: Prisma.EtfStockAnalyzerInfoWhereInput | null = category
+    ? { category: { equals: category, mode: 'insensitive' } }
+    : assetClass
+    ? { assetClass: { equals: assetClass, mode: 'insensitive' } }
+    : null;
+
+  if (!stockAnalyzerInfoFilter) return [];
+
+  const candidates = await prisma.etf.findMany({
+    where: {
+      spaceId: where.spaceId,
+      id: { not: etfRecord.id },
+      stockAnalyzerInfo: { is: stockAnalyzerInfoFilter },
+    },
+    include: {
+      financialInfo: true,
+      stockAnalyzerInfo: true,
+      cachedScore: true,
+    },
+    take: CANDIDATE_LIMIT,
+  });
+
+  const currentAum: number | null = parseNumericStringValue(etfRecord.financialInfo?.aum);
+
+  // Rank by AUM proximity when both sides have a parseable AUM; otherwise push to the end.
+  const ranked = candidates
+    .map((c) => {
+      const aumNum: number | null = parseNumericStringValue(c.financialInfo?.aum);
+      const distance: number = currentAum !== null && aumNum !== null ? Math.abs(aumNum - currentAum) : Number.POSITIVE_INFINITY;
+      return { etf: c, distance };
+    })
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, MAX_RESULTS);
+
+  return ranked.map((r) => ({
+    id: r.etf.id,
+    name: r.etf.name,
+    symbol: r.etf.symbol,
+    exchange: r.etf.exchange,
+    aum: r.etf.financialInfo?.aum ?? null,
+    category: r.etf.stockAnalyzerInfo?.category ?? null,
+    assetClass: r.etf.stockAnalyzerInfo?.assetClass ?? null,
+    cachedScore: r.etf.cachedScore ? { finalScore: r.etf.cachedScore.finalScore } : null,
+  }));
+}
+
+export const GET = withErrorHandlingV2<SimilarEtf[]>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -8,7 +8,6 @@ export interface SimilarEtf {
   name: string;
   symbol: string;
   exchange: string;
-  reason: string | null;
   aum: string | null;
   category: string | null;
   assetClass: string | null;
@@ -55,7 +54,6 @@ async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceI
         name: matched.name || s.name || s.symbol,
         symbol: matched.symbol,
         exchange: matched.exchange,
-        reason: s.reason,
         aum: matched.financialInfo?.aum ?? null,
         category: matched.stockAnalyzerInfo?.category ?? null,
         assetClass: matched.stockAnalyzerInfo?.assetClass ?? null,

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -5,14 +5,9 @@ import { NextRequest } from 'next/server';
 
 export interface SimilarEtf {
   id: string;
-  name: string;
   symbol: string;
   exchange: string;
-  aum: string | null;
-  category: string | null;
-  assetClass: string | null;
-  cachedScore: { finalScore: number } | null;
-  inDb: boolean;
+  name: string;
 }
 
 const MAX_RESULTS = 6;
@@ -30,37 +25,15 @@ async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceI
   const stored = await prisma.etfSimilarEtf.findMany({
     where: { sourceEtfId: sourceEtf.id },
     orderBy: { sortOrder: 'asc' },
-    include: {
-      matchedEtf: {
-        include: {
-          financialInfo: true,
-          stockAnalyzerInfo: true,
-          cachedScore: true,
-        },
-      },
-    },
+    take: MAX_RESULTS,
   });
 
-  // Show only ETFs that exist in our DB so the cards link to a real page
-  // and can display score / AUM. The LLM is asked for at least 6, so most
-  // should resolve.
-  return stored
-    .filter((s) => s.matchedEtf !== null)
-    .slice(0, MAX_RESULTS)
-    .map((s) => {
-      const matched = s.matchedEtf!;
-      return {
-        id: matched.id,
-        name: matched.name || s.name || s.symbol,
-        symbol: matched.symbol,
-        exchange: matched.exchange,
-        aum: matched.financialInfo?.aum ?? null,
-        category: matched.stockAnalyzerInfo?.category ?? null,
-        assetClass: matched.stockAnalyzerInfo?.assetClass ?? null,
-        cachedScore: matched.cachedScore ? { finalScore: matched.cachedScore.finalScore } : null,
-        inDb: true,
-      };
-    });
+  return stored.map((s) => ({
+    id: s.id,
+    symbol: s.symbol,
+    exchange: s.exchange,
+    name: s.name || s.symbol,
+  }));
 }
 
 export const GET = withErrorHandlingV2<SimilarEtf[]>(getHandler);

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -16,6 +16,7 @@ import { getCountryByExchange, SupportedCountries, formatExchangeWithCountry, to
 import { generateEtfDetailMetadata, generateEtfDetailArticleJsonLd, generateEtfDetailBreadcrumbJsonLd } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { splitMarkdownAtParagraph } from '@/utils/etf-display-format-utils';
 import { RadarSkeleton } from '@/app/stocks/[exchange]/[ticker]/RadarSkeleton';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -255,6 +256,7 @@ function BreadcrumbsFromData({ data }: { data: Promise<EtfFastResponse> }): JSX.
 
 function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Element {
   const d: EtfFastResponse = use(data);
+  const { head: indexStrategyHead } = splitMarkdownAtParagraph(d.indexStrategy, 2);
 
   return (
     <section id="introduction" className="text-left">
@@ -274,12 +276,23 @@ function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Eleme
         </div>
       )}
 
-      {/* Index & Strategy (if available) */}
-      {d.indexStrategy && d.indexStrategy.trim() && (
+      {/* Index & Strategy — first 2 paragraphs. Remaining paragraphs render below the price chart. */}
+      {indexStrategyHead && (
         <div className="mb-2">
-          <div className="markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(d.indexStrategy) }} />
+          <div className="markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(indexStrategyHead) }} />
         </div>
       )}
+    </section>
+  );
+}
+
+function EtfIndexStrategyTail({ data }: { data: Promise<EtfFastResponse> }): JSX.Element | null {
+  const d: EtfFastResponse = use(data);
+  const { tail } = splitMarkdownAtParagraph(d.indexStrategy, 2);
+  if (!tail) return null;
+  return (
+    <section id="index-strategy-tail" className="mb-8">
+      <div className="markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(tail) }} />
     </section>
   );
 }
@@ -450,6 +463,9 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
             priceHistoryPromise={priceHistoryPromise}
           />
         </Suspense>
+
+        {/* Remaining Index & Strategy paragraphs, rendered after the price chart. */}
+        <EtfIndexStrategyTail data={etfInfo} />
 
         <Suspense fallback={null}>
           <EtfAnalysisSection analysisPromise={analysisPromise} exchange={exchange} symbol={etf} />

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -3,9 +3,11 @@ import { EtfFinancialInfoResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[
 import { PriceHistoryResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/price-history/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import { EtfScoresResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route';
+import { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
 import EtfAnalysisSections from '@/components/etf-reportsv1/analysis/EtfAnalysisSections';
 import EtfRadarChart from '@/components/etf-reportsv1/analysis/EtfRadarChart';
 import EtfFinancialInfo from '@/components/etf-reportsv1/EtfFinancialInfo';
+import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import { FinancialCard } from '@/components/ticker-reportsv1/FinancialInfo';
 import PriceChart from '@/components/ticker-reportsv1/PriceChart';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -97,6 +99,21 @@ async function fetchEtfScores(exchange: string, etf: string): Promise<EtfScoresR
     return (await res.json()) as EtfScoresResponse | null;
   } catch {
     return null;
+  }
+}
+
+async function fetchSimilarEtfs(exchange: string, etf: string): Promise<SimilarEtf[]> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange.toUpperCase()}/${etf.toUpperCase()}/similar-etfs`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) {
+      console.error(`fetchSimilarEtfs failed (${res.status}): ${url}`);
+      return [];
+    }
+    return (await res.json()) as SimilarEtf[];
+  } catch (error) {
+    console.error(`fetchSimilarEtfs error for ${etf}:`, error);
+    return [];
   }
 }
 
@@ -363,6 +380,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
   const analysisPromise = fetchEtfAnalysis(exchange, etf);
   const scoresPromise = fetchEtfScores(exchange, etf);
   const priceHistoryPromise = fetchEtfPriceHistory(exchange, etf);
+  const similarEtfsPromise = fetchSimilarEtfs(exchange, etf);
 
   // Derive dates for semantic footer (based solely on etfData)
   const now = new Date();
@@ -436,6 +454,14 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
         <Suspense fallback={null}>
           <EtfAnalysisSection analysisPromise={analysisPromise} exchange={exchange} symbol={etf} />
         </Suspense>
+
+        <div className="mx-auto max-w-7xl">
+          <section className="mb-6">
+            <Suspense fallback={null}>
+              <SimilarEtfs dataPromise={similarEtfsPromise} />
+            </Suspense>
+          </section>
+        </div>
 
         <EtfArticleFooter modifiedDate={modifiedDate} formattedModifiedDate={formattedModifiedDate} />
       </article>

--- a/insights-ui/src/components/etf-reportsv1/EtfFinancialInfo.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfFinancialInfo.tsx
@@ -1,48 +1,10 @@
 import { EtfFinancialInfoResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/financial-info/route';
 import { FinancialCard } from '@/components/ticker-reportsv1/FinancialInfo';
 import { formatNumber, formatPercentageDecimal, formatVolume } from '@/components/reportsv1/financialFormatters';
+import { formatCompactAmount, formatCompactMillions } from '@/utils/etf-display-format-utils';
 
 interface EtfFinancialInfoProps {
   data: EtfFinancialInfoResponse;
-}
-
-function parseNumericString(value: string | null): number | null {
-  if (!value) return null;
-  const raw = value.trim();
-  if (!raw) return null;
-
-  // Supports values like:
-  // - "$47.46B", "257.25M", "1.60M", "259,668"
-  // Keep parsing tolerant because we store "display strings" in DB.
-  const cleaned = raw.replace(/,/g, '').replace(/^\$/, '').trim();
-  const match = cleaned.match(/^([+-]?\d+(?:\.\d+)?)\s*([KMBT])?$/i);
-  if (!match) return null;
-
-  const num = Number(match[1]);
-  if (!Number.isFinite(num)) return null;
-
-  const suffix = (match[2] || '').toUpperCase();
-  const mult = suffix === 'K' ? 1_000 : suffix === 'M' ? 1_000_000 : suffix === 'B' ? 1_000_000_000 : suffix === 'T' ? 1_000_000_000_000 : 1;
-  return num * mult;
-}
-
-function formatCompactAmount(value: string | null): string {
-  const n = parseNumericString(value);
-  if (n === null) return 'N/A';
-  const prefix = (value ?? '').trim().startsWith('$') ? '$' : '';
-  if (n >= 1_000_000_000) return `${prefix}${(n / 1_000_000_000).toFixed(2)}B`;
-  if (n >= 1_000_000) return `${prefix}${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${prefix}${(n / 1_000).toFixed(2)}K`;
-  return `${prefix}${n.toFixed(2)}`;
-}
-
-function formatCompactMillions(value: string | null): string {
-  const n = parseNumericString(value);
-  if (n === null) return 'N/A';
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(2)}K`;
-  return `${n.toFixed(2)}`;
 }
 
 // Helper to format integer

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -1,6 +1,4 @@
 import type { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
-import { formatCompactAmount } from '@/utils/etf-display-format-utils';
-import { getScoreColorClasses } from '@/utils/score-utils';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 import { use } from 'react';
@@ -9,9 +7,6 @@ export interface SimilarEtfsProps {
   /** Promise-based fetch (resolved via `use()` to keep Suspense at the caller). */
   dataPromise: Promise<SimilarEtf[]>;
 }
-
-// Final score is the sum of 4 category scores, each capped at 5 factors → 20.
-const ETF_MAX_SCORE = 20;
 
 export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Element | null {
   const similarEtfs: ReadonlyArray<SimilarEtf> = use(dataPromise);
@@ -24,44 +19,23 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
       <p className="text-gray-300 mb-4">True peers tracking the same or a very similar index in the same category:</p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {similarEtfs.map((similarEtf) => {
-          const rawScore: number | null = similarEtf.cachedScore?.finalScore ?? null;
-          // getScoreColorClasses uses /25 thresholds; scale ETF /20 score onto that range for color.
-          const scaledForColor: number | null = rawScore !== null ? (rawScore / ETF_MAX_SCORE) * 25 : null;
-          const { textColorClass } = scaledForColor !== null ? getScoreColorClasses(scaledForColor) : { textColorClass: 'text-gray-400' };
-          const formattedAum: string = formatCompactAmount(similarEtf.aum);
-
-          return (
-            <Link
-              key={similarEtf.id}
-              href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
-              className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
-            >
-              <div className="flex flex-col gap-y-2">
-                <div className="flex items-center justify-between gap-x-3">
-                  <div className="flex items-center gap-x-2 min-w-0">
-                    <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{similarEtf.name}</h3>
-                    <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
-                  </div>
-                  {rawScore !== null && (
-                    <span
-                      className={`flex-shrink-0 inline-flex items-baseline gap-0.5 rounded-full bg-gray-900/60 px-2 py-0.5 text-sm font-semibold ${textColorClass}`}
-                    >
-                      {rawScore}
-                      <span className="text-xs font-normal text-gray-400">/{ETF_MAX_SCORE}</span>
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="text-sm text-gray-400">
-                    {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
-                  </div>
-                  {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: ${formattedAum}</div>}
-                </div>
+        {similarEtfs.map((similarEtf) => (
+          <Link
+            key={similarEtf.id}
+            href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
+            className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
+          >
+            <div className="flex flex-col gap-y-2">
+              <div className="flex items-center gap-x-2 min-w-0">
+                <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{similarEtf.name}</h3>
+                <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
               </div>
-            </Link>
-          );
-        })}
+              <div className="text-sm text-gray-400">
+                {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
+              </div>
+            </div>
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -56,7 +56,7 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
                   <div className="text-sm text-gray-400">
                     {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
                   </div>
-                  {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: {formattedAum}</div>}
+                  {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: ${formattedAum}</div>}
                 </div>
               </div>
             </Link>

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -22,7 +22,7 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
   return (
     <div id="similar-etfs" className="bg-gray-900 rounded-lg shadow-sm p-6 mb-8">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
-      <p className="text-gray-300 mb-4">Based on ETF category and AUM proximity:</p>
+      <p className="text-gray-300 mb-4">True peers tracking the same or a very similar index in the same category:</p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {similarEtfs.map((similarEtf) => {
           const rawScore: number | null = similarEtf.cachedScore?.finalScore ?? null;
@@ -58,6 +58,7 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
                   </div>
                   {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: ${formattedAum}</div>}
                 </div>
+                {similarEtf.reason && <p className="text-xs text-gray-400 leading-snug line-clamp-2">{similarEtf.reason}</p>}
               </div>
             </Link>
           );

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -1,4 +1,6 @@
 import type { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
+import { formatCompactAmount } from '@/utils/etf-display-format-utils';
+import { getScoreColorClasses } from '@/utils/score-utils';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 import { use } from 'react';
@@ -7,6 +9,9 @@ export interface SimilarEtfsProps {
   /** Promise-based fetch (resolved via `use()` to keep Suspense at the caller). */
   dataPromise: Promise<SimilarEtf[]>;
 }
+
+// Final score is the sum of 4 category scores, each capped at 5 factors → 20.
+const ETF_MAX_SCORE = 20;
 
 export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Element | null {
   const similarEtfs: ReadonlyArray<SimilarEtf> = use(dataPromise);
@@ -19,28 +24,44 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
       <p className="text-gray-300 mb-4">Based on ETF category and AUM proximity:</p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {similarEtfs.map((similarEtf) => (
-          <Link
-            key={similarEtf.id}
-            href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
-            className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
-          >
-            <div className="flex flex-col gap-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-x-2">
-                  <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors">{similarEtf.name}</h3>
-                  <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors" />
+        {similarEtfs.map((similarEtf) => {
+          const rawScore: number | null = similarEtf.cachedScore?.finalScore ?? null;
+          // getScoreColorClasses uses /25 thresholds; scale ETF /20 score onto that range for color.
+          const scaledForColor: number | null = rawScore !== null ? (rawScore / ETF_MAX_SCORE) * 25 : null;
+          const { textColorClass } = scaledForColor !== null ? getScoreColorClasses(scaledForColor) : { textColorClass: 'text-gray-400' };
+          const formattedAum: string = formatCompactAmount(similarEtf.aum);
+
+          return (
+            <Link
+              key={similarEtf.id}
+              href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
+              className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
+            >
+              <div className="flex flex-col gap-y-2">
+                <div className="flex items-center justify-between gap-x-3">
+                  <div className="flex items-center gap-x-2 min-w-0">
+                    <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{similarEtf.name}</h3>
+                    <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
+                  </div>
+                  {rawScore !== null && (
+                    <span
+                      className={`flex-shrink-0 inline-flex items-baseline gap-0.5 rounded-full bg-gray-900/60 px-2 py-0.5 text-sm font-semibold ${textColorClass}`}
+                    >
+                      {rawScore}
+                      <span className="text-xs font-normal text-gray-400">/{ETF_MAX_SCORE}</span>
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-gray-400">
+                    {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
+                  </div>
+                  {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: {formattedAum}</div>}
                 </div>
               </div>
-              <div className="flex items-center justify-between">
-                <div className="text-sm text-gray-400">
-                  {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
-                </div>
-                {similarEtf.aum && <div className="text-sm text-gray-300">AUM: {similarEtf.aum}</div>}
-              </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -58,7 +58,6 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
                   </div>
                   {formattedAum !== 'N/A' && <div className="text-sm text-gray-300">AUM: ${formattedAum}</div>}
                 </div>
-                {similarEtf.reason && <p className="text-xs text-gray-400 leading-snug line-clamp-2">{similarEtf.reason}</p>}
               </div>
             </Link>
           );

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -1,0 +1,47 @@
+import type { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
+import Link from 'next/link';
+import { use } from 'react';
+
+export interface SimilarEtfsProps {
+  /** Promise-based fetch (resolved via `use()` to keep Suspense at the caller). */
+  dataPromise: Promise<SimilarEtf[]>;
+}
+
+export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Element | null {
+  const similarEtfs: ReadonlyArray<SimilarEtf> = use(dataPromise);
+  if (!similarEtfs || similarEtfs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div id="similar-etfs" className="bg-gray-900 rounded-lg shadow-sm p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
+      <p className="text-gray-300 mb-4">Based on ETF category and AUM proximity:</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {similarEtfs.map((similarEtf) => (
+          <Link
+            key={similarEtf.id}
+            href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
+            className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
+          >
+            <div className="flex flex-col gap-y-2">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-x-2">
+                  <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors">{similarEtf.name}</h3>
+                  <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors" />
+                </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-gray-400">
+                  {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
+                </div>
+                {similarEtf.aum && <div className="text-sm text-gray-300">AUM: {similarEtf.aum}</div>}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -47,8 +47,16 @@ export interface EtfFinalSummaryResponse {
   summary: string;
 }
 
+export interface EtfIndexStrategySimilarEtf {
+  symbol: string;
+  exchange: string;
+  name: string;
+  reason: string;
+}
+
 export interface EtfIndexStrategyResponse {
   indexStrategy: string;
+  similarEtfs: EtfIndexStrategySimilarEtf[];
 }
 
 export interface EtfAnalysisFactorDefinition {

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -51,7 +51,6 @@ export interface EtfIndexStrategySimilarEtf {
   symbol: string;
   exchange: string;
   name: string;
-  reason: string;
 }
 
 export interface EtfIndexStrategyResponse {

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -50,7 +50,6 @@ export interface EtfFinalSummaryResponse {
 export interface EtfIndexStrategySimilarEtf {
   symbol: string;
   exchange: string;
-  name: string;
 }
 
 export interface EtfIndexStrategyResponse {

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -1,9 +1,18 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { EtfAnalysisCategory, EtfCategoryAnalysisResponse, EtfFinalSummaryResponse, EtfIndexStrategyResponse } from '@/types/etf/etf-analysis-types';
+import {
+  EtfAnalysisCategory,
+  EtfCategoryAnalysisResponse,
+  EtfFinalSummaryResponse,
+  EtfIndexStrategyResponse,
+  EtfIndexStrategySimilarEtf,
+} from '@/types/etf/etf-analysis-types';
 import { findFactorDefinition } from '@/utils/etf-analysis-reports/etf-report-input-json-utils';
 import { fetchEtfBySymbolAndExchange } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { USExchanges } from '@/utils/countryExchangeUtils';
+
+const SUPPORTED_SIMILAR_ETF_EXCHANGES: ReadonlySet<string> = new Set<string>([USExchanges.BATS, USExchanges.NASDAQ, USExchanges.NYSE, USExchanges.NYSEARCA]);
 
 export async function saveEtfFactorAnalysisResponse(
   symbol: string,
@@ -101,7 +110,82 @@ export async function saveEtfIndexStrategyResponse(symbol: string, exchange: str
     },
   });
 
+  await replaceEtfSimilarEtfs(etfRecord.id, etfRecord.spaceId, symbol, exchange, response.similarEtfs ?? []);
+
   revalidateEtfAndExchangeTag(symbol, exchange);
+}
+
+/**
+ * Replace the source ETF's stored similar-ETF list with the LLM-provided one.
+ *
+ * - Drops entries whose exchange is not one of the supported US exchanges
+ *   (BATS / NASDAQ / NYSE / NYSEARCA).
+ * - Drops self-references.
+ * - Normalizes symbol + exchange to uppercase.
+ * - De-duplicates on (symbol, exchange) preserving the first occurrence's order.
+ * - Looks each entry up in the `etfs` table to populate `matchedEtfId` when present.
+ */
+async function replaceEtfSimilarEtfs(
+  sourceEtfId: string,
+  spaceId: string,
+  sourceSymbol: string,
+  sourceExchange: string,
+  similarEtfs: ReadonlyArray<EtfIndexStrategySimilarEtf>
+): Promise<void> {
+  const sourceSymbolUpper: string = sourceSymbol.trim().toUpperCase();
+  const sourceExchangeUpper: string = sourceExchange.trim().toUpperCase();
+
+  const seen: Set<string> = new Set<string>();
+  const cleaned: { symbol: string; exchange: string; name: string; reason: string }[] = [];
+
+  for (const entry of similarEtfs) {
+    if (!entry || typeof entry.symbol !== 'string' || typeof entry.exchange !== 'string') continue;
+    const symbolUpper: string = entry.symbol.trim().toUpperCase();
+    const exchangeUpper: string = entry.exchange.trim().toUpperCase();
+    if (!symbolUpper || !exchangeUpper) continue;
+    if (!SUPPORTED_SIMILAR_ETF_EXCHANGES.has(exchangeUpper)) continue;
+    if (symbolUpper === sourceSymbolUpper && exchangeUpper === sourceExchangeUpper) continue;
+    const key: string = `${symbolUpper}|${exchangeUpper}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    cleaned.push({
+      symbol: symbolUpper,
+      exchange: exchangeUpper,
+      name: (entry.name ?? '').trim(),
+      reason: (entry.reason ?? '').trim(),
+    });
+  }
+
+  // Look up which of these exist in our DB so we can pre-populate matchedEtfId.
+  const existing = cleaned.length
+    ? await prisma.etf.findMany({
+        where: {
+          spaceId,
+          OR: cleaned.map((c) => ({ symbol: c.symbol, exchange: c.exchange })),
+        },
+        select: { id: true, symbol: true, exchange: true },
+      })
+    : [];
+  const matchByKey: Map<string, string> = new Map<string, string>(existing.map((e) => [`${e.symbol}|${e.exchange}`, e.id]));
+
+  await prisma.$transaction(async (tx) => {
+    await tx.etfSimilarEtf.deleteMany({ where: { sourceEtfId } });
+
+    if (cleaned.length === 0) return;
+
+    await tx.etfSimilarEtf.createMany({
+      data: cleaned.map((c, idx) => ({
+        sourceEtfId,
+        spaceId,
+        symbol: c.symbol,
+        exchange: c.exchange,
+        name: c.name || null,
+        reason: c.reason || null,
+        sortOrder: idx,
+        matchedEtfId: matchByKey.get(`${c.symbol}|${c.exchange}`) ?? null,
+      })),
+    });
+  });
 }
 
 async function updateEtfCachedScore(etfId: string, categoryKey: EtfAnalysisCategory, categoryScore: number): Promise<void> {

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -136,7 +136,7 @@ async function replaceEtfSimilarEtfs(
   const sourceExchangeUpper: string = sourceExchange.trim().toUpperCase();
 
   const seen: Set<string> = new Set<string>();
-  const cleaned: { symbol: string; exchange: string; name: string; reason: string }[] = [];
+  const cleaned: { symbol: string; exchange: string; name: string }[] = [];
 
   for (const entry of similarEtfs) {
     if (!entry || typeof entry.symbol !== 'string' || typeof entry.exchange !== 'string') continue;
@@ -152,7 +152,6 @@ async function replaceEtfSimilarEtfs(
       symbol: symbolUpper,
       exchange: exchangeUpper,
       name: (entry.name ?? '').trim(),
-      reason: (entry.reason ?? '').trim(),
     });
   }
 
@@ -180,7 +179,6 @@ async function replaceEtfSimilarEtfs(
         symbol: c.symbol,
         exchange: c.exchange,
         name: c.name || null,
-        reason: c.reason || null,
         sortOrder: idx,
         matchedEtfId: matchByKey.get(`${c.symbol}|${c.exchange}`) ?? null,
       })),

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -123,6 +123,8 @@ export async function saveEtfIndexStrategyResponse(symbol: string, exchange: str
  * - Drops self-references.
  * - Normalizes symbol + exchange to uppercase.
  * - De-duplicates on (symbol, exchange) preserving the first occurrence's order.
+ * - Only inserts entries that already exist in the `etfs` table (we need a
+ *   report page to link to, and the name comes from `Etf` at read time).
  */
 async function replaceEtfSimilarEtfs(
   sourceEtfId: string,
@@ -135,7 +137,7 @@ async function replaceEtfSimilarEtfs(
   const sourceExchangeUpper: string = sourceExchange.trim().toUpperCase();
 
   const seen: Set<string> = new Set<string>();
-  const cleaned: { symbol: string; exchange: string; name: string }[] = [];
+  const cleaned: { symbol: string; exchange: string }[] = [];
 
   for (const entry of similarEtfs) {
     if (!entry || typeof entry.symbol !== 'string' || typeof entry.exchange !== 'string') continue;
@@ -147,25 +149,34 @@ async function replaceEtfSimilarEtfs(
     const key: string = `${symbolUpper}|${exchangeUpper}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    cleaned.push({
-      symbol: symbolUpper,
-      exchange: exchangeUpper,
-      name: (entry.name ?? '').trim(),
-    });
+    cleaned.push({ symbol: symbolUpper, exchange: exchangeUpper });
   }
+
+  // Only keep entries that actually exist in our Etf table so each card
+  // resolves to a real report page.
+  const existing = cleaned.length
+    ? await prisma.etf.findMany({
+        where: {
+          spaceId,
+          OR: cleaned.map((c) => ({ symbol: c.symbol, exchange: c.exchange })),
+        },
+        select: { symbol: true, exchange: true },
+      })
+    : [];
+  const existingKeys: Set<string> = new Set<string>(existing.map((e) => `${e.symbol}|${e.exchange}`));
+  const toInsert = cleaned.filter((c) => existingKeys.has(`${c.symbol}|${c.exchange}`));
 
   await prisma.$transaction(async (tx) => {
     await tx.etfSimilarEtf.deleteMany({ where: { sourceEtfId } });
 
-    if (cleaned.length === 0) return;
+    if (toInsert.length === 0) return;
 
     await tx.etfSimilarEtf.createMany({
-      data: cleaned.map((c, idx) => ({
+      data: toInsert.map((c, idx) => ({
         sourceEtfId,
         spaceId,
         symbol: c.symbol,
         exchange: c.exchange,
-        name: c.name || null,
         sortOrder: idx,
       })),
     });

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -123,7 +123,6 @@ export async function saveEtfIndexStrategyResponse(symbol: string, exchange: str
  * - Drops self-references.
  * - Normalizes symbol + exchange to uppercase.
  * - De-duplicates on (symbol, exchange) preserving the first occurrence's order.
- * - Looks each entry up in the `etfs` table to populate `matchedEtfId` when present.
  */
 async function replaceEtfSimilarEtfs(
   sourceEtfId: string,
@@ -155,18 +154,6 @@ async function replaceEtfSimilarEtfs(
     });
   }
 
-  // Look up which of these exist in our DB so we can pre-populate matchedEtfId.
-  const existing = cleaned.length
-    ? await prisma.etf.findMany({
-        where: {
-          spaceId,
-          OR: cleaned.map((c) => ({ symbol: c.symbol, exchange: c.exchange })),
-        },
-        select: { id: true, symbol: true, exchange: true },
-      })
-    : [];
-  const matchByKey: Map<string, string> = new Map<string, string>(existing.map((e) => [`${e.symbol}|${e.exchange}`, e.id]));
-
   await prisma.$transaction(async (tx) => {
     await tx.etfSimilarEtf.deleteMany({ where: { sourceEtfId } });
 
@@ -180,7 +167,6 @@ async function replaceEtfSimilarEtfs(
         exchange: c.exchange,
         name: c.name || null,
         sortOrder: idx,
-        matchedEtfId: matchByKey.get(`${c.symbol}|${c.exchange}`) ?? null,
       })),
     });
   });

--- a/insights-ui/src/utils/etf-display-format-utils.ts
+++ b/insights-ui/src/utils/etf-display-format-utils.ts
@@ -1,0 +1,55 @@
+import { parseNumericStringValue } from '@/utils/etf-filter-utils';
+
+/**
+ * Format an AUM/sharesOut-style display string into a compact representation
+ * (B/M/K), preserving a leading "$" if present. Returns "N/A" when the value
+ * cannot be parsed.
+ */
+export function formatCompactAmount(value: string | null | undefined): string {
+  const n = parseNumericStringValue(value ?? null);
+  if (n === null) return 'N/A';
+  const prefix = (value ?? '').trim().startsWith('$') ? '$' : '';
+  if (n >= 1_000_000_000) return `${prefix}${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${prefix}${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${prefix}${(n / 1_000).toFixed(2)}K`;
+  return `${prefix}${n.toFixed(2)}`;
+}
+
+/**
+ * Same as formatCompactAmount but always strips any "$" prefix.
+ */
+export function formatCompactMillions(value: string | null | undefined): string {
+  const n = parseNumericStringValue(value ?? null);
+  if (n === null) return 'N/A';
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(2)}K`;
+  return `${n.toFixed(2)}`;
+}
+
+/**
+ * Split a markdown string into paragraph blocks separated by blank lines.
+ * Trims and drops empty entries. Preserves intra-paragraph line breaks.
+ */
+export function splitMarkdownParagraphs(markdown: string): string[] {
+  return markdown
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Split markdown into "head" and "tail" pieces. The head receives the first
+ * `headCount` paragraphs; the tail receives everything after that. When there
+ * are fewer paragraphs than `headCount`, the head gets all and the tail is
+ * empty.
+ */
+export function splitMarkdownAtParagraph(markdown: string | null | undefined, headCount: number): { head: string; tail: string } {
+  if (!markdown || !markdown.trim()) return { head: '', tail: '' };
+  const paragraphs = splitMarkdownParagraphs(markdown);
+  if (paragraphs.length <= headCount) return { head: paragraphs.join('\n\n'), tail: '' };
+  return {
+    head: paragraphs.slice(0, headCount).join('\n\n'),
+    tail: paragraphs.slice(headCount).join('\n\n'),
+  };
+}


### PR DESCRIPTION
## Summary

Adds a Similar ETFs section to the ETF detail page (`/etfs/[exchange]/[etf]`) mirroring the SimilarTickers pattern used on the stocks page.

- New API route `GET /api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs` that:
  - Looks up the current ETF and reads `EtfStockAnalyzerInfo.category` (fallback to `assetClass` when category is missing).
  - Filters candidate ETFs (excluding the current one) whose `EtfStockAnalyzerInfo` matches that key (case-insensitive).
  - Parses each candidate's `EtfFinancialInfo.aum` with `parseNumericStringValue` and ranks by absolute AUM distance from the current ETF.
  - Returns up to 6 results with `id`, `name`, `symbol`, `exchange`, `aum`, `category`, `assetClass`, and `cachedScore.finalScore`.
- New `SimilarEtfs` server component that consumes the fetch promise via `use()` and renders cards linking to `/etfs/{EXCHANGE}/{SYMBOL}`.
- Wired into `app/etfs/[exchange]/[etf]/page.tsx` inside a `Suspense` block, sharing the existing `etfAndExchangeTag` cache tag for revalidation.

## Test plan

- [ ] Visit an ETF page with a populated `category` (e.g. `/etfs/NASDAQ/QQQI`) and confirm the Similar ETFs section renders 1–6 cards from the same category, ordered by AUM proximity.
- [ ] Visit an ETF whose `category` is null but `assetClass` is set; confirm the section still renders using the assetClass fallback.
- [ ] Visit an ETF with neither `category` nor `assetClass`; confirm the section is hidden (no empty card grid).
- [ ] Click a Similar ETF card and confirm it navigates to the correct ETF detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)