### PR TITLE
Pre-fetch missing MOR data when creating ETF analysis generation requests

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/fetch-mor-info/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/fetch-mor-info/route.ts
@@ -1,9 +1,9 @@
 import { withAdminOrToken } from '@/app/api/helpers/withAdminOrToken';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
-import { AllExchanges, toExchange, USExchanges } from '@/utils/countryExchangeUtils';
+import { MorKind, triggerMorScrape } from '@/utils/etf-analysis-reports/mor-scrape-utils';
 import { NextRequest } from 'next/server';
 
-export type MorKind = 'quote' | 'risk' | 'people' | 'portfolio';
+export type { MorKind } from '@/utils/etf-analysis-reports/mor-scrape-utils';
 
 export interface TriggerMorScrapeRequest {
   kind: MorKind;
@@ -16,47 +16,9 @@ export interface TriggerMorScrapeResponse {
   kind: MorKind;
 }
 
-const LAMBDA_URL = process.env.ETF_MORN_LAMBDA_URL || '';
-const CALLBACK_BASE_URL = process.env.REPORT_GENERATION_CALLBACK_BASE_URL || 'https://koalagains.com';
-
-function normalizeUpperTrim(v: string | null | undefined): string {
-  return (v ?? '').toUpperCase().trim();
-}
-
 function toKind(v: unknown): MorKind {
   if (v === 'quote' || v === 'risk' || v === 'people' || v === 'portfolio') return v;
   throw new Error('Invalid kind. Expected quote, risk, people, or portfolio.');
-}
-
-function joinUrl(base: string, path: string): string {
-  const b = (base ?? '').replace(/\/+$/, '');
-  const p = (path ?? '').replace(/^\/+/, '');
-  return `${b}/${p}`;
-}
-
-type MorEtfExchangeSegment = 'xnys' | 'xnas' | 'arcx' | 'bats';
-
-function toMorEtfExchangeSegment(exchange: AllExchanges): MorEtfExchangeSegment {
-  switch (exchange) {
-    case USExchanges.NYSE:
-      return 'xnys';
-    case USExchanges.NASDAQ:
-      return 'xnas';
-    case USExchanges.NYSEARCA:
-      return 'arcx';
-    case USExchanges.BATS:
-      return 'bats';
-    default:
-      throw new Error(`Unsupported exchange: ${exchange}`);
-  }
-}
-
-function buildMorEtfRelativePath(params: { exchange: string; symbol: string; kind: MorKind }): string {
-  const ex = toExchange(params.exchange);
-  const seg = toMorEtfExchangeSegment(ex);
-  const sym = (params.symbol ?? '').trim().toLowerCase();
-  if (!sym) throw new Error('Invalid ETF symbol');
-  return `/${seg}/${encodeURIComponent(sym)}/${params.kind}`;
 }
 
 async function postHandler(
@@ -64,41 +26,11 @@ async function postHandler(
   _userContext: KoalaGainsJwtTokenPayload | null,
   { params }: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }
 ): Promise<TriggerMorScrapeResponse> {
-  if (!LAMBDA_URL) {
-    throw new Error('ETF_MORN_LAMBDA_URL environment variable is not set');
-  }
-  if (!CALLBACK_BASE_URL) {
-    throw new Error('REPORT_GENERATION_CALLBACK_BASE_URL environment variable is not set');
-  }
-
   const body = (await req.json().catch(() => ({}))) as Partial<TriggerMorScrapeRequest>;
   const kind = toKind(body.kind);
 
   const { spaceId, exchange, etf } = await params;
-  const ex = normalizeUpperTrim(exchange);
-  const symbol = normalizeUpperTrim(etf);
-  const morRelativePath = buildMorEtfRelativePath({ exchange: ex, symbol, kind });
-  const callbackUrl = joinUrl(
-    CALLBACK_BASE_URL,
-    `/api/${encodeURIComponent(spaceId)}/etfs-v1/exchange/${encodeURIComponent(ex)}/${encodeURIComponent(symbol)}/mor-info-callback`
-  );
-
-  const lambdaBase = (LAMBDA_URL ?? '').replace(/\/+$/, '');
-  const resp = await fetch(lambdaBase, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ url: morRelativePath, callbackUrl }),
-  });
-
-  if (!resp.ok) {
-    throw new Error(`Lambda request failed: ${resp.status} ${resp.statusText}`);
-  }
-
-  // Lambda returns immediately with "Request accepted..." when callbackUrl is provided.
-  const json = (await resp.json().catch(() => null)) as any;
-  const message = (json?.message as string) || 'Default Message';
-
-  return { success: true, message, url: morRelativePath, kind };
+  return triggerMorScrape({ spaceId, exchange, symbol: etf, kind });
 }
 
 export const POST = withAdminOrToken<TriggerMorScrapeResponse>(postHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/generation-requests/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/generation-requests/route.ts
@@ -2,6 +2,7 @@ import { withAdminOrToken } from '@/app/api/helpers/withAdminOrToken';
 import { prisma } from '@/prisma';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { EtfGenerationRequestStatus, EtfReportType } from '@/types/etf/etf-analysis-types';
+import { ensureMorDataForAnalysis } from '@/utils/etf-analysis-reports/mor-scrape-utils';
 import { calculateEtfPendingSteps } from '@/utils/etf-analysis-reports/etf-report-steps-statuses';
 import { EtfGenerationRequest } from '@prisma/client';
 import { NextRequest } from 'next/server';
@@ -149,6 +150,21 @@ async function postHandler(
       },
       select: { id: true },
     });
+
+    const needsMorData =
+      regenerateOptions.regeneratePerformanceAndReturns ||
+      regenerateOptions.regenerateCostEfficiencyAndTeam ||
+      regenerateOptions.regenerateRiskAnalysis ||
+      (regenerateOptions.regenerateFuturePerformanceOutlook ?? true);
+
+    if (needsMorData) {
+      await ensureMorDataForAnalysis({
+        etfId: etfRecord.id,
+        spaceId,
+        exchange: etf.exchange,
+        symbol: etf.symbol,
+      });
+    }
 
     const existingRequest = await prisma.etfGenerationRequest.findFirst({
       where: {

--- a/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
@@ -1,0 +1,132 @@
+import { prisma } from '@/prisma';
+import { AllExchanges, toExchange, USExchanges } from '@/utils/countryExchangeUtils';
+
+export type MorKind = 'quote' | 'risk' | 'people' | 'portfolio';
+
+export interface TriggerMorScrapeParams {
+  spaceId: string;
+  exchange: string;
+  symbol: string;
+  kind: MorKind;
+}
+
+export interface TriggerMorScrapeResult {
+  success: boolean;
+  message: string;
+  url: string;
+  kind: MorKind;
+}
+
+type MorEtfExchangeSegment = 'xnys' | 'xnas' | 'arcx' | 'bats';
+
+function toMorEtfExchangeSegment(exchange: AllExchanges): MorEtfExchangeSegment {
+  switch (exchange) {
+    case USExchanges.NYSE:
+      return 'xnys';
+    case USExchanges.NASDAQ:
+      return 'xnas';
+    case USExchanges.NYSEARCA:
+      return 'arcx';
+    case USExchanges.BATS:
+      return 'bats';
+    default:
+      throw new Error(`Unsupported exchange: ${exchange}`);
+  }
+}
+
+function joinUrl(base: string, path: string): string {
+  const b = (base ?? '').replace(/\/+$/, '');
+  const p = (path ?? '').replace(/^\/+/, '');
+  return `${b}/${p}`;
+}
+
+function buildMorEtfRelativePath(params: { exchange: string; symbol: string; kind: MorKind }): string {
+  const ex = toExchange(params.exchange);
+  const seg = toMorEtfExchangeSegment(ex);
+  const sym = (params.symbol ?? '').trim().toLowerCase();
+  if (!sym) throw new Error('Invalid ETF symbol');
+  return `/${seg}/${encodeURIComponent(sym)}/${params.kind}`;
+}
+
+function normalizeUpperTrim(v: string | null | undefined): string {
+  return (v ?? '').toUpperCase().trim();
+}
+
+export async function triggerMorScrape(params: TriggerMorScrapeParams): Promise<TriggerMorScrapeResult> {
+  const lambdaUrl = process.env.ETF_MORN_LAMBDA_URL || '';
+  const callbackBaseUrl = process.env.REPORT_GENERATION_CALLBACK_BASE_URL || 'https://koalagains.com';
+
+  if (!lambdaUrl) {
+    throw new Error('ETF_MORN_LAMBDA_URL environment variable is not set');
+  }
+  if (!callbackBaseUrl) {
+    throw new Error('REPORT_GENERATION_CALLBACK_BASE_URL environment variable is not set');
+  }
+
+  const ex = normalizeUpperTrim(params.exchange);
+  const symbol = normalizeUpperTrim(params.symbol);
+  const morRelativePath = buildMorEtfRelativePath({ exchange: ex, symbol, kind: params.kind });
+  const callbackUrl = joinUrl(
+    callbackBaseUrl,
+    `/api/${encodeURIComponent(params.spaceId)}/etfs-v1/exchange/${encodeURIComponent(ex)}/${encodeURIComponent(symbol)}/mor-info-callback`
+  );
+
+  const lambdaBase = lambdaUrl.replace(/\/+$/, '');
+  const resp = await fetch(lambdaBase, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: morRelativePath, callbackUrl }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Lambda request failed: ${resp.status} ${resp.statusText}`);
+  }
+
+  const json = (await resp.json().catch(() => null)) as { message?: string } | null;
+  const message = json?.message ?? 'Default Message';
+
+  return { success: true, message, url: morRelativePath, kind: params.kind };
+}
+
+export interface EnsureMorDataParams {
+  etfId: string;
+  spaceId: string;
+  exchange: string;
+  symbol: string;
+}
+
+/**
+ * Fire-and-forget: for any of the 4 MOR tables that does not yet have a row for this ETF,
+ * trigger the scraping lambda to populate it. Lambda callbacks arrive asynchronously and
+ * upsert the tables, so by the time a worker picks up the generation request the data
+ * should be present. Failures to trigger any individual kind are logged but do not throw,
+ * so request creation is never blocked by a transient lambda outage.
+ */
+export async function ensureMorDataForAnalysis(params: EnsureMorDataParams): Promise<MorKind[]> {
+  const [analyzerCount, riskCount, peopleCount, portfolioCount] = await Promise.all([
+    prisma.etfMorAnalyzerInfo.count({ where: { etfId: params.etfId } }),
+    prisma.etfMorRiskInfo.count({ where: { etfId: params.etfId } }),
+    prisma.etfMorPeopleInfo.count({ where: { etfId: params.etfId } }),
+    prisma.etfMorPortfolioInfo.count({ where: { etfId: params.etfId } }),
+  ]);
+
+  const missingKinds: MorKind[] = [];
+  if (analyzerCount === 0) missingKinds.push('quote');
+  if (riskCount === 0) missingKinds.push('risk');
+  if (peopleCount === 0) missingKinds.push('people');
+  if (portfolioCount === 0) missingKinds.push('portfolio');
+
+  if (missingKinds.length === 0) return [];
+
+  await Promise.all(
+    missingKinds.map(async (kind) => {
+      try {
+        await triggerMorScrape({ spaceId: params.spaceId, exchange: params.exchange, symbol: params.symbol, kind });
+      } catch (err) {
+        console.error(`[ensureMorDataForAnalysis] Failed to trigger ${kind} scrape for ${params.symbol}:`, err);
+      }
+    })
+  );
+
+  return missingKinds;
+}


### PR DESCRIPTION
## Summary

When a generation request is created for Performance, Cost & Team, Risk, or Future Outlook analysis, the prompt input depends on data in four MOR tables: `EtfMorAnalyzerInfo`, `EtfMorRiskInfo`, `EtfMorPeopleInfo`, `EtfMorPortfolioInfo`. If any of those rows are missing, the generated report ends up blank or incomplete.

This PR adds a simple pre-check to the generation-requests POST handler:

- If the incoming payload asks to regenerate any of the four analysis categories, query the 4 MOR tables for the ETF.
- For every missing table, fire the existing `ETF_MORN_LAMBDA_URL` scrape lambda (kinds: `quote` / `risk` / `people` / `portfolio`). The lambda responds immediately and populates the table async via the existing `mor-info-callback` route.
- Continue to create / update the generation request as before. By the time a worker picks up the `NotStarted` request, the callbacks will have upserted the MOR rows.

The lambda-trigger logic previously lived inline in `fetch-mor-info/route.ts`; it's now extracted into `src/utils/etf-analysis-reports/mor-scrape-utils.ts` and reused. Individual trigger failures are logged but do not block request creation.

## Files

- `insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts` (new) — `triggerMorScrape` + `ensureMorDataForAnalysis`
- `insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/fetch-mor-info/route.ts` — refactored to use the shared helper
- `insights-ui/src/app/api/[spaceId]/etfs-v1/generation-requests/route.ts` — calls `ensureMorDataForAnalysis` before writing the request row when any of Performance / Cost & Team / Risk / Future Outlook is requested

## Test plan

- [ ] Create a generation request for an ETF whose 4 MOR tables are all populated — verify no lambda calls are fired.
- [ ] Create a generation request for an ETF missing one or more MOR tables — verify the matching lambda kinds are triggered and rows appear after the callback arrives.
- [ ] Create a generation request with only `regenerateIndexStrategy=true` / `regenerateFinalSummary=true` (and all 4 analysis flags false, `regenerateFuturePerformanceOutlook: false` explicit) — verify no MOR check runs.
- [ ] Existing `POST /fetch-mor-info` endpoint still works (refactor is behavior-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)