### PR TITLE
feat(etf-admin): per-report-type status columns and per-type Select Missing

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { EtfReportRow } from '@/app/api/[spaceId]/etfs-v1/etf-admin-reports/route';
+import { EtfReportRow, EtfReportStatus } from '@/app/api/[spaceId]/etfs-v1/etf-admin-reports/route';
 import Link from 'next/link';
 import EtfRowActionsDropdown from './EtfRowActionsDropdown';
 
@@ -8,13 +8,18 @@ function StatusPill({ ok }: { ok: boolean }): JSX.Element {
   return <span className={`px-2 py-1 rounded-full text-xs ${ok ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'}`}>{ok ? 'Yes' : 'No'}</span>;
 }
 
-function AnalysisPill({ count }: { count: number }): JSX.Element {
-  if (count === 0) return <span className="px-2 py-1 rounded-full text-xs bg-red-900 text-red-200">—</span>;
-  return <span className="px-2 py-1 rounded-full text-xs bg-green-900 text-green-200">{count}</span>;
-}
-
-function SummaryPill({ ok }: { ok: boolean }): JSX.Element {
-  return <span className={`px-2 py-1 rounded-full text-xs ${ok ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'}`}>{ok ? 'Yes' : 'No'}</span>;
+function ReportStatusPill({ status, count }: { status: EtfReportStatus; count?: number }): JSX.Element {
+  if (status === 'generated') {
+    const label = typeof count === 'number' ? String(count) : 'Yes';
+    return <span className="px-2 py-1 rounded-full text-xs bg-green-900 text-green-200">{label}</span>;
+  }
+  if (status === 'in-progress') {
+    return <span className="px-2 py-1 rounded-full text-xs bg-blue-900 text-blue-200">In Progress</span>;
+  }
+  if (status === 'failed') {
+    return <span className="px-2 py-1 rounded-full text-xs bg-orange-900 text-orange-200">Failed</span>;
+  }
+  return <span className="px-2 py-1 rounded-full text-xs bg-red-900 text-red-200">Missing</span>;
 }
 
 export interface EtfReportsTableProps {
@@ -55,8 +60,9 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Performance</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Cost & Team</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Risk</th>
-            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Index & Strategy</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Summary</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Index & Strategy</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Future Outlook</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Action</th>
           </tr>
         </thead>
@@ -101,19 +107,22 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
                 <StatusPill ok={e.hasMorPortfolioInfo} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
-                <AnalysisPill count={e.performanceAnalysisCount} />
+                <ReportStatusPill status={e.reportStatuses.performance} count={e.performanceAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
-                <AnalysisPill count={e.costEfficiencyAnalysisCount} />
+                <ReportStatusPill status={e.reportStatuses.costEfficiencyAndTeam} count={e.costEfficiencyAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
-                <AnalysisPill count={e.riskAnalysisCount} />
+                <ReportStatusPill status={e.reportStatuses.risk} count={e.riskAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
-                <StatusPill ok={e.hasIndexStrategy} />
+                <ReportStatusPill status={e.reportStatuses.summary} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
-                <SummaryPill ok={e.hasSummary} />
+                <ReportStatusPill status={e.reportStatuses.indexStrategy} />
+              </td>
+              <td className="px-4 py-3 text-sm text-center">
+                <ReportStatusPill status={e.reportStatuses.futureOutlook} count={e.futureOutlookAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
                 <div className="flex items-center justify-center gap-2">
@@ -133,7 +142,7 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
 
           {etfs.length === 0 && (
             <tr>
-              <td colSpan={14} className="px-4 py-10 text-center text-gray-300">
+              <td colSpan={15} className="px-4 py-10 text-center text-gray-300">
                 No ETFs found.
               </td>
             </tr>

--- a/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
@@ -8,6 +8,28 @@ interface MissingCategory {
   filter: (e: EtfReportRow) => boolean;
 }
 
+const isReportMissing = (status: 'generated' | 'missing' | 'in-progress' | 'failed'): boolean => status !== 'generated';
+
+const reportTypeCategories: MissingCategory[] = [
+  { key: 'missingPerformance', label: 'Missing Performance', filter: (e) => isReportMissing(e.reportStatuses.performance) },
+  { key: 'missingCostEfficiencyAndTeam', label: 'Missing Cost & Team', filter: (e) => isReportMissing(e.reportStatuses.costEfficiencyAndTeam) },
+  { key: 'missingRisk', label: 'Missing Risk', filter: (e) => isReportMissing(e.reportStatuses.risk) },
+  { key: 'missingSummary', label: 'Missing Summary', filter: (e) => isReportMissing(e.reportStatuses.summary) },
+  { key: 'missingIndexStrategy', label: 'Missing Index & Strategy', filter: (e) => isReportMissing(e.reportStatuses.indexStrategy) },
+  { key: 'missingFutureOutlook', label: 'Missing Future Outlook', filter: (e) => isReportMissing(e.reportStatuses.futureOutlook) },
+  {
+    key: 'missingAllAnalysis',
+    label: 'Missing All Analysis',
+    filter: (e) =>
+      isReportMissing(e.reportStatuses.performance) &&
+      isReportMissing(e.reportStatuses.costEfficiencyAndTeam) &&
+      isReportMissing(e.reportStatuses.risk) &&
+      isReportMissing(e.reportStatuses.summary) &&
+      isReportMissing(e.reportStatuses.indexStrategy) &&
+      isReportMissing(e.reportStatuses.futureOutlook),
+  },
+];
+
 const categories: MissingCategory[] = [
   { key: 'financialInfo', label: 'Financial Info', filter: (e) => !e.hasFinancialInfo },
   { key: 'stockAnalyzer', label: 'Stock Analyzer', filter: (e) => !e.hasStockAnalyzerInfo },
@@ -15,12 +37,7 @@ const categories: MissingCategory[] = [
   { key: 'morRisk', label: 'MOR Risk', filter: (e) => !e.hasMorRiskInfo },
   { key: 'morPeople', label: 'MOR People', filter: (e) => !e.hasMorPeopleInfo },
   { key: 'morPortfolio', label: 'MOR Portfolio', filter: (e) => !e.hasMorPortfolioInfo },
-  { key: 'summary', label: 'Missing Summary', filter: (e) => !e.hasSummary },
-  {
-    key: 'analysis',
-    label: 'Missing Analysis',
-    filter: (e) => e.performanceAnalysisCount === 0 || e.costEfficiencyAnalysisCount === 0 || e.riskAnalysisCount === 0,
-  },
+  ...reportTypeCategories,
 ];
 
 export interface SelectMissingBarProps {
@@ -36,7 +53,7 @@ export default function SelectMissingBar({ etfs, onSelectIds }: SelectMissingBar
   const buttonClass = 'px-3 py-1.5 text-xs font-medium rounded-md transition-colors bg-gray-700 text-gray-200 hover:bg-gray-600';
 
   return (
-    <div className="flex items-center gap-3 px-6 py-3 bg-amber-900/30 border-b border-amber-700/40">
+    <div className="flex flex-wrap items-center gap-3 px-6 py-3 bg-amber-900/30 border-b border-amber-700/40">
       <span className="text-sm font-medium text-amber-200">Select missing</span>
       <div className="h-4 w-px bg-amber-700/50" />
       {activeCats.map((cat) => {

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
@@ -1,8 +1,20 @@
 import { withAdminOrToken } from '@/app/api/helpers/withAdminOrToken';
 import { prisma } from '@/prisma';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
+import { EtfGenerationRequestStatus, EtfReportType } from '@/types/etf/etf-analysis-types';
 import { AllExchanges, EXCHANGES, isExchange } from '@/utils/countryExchangeUtils';
 import { NextRequest } from 'next/server';
+
+export type EtfReportStatus = 'generated' | 'missing' | 'in-progress' | 'failed';
+
+export interface EtfReportStatuses {
+  performance: EtfReportStatus;
+  costEfficiencyAndTeam: EtfReportStatus;
+  risk: EtfReportStatus;
+  futureOutlook: EtfReportStatus;
+  indexStrategy: EtfReportStatus;
+  summary: EtfReportStatus;
+}
 
 export interface EtfReportRow {
   id: string;
@@ -20,6 +32,8 @@ export interface EtfReportRow {
   performanceAnalysisCount: number;
   costEfficiencyAnalysisCount: number;
   riskAnalysisCount: number;
+  futureOutlookAnalysisCount: number;
+  reportStatuses: EtfReportStatuses;
 }
 
 export interface EtfReportsResponse {
@@ -64,6 +78,41 @@ function toMissingFilter(v: string | null): MissingFilter {
   if (normalized === 'mor') return 'mor';
   if (normalized === 'analysis') return 'analysis';
   return '';
+}
+
+type LatestRequestSummary = {
+  status: string;
+  regeneratePerformanceAndReturns: boolean;
+  regenerateCostEfficiencyAndTeam: boolean;
+  regenerateRiskAnalysis: boolean;
+  regenerateFuturePerformanceOutlook: boolean;
+  regenerateIndexStrategy: boolean;
+  regenerateFinalSummary: boolean;
+  completedSteps: string[];
+  failedSteps: string[];
+};
+
+type RegenerateFlagKey =
+  | 'regeneratePerformanceAndReturns'
+  | 'regenerateCostEfficiencyAndTeam'
+  | 'regenerateRiskAnalysis'
+  | 'regenerateFuturePerformanceOutlook'
+  | 'regenerateIndexStrategy'
+  | 'regenerateFinalSummary';
+
+function computeReportStatus(hasData: boolean, step: EtfReportType, flag: RegenerateFlagKey, latestRequest: LatestRequestSummary | undefined): EtfReportStatus {
+  if (hasData) return 'generated';
+  if (!latestRequest) return 'missing';
+
+  if (latestRequest.failedSteps.includes(step)) return 'failed';
+
+  const wasRequested = latestRequest[flag];
+  const alreadyCompleted = latestRequest.completedSteps.includes(step);
+  const activeStatus = latestRequest.status === EtfGenerationRequestStatus.InProgress || latestRequest.status === EtfGenerationRequestStatus.NotStarted;
+
+  if (wasRequested && !alreadyCompleted && activeStatus) return 'in-progress';
+
+  return 'missing';
 }
 
 const getHandler = async (
@@ -125,6 +174,21 @@ const getHandler = async (
         analysisCategoryFactorResults: {
           select: { categoryKey: true },
         },
+        generationRequests: {
+          orderBy: { updatedAt: 'desc' },
+          take: 1,
+          select: {
+            status: true,
+            regeneratePerformanceAndReturns: true,
+            regenerateCostEfficiencyAndTeam: true,
+            regenerateRiskAnalysis: true,
+            regenerateFuturePerformanceOutlook: true,
+            regenerateIndexStrategy: true,
+            regenerateFinalSummary: true,
+            completedSteps: true,
+            failedSteps: true,
+          },
+        },
       },
       orderBy: [{ symbol: 'asc' }, { exchange: 'asc' }],
       skip: (page - 1) * limit,
@@ -145,6 +209,34 @@ const getHandler = async (
   return {
     etfs: supportedEtfs.map((e) => {
       const factorResults = e.analysisCategoryFactorResults || [];
+      const performanceAnalysisCount = factorResults.filter((r) => r.categoryKey === 'PerformanceAndReturns').length;
+      const costEfficiencyAnalysisCount = factorResults.filter((r) => r.categoryKey === 'CostEfficiencyAndTeam').length;
+      const riskAnalysisCount = factorResults.filter((r) => r.categoryKey === 'RiskAnalysis').length;
+      const futureOutlookAnalysisCount = factorResults.filter((r) => r.categoryKey === 'FuturePerformanceOutlook').length;
+      const hasIndexStrategy = Boolean(e.indexStrategy && e.indexStrategy.trim());
+      const hasSummary = Boolean(e.summary && e.summary.trim());
+
+      const latestRequest = e.generationRequests[0];
+
+      const reportStatuses: EtfReportStatuses = {
+        performance: computeReportStatus(performanceAnalysisCount > 0, EtfReportType.PERFORMANCE_AND_RETURNS, 'regeneratePerformanceAndReturns', latestRequest),
+        costEfficiencyAndTeam: computeReportStatus(
+          costEfficiencyAnalysisCount > 0,
+          EtfReportType.COST_EFFICIENCY_AND_TEAM,
+          'regenerateCostEfficiencyAndTeam',
+          latestRequest
+        ),
+        risk: computeReportStatus(riskAnalysisCount > 0, EtfReportType.RISK_ANALYSIS, 'regenerateRiskAnalysis', latestRequest),
+        futureOutlook: computeReportStatus(
+          futureOutlookAnalysisCount > 0,
+          EtfReportType.FUTURE_PERFORMANCE_OUTLOOK,
+          'regenerateFuturePerformanceOutlook',
+          latestRequest
+        ),
+        indexStrategy: computeReportStatus(hasIndexStrategy, EtfReportType.INDEX_STRATEGY, 'regenerateIndexStrategy', latestRequest),
+        summary: computeReportStatus(hasSummary, EtfReportType.FINAL_SUMMARY, 'regenerateFinalSummary', latestRequest),
+      };
+
       return {
         id: e.id,
         symbol: e.symbol,
@@ -156,11 +248,13 @@ const getHandler = async (
         hasMorRiskInfo: !!e.morRiskInfo,
         hasMorPeopleInfo: !!e.morPeopleInfo,
         hasMorPortfolioInfo: !!e.morPortfolioInfo,
-        hasIndexStrategy: Boolean(e.indexStrategy && e.indexStrategy.trim()),
-        hasSummary: Boolean(e.summary && e.summary.trim()),
-        performanceAnalysisCount: factorResults.filter((r) => r.categoryKey === 'PerformanceAndReturns').length,
-        costEfficiencyAnalysisCount: factorResults.filter((r) => r.categoryKey === 'CostEfficiencyAndTeam').length,
-        riskAnalysisCount: factorResults.filter((r) => r.categoryKey === 'RiskAnalysis').length,
+        hasIndexStrategy,
+        hasSummary,
+        performanceAnalysisCount,
+        costEfficiencyAnalysisCount,
+        riskAnalysisCount,
+        futureOutlookAnalysisCount,
+        reportStatuses,
       };
     }),
     // totalCount comes from the DB query; UI can still show a correct pager even if we


### PR DESCRIPTION
## Summary

Updates the ETF reports admin page (`insights-ui/src/app/admin-v1/etf-reports/page.tsx` and helpers) to cover every supported report type uniformly.

- **Table columns**: adds a Future Outlook column and switches all six report-type columns (Performance, Cost & Team, Risk, Summary, Index & Strategy, Future Outlook) from a simple data-present/absent pill to a per-ETF status pill reflecting `generated` / `missing` / `in-progress` / `failed`. Status is derived from data presence + the most recent `EtfGenerationRequest` (status + completedSteps + failedSteps).
- **Select Missing bar**: removes the generic "Missing Analysis" button and replaces it with per-report-type options: `Missing Performance`, `Missing Cost & Team`, `Missing Risk`, `Missing Summary`, `Missing Index & Strategy`, `Missing Future Outlook`. Adds a new `Missing All Analysis` option that selects only ETFs missing every one of these report types.
- **API**: `/api/:spaceId/etfs-v1/etf-admin-reports` now returns `futureOutlookAnalysisCount` and a `reportStatuses` object per ETF so the UI does not have to recompute status from raw counts and request fields.
- **Per-ETF Generate All Analysis**: verified (and the per-type generation options remain) that the row-action enqueues every supported report type (Performance, Cost & Team, Risk, Summary, Index & Strategy, Future Outlook).

## Test plan
- [ ] Open `/admin-v1/etf-reports` and verify the Future Outlook column is present and shows `Missing` / `In Progress` / `Failed` / count for a variety of ETFs.
- [ ] Queue a single-type generation (e.g. Risk) for an ETF and confirm the Risk column flips to `In Progress` while others stay unchanged.
- [ ] If a generation request fails a step, confirm the corresponding column shows `Failed`.
- [ ] Click each `Missing <Type>` option and confirm only ETFs missing that report type are selected.
- [ ] Click `Missing All Analysis` and confirm only ETFs missing every report type are selected.
- [ ] Click per-ETF `Generate All Analysis` and verify a generation request is created with all six `regenerate*` flags set to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)