### PR TITLE
feat(etf-admin): reorder Future Outlook column and add 'Updated before' date filter

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-reports/EtfReportsFilters.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfReportsFilters.tsx
@@ -11,6 +11,8 @@ export interface EtfReportsFiltersProps {
   onMissingChange: (value: '' | 'stockAnalyze' | 'mor' | 'analysis') => void;
   search: string;
   onSearchChange: (value: string) => void;
+  updatedBefore: string;
+  onUpdatedBeforeChange: (value: string) => void;
 }
 
 function toExchangeItems(exchanges: ReadonlyArray<AllExchanges>): StyledSelectItem[] {
@@ -32,13 +34,15 @@ export default function EtfReportsFilters({
   onMissingChange,
   search,
   onSearchChange,
+  updatedBefore,
+  onUpdatedBeforeChange,
 }: EtfReportsFiltersProps): JSX.Element {
   const items = toExchangeItems(availableExchanges);
   const selectedId = exchange || 'All';
   const selectedMissing = missing || 'All';
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-end">
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-end">
       <div className="w-56">
         <StyledSelect
           label="Exchange"
@@ -54,6 +58,29 @@ export default function EtfReportsFilters({
           selectedItemId={selectedMissing}
           setSelectedItemId={(id: string | null) => onMissingChange(id && id !== 'All' ? (id as 'stockAnalyze' | 'mor' | 'analysis') : '')}
         />
+      </div>
+      <div className="w-56">
+        <label className="block text-sm font-medium text-gray-300 mb-1" title="Show ETFs whose last updatedAt is before this date">
+          Updated before
+        </label>
+        <div className="flex items-center gap-1">
+          <input
+            type="date"
+            value={updatedBefore}
+            onChange={(e) => onUpdatedBeforeChange(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-800 text-gray-200 border border-gray-700 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          {updatedBefore && (
+            <button
+              type="button"
+              onClick={() => onUpdatedBeforeChange('')}
+              className="px-2 py-2 text-xs text-gray-300 hover:text-white"
+              title="Clear date filter"
+            >
+              ×
+            </button>
+          )}
+        </div>
       </div>
       <div className="w-80">
         <label className="block text-sm font-medium text-gray-300 mb-1">Search</label>

--- a/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
@@ -60,9 +60,9 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Performance</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Cost & Team</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Risk</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Future Outlook</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Summary</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Index & Strategy</th>
-            <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Future Outlook</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider">Action</th>
           </tr>
         </thead>
@@ -116,13 +116,13 @@ export default function EtfReportsTable({ etfs, onRefresh, selectedIds, onToggle
                 <ReportStatusPill status={e.reportStatuses.risk} count={e.riskAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
+                <ReportStatusPill status={e.reportStatuses.futureOutlook} count={e.futureOutlookAnalysisCount} />
+              </td>
+              <td className="px-4 py-3 text-sm text-center">
                 <ReportStatusPill status={e.reportStatuses.summary} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
                 <ReportStatusPill status={e.reportStatuses.indexStrategy} />
-              </td>
-              <td className="px-4 py-3 text-sm text-center">
-                <ReportStatusPill status={e.reportStatuses.futureOutlook} count={e.futureOutlookAnalysisCount} />
               </td>
               <td className="px-4 py-3 text-sm text-center">
                 <div className="flex items-center justify-center gap-2">

--- a/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfReportsTable.tsx
@@ -19,7 +19,7 @@ function ReportStatusPill({ status, count }: { status: EtfReportStatus; count?: 
   if (status === 'failed') {
     return <span className="px-2 py-1 rounded-full text-xs bg-orange-900 text-orange-200">Failed</span>;
   }
-  return <span className="px-2 py-1 rounded-full text-xs bg-red-900 text-red-200">Missing</span>;
+  return <span className="px-2 py-1 rounded-full text-xs bg-red-900 text-red-200">No</span>;
 }
 
 export interface EtfReportsTableProps {

--- a/insights-ui/src/app/admin-v1/etf-reports/page.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/page.tsx
@@ -20,6 +20,7 @@ export default function EtfReportsPage(): JSX.Element {
   const [exchange, setExchange] = useState<AllExchanges | ''>('');
   const [missing, setMissing] = useState<'' | 'stockAnalyze' | 'mor' | 'analysis'>('');
   const [search, setSearch] = useState<string>('');
+  const [updatedBefore, setUpdatedBefore] = useState<string>('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const pageSize = 100;
 
@@ -27,11 +28,11 @@ export default function EtfReportsPage(): JSX.Element {
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [exchange, missing, debouncedSearch]);
+  }, [exchange, missing, debouncedSearch, updatedBefore]);
 
   useEffect(() => {
     setSelectedIds(new Set());
-  }, [currentPage, exchange, missing, debouncedSearch]);
+  }, [currentPage, exchange, missing, debouncedSearch, updatedBefore]);
 
   const apiUrl = useMemo(() => {
     const params = new URLSearchParams();
@@ -40,8 +41,9 @@ export default function EtfReportsPage(): JSX.Element {
     if (exchange) params.set('exchange', exchange);
     if (missing) params.set('missing', missing);
     if (debouncedSearch.trim()) params.set('q', debouncedSearch.trim());
+    if (updatedBefore) params.set('updatedBefore', updatedBefore);
     return `${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/etf-admin-reports?${params.toString()}`;
-  }, [currentPage, exchange, missing, debouncedSearch]);
+  }, [currentPage, exchange, missing, debouncedSearch, updatedBefore]);
 
   const { data: response, loading, reFetchData } = useFetchData<EtfReportsResponse>(apiUrl, {}, 'Failed to load ETFs');
 
@@ -96,6 +98,8 @@ export default function EtfReportsPage(): JSX.Element {
             onMissingChange={setMissing}
             search={search}
             onSearchChange={setSearch}
+            updatedBefore={updatedBefore}
+            onUpdatedBeforeChange={setUpdatedBefore}
           />
         </div>
       </div>

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/etf-admin-reports/route.ts
@@ -130,6 +130,9 @@ const getHandler = async (
   const exchange: AllExchanges | '' = exchangeRaw && isExchange(exchangeRaw) ? exchangeRaw : '';
   const q = searchParams.get('q');
   const missing = toMissingFilter(searchParams.get('missing'));
+  const updatedBeforeRaw = (searchParams.get('updatedBefore') ?? '').trim();
+  const updatedBeforeDate = updatedBeforeRaw && /^\d{4}-\d{2}-\d{2}$/.test(updatedBeforeRaw) ? new Date(`${updatedBeforeRaw}T00:00:00.000Z`) : null;
+  const updatedBeforeWhere: any = updatedBeforeDate && !Number.isNaN(updatedBeforeDate.getTime()) ? { updatedAt: { lt: updatedBeforeDate } } : null;
 
   const searchWhere = buildSearchWhere(q);
 
@@ -153,6 +156,7 @@ const getHandler = async (
     ...(exchange ? { exchange } : {}),
     ...(searchWhere ? searchWhere : {}),
     ...(missingWhere ? missingWhere : {}),
+    ...(updatedBeforeWhere ? updatedBeforeWhere : {}),
   };
 
   const [etfs, totalCount, distinctExchanges] = await Promise.all([


### PR DESCRIPTION
## Summary

- Reorder the report-type columns in the ETF admin table so **Future Outlook** sits right after **Risk** (and before Summary / Index & Strategy) — groups the four category analyses together.
- Add an **Updated before** date picker to the filters bar. Selecting a date narrows the table to ETFs whose `Etf.updatedAt` is strictly before that date, which helps admins find and regenerate ETFs whose reports are stale.

## Test plan
- [ ] Open `/admin-v1/etf-reports` and verify column order is: Performance, Cost & Team, Risk, Future Outlook, Summary, Index & Strategy.
- [ ] Pick a past date in the new "Updated before" filter and confirm only ETFs with `updatedAt` before that date are listed.
- [ ] Clear the date (× button) and confirm the full list is restored.
- [ ] Combine the date filter with Exchange / Missing / Search and confirm filters intersect correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)