### PR TITLE
feat(etf): add holdings table + full holdings page

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route.ts
@@ -1,0 +1,30 @@
+import { getEtfWhereClause } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
+import { prisma } from '@/prisma';
+import { EtfMorPortfolioHoldings } from '@/types/prismaTypes';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+export interface EtfPortfolioHoldingsResponse {
+  holdings: EtfMorPortfolioHoldings | null;
+}
+
+async function getHandler(
+  _req: NextRequest,
+  context: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }
+): Promise<EtfPortfolioHoldingsResponse> {
+  const { spaceId, exchange, etf } = await context.params;
+  const whereClause = getEtfWhereClause({ spaceId, exchange, etf });
+  if (!whereClause.symbol || !whereClause.exchange) {
+    return { holdings: null };
+  }
+
+  const etfRecord = await prisma.etf.findFirst({
+    where: { ...whereClause },
+    select: { morPortfolioInfo: { select: { holdings: true } } },
+  });
+
+  const holdings = (etfRecord?.morPortfolioInfo?.holdings ?? null) as EtfMorPortfolioHoldings | null;
+  return { holdings };
+}
+
+export const GET = withErrorHandlingV2<EtfPortfolioHoldingsResponse>(getHandler);

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/EtfActions.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/EtfActions.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { EtfGenerationRequestPayload, EtfIdentifier } from '@/app/api/[spaceId]/etfs-v1/generation-requests/route';
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { KoalaGainsSession } from '@/types/auth';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { revalidateEtfCache } from '@/utils/cache-actions';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import FullPageModal from '@dodao/web-core/components/core/modals/FullPageModal';
+import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { useRouter } from 'next/navigation';
+import React, { useState } from 'react';
+
+interface EtfActionsProps {
+  etf: EtfIdentifier;
+  session?: KoalaGainsSession;
+}
+
+type GenerateKey =
+  | 'generate-all'
+  | 'performance-and-returns'
+  | 'cost-efficiency-and-team'
+  | 'risk-analysis'
+  | 'future-performance-outlook'
+  | 'index-strategy'
+  | 'final-summary';
+
+const REPORT_OPTIONS: Array<{ key: GenerateKey; label: string }> = [
+  { key: 'generate-all', label: 'Generate All Reports' },
+  { key: 'performance-and-returns', label: 'Generate Performance & Returns' },
+  { key: 'cost-efficiency-and-team', label: 'Generate Cost, Efficiency & Team' },
+  { key: 'risk-analysis', label: 'Generate Risk Analysis' },
+  { key: 'future-performance-outlook', label: 'Generate Future Outlook' },
+  { key: 'index-strategy', label: 'Generate Index & Strategy' },
+  { key: 'final-summary', label: 'Generate Final Summary' },
+];
+
+function buildPayload(etf: EtfIdentifier, key: GenerateKey): EtfGenerationRequestPayload {
+  const all = key === 'generate-all';
+  return {
+    etf,
+    regeneratePerformanceAndReturns: all || key === 'performance-and-returns',
+    regenerateCostEfficiencyAndTeam: all || key === 'cost-efficiency-and-team',
+    regenerateRiskAnalysis: all || key === 'risk-analysis',
+    regenerateFuturePerformanceOutlook: all || key === 'future-performance-outlook',
+    regenerateIndexStrategy: all || key === 'index-strategy',
+    regenerateFinalSummary: all || key === 'final-summary',
+  };
+}
+
+export default function EtfActions({ etf, session }: EtfActionsProps): JSX.Element {
+  const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { postData: createGenerationRequest, loading: creatingGenRequest } = usePostData<unknown, EtfGenerationRequestPayload[]>({
+    successMessage: 'Analysis generation request created!',
+    errorMessage: 'Failed to create generation request',
+  });
+
+  const dropdownItems: EllipsisDropdownItem[] = [
+    { key: 'generate-report', label: 'Generate Report' },
+    { key: 'invalidate-cache', label: 'Invalidate Cache' },
+  ];
+
+  const handleDropdownSelect = async (key: string) => {
+    if (key === 'generate-report') {
+      setIsModalOpen(true);
+    } else if (key === 'invalidate-cache') {
+      await revalidateEtfCache(etf.symbol, etf.exchange);
+      router.refresh();
+    }
+  };
+
+  const handleModalSelect = async (key: GenerateKey) => {
+    setIsModalOpen(false);
+    try {
+      await createGenerationRequest(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/generation-requests`, [buildPayload(etf, key)]);
+      router.push('/admin-v1/etf-generation-requests');
+    } catch (error) {
+      console.error('Error generating ETF report:', error);
+    }
+  };
+
+  return (
+    <>
+      <PrivateWrapper session={session}>
+        <EllipsisDropdown items={dropdownItems} className="px-2 py-2 z-10" onSelect={handleDropdownSelect} />
+      </PrivateWrapper>
+
+      <FullPageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Generate Report">
+        <div className="p-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {REPORT_OPTIONS.map((item) => (
+              <button
+                key={item.key}
+                onClick={() => handleModalSelect(item.key)}
+                disabled={creatingGenRequest}
+                className="text-left px-3 py-2 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors duration-200 border border-gray-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <span className="text-white">{item.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </FullPageModal>
+    </>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -1,0 +1,97 @@
+import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
+import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ exchange: string; etf: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+async function fetchEtf(exchange: string, etf: string): Promise<EtfFastResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}?allowNull=true`;
+  const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+  if (!res.ok) return null;
+  return (await res.json()) as EtfFastResponse | null;
+}
+
+async function fetchHoldings(exchange: string, etf: string): Promise<EtfPortfolioHoldingsResponse['holdings']> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}/portfolio-holdings`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) return null;
+    const wrapper = (await res.json()) as EtfPortfolioHoldingsResponse;
+    return wrapper.holdings;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  let etfName = symbol;
+  try {
+    const data = await fetchEtf(exchange, symbol);
+    if (data) etfName = data.name ?? etfName;
+  } catch {
+    /* keep generic */
+  }
+
+  const title = `${etfName} (${symbol}) Holdings`;
+  return {
+    title,
+    description: `Full list of holdings for ${etfName} (${symbol}) ETF, including portfolio weights and sector exposure.`,
+    alternates: { canonical: `/etfs/${exchange}/${symbol}/holdings` },
+  };
+}
+
+export default async function EtfHoldingsPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const { exchange: rawExchange, etf: rawEtf } = await params;
+  const exchange = rawExchange.toUpperCase();
+  const symbol = rawEtf.toUpperCase();
+
+  const [etfData, holdings] = await Promise.all([fetchEtf(exchange, symbol), fetchHoldings(exchange, symbol)]);
+  if (!etfData) notFound();
+
+  const breadcrumbs: BreadcrumbsOjbect[] = [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: `${etfData.name} (${symbol})`, href: `/etfs/${exchange}/${symbol}`, current: false },
+    { name: 'Holdings', href: `/etfs/${exchange}/${symbol}/holdings`, current: true },
+  ];
+
+  const totalHoldings = holdings?.holdings?.length ?? 0;
+
+  return (
+    <PageWrapper>
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+
+      <header className="mb-4 mt-2">
+        <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl">
+          {etfData.name} ({symbol}) &mdash; Holdings
+        </h1>
+        <p className="text-sm text-gray-400 mt-1">Full list of reported holdings for this ETF.</p>
+      </header>
+
+      {totalHoldings > 0 ? (
+        <EtfHoldings data={holdings} title="All Holdings" />
+      ) : (
+        <div className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
+          <p className="text-sm text-gray-400">No holdings data available for this ETF.</p>
+        </div>
+      )}
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -5,6 +5,7 @@ import { PriceHistoryResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exch
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import { EtfScoresResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route';
 import { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
+import EtfActions from '@/app/etfs/[exchange]/[etf]/EtfActions';
 import EtfAnalysisSections from '@/components/etf-reportsv1/analysis/EtfAnalysisSections';
 import EtfRadarChart from '@/components/etf-reportsv1/analysis/EtfRadarChart';
 import EtfFinancialInfo from '@/components/etf-reportsv1/EtfFinancialInfo';
@@ -269,7 +270,7 @@ function BreadcrumbsFromData({ data }: { data: Promise<EtfFastResponse> }): JSX.
           { name: etf, href: `/etfs/${exchange}/${etf}`, current: true },
         ];
 
-  return <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />;
+  return <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} rightButton={<EtfActions etf={{ symbol: etf, exchange }} />} />;
 }
 
 function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Element {

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -1,5 +1,6 @@
 import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfFinancialInfoResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/financial-info/route';
+import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
 import { PriceHistoryResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/price-history/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import { EtfScoresResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/scores/route';
@@ -7,6 +8,7 @@ import { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf
 import EtfAnalysisSections from '@/components/etf-reportsv1/analysis/EtfAnalysisSections';
 import EtfRadarChart from '@/components/etf-reportsv1/analysis/EtfRadarChart';
 import EtfFinancialInfo from '@/components/etf-reportsv1/EtfFinancialInfo';
+import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
 import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import { FinancialCard } from '@/components/ticker-reportsv1/FinancialInfo';
 import PriceChart from '@/components/ticker-reportsv1/PriceChart';
@@ -115,6 +117,22 @@ async function fetchSimilarEtfs(exchange: string, etf: string): Promise<SimilarE
   } catch (error) {
     console.error(`fetchSimilarEtfs error for ${etf}:`, error);
     return [];
+  }
+}
+
+async function fetchEtfPortfolioHoldings(exchange: string, etf: string): Promise<EtfPortfolioHoldingsResponse['holdings']> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange.toUpperCase()}/${etf.toUpperCase()}/portfolio-holdings`;
+  try {
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
+    if (!res.ok) {
+      console.error(`fetchEtfPortfolioHoldings failed (${res.status}): ${url}`);
+      return null;
+    }
+    const wrapper = (await res.json()) as EtfPortfolioHoldingsResponse;
+    return wrapper.holdings;
+  } catch (error) {
+    console.error(`fetchEtfPortfolioHoldings error for ${etf}:`, error);
+    return null;
   }
 }
 
@@ -375,6 +393,21 @@ function EtfAnalysisSection({
   return <EtfAnalysisSections data={analysis} exchange={exchange} symbol={symbol} />;
 }
 
+const HOLDINGS_PREVIEW_LIMIT = 10;
+
+function EtfHoldingsSection({
+  holdingsPromise,
+  exchange,
+  symbol,
+}: {
+  holdingsPromise: Promise<EtfPortfolioHoldingsResponse['holdings']>;
+  exchange: string;
+  symbol: string;
+}): JSX.Element | null {
+  const holdings = use(holdingsPromise);
+  return <EtfHoldings data={holdings} maxRows={HOLDINGS_PREVIEW_LIMIT} viewMoreHref={`/etfs/${exchange}/${symbol}/holdings`} />;
+}
+
 /** PAGE */
 export default async function EtfDetailsPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
   // Main ETF data (promise for selective Suspense usage)
@@ -394,6 +427,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
   const scoresPromise = fetchEtfScores(exchange, etf);
   const priceHistoryPromise = fetchEtfPriceHistory(exchange, etf);
   const similarEtfsPromise = fetchSimilarEtfs(exchange, etf);
+  const portfolioHoldingsPromise = fetchEtfPortfolioHoldings(exchange, etf);
 
   // Derive dates for semantic footer (based solely on etfData)
   const now = new Date();
@@ -466,6 +500,10 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
 
         {/* Remaining Index & Strategy paragraphs, rendered after the price chart. */}
         <EtfIndexStrategyTail data={etfInfo} />
+
+        <Suspense fallback={null}>
+          <EtfHoldingsSection holdingsPromise={portfolioHoldingsPromise} exchange={exchange} symbol={etf} />
+        </Suspense>
 
         <Suspense fallback={null}>
           <EtfAnalysisSection analysisPromise={analysisPromise} exchange={exchange} symbol={etf} />

--- a/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
@@ -1,82 +1,6 @@
 import { EtfMorPortfolioHoldingRow, EtfMorPortfolioHoldings } from '@/types/prismaTypes';
+import { buildEtfHoldingColumnDefs } from '@/utils/etf-holdings-utils';
 import Link from 'next/link';
-
-type HoldingColumnDef = { label: string; field: keyof EtfMorPortfolioHoldingRow };
-
-const HOLDING_FIELD_ORDER: Array<keyof EtfMorPortfolioHoldingRow> = [
-  'portfolioWeightPct',
-  'firstBought',
-  'marketValue',
-  'currency',
-  'oneYearReturn',
-  'forwardPE',
-  'maturityDate',
-  'couponRate',
-  'sector',
-];
-
-const HOLDING_FIELD_LABELS: Record<keyof EtfMorPortfolioHoldingRow, string> = {
-  name: 'Name',
-  portfolioWeightPct: 'Weight %',
-  firstBought: 'First bought',
-  marketValue: 'Market value',
-  marketValueAsOfDate: 'Market value as of',
-  currency: 'Cur',
-  oneYearReturn: '1Y return',
-  forwardPE: 'Fwd P/E',
-  maturityDate: 'Maturity',
-  couponRate: 'Coupon %',
-  sector: 'Sector',
-};
-
-function holdingHeaderToField(header: string): keyof EtfMorPortfolioHoldingRow | null {
-  const h = header.toLowerCase().replace(/\s+/g, ' ').trim();
-  if (h === 'holdings' || h === 'name') return 'name';
-  if (h === '% portfolio weight' || h === 'portfolio weight' || h === 'weight %' || h === 'weight') return 'portfolioWeightPct';
-  if (h === 'first bought') return 'firstBought';
-  if (h.startsWith('market value')) return 'marketValue';
-  if (h === 'cur' || h === 'currency') return 'currency';
-  if (h === '1-year return' || h === '1 year return' || h === '1y return') return 'oneYearReturn';
-  if (h === 'forward p/e' || h === 'fwd p/e') return 'forwardPE';
-  if (h === 'maturity date' || h === 'maturity') return 'maturityDate';
-  if (h === 'coupon rate' || h === 'coupon' || h === 'coupon %') return 'couponRate';
-  if (h === 'sector') return 'sector';
-  return null;
-}
-
-/**
- * Build the ordered list of columns to render for this ETF's holdings,
- * skipping any column whose rows are all empty. The optional `columns`
- * metadata on the payload preserves the source order when present.
- */
-export function buildEtfHoldingColumnDefs(data: EtfMorPortfolioHoldings, rows: EtfMorPortfolioHoldingRow[]): HoldingColumnDef[] {
-  const hasValue = (field: keyof EtfMorPortfolioHoldingRow): boolean => rows.some((row) => row[field] != null && String(row[field]).trim() !== '');
-
-  const defs: HoldingColumnDef[] = [];
-  const seen = new Set<keyof EtfMorPortfolioHoldingRow>();
-  const push = (field: keyof EtfMorPortfolioHoldingRow, label?: string): void => {
-    if (seen.has(field)) return;
-    if (field !== 'name' && !hasValue(field)) return;
-    seen.add(field);
-    defs.push({ field, label: label ?? HOLDING_FIELD_LABELS[field] });
-  };
-
-  push('name');
-
-  if (Array.isArray(data.columns) && data.columns.length > 0) {
-    for (const header of data.columns) {
-      const field = holdingHeaderToField(header);
-      if (!field || field === 'name') continue;
-      push(field, HOLDING_FIELD_LABELS[field]);
-    }
-  }
-
-  for (const field of HOLDING_FIELD_ORDER) {
-    push(field);
-  }
-
-  return defs;
-}
 
 interface EtfHoldingsProps {
   data: EtfMorPortfolioHoldings | null;
@@ -87,7 +11,7 @@ interface EtfHoldingsProps {
   title?: string;
 }
 
-export default function EtfHoldings({ data, maxRows, viewMoreHref, title = 'Top Holdings' }: EtfHoldingsProps): JSX.Element | null {
+export default function EtfHoldings({ data, maxRows, viewMoreHref, title }: EtfHoldingsProps): JSX.Element | null {
   if (!data) return null;
   const list: EtfMorPortfolioHoldingRow[] = Array.isArray(data.holdings) ? data.holdings : [];
   if (list.length === 0) return null;
@@ -98,12 +22,13 @@ export default function EtfHoldings({ data, maxRows, viewMoreHref, title = 'Top 
 
   const marketValueAsOf = list.find((h) => h.marketValueAsOfDate)?.marketValueAsOfDate ?? null;
   const subtitle = marketValueAsOf ? `Market value as of ${marketValueAsOf}.` : null;
+  const resolvedTitle = title ?? (typeof maxRows === 'number' && list.length > maxRows ? `Top ${displayRows.length} Holdings` : 'Holdings');
 
   return (
     <section id="etf-holdings" className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6 mb-8">
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-gray-700">
         <div>
-          <h2 className="text-xl font-bold text-gray-100">{title}</h2>
+          <h2 className="text-xl font-bold text-gray-100">{resolvedTitle}</h2>
           {subtitle ? <p className="text-xs text-gray-400 mt-1">{subtitle}</p> : null}
         </div>
         <div className="text-xs text-gray-400">
@@ -124,7 +49,7 @@ export default function EtfHoldings({ data, maxRows, viewMoreHref, title = 'Top 
           </thead>
           <tbody className="divide-y divide-gray-700">
             {displayRows.map((row, idx) => (
-              <tr key={`${row.name}-${idx}`} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
+              <tr key={idx} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
                 {colDefs.map((c) => {
                   const cellValue = row[c.field];
                   const isEmpty = cellValue === null || cellValue === undefined || String(cellValue).trim() === '';
@@ -142,7 +67,7 @@ export default function EtfHoldings({ data, maxRows, viewMoreHref, title = 'Top 
 
       {showViewMore && viewMoreHref ? (
         <div className="mt-4 flex justify-end">
-          <Link href={viewMoreHref} className="text-sm font-medium text-indigo-400 hover:text-indigo-300">
+          <Link href={viewMoreHref} className="text-sm font-medium link-color hover:underline">
             View more holdings &rarr;
           </Link>
         </div>

--- a/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
@@ -1,0 +1,152 @@
+import { EtfMorPortfolioHoldingRow, EtfMorPortfolioHoldings } from '@/types/prismaTypes';
+import Link from 'next/link';
+
+type HoldingColumnDef = { label: string; field: keyof EtfMorPortfolioHoldingRow };
+
+const HOLDING_FIELD_ORDER: Array<keyof EtfMorPortfolioHoldingRow> = [
+  'portfolioWeightPct',
+  'firstBought',
+  'marketValue',
+  'currency',
+  'oneYearReturn',
+  'forwardPE',
+  'maturityDate',
+  'couponRate',
+  'sector',
+];
+
+const HOLDING_FIELD_LABELS: Record<keyof EtfMorPortfolioHoldingRow, string> = {
+  name: 'Name',
+  portfolioWeightPct: 'Weight %',
+  firstBought: 'First bought',
+  marketValue: 'Market value',
+  marketValueAsOfDate: 'Market value as of',
+  currency: 'Cur',
+  oneYearReturn: '1Y return',
+  forwardPE: 'Fwd P/E',
+  maturityDate: 'Maturity',
+  couponRate: 'Coupon %',
+  sector: 'Sector',
+};
+
+function holdingHeaderToField(header: string): keyof EtfMorPortfolioHoldingRow | null {
+  const h = header.toLowerCase().replace(/\s+/g, ' ').trim();
+  if (h === 'holdings' || h === 'name') return 'name';
+  if (h === '% portfolio weight' || h === 'portfolio weight' || h === 'weight %' || h === 'weight') return 'portfolioWeightPct';
+  if (h === 'first bought') return 'firstBought';
+  if (h.startsWith('market value')) return 'marketValue';
+  if (h === 'cur' || h === 'currency') return 'currency';
+  if (h === '1-year return' || h === '1 year return' || h === '1y return') return 'oneYearReturn';
+  if (h === 'forward p/e' || h === 'fwd p/e') return 'forwardPE';
+  if (h === 'maturity date' || h === 'maturity') return 'maturityDate';
+  if (h === 'coupon rate' || h === 'coupon' || h === 'coupon %') return 'couponRate';
+  if (h === 'sector') return 'sector';
+  return null;
+}
+
+/**
+ * Build the ordered list of columns to render for this ETF's holdings,
+ * skipping any column whose rows are all empty. The optional `columns`
+ * metadata on the payload preserves the source order when present.
+ */
+export function buildEtfHoldingColumnDefs(data: EtfMorPortfolioHoldings, rows: EtfMorPortfolioHoldingRow[]): HoldingColumnDef[] {
+  const hasValue = (field: keyof EtfMorPortfolioHoldingRow): boolean => rows.some((row) => row[field] != null && String(row[field]).trim() !== '');
+
+  const defs: HoldingColumnDef[] = [];
+  const seen = new Set<keyof EtfMorPortfolioHoldingRow>();
+  const push = (field: keyof EtfMorPortfolioHoldingRow, label?: string): void => {
+    if (seen.has(field)) return;
+    if (field !== 'name' && !hasValue(field)) return;
+    seen.add(field);
+    defs.push({ field, label: label ?? HOLDING_FIELD_LABELS[field] });
+  };
+
+  push('name');
+
+  if (Array.isArray(data.columns) && data.columns.length > 0) {
+    for (const header of data.columns) {
+      const field = holdingHeaderToField(header);
+      if (!field || field === 'name') continue;
+      push(field, HOLDING_FIELD_LABELS[field]);
+    }
+  }
+
+  for (const field of HOLDING_FIELD_ORDER) {
+    push(field);
+  }
+
+  return defs;
+}
+
+interface EtfHoldingsProps {
+  data: EtfMorPortfolioHoldings | null;
+  /** When set, only the first `maxRows` holdings are rendered. */
+  maxRows?: number;
+  /** When set and the full list is longer than `maxRows`, renders a "View more" link to this href. */
+  viewMoreHref?: string;
+  title?: string;
+}
+
+export default function EtfHoldings({ data, maxRows, viewMoreHref, title = 'Top Holdings' }: EtfHoldingsProps): JSX.Element | null {
+  if (!data) return null;
+  const list: EtfMorPortfolioHoldingRow[] = Array.isArray(data.holdings) ? data.holdings : [];
+  if (list.length === 0) return null;
+
+  const colDefs = buildEtfHoldingColumnDefs(data, list);
+  const displayRows = typeof maxRows === 'number' ? list.slice(0, maxRows) : list;
+  const showViewMore = Boolean(viewMoreHref) && typeof maxRows === 'number' && list.length > maxRows;
+
+  const marketValueAsOf = list.find((h) => h.marketValueAsOfDate)?.marketValueAsOfDate ?? null;
+  const subtitle = marketValueAsOf ? `Market value as of ${marketValueAsOf}.` : null;
+
+  return (
+    <section id="etf-holdings" className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6 mb-8">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-gray-700">
+        <div>
+          <h2 className="text-xl font-bold text-gray-100">{title}</h2>
+          {subtitle ? <p className="text-xs text-gray-400 mt-1">{subtitle}</p> : null}
+        </div>
+        <div className="text-xs text-gray-400">
+          Showing {displayRows.length} of {list.length}
+        </div>
+      </div>
+
+      <div className="mt-4 overflow-x-auto rounded-lg border border-gray-700">
+        <table className="min-w-full">
+          <thead className="bg-gray-800">
+            <tr>
+              {colDefs.map((c) => (
+                <th key={c.field} className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap">
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700">
+            {displayRows.map((row, idx) => (
+              <tr key={`${row.name}-${idx}`} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
+                {colDefs.map((c) => {
+                  const cellValue = row[c.field];
+                  const isEmpty = cellValue === null || cellValue === undefined || String(cellValue).trim() === '';
+                  return (
+                    <td key={c.field} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap">
+                      {isEmpty ? <span className="text-gray-500">&mdash;</span> : String(cellValue)}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {showViewMore && viewMoreHref ? (
+        <div className="mt-4 flex justify-end">
+          <Link href={viewMoreHref} className="text-sm font-medium text-indigo-400 hover:text-indigo-300">
+            View more holdings &rarr;
+          </Link>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
@@ -8,11 +8,11 @@ import {
   EtfMorPortfolioBondBreakdown,
   EtfMorPortfolioFixedIncomeStyle,
   EtfMorPortfolioHoldings,
-  EtfMorPortfolioHoldingRow,
   EtfMorPortfolioSectorExposure,
   EtfMorPortfolioSectorExposureRow,
   EtfMorPortfolioStyleMeasures,
 } from '@/types/prismaTypes';
+import { buildEtfHoldingColumnDefs } from '@/utils/etf-holdings-utils';
 
 function SectionHeading({ title, subtitle }: { title: string; subtitle?: string }): JSX.Element {
   return (
@@ -450,84 +450,6 @@ function MorPortfolioBondBreakdownBlock({ data }: { data: EtfMorPortfolioBondBre
   );
 }
 
-type HoldingColumnDef = { label: string; field: keyof EtfMorPortfolioHoldingRow };
-
-const HOLDING_FIELD_ORDER: Array<keyof EtfMorPortfolioHoldingRow> = [
-  'portfolioWeightPct',
-  'firstBought',
-  'marketValue',
-  'currency',
-  'oneYearReturn',
-  'forwardPE',
-  'maturityDate',
-  'couponRate',
-  'sector',
-];
-
-const HOLDING_FIELD_LABELS: Record<keyof EtfMorPortfolioHoldingRow, string> = {
-  name: 'Name',
-  portfolioWeightPct: 'Weight %',
-  firstBought: 'First bought',
-  marketValue: 'Market value',
-  marketValueAsOfDate: 'Market value as of',
-  currency: 'Cur',
-  oneYearReturn: '1Y return',
-  forwardPE: 'Fwd P/E',
-  maturityDate: 'Maturity',
-  couponRate: 'Coupon %',
-  sector: 'Sector',
-};
-
-function holdingHeaderToField(header: string): keyof EtfMorPortfolioHoldingRow | null {
-  const h = header.toLowerCase().replace(/\s+/g, ' ').trim();
-  if (h === 'holdings' || h === 'name') return 'name';
-  if (h === '% portfolio weight' || h === 'portfolio weight' || h === 'weight %' || h === 'weight') return 'portfolioWeightPct';
-  if (h === 'first bought') return 'firstBought';
-  if (h.startsWith('market value')) return 'marketValue';
-  if (h === 'cur' || h === 'currency') return 'currency';
-  if (h === '1-year return' || h === '1 year return' || h === '1y return') return 'oneYearReturn';
-  if (h === 'forward p/e' || h === 'fwd p/e') return 'forwardPE';
-  if (h === 'maturity date' || h === 'maturity') return 'maturityDate';
-  if (h === 'coupon rate' || h === 'coupon' || h === 'coupon %') return 'couponRate';
-  if (h === 'sector') return 'sector';
-  return null;
-}
-
-function buildHoldingColumnDefs(data: EtfMorPortfolioHoldings): HoldingColumnDef[] {
-  const list = Array.isArray(data.holdings) ? data.holdings : [];
-  const hasValue = (field: keyof EtfMorPortfolioHoldingRow): boolean => list.some((row) => row[field] != null && String(row[field]).trim() !== '');
-
-  const defs: HoldingColumnDef[] = [];
-  const seen = new Set<keyof EtfMorPortfolioHoldingRow>();
-  const push = (field: keyof EtfMorPortfolioHoldingRow, label?: string): void => {
-    if (seen.has(field)) return;
-    if (field !== 'name' && !hasValue(field)) return;
-    seen.add(field);
-    defs.push({ field, label: label ?? HOLDING_FIELD_LABELS[field] });
-  };
-
-  push('name');
-
-  // If the scraper captured the MOR column order, prefer it so the
-  // table matches what the user sees on MOR.com. Skip premium /
-  // unknown columns that don't map to a known field.
-  if (Array.isArray(data.columns) && data.columns.length > 0) {
-    for (const header of data.columns) {
-      const field = holdingHeaderToField(header);
-      if (!field || field === 'name') continue;
-      push(field, HOLDING_FIELD_LABELS[field]);
-    }
-  }
-
-  // Backfill any fields that have values but weren't in the header list
-  // (e.g. scraped currency that lambda inferred but header omitted).
-  for (const field of HOLDING_FIELD_ORDER) {
-    push(field);
-  }
-
-  return defs;
-}
-
 function MorPortfolioHoldingsBlock({ data }: { data: EtfMorPortfolioHoldings | null }): JSX.Element | null {
   if (!data) return null;
   const summary = data.summary ?? {};
@@ -544,7 +466,7 @@ function MorPortfolioHoldingsBlock({ data }: { data: EtfMorPortfolioHoldings | n
   ];
 
   const list = Array.isArray(data.holdings) ? data.holdings : [];
-  const colDefs = buildHoldingColumnDefs(data);
+  const colDefs = buildEtfHoldingColumnDefs(data, list);
 
   const holdingRows = list.map((h) => {
     const row: Record<string, unknown> = {};

--- a/insights-ui/src/utils/etf-holdings-utils.ts
+++ b/insights-ui/src/utils/etf-holdings-utils.ts
@@ -1,0 +1,78 @@
+import { EtfMorPortfolioHoldingRow, EtfMorPortfolioHoldings } from '@/types/prismaTypes';
+
+export type EtfHoldingColumnDef = { label: string; field: keyof EtfMorPortfolioHoldingRow };
+
+export const HOLDING_FIELD_ORDER: Array<keyof EtfMorPortfolioHoldingRow> = [
+  'portfolioWeightPct',
+  'firstBought',
+  'marketValue',
+  'currency',
+  'oneYearReturn',
+  'forwardPE',
+  'maturityDate',
+  'couponRate',
+  'sector',
+];
+
+export const HOLDING_FIELD_LABELS: Record<keyof EtfMorPortfolioHoldingRow, string> = {
+  name: 'Name',
+  portfolioWeightPct: 'Weight %',
+  firstBought: 'First bought',
+  marketValue: 'Market value',
+  marketValueAsOfDate: 'Market value as of',
+  currency: 'Cur',
+  oneYearReturn: '1Y return',
+  forwardPE: 'Fwd P/E',
+  maturityDate: 'Maturity',
+  couponRate: 'Coupon %',
+  sector: 'Sector',
+};
+
+export function holdingHeaderToField(header: string): keyof EtfMorPortfolioHoldingRow | null {
+  const h = header.toLowerCase().replace(/\s+/g, ' ').trim();
+  if (h === 'holdings' || h === 'name') return 'name';
+  if (h === '% portfolio weight' || h === 'portfolio weight' || h === 'weight %' || h === 'weight') return 'portfolioWeightPct';
+  if (h === 'first bought') return 'firstBought';
+  if (h.startsWith('market value')) return 'marketValue';
+  if (h === 'cur' || h === 'currency') return 'currency';
+  if (h === '1-year return' || h === '1 year return' || h === '1y return') return 'oneYearReturn';
+  if (h === 'forward p/e' || h === 'fwd p/e') return 'forwardPE';
+  if (h === 'maturity date' || h === 'maturity') return 'maturityDate';
+  if (h === 'coupon rate' || h === 'coupon' || h === 'coupon %') return 'couponRate';
+  if (h === 'sector') return 'sector';
+  return null;
+}
+
+/**
+ * Build the ordered list of columns to render for this ETF's holdings,
+ * skipping any column whose rows are all empty. The optional `columns`
+ * metadata on the payload preserves the source order when present.
+ */
+export function buildEtfHoldingColumnDefs(data: EtfMorPortfolioHoldings, rows: EtfMorPortfolioHoldingRow[]): EtfHoldingColumnDef[] {
+  const hasValue = (field: keyof EtfMorPortfolioHoldingRow): boolean => rows.some((row) => row[field] != null && String(row[field]).trim() !== '');
+
+  const defs: EtfHoldingColumnDef[] = [];
+  const seen = new Set<keyof EtfMorPortfolioHoldingRow>();
+  const push = (field: keyof EtfMorPortfolioHoldingRow, label?: string): void => {
+    if (seen.has(field)) return;
+    if (field !== 'name' && !hasValue(field)) return;
+    seen.add(field);
+    defs.push({ field, label: label ?? HOLDING_FIELD_LABELS[field] });
+  };
+
+  push('name');
+
+  if (Array.isArray(data.columns) && data.columns.length > 0) {
+    for (const header of data.columns) {
+      const field = holdingHeaderToField(header);
+      if (!field || field === 'name') continue;
+      push(field, HOLDING_FIELD_LABELS[field]);
+    }
+  }
+
+  for (const field of HOLDING_FIELD_ORDER) {
+    push(field);
+  }
+
+  return defs;
+}


### PR DESCRIPTION
## Summary
- Render top 10 rows from `EtfMorPortfolioInfo.holdings` on the ETF detail page, directly below the strategy section.
- When more than 10 holdings exist, show a **View more holdings →** link that navigates to a new `/etfs/[exchange]/[etf]/holdings` page listing all reported holdings.
- Columns with no values for the current ETF are dropped automatically so equity ETFs don't get bond-only columns (and vice versa).
- Added a dedicated `portfolio-holdings` API route that returns just the holdings JSON for the requested ETF.

## Files
- `src/components/etf-reportsv1/EtfHoldings.tsx` (new) — shared table component with column-filtering logic.
- `src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route.ts` (new) — data source.
- `src/app/etfs/[exchange]/[etf]/holdings/page.tsx` (new) — full holdings page.
- `src/app/etfs/[exchange]/[etf]/page.tsx` — wires the top-10 preview under `<Suspense>` after the strategy tail.

## Test plan
- [ ] Visit an ETF with >10 holdings and confirm only 10 rows render with a working **View more holdings →** link.
- [ ] Visit an ETF with ≤10 holdings and confirm no "View more" link is shown.
- [ ] Visit an equity ETF and confirm bond-only columns (Maturity, Coupon %) are hidden.
- [ ] Visit a bond ETF and confirm equity-only columns (Fwd P/E, 1Y return) are hidden when empty.
- [ ] Visit an ETF with no `morPortfolioInfo` data and confirm the section is hidden (page renders otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)