### PR TITLE
feat(etf-analysis): add target investor groups taxonomy

### DIFF
--- a/insights-ui/src/app/etf-investors/[investorKey]/[goalKey]/page.tsx
+++ b/insights-ui/src/app/etf-investors/[investorKey]/[goalKey]/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import EtfInvestorGoalDetailView from '@/components/etf-investors/EtfInvestorGoalDetailView';
+import EtfInvestorPageLayout from '@/components/etf-investors/EtfInvestorPageLayout';
+import { getAllInvestors, getInvestorGoal } from '@/etf-analysis-data/etf-investor-taxonomy';
+
+export const dynamic = 'force-static';
+export const dynamicParams = false;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ investorKey: string; goalKey: string }>>;
+
+export function generateStaticParams(): Array<{ investorKey: string; goalKey: string }> {
+  const params: Array<{ investorKey: string; goalKey: string }> = [];
+  for (const investor of getAllInvestors()) {
+    for (const goal of investor.etfInvestorGoals) {
+      params.push({ investorKey: investor.key, goalKey: goal.key });
+    }
+  }
+  return params;
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { investorKey, goalKey } = await params;
+  const lookup = getInvestorGoal(investorKey, goalKey);
+  if (!lookup) {
+    return { title: 'Investor Goal Not Found | KoalaGains' };
+  }
+  return {
+    title: `${lookup.goal.name} — ${lookup.investor.name} | KoalaGains`,
+    description: lookup.goal.shortDescription,
+  };
+}
+
+export default async function EtfInvestorGoalPage({ params }: { params: RouteParams }) {
+  const { investorKey, goalKey } = await params;
+  const lookup = getInvestorGoal(investorKey, goalKey);
+
+  if (!lookup) {
+    notFound();
+  }
+
+  const breadcrumbs = [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: 'Investor Goals', href: '/etf-investors', current: false },
+    { name: lookup.investor.name, href: '/etf-investors', current: false },
+    { name: lookup.goal.name, href: `/etf-investors/${lookup.investor.key}/${lookup.goal.key}`, current: true },
+  ];
+
+  return (
+    <EtfInvestorPageLayout title={lookup.goal.name} breadcrumbs={breadcrumbs}>
+      <EtfInvestorGoalDetailView investor={lookup.investor} goal={lookup.goal} />
+    </EtfInvestorPageLayout>
+  );
+}

--- a/insights-ui/src/app/etf-investors/page.tsx
+++ b/insights-ui/src/app/etf-investors/page.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from 'next';
+import EtfInvestorListingGrid from '@/components/etf-investors/EtfInvestorListingGrid';
+import EtfInvestorPageLayout from '@/components/etf-investors/EtfInvestorPageLayout';
+import { getInvestorTaxonomy } from '@/etf-analysis-data/etf-investor-taxonomy';
+
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export const metadata: Metadata = {
+  title: 'ETF Investor Goals | KoalaGains',
+  description:
+    'A taxonomy of investor types — retail, HNW / family office, pension / endowment, insurance / treasury, RIA, hedge fund — and the specific goals each pursues when buying ETFs.',
+};
+
+export default async function EtfInvestorsPage() {
+  const taxonomy = getInvestorTaxonomy();
+
+  return (
+    <EtfInvestorPageLayout
+      title="ETF Investor Goals"
+      description="Six non-overlapping investor types and the specific goals each pursues when buying ETFs. Click a goal to see its analysis angle, key considerations, and the recommended ETFs."
+    >
+      <EtfInvestorListingGrid investors={taxonomy.investors} />
+    </EtfInvestorPageLayout>
+  );
+}

--- a/insights-ui/src/components/etf-investors/EtfInvestorCard.tsx
+++ b/insights-ui/src/components/etf-investors/EtfInvestorCard.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { EtfInvestor } from '@/types/etf/etf-analysis-types';
+
+export default function EtfInvestorCard({ investor }: { investor: EtfInvestor }): JSX.Element {
+  return (
+    <div className="bg-[#1F2937] border border-[#374151] rounded-lg overflow-hidden flex flex-col">
+      <div className="px-4 py-3 bg-[#374151]">
+        <h3 className="text-base font-semibold text-white leading-snug">{investor.name}</h3>
+        <p className="text-xs text-gray-300 mt-1 line-clamp-3">{investor.shortDescription}</p>
+      </div>
+
+      <ul className="px-2 py-2 space-y-1 flex-1">
+        {investor.etfInvestorGoals.map((goal) => (
+          <li key={goal.key}>
+            <Link
+              href={`/etf-investors/${investor.key}/${goal.key}`}
+              className="flex items-start justify-between gap-2 px-2 py-1.5 rounded hover:bg-[#2D3748] transition-colors group"
+            >
+              <span className="text-sm text-white group-hover:text-[#FBBF24]">{goal.name}</span>
+              <span className="text-xs text-gray-500 whitespace-nowrap pt-0.5">{goal.etfs.length} ETFs</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <div className="px-4 py-2 border-t border-[#374151] text-xs text-gray-400">{investor.etfInvestorGoals.length} goals</div>
+    </div>
+  );
+}

--- a/insights-ui/src/components/etf-investors/EtfInvestorGoalDetailView.tsx
+++ b/insights-ui/src/components/etf-investors/EtfInvestorGoalDetailView.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+import { EtfInvestor, EtfInvestorGoal, EtfInvestorGoalEtf, EtfInvestorProfile } from '@/types/etf/etf-analysis-types';
+
+function ProfileGrid({ profile }: { profile: EtfInvestorProfile }): JSX.Element {
+  const items: Array<{ label: string; value: string }> = [
+    { label: 'Investment horizon', value: profile.investmentHorizon },
+    { label: 'Risk tolerance', value: profile.riskTolerance },
+    { label: 'Primary goal', value: profile.primaryGoal },
+    { label: 'Income need', value: profile.incomeNeed },
+    { label: 'Tax sensitivity', value: profile.taxSensitivity },
+  ];
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+      {items.map((item) => (
+        <div key={item.label} className="bg-[#111827] border border-[#374151] rounded-md px-3 py-2">
+          <p className="text-[10px] uppercase tracking-wide text-gray-400">{item.label}</p>
+          <p className="text-sm text-white font-semibold mt-0.5">{item.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BulletList({ title, items, accent }: { title: string; items: string[]; accent: 'neutral' | 'warning' }): JSX.Element {
+  const titleColor = accent === 'warning' ? 'text-red-300' : 'text-gray-300';
+  return (
+    <div>
+      <h3 className={`text-sm font-semibold uppercase tracking-wide mb-2 ${titleColor}`}>{title}</h3>
+      <ul className="list-disc list-outside pl-5 space-y-1.5 text-sm text-[#E5E7EB]">
+        {items.map((item, idx) => (
+          <li key={idx}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function EtfRecommendationCard({ etf }: { etf: EtfInvestorGoalEtf }): JSX.Element {
+  return (
+    <div className="bg-[#111827] border border-[#374151] rounded-md p-3 flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <Link href={`/etfs/${etf.exchange}/${etf.symbol}`} className="inline-flex items-center gap-1 text-white hover:text-[#FBBF24] transition-colors">
+          <span className="text-xs font-bold bg-[#4F46E5] text-white px-1.5 py-0.5 rounded">{etf.symbol}</span>
+          <span className="text-xs text-gray-400">· {etf.exchange}</span>
+        </Link>
+      </div>
+      <p className="text-sm text-white font-medium leading-snug">{etf.name}</p>
+      <p className="text-xs text-gray-300 leading-relaxed">{etf.why}</p>
+    </div>
+  );
+}
+
+interface EtfInvestorGoalDetailViewProps {
+  investor: EtfInvestor;
+  goal: EtfInvestorGoal;
+}
+
+export default function EtfInvestorGoalDetailView({ investor, goal }: EtfInvestorGoalDetailViewProps): JSX.Element {
+  return (
+    <article className="text-[#E5E7EB]">
+      <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">{investor.name}</p>
+      <h1 className="text-3xl font-bold text-white mb-3">{goal.name}</h1>
+      <p className="text-base text-[#E5E7EB] mb-6">{goal.shortDescription}</p>
+
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold text-white mb-3">Investor profile</h2>
+        <ProfileGrid profile={goal.profile} />
+        <div className="bg-[#111827] border border-[#374151] rounded-md px-3 py-2">
+          <p className="text-[10px] uppercase tracking-wide text-gray-400">Typical investor</p>
+          <p className="text-sm text-white mt-0.5 leading-relaxed">{goal.profile.typicalInvestor}</p>
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Analysis angle</h2>
+        <p className="text-sm text-[#E5E7EB] leading-relaxed">{goal.analysisAngle}</p>
+      </section>
+
+      <section className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <BulletList title="Key considerations" items={goal.keyConsiderations} accent="neutral" />
+        <BulletList title="Red flags" items={goal.redFlags} accent="warning" />
+      </section>
+
+      <section className="bg-[#1F2937] border border-[#374151] rounded-lg p-4">
+        <h2 className="text-lg font-semibold text-white mb-3">Recommended ETFs</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {goal.etfs.map((etf) => (
+            <EtfRecommendationCard key={`${etf.exchange}-${etf.symbol}`} etf={etf} />
+          ))}
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/insights-ui/src/components/etf-investors/EtfInvestorListingGrid.tsx
+++ b/insights-ui/src/components/etf-investors/EtfInvestorListingGrid.tsx
@@ -1,0 +1,20 @@
+import { EtfInvestor } from '@/types/etf/etf-analysis-types';
+import EtfInvestorCard from './EtfInvestorCard';
+
+export default function EtfInvestorListingGrid({ investors }: { investors: EtfInvestor[] }): JSX.Element {
+  if (investors.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[#E5E7EB] text-lg">No investor types defined yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {investors.map((investor) => (
+        <EtfInvestorCard key={investor.key} investor={investor} />
+      ))}
+    </div>
+  );
+}

--- a/insights-ui/src/components/etf-investors/EtfInvestorPageLayout.tsx
+++ b/insights-ui/src/components/etf-investors/EtfInvestorPageLayout.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+
+interface EtfInvestorPageLayoutProps {
+  title: string;
+  description?: string;
+  breadcrumbs?: BreadcrumbsOjbect[];
+  rightButton?: ReactNode;
+  children: ReactNode;
+}
+
+function defaultBreadcrumbs(): BreadcrumbsOjbect[] {
+  return [
+    { name: 'US ETFs', href: '/etfs', current: false },
+    { name: 'Investor Goals', href: '/etf-investors', current: true },
+  ];
+}
+
+export default function EtfInvestorPageLayout({ title, description, breadcrumbs, rightButton, children }: EtfInvestorPageLayoutProps) {
+  return (
+    <PageWrapper>
+      <div className="overflow-x-auto">
+        <Breadcrumbs breadcrumbs={breadcrumbs ?? defaultBreadcrumbs()} rightButton={rightButton} />
+      </div>
+
+      <div className="w-full mb-8">
+        <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
+        {description && <p className="text-[#E5E7EB] text-md mb-4">{description}</p>}
+      </div>
+
+      {children}
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/etf-analysis-data/etf-investor-taxonomy.ts
+++ b/insights-ui/src/etf-analysis-data/etf-investor-taxonomy.ts
@@ -1,0 +1,29 @@
+import { EtfInvestor, EtfInvestorGoal, EtfInvestorTaxonomyConfig } from '@/types/etf/etf-analysis-types';
+import data from './etf-target-investor-groups.json';
+
+const taxonomy = data as EtfInvestorTaxonomyConfig;
+
+export function getInvestorTaxonomy(): EtfInvestorTaxonomyConfig {
+  return taxonomy;
+}
+
+export function getAllInvestors(): EtfInvestor[] {
+  return taxonomy.investors;
+}
+
+export function getInvestorByKey(key: string): EtfInvestor | undefined {
+  return taxonomy.investors.find((inv) => inv.key === key);
+}
+
+export interface InvestorGoalLookup {
+  investor: EtfInvestor;
+  goal: EtfInvestorGoal;
+}
+
+export function getInvestorGoal(investorKey: string, goalKey: string): InvestorGoalLookup | undefined {
+  const investor = getInvestorByKey(investorKey);
+  if (!investor) return undefined;
+  const goal = investor.etfInvestorGoals.find((g) => g.key === goalKey);
+  if (!goal) return undefined;
+  return { investor, goal };
+}

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,5 +1,5 @@
 {
-  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Each group describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and the ETF groups + specific Morningstar categories from etf-analysis-categories.json that fit. Groups are NOT mutually exclusive — a single ETF can be relevant to several investor groups (e.g. a TIPS fund fits both retirement-income-seeker and inflation-real-asset-hedger, and HNW investors often overlap with tax-sensitive-high-earner). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
+  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Note: the word 'group' here is a generic 'investor archetype' (e.g., 'investors expecting high dividends', 'pension funds', 'HNW family offices'); it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and a short list of highlighted Morningstar categories that are commonly relevant. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
   "investorGroups": [
     {
       "key": "first-time-investor",
@@ -27,48 +27,6 @@
         "K-1 tax reporting for a beginner taxable account.",
         "Expense ratio above ~0.50% for what is fundamentally an index product.",
         "AUM under $100M with declining trend (real closure risk)."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Total-market and S&P 500 trackers are the canonical first-purchase ETF."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "primary",
-          "rationale": "A single target-date fund is the simplest one-decision retirement portfolio."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "A small treasury or aggregate-bond sleeve adds resilience once the equity base is in place."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "occasional",
-          "rationale": "Only after a broad-market base exists; a sector fund is a satellite, not a starter holding."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Credit risk is hard to evaluate as a beginner — better to wait until the broad base is established."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "occasional",
-          "rationale": "Tax benefits rarely matter for beginners in low-bracket or tax-advantaged accounts."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "avoid",
-          "rationale": "Complex strategies are easy to misunderstand and create surprise tax or distribution outcomes."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Daily reset and decay make these unsuitable for any beginner buy-and-hold context."
-        }
       ],
       "highlightedCategories": [
         {
@@ -123,48 +81,6 @@
         "Manager or strategy churn within an active core holding.",
         "Persistent tracking error well above peer median for a passive fund.",
         "Repeated capital-gain distributions in a passive equity ETF held in a taxable account."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Diversified equity across cap, style, and geography is the core of a multi-decade portfolio."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "primary",
-          "rationale": "Long-dated target-date funds embed equity-heavy glide paths designed exactly for this horizon."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "REITs, infrastructure, and broad-tech can supplement a core; narrow themes are satellite, not core."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "A small bond sleeve becomes more relevant as the horizon shortens past 10 years."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "occasional",
-          "rationale": "Most alt strategies dilute long-run equity premium; only useful as small uncorrelated sleeves."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Credit adds yield but historically underperforms equity over very long horizons."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "occasional",
-          "rationale": "Only relevant for high-bracket investors funding a taxable bond sleeve."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Daily-reset decay makes these structurally unsuitable for buy-and-hold."
-        }
       ],
       "highlightedCategories": [
         {
@@ -229,48 +145,6 @@
         "Concentration so extreme that 5 holdings drive most of the return.",
         "High turnover combined with a high expense ratio in a taxable account.",
         "Daily-leveraged structure used as a 'growth' substitute (decay erases the edge)."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Growth, small-cap, EM, and foreign-growth sub-categories deliver higher expected return at the cost of higher volatility."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "primary",
-          "rationale": "Tech, communications, consumer cyclical, and digital-asset equities give targeted growth tilt."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Spot digital-asset and commodities-focused funds can serve as small high-growth satellites."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "secondary",
-          "rationale": "Aggressive-allocation and far-dated target-date funds align with the high-equity tilt."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "occasional",
-          "rationale": "Only for tactical sub-week trades; unsuitable as a growth holding due to decay."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "occasional",
-          "rationale": "Small allocation only; bonds dilute the growth tilt this investor wants."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "avoid",
-          "rationale": "Yield doesn't compound like equity over multi-decade horizons."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "avoid",
-          "rationale": "Tax-exempt income is irrelevant for an accumulator with no income need."
-        }
       ],
       "highlightedCategories": [
         {
@@ -346,48 +220,6 @@
         "High-yield distribution that is largely ROC (lowers cost basis silently).",
         "Long-duration bond fund without an explicit duration tolerance discussion.",
         "Active manager with under 3 years tenure on a fund used for income."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "primary",
-          "rationale": "Investment-grade core, short-term Treasuries, TIPS, and money market are the income / preservation backbone of a retirement portfolio."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "primary",
-          "rationale": "Retirement-dated and conservative-allocation funds are designed for exactly this glide-path."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "secondary",
-          "rationale": "Tax-equivalent yield is meaningful when retirement income pushes the investor into a high bracket."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Derivative-income (covered-call) and defined-outcome buffer funds trade upside for income / downside protection."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "secondary",
-          "rationale": "A modest equity sleeve (especially large value / dividend-tilted) hedges longevity risk without excess drawdown."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Some HY / preferred / multisector exposure can boost yield, but credit drawdowns hurt retirees disproportionately."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "occasional",
-          "rationale": "Real estate and utilities can supplement income; growth-tilted sectors don't fit."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Volatility decay and path dependency are incompatible with capital preservation."
-        }
       ],
       "highlightedCategories": [
         {
@@ -465,48 +297,6 @@
         "High-turnover active equity ETF in a taxable account.",
         "Non-AMT-aware muni allocation for an investor exposed to AMT."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "muni",
-          "fit": "primary",
-          "rationale": "Federally tax-exempt income is the entire reason this group exists; in-state funds add state-tax exemption."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Low-turnover passive index ETFs are the most tax-efficient way to hold equity in a taxable account."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "secondary",
-          "rationale": "Useful only when the underlying holdings are tax-efficient passive sleeves."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "Treasuries are state-tax exempt — meaningful for high-state-tax investors."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "occasional",
-          "rationale": "Acceptable when low-turnover and passive; methodology rebalancing can still cause cap-gain distributions."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Yield is taxable at ordinary rates — usually loses to muni TEY at this bracket."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "avoid",
-          "rationale": "K-1 reporting, ROC distributions, and high turnover create tax surprises that erode the after-tax return."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "High realized short-term gains taxed at ordinary rates — the worst possible structure for taxable accounts."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Muni National Interm",
@@ -582,48 +372,6 @@
         "Single-issuer or single-country concentration that is not visible from the yield.",
         "Covered-call strategy whose total return has lagged the underlying by more than the option-premium income.",
         "High-yield muni labeled as 'muni' but functioning as a credit play."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "primary",
-          "rationale": "High-yield, bank loan, EM debt, preferred, and multisector are the canonical taxable-income vehicles."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "primary",
-          "rationale": "Derivative-income and defined-outcome funds engineer high distribution rates by selling options."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "REITs, utilities, energy LPs, and infrastructure deliver equity income and inflation pass-through."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "Long bond, corporate bond, and TIPS deliver investment-grade income with manageable credit risk."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "secondary",
-          "rationale": "Tax-equivalent yield matters when the investor is in a high bracket."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "occasional",
-          "rationale": "Large value and dividend-tilted blends deliver modest but qualified-dividend income."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "occasional",
-          "rationale": "Conservative allocation funds blend income sleeves but are not income-optimized by design."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Not an income vehicle; daily-reset structure is incompatible with distribution stability."
-        }
       ],
       "highlightedCategories": [
         {
@@ -714,48 +462,6 @@
         "Single-stock exposure above ~25% (turns the fund into a single-stock proxy).",
         "Recent inception (<2 years) for a niche theme without issuer track record.",
         "AUM under $50M with declining trend (closure risk in a specialty fund is high)."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "primary",
-          "rationale": "Every category in this group is exactly a sector or thematic expression."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "primary",
-          "rationale": "Spot digital assets, commodities, and single-currency funds are pure thematic real-asset / FX expressions."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "secondary",
-          "rationale": "Single-country and regional funds (China, India, Japan, Latin America) are equity-thematic by definition."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "occasional",
-          "rationale": "Acceptable only as a short-term tactical expression, never as the long-form thematic holding."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "EM debt and certain credit themes can express a macro view."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "occasional",
-          "rationale": "Duration / curve tilts (long government, TIPS) can express macro themes."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "occasional",
-          "rationale": "State-specific muni funds are technically thematic on state-fiscal health."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "avoid",
-          "rationale": "Multi-asset blends dilute any single thematic view."
-        }
       ],
       "highlightedCategories": [
         {
@@ -867,48 +573,6 @@
         "Persistent tracking gap vs the daily-leverage objective.",
         "Marketing language that downplays the daily-reset / decay mechanism."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "primary",
-          "rationale": "Daily-leveraged and inverse funds are the direct expression vehicle for short-term tactical bets."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "primary",
-          "rationale": "Single-currency, commodity, and digital-asset funds give clean tactical exposure to macro factors."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "Narrow sector ETFs are useful for sector-rotation trades and short-term hedges."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "secondary",
-          "rationale": "Single-country / regional funds enable macro-tactical bets on specific economies."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "Treasury-duration ETFs (TLT, IEF) are standard rate-bet expression vehicles."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "HY-credit ETFs can express risk-on / risk-off tactical views."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "avoid",
-          "rationale": "Wide bid-ask and slow underlying market make muni ETFs unsuitable for short-term trading."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "avoid",
-          "rationale": "Multi-asset blends are too diluted for any tactical thesis."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Trading--Leveraged Equity",
@@ -988,48 +652,6 @@
         "High fees on a 'multi-strategy' fund that just delivers equity beta.",
         "Manager change without succession plan in an active alt sleeve.",
         "Mandate drift — fund relabels from 'market neutral' to 'long-short' (different risk profile)."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "primary",
-          "rationale": "Static balanced, tactical, and global allocation funds are pre-built diversified sleeves."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "primary",
-          "rationale": "Managed futures, market neutral, long-short, and multistrategy are the canonical low-correlation diversifiers."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "Treasuries and TIPS provide the classic risk-off ballast in a 60/40 portfolio."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "secondary",
-          "rationale": "Foreign and EM equity diversify the US-equity risk concentration."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "occasional",
-          "rationale": "Real estate, gold-mining, and infrastructure can serve as thematic diversifiers but carry sector risk."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Credit correlates with equity in stress — limited diversification value."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "occasional",
-          "rationale": "Useful when the diversifier need is also tax-efficient."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Volatility decay makes these unsuitable as portfolio diversifiers."
-        }
       ],
       "highlightedCategories": [
         {
@@ -1126,48 +748,6 @@
         "Equity REIT being treated as a pure inflation hedge despite high equity-market beta.",
         "Gold-mining ETF treated as gold (mining equities can decouple sharply from spot)."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "alt-strategies",
-          "fit": "primary",
-          "rationale": "Commodities, precious metals, and digital-asset funds are the most direct real-asset / debasement hedges."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "primary",
-          "rationale": "Real estate, natural resources, infrastructure, energy, and MLPs are the equity-style real-asset proxies."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "TIPS and short-term TIPS are the direct inflation-linked Treasury hedge."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "occasional",
-          "rationale": "Value tilt and EM equity historically perform better than growth in inflation regimes."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Bank loans (floating rate) can hold up in rising-rate inflation regimes."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "occasional",
-          "rationale": "Most allocation funds underweight real assets; check the actual inflation hedge sleeve."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "avoid",
-          "rationale": "Long-duration nominal munis lose to inflation; not a hedge."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Decay structure makes these unsuitable for a multi-year inflation hedge."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Commodities Broad Basket",
@@ -1262,48 +842,6 @@
         "Distribution character largely ROC or short-term gain without disclosure.",
         "ETF that is strictly worse than direct indexing for a $1M+ position with harvesting needs."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Tax-efficient passive beta — large-blend, foreign-blend, EM as the public-equity core."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "primary",
-          "rationale": "State-specific and national muni for the taxable fixed-income sleeve at top brackets."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "Thematic tilts (real estate, infrastructure, healthcare) as satellites around the core."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Defined outcome, derivative income, gold, and commodities provide diversification and downside structure."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "occasional",
-          "rationale": "Preferred and EM debt as small income sleeves; muni usually wins after-tax."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "occasional",
-          "rationale": "Use only inside tax-deferred accounts; muni dominates in taxable."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "occasional",
-          "rationale": "Rare — HNW investors typically construct their own asset allocation rather than use packaged glide paths."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Short-term capital gains taxed at marginal rate; structurally bad for after-tax wealth."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Large Blend",
@@ -1367,48 +905,6 @@
         "Methodology drift that breaks IPS benchmark consistency over multiple years.",
         "ESG-labeled funds with weak or self-graded underlying screens (greenwashing risk for foundations).",
         "Concentration / closure risk from a single large investor's outflow."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Cap-weighted US, international, and EM index ETFs for the equity-beta sleeve."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "primary",
-          "rationale": "Long treasuries and TIPS for liability-matching duration; intermediate core for general fixed-income beta."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Managed futures, market-neutral, and commodities as overlays — often preferred via SMA but ETF wrappers are used for liquidity sleeves."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "Real estate, infrastructure, and natural resources as inflation-hedge and real-asset sleeves."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "secondary",
-          "rationale": "High-yield, EM debt, and bank loans as a return-seeking credit sleeve when the IPS allows."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "occasional",
-          "rationale": "Rare — institutions construct their own glide path; target-date funds appear only inside DC plan menus offered to participants."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "avoid",
-          "rationale": "Tax-exempt status erases the muni advantage; taxable bonds with higher pre-tax yield dominate."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "IPS guidelines almost universally prohibit daily-reset leveraged products."
-        }
       ],
       "highlightedCategories": [
         {
@@ -1479,48 +975,6 @@
         "Active strategy that complicates the simple 'we use low-cost passive' value-prop.",
         "Closure risk that would force a cross-account taxable transition for hundreds of clients."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "Diversified equity index ETFs are the workhorse building block of every risk-tier model."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "primary",
-          "rationale": "Investment-grade core, short-term, and TIPS form the bond sleeve of every model."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "secondary",
-          "rationale": "REITs and select sector tilts as model satellites."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "secondary",
-          "rationale": "Used for high-bracket client sub-models holding in taxable accounts."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "secondary",
-          "rationale": "Multisector and preferred sleeves to add yield in income-tilted models."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Managed futures and market-neutral as small uncorrelated sleeves; derivative income for retiree models."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "occasional",
-          "rationale": "Advisors usually construct their own allocation rather than outsource it to a target-date fund."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Daily-reset products do not belong in a long-term advisory model portfolio."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Large Blend",
@@ -1590,48 +1044,6 @@
         "Wide premium/discount during normal conditions (AP friction or low primary-market activity).",
         "AUM small enough that a normal block trade visibly moves the price."
       ],
-      "etfGroupFit": [
-        {
-          "groupKey": "broad-equity",
-          "fit": "primary",
-          "rationale": "S&P 500, NDX, Russell 2000 wrappers (SPY, QQQ, IWM) are the standard equity-beta vehicles for desks."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "primary",
-          "rationale": "Sector ETFs (XLK, XLE, XLF) are the standard relative-value pair-trade vehicles."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "secondary",
-          "rationale": "Daily-leveraged and inverse products for tactical hedging and short-term directional bets."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "secondary",
-          "rationale": "Single-currency, commodities, and digital-asset ETFs for macro directional bets."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "secondary",
-          "rationale": "HYG / JNK / LQD as standard credit-spread expression vehicles."
-        },
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "secondary",
-          "rationale": "TLT / IEF / SHY for rate / duration tactical bets and curve trades."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "avoid",
-          "rationale": "Diversified retail-targeted vehicles with no trading utility."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "avoid",
-          "rationale": "OTC-underlying friction and limited options market make munis unsuitable for trading desks."
-        }
-      ],
       "highlightedCategories": [
         {
           "category": "Large Blend",
@@ -1700,48 +1112,6 @@
         "Long duration exposure incompatible with operating-cash mandate.",
         "Unclear regulatory look-through treatment — risk team can't approve.",
         "Thin liquidity that would force NAV-discount selling under outflow stress."
-      ],
-      "etfGroupFit": [
-        {
-          "groupKey": "fixed-income-core",
-          "fit": "primary",
-          "rationale": "Treasuries, ultrashort, short-term IG corporate, and IG core are the entire usable universe for most policies."
-        },
-        {
-          "groupKey": "muni",
-          "fit": "secondary",
-          "rationale": "Insurance general accounts can use muni for after-tax yield where the policy permits."
-        },
-        {
-          "groupKey": "fixed-income-credit",
-          "fit": "avoid",
-          "rationale": "High-yield, EM debt, preferred, and bank-loan products are typically prohibited by IG-only policies."
-        },
-        {
-          "groupKey": "broad-equity",
-          "fit": "avoid",
-          "rationale": "Most insurance / treasury policies prohibit equity exposure inside the operating account."
-        },
-        {
-          "groupKey": "sector-thematic-equity",
-          "fit": "avoid",
-          "rationale": "Equity exposure of any kind is typically prohibited."
-        },
-        {
-          "groupKey": "alt-strategies",
-          "fit": "avoid",
-          "rationale": "Strategy complexity and capital-charge uncertainty rule these out."
-        },
-        {
-          "groupKey": "allocation-target-date",
-          "fit": "avoid",
-          "rationale": "Embedded equity exposure violates IG-only mandates."
-        },
-        {
-          "groupKey": "leveraged-inverse",
-          "fit": "avoid",
-          "rationale": "Derivative-driven structures with capital-charge uncertainty — disallowed almost universally."
-        }
       ],
       "highlightedCategories": [
         {

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,430 +1,287 @@
 {
-  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Two shapes appear in the investorGroups array: (1) flat goal-persona entries with key/name/shortDescription/profile/analysisAngle/keyConsiderations/redFlags (used for retail goals like first-time-investor, growth-accumulator, retirement-income-seeker, plus single-purpose institutional ones like institutional-trading-desk and insurance-corporate-treasury); and (2) audience entries with key/name/shortDescription/goals[], where the goals[] array holds nested goal-persona entries — used for broad audiences (HNW / family office, pension / endowment / foundation, RIA / financial advisor) that have multiple distinct goals worth analyzing separately. Note: the word 'group' here is a generic 'investor archetype'; it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
-  "investorGroups": [
+  "description": "ETF investor taxonomy used to write ETF analyses from the perspective of who the potential investors are. Two-level structure: top level is investor type (EtfInvestor — name, shortDescription, etfInvestorGoals[]); second level is goals an investor of that type pursues when buying ETFs (each goal has profile, analysisAngle, keyConsiderations, redFlags). 6 investor types: retail individual, HNW / family office, pension / endowment / foundation / sovereign, insurance / bank / corporate treasury, financial advisor / RIA / wealth manager, hedge fund / asset manager / trading desk. Types are intentionally non-overlapping (each defined by a distinct funding source / governance / regulatory context). Goals can recur across types (e.g., inflation hedge appears in retail, HNW, and pension) but each instance is framed for that type's specific perspective. Conforms to EtfInvestorTaxonomyConfig in src/types/etf/etf-analysis-types.ts.",
+  "investors": [
     {
-      "key": "first-time-investor",
-      "name": "First-Time / Beginner Investor",
-      "shortDescription": "New to investing, wants the simplest possible exposure to broad markets without making fund-selection mistakes that compound over decades.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "None",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Someone in their 20s or 30s opening a brokerage or Roth IRA for the first time, contributing monthly, with little appetite for picking individual sub-categories or sectors."
-      },
-      "analysisAngle": "Default to the simplest, cheapest, most diversified option. Explain the fund as if the reader has never bought an ETF before. Always anchor to the boring baseline (a total-market or S&P 500 fund, or a target-date fund) and explain whether this fund adds anything over that baseline that justifies the additional complexity. Avoid jargon; if a term like 'duration' or 'tracking error' is used, define it inline.",
-      "keyConsiderations": [
-        "Expense ratio under ~0.10% for passive broad-equity, under ~0.20% for target-date.",
-        "Fund size large enough that closure is not a concern (>$1B AUM ideal).",
-        "Mandate stability — no recent benchmark or category changes.",
-        "Tracking error vs the index is small and consistent.",
-        "Distribution character is simple (qualified dividends, no surprise capital-gain distributions)."
-      ],
-      "redFlags": [
-        "Daily-leveraged or inverse structure (path-dependent, not for buy-and-hold).",
-        "Single-country, single-sector, single-currency, or single-stock concentration.",
-        "K-1 tax reporting for a beginner taxable account.",
-        "Expense ratio above ~0.50% for what is fundamentally an index product.",
-        "AUM under $100M with declining trend (real closure risk)."
-      ]
-    },
-    {
-      "key": "long-term-wealth-builder",
-      "name": "Long-Term Wealth Builder (Buy & Hold)",
-      "shortDescription": "Multi-decade horizon, comfortable with equity volatility, focused on cumulative compounding and minimizing fee drag over 20-30+ years.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "None",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Working-age investor 5-30 years from retirement, dollar-cost-averaging into a core portfolio, cares more about the next 25 years than the next 25 weeks."
-      },
-      "analysisAngle": "Frame everything in cumulative-compounding terms: a 0.30% fee gap is ~9% of an ending balance over 30 years. Emphasize tracking fidelity, mandate stability, and downside drawdown / recovery time. De-emphasize 1-year performance; weight 5-year and 10-year risk-adjusted return. Note dividend reinvestment and the practical difference between a total-return and price index.",
-      "keyConsiderations": [
-        "Cumulative fee drag over 20-30 years vs the lowest-cost peer.",
-        "Tracking error consistency across market regimes.",
-        "Drawdown depth and recovery time in 2008, 2020, 2022.",
-        "Tax efficiency — capital-gain distribution history for taxable accounts.",
-        "Issuer scale and operational stability over decades."
-      ],
-      "redFlags": [
-        "Mandate or benchmark changes mid-life (breaks the historical record).",
-        "Manager or strategy churn within an active core holding.",
-        "Persistent tracking error well above peer median for a passive fund.",
-        "Repeated capital-gain distributions in a passive equity ETF held in a taxable account."
-      ]
-    },
-    {
-      "key": "growth-accumulator",
-      "name": "Growth-Focused Accumulator",
-      "shortDescription": "Younger investor with a long horizon and high risk tolerance, willing to accept large drawdowns in pursuit of higher long-run growth — overweight to growth, small-cap, EM, and innovation themes.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "High",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "None",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "20s-30s investor with stable income, no near-term capital needs, willing to accept 30-50% peak-to-trough drawdowns in exchange for higher expected returns over 20+ years."
-      },
-      "analysisAngle": "Emphasize factor tilt (growth, small-cap, momentum), top-holding concentration, and drawdown / recovery behavior — this investor needs to know *how* painful the down years will be and how long recovery has historically taken. Reinforce that past bull-run leadership does not guarantee future leadership; address sequence risk only lightly because the horizon is long.",
-      "keyConsiderations": [
-        "Factor exposure (growth vs blend vs value tilt) and how it has driven returns.",
-        "Top-10 holdings concentration — a 'growth' fund that is 50% mega-cap tech is concentrated, not diversified.",
-        "Volatility (std dev) and beta vs the S&P 500.",
-        "Worst 1-year and worst peak-to-trough drawdown, plus recovery time.",
-        "Theme purity — does the fund actually own the names that describe it?"
-      ],
-      "redFlags": [
-        "Thematic fund chasing a recently-hot theme with under 2 years of history.",
-        "Concentration so extreme that 5 holdings drive most of the return.",
-        "High turnover combined with a high expense ratio in a taxable account.",
-        "Daily-leveraged structure used as a 'growth' substitute (decay erases the edge)."
-      ]
-    },
-    {
-      "key": "retirement-income-seeker",
-      "name": "Retirement Income Seeker",
-      "shortDescription": "At or near retirement, drawing from the portfolio for living expenses. Prioritizes capital preservation, predictable income, and shallow drawdowns over absolute return.",
-      "profile": {
-        "investmentHorizon": "Medium (1-5y)",
-        "riskTolerance": "Low-Moderate",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "High",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Investor in their 60s-70s living off portfolio distributions, where a single deep drawdown in the wrong year can permanently impair retirement consumption (sequence-of-returns risk)."
-      },
-      "analysisAngle": "Lead with downside: worst calendar year, worst drawdown, recovery time, and distribution stability. Income consistency matters more than headline yield — a fund that paid every quarter through 2008 and 2020 is more useful than one with a higher headline yield and an erratic record. Address sequence-of-returns risk explicitly: a 30% drawdown in year 1 of retirement is fundamentally different from year 20.",
-      "keyConsiderations": [
-        "Distribution stability and history — quarterly/monthly consistency through stress periods.",
-        "Duration risk and sensitivity to a sudden rate move.",
-        "Worst peak-to-trough drawdown and time-to-recover (a retiree may not have the time).",
-        "Income character — qualified dividends vs ordinary income vs return-of-capital.",
-        "Sequence-of-returns risk — a deep drawdown in year 1-3 of retirement is uniquely damaging."
-      ],
-      "redFlags": [
-        "Daily-leveraged or inverse structure (any holding period).",
-        "Concentrated single-sector or single-country bets.",
-        "High-yield distribution that is largely ROC (lowers cost basis silently).",
-        "Long-duration bond fund without an explicit duration tolerance discussion.",
-        "Active manager with under 3 years tenure on a fund used for income."
-      ]
-    },
-    {
-      "key": "tax-sensitive-high-earner",
-      "name": "Tax-Sensitive High-Income Investor",
-      "shortDescription": "High federal-bracket investor (often in a high-tax state) for whom after-tax return is the only return that matters. Heavy use of muni bonds and tax-efficient passive equity.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Tax Optimization",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "High",
-        "typicalInvestor": "Top federal-bracket professional or business owner in a high-tax state (CA, NY, NJ, MA), with a large taxable account where every percent of tax drag compounds."
-      },
-      "analysisAngle": "State the marginal tax assumption explicitly (e.g. 37% federal + 13.3% CA = ~46% combined). For muni funds compute tax-equivalent yield (TEY = SEC yield / (1 − marginal rate)) and compare to taxable peers of similar duration / credit quality. Flag distribution character (qualified dividend vs ROC vs ordinary) and surface K-1 reporting wherever it appears. For equity sleeves, prefer low-turnover passive index funds over high-turnover active.",
-      "keyConsiderations": [
-        "Tax-equivalent yield at the investor's marginal rate vs taxable bond peers.",
-        "AMT treatment for private-activity-bond muni funds.",
-        "State tax exemption — in-state muni funds give triple-exempt yield in high-tax states.",
-        "Distribution character (qualified dividends, return-of-capital, ordinary income).",
-        "Capital-gain distribution history — a passive ETF should essentially never pay one.",
-        "K-1 vs 1099 reporting for any commodity / MLP / certain alt-strategy funds."
-      ],
-      "redFlags": [
-        "Repeated capital-gain distributions from an ETF marketed as passive.",
-        "K-1 reporting in a fund being considered for a taxable buy-and-hold sleeve.",
-        "Derivative-income fund whose 'yield' is largely return-of-capital without disclosure.",
-        "High-turnover active equity ETF in a taxable account.",
-        "Non-AMT-aware muni allocation for an investor exposed to AMT."
-      ]
-    },
-    {
-      "key": "income-yield-seeker",
-      "name": "Income / High-Yield Seeker",
-      "shortDescription": "Wants the highest sustainable cash distribution the portfolio can produce, accepting credit risk, derivative complexity, or sector concentration to get there.",
-      "profile": {
-        "investmentHorizon": "Medium (1-5y)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Income Generation",
-        "incomeNeed": "High",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Investor whose portfolio purpose is producing monthly or quarterly cash — semi-retired, FIRE, or someone funding a specific spending program — willing to underweight pure capital appreciation in exchange for distributable yield."
-      },
-      "analysisAngle": "Lead with distribution yield, distribution frequency, and the *sustainability* of the distribution. Decompose the yield into character (qualified dividend / ordinary income / ROC / short-term gain) and the source of return (coupon, option premium, credit spread, REIT FFO). Stress-test distributions against credit drawdowns (2008, 2020, 2022) and option-premium compression in low-vol regimes. A high yield that proved unstable is worse than a lower yield that proved durable.",
-      "keyConsiderations": [
-        "Trailing 12-month distribution yield AND SEC yield (the gap reveals optical yield).",
-        "Distribution character — qualified vs ordinary vs ROC vs short-term gain.",
-        "Distribution stability through 2008, 2020 March, 2022.",
-        "Credit quality mix (HY vs IG, AAA muni vs BB) — yield premium reflects real default risk.",
-        "Concentration risk — REIT, utility, energy MLP, EM debt all carry single-factor exposure.",
-        "For derivative-income funds: cap on upside, behavior in sustained bull markets."
-      ],
-      "redFlags": [
-        "Headline yield meaningfully above SEC yield without disclosed ROC accounting.",
-        "Distribution cut history that the fund's marketing buries.",
-        "Single-issuer or single-country concentration that is not visible from the yield.",
-        "Covered-call strategy whose total return has lagged the underlying by more than the option-premium income.",
-        "High-yield muni labeled as 'muni' but functioning as a credit play."
-      ]
-    },
-    {
-      "key": "sector-thematic-conviction",
-      "name": "Sector / Thematic Conviction Investor",
-      "shortDescription": "Has a directional view on a specific sector, theme, region, or commodity and wants the cleanest expression of that thesis.",
-      "profile": {
-        "investmentHorizon": "Medium (1-5y)",
-        "riskTolerance": "High",
-        "primaryGoal": "Thematic Exposure",
-        "incomeNeed": "None",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Investor who has formed a specific view (AI infrastructure will outperform, India will outgrow EM, gold will benefit from real-rate path) and wants a single ETF that expresses that view rather than picking individual stocks."
-      },
-      "analysisAngle": "Focus on theme purity — does the fund actually own the names that match its label? Decompose top holdings, methodology, and how the index defines the theme. Compare against the obvious peers in the same theme (XLK vs VGT vs IYW for tech; KWEB vs MCHI vs FXI for China). Surface concentration, weighting methodology (cap vs equal vs revenue), and rebalancing cadence. Avoid over-weighting historical returns — themes rotate and recent leadership is a poor predictor.",
-      "keyConsiderations": [
-        "Methodology — what does the index actually screen for, and how strict is the filter?",
-        "Theme purity — top-10 holdings vs the stated thesis.",
-        "Peer comparison within the same theme (multiple ETFs often exist).",
-        "Concentration — how much of return is driven by the top 5 names?",
-        "Weighting scheme (market-cap vs equal-weight vs revenue-weight) materially changes risk profile.",
-        "Rebalancing cadence and turnover — high-rebalance themes generate cap gains in taxable accounts."
-      ],
-      "redFlags": [
-        "Theme name that does not match the actual top holdings (e.g. an 'AI' fund holding mostly mega-cap tech).",
-        "Single-stock exposure above ~25% (turns the fund into a single-stock proxy).",
-        "Recent inception (<2 years) for a niche theme without issuer track record.",
-        "AUM under $50M with declining trend (closure risk in a specialty fund is high)."
-      ]
-    },
-    {
-      "key": "active-trader-speculator",
-      "name": "Active Trader / Tactical Speculator",
-      "shortDescription": "Holds positions for hours to weeks, uses ETFs as expression vehicles for short-term directional or hedging trades. Tolerates structural decay in exchange for liquidity and leverage.",
-      "profile": {
-        "investmentHorizon": "Short (<1y)",
-        "riskTolerance": "Very High",
-        "primaryGoal": "Speculation / Trading",
-        "incomeNeed": "None",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Active trader running directional or pairs trades, hedging an existing book, or expressing tactical macro views with daily-leveraged or single-currency / single-commodity products."
-      },
-      "analysisAngle": "Focus on intraday liquidity, bid-ask spread, daily volume, and daily-leverage tracking fidelity. For leveraged products, hammer the holding-period warning: 2-3% all-in annual decay (financing + volatility drag + expense ratio) means these are not buy-and-hold. Address pair-trade construction (TQQQ vs SQQQ, TLT vs TBT) and the impact of overnight gap risk. Tax efficiency is largely irrelevant — short-term gains are short-term gains.",
-      "keyConsiderations": [
-        "Average daily dollar volume — must support entry/exit at intended size without slippage.",
-        "Bid-ask spread in bps — direct round-trip cost for high-frequency trading.",
-        "Daily-leverage tracking fidelity vs the stated multiplier.",
-        "Underlying market hours — single-currency and commodity ETFs may gap on overnight underlying moves.",
-        "Volatility decay magnitude in the recent regime.",
-        "Suitability for pair trades (matched leverage long/short pairs)."
-      ],
-      "redFlags": [
-        "Wide bid-ask that erodes round-trip economics.",
-        "Thin volume that prevents large-order exits without market impact.",
-        "Persistent tracking gap vs the daily-leverage objective.",
-        "Marketing language that downplays the daily-reset / decay mechanism."
-      ]
-    },
-    {
-      "key": "all-weather-diversifier",
-      "name": "All-Weather Diversifier / Risk-Off Hedger",
-      "shortDescription": "Cares about portfolio-level outcomes more than any one fund's return. Prioritizes low correlation, drawdown reduction, and risk-adjusted return; allocates to alternatives and balanced sleeves.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Sophisticated investor (often someone with finance background or working with an advisor) building a portfolio that holds up across regimes — not just bull markets — and willing to accept lower expected return for shallower drawdowns."
-      },
-      "analysisAngle": "Focus on correlation to S&P 500 and to a 60/40 benchmark, drawdown depth in 2008 / 2020 / 2022, and whether the strategy actually delivered its mandate (low correlation, downside protection, uncorrelated returns) — not whether it beat the S&P. Emphasize that the right yardstick for an alt strategy is mandate adherence in stress, not absolute return in a bull market. Address how this fund interacts with a typical equity-heavy portfolio.",
-      "keyConsiderations": [
-        "Realized correlation to S&P 500 across full cycle and in stress periods.",
-        "Maximum drawdown vs an equity benchmark — did it cut drawdown materially?",
-        "Mandate delivery — did the strategy do what it said (managed-futures up in 2022, market-neutral flat through 2020)?",
-        "Risk-adjusted return (Sharpe / Sortino) vs both peers and a passive blend.",
-        "Fee justification — alt-strategy fees only earn their keep if the diversification is real.",
-        "Capacity / scaling — has the strategy degraded as AUM grew?"
-      ],
-      "redFlags": [
-        "Strategy that quietly tracks equities in stress (correlation spike when it matters most).",
-        "High fees on a 'multi-strategy' fund that just delivers equity beta.",
-        "Manager change without succession plan in an active alt sleeve.",
-        "Mandate drift — fund relabels from 'market neutral' to 'long-short' (different risk profile)."
-      ]
-    },
-    {
-      "key": "inflation-real-asset-hedger",
-      "name": "Inflation & Real-Asset Hedger",
-      "shortDescription": "Worried about CPI / debasement / cost-of-living erosion of purchasing power. Allocates to commodities, real estate, infrastructure, energy equities, gold, and TIPS.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Investor explicitly worried about inflation regimes (post-2021 type), sustained debasement, or cost-of-living erosion of the bond and growth-equity portion of their portfolio."
-      },
-      "analysisAngle": "Focus on real-return correlation and inflation beta. Distinguish *direct* inflation hedges (commodities, TIPS, gold) from *equity-style* real-asset proxies (REITs, infrastructure, energy equities, MLPs) — the equity proxies have meaningful equity-market beta and are imperfect hedges in pure inflation shocks. Address regime sensitivity: gold and commodities perform very differently across stagflation, demand-pull, and rate-hike inflation. Surface tax / K-1 complications for commodity pools and MLPs.",
-      "keyConsiderations": [
-        "Direct vs proxy inflation exposure — physical commodities vs producer equities have different betas.",
-        "Inflation beta in actual inflation regimes (2021-2023, 2008 commodity spike).",
-        "Real-rate sensitivity — TIPS lose value when real rates rise even if breakevens hold.",
-        "K-1 vs 1099 reporting for commodity pools, MLPs, and certain alt funds.",
-        "Concentration — a 'commodities' fund may be 80% energy.",
-        "Equity-market beta of REITs, infrastructure, and natural-resource equities (they are not pure inflation hedges)."
-      ],
-      "redFlags": [
-        "Long-duration nominal bond fund being marketed as part of an inflation portfolio.",
-        "Single-commodity fund being used as the broad inflation hedge.",
-        "Equity REIT being treated as a pure inflation hedge despite high equity-market beta.",
-        "Gold-mining ETF treated as gold (mining equities can decouple sharply from spot)."
-      ]
-    },
-    {
-      "key": "institutional-trading-desk",
-      "name": "Institutional Trading Desk / Hedge Fund / Asset Manager",
-      "shortDescription": "Professional trading desk using ETFs as efficient wrappers for short-term beta, hedging, basket trades, transition management, or pair trades.",
-      "profile": {
-        "investmentHorizon": "Short (<1y)",
-        "riskTolerance": "Very High",
-        "primaryGoal": "Speculation / Trading",
-        "incomeNeed": "None",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Hedge fund PM (long-short, macro, multi-strategy), proprietary trading desk, mutual fund manager doing transition management, or fund-of-funds allocator. Holds ETFs for hours to weeks, often with options overlays; pass-through tax structure means short-term gains aren't a concern."
-      },
-      "analysisAngle": "ETFs are wrappers — judged purely on cleanliness of exposure, liquidity, and shortable inventory. Focus on: bid-ask in bps, average daily dollar volume in $hundreds of millions, options-market liquidity (open interest, IV surface tightness), securities-borrow availability and cost for short positions, and creation-redemption efficiency for AP arbitrage. Tax considerations are minimal. For sector / single-country / leveraged products, the question is implementation efficiency vs the alternative (futures, swaps, baskets of underlyings).",
-      "keyConsiderations": [
-        "Average daily dollar volume in $hundreds of millions — supports block trades without slippage.",
-        "Options-market depth and IV surface tightness for hedging overlays.",
-        "Securities-borrow availability and cost for short positions.",
-        "Creation/redemption baskets and AP friction during stress windows.",
-        "Premium/discount drift in stress windows (March 2020, Oct 2022)."
-      ],
-      "redFlags": [
-        "Options market thin or non-existent — no efficient hedging path.",
-        "High borrow cost or limited shortable supply for short-side strategies.",
-        "Wide premium/discount during normal conditions (AP friction or low primary-market activity).",
-        "AUM small enough that a normal block trade visibly moves the price."
-      ]
-    },
-    {
-      "key": "insurance-corporate-treasury",
-      "name": "Insurance General Account / Corporate Treasury",
-      "shortDescription": "Regulated balance-sheet investor with strict capital-preservation and liability-matching constraints — uses ETFs sparingly for liquid investment-grade fixed-income exposure inside policy limits.",
-      "profile": {
-        "investmentHorizon": "Medium (1-5y)",
-        "riskTolerance": "Low",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Insurance company general account (life or P&C), bank treasury, or large-corporate operating-cash treasury team. Constrained by NAIC ratings (insurers), Basel / HQLA / regulatory capital (banks), or board-approved investment policy (corporates) — usually limited to investment-grade short-duration."
-      },
-      "analysisAngle": "Regulatory constraints dominate every decision — for insurers, NAIC ratings drive risk-based capital charges; for banks, HQLA classification and Basel III constraints apply; for corporate treasuries, the policy almost always limits to investment-grade short-duration. ETFs are used sparingly because the underlying bond ratings flow through to the holder for many regulatory frameworks, and look-through treatment varies. Focus on: underlying credit quality (95%+ IG), duration ≤ 3 years for treasury use, NAIC / Basel look-through treatment, and AUM/liquidity for unwinding without slippage. Do NOT discuss yield-pickup strategies — these holders are constrained from chasing yield and will reject the analysis if it ignores their guardrails.",
-      "keyConsiderations": [
-        "Underlying credit quality (95%+ investment grade for most policies).",
-        "Duration profile compatible with the policy (often ≤ 3 years for operating treasury).",
-        "NAIC / Basel / look-through treatment of the wrapper for capital-charge calculation.",
-        "AUM and bid-ask depth sized for the mandate (often $50-500M positions).",
-        "Distribution mechanics — monthly cash flow for treasury, accrual treatment for accounting."
-      ],
-      "redFlags": [
-        "Any sub-investment-grade exposure inside the wrapper — immediate policy violation for many holders.",
-        "Long duration exposure incompatible with operating-cash mandate.",
-        "Unclear regulatory look-through treatment — risk team can't approve.",
-        "Thin liquidity that would force NAV-discount selling under outflow stress."
-      ]
-    },
-    {
-      "key": "esg-impact-investor",
-      "name": "ESG / Sustainable / Impact Investor",
-      "shortDescription": "Investor who screens for environmental, social, and governance criteria — willing to accept some return or fee tradeoff for portfolio alignment with values, climate goals, or impact mandates.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "None",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Retail investor, foundation, university endowment, religious institution, or impact-focused family office that explicitly excludes fossil fuels, weapons, tobacco, or other fails-to-screen issuers — or that actively allocates to climate-solutions, gender-lens, clean-energy, or community-development themes. Will accept measured return giveup or higher fees in exchange for screen integrity."
-      },
-      "analysisAngle": "Screen integrity is the primary test — does the methodology actually deliver what the label promises, and is it auditable? Many ESG-labeled ETFs have weak underlying screens (greenwashing risk) or hold companies that obviously violate the spirit of the label. Compare the methodology disclosure and actual top holdings against the stated mandate. Discuss the return / fee tradeoff vs the equivalent unscreened index. For impact-themed funds (clean energy, gender lens, community development) focus on whether the theme is implementable as a diversified portfolio or whether it becomes a concentrated single-sector bet in disguise.",
-      "keyConsiderations": [
-        "Methodology disclosure — exclusion list, integration approach, third-party rating provider, refresh cadence.",
-        "Actual top holdings vs the spirit of the screen (greenwashing detection).",
-        "Return and fee tradeoff vs the equivalent unscreened broad-market index.",
-        "Coverage breadth — does the screened universe still produce diversified factor and sector exposure?",
-        "Issuer's broader ESG record, including proxy voting on shareholder proposals."
-      ],
-      "redFlags": [
-        "Top holdings include obvious screen violators — greenwashing.",
-        "Third-party ESG rating relied on without underlying methodology transparency.",
-        "Headline fee well above the unscreened equivalent without screen-quality evidence to justify it.",
-        "Theme fund framed as broad ESG but delivering concentrated single-sector exposure (e.g., clean-energy ETFs that are functionally tech bets)."
-      ]
-    },
-    {
-      "key": "short-term-liquidity-parker",
-      "name": "Short-Term Liquidity Parker",
-      "shortDescription": "Investor with a known near-term cash need (months to ~2 years) — down payment, emergency fund, business reserves, deal pipeline — wanting yield without duration risk or drawdown.",
-      "profile": {
-        "investmentHorizon": "Short (<1y)",
-        "riskTolerance": "Low",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Retail saver with a near-term goal (home down payment in 12-24 months, kid's tuition, emergency fund), self-employed professional managing operating cash, or angel investor warehousing dry powder between deals. Wants the cash to earn meaningful yield but cannot afford a drawdown when the money is needed."
-      },
-      "analysisAngle": "Capital preservation and same-day liquidity dominate every other consideration — yield matters only after those two constraints are satisfied. Default recommendation is ultrashort treasury or money-market wrappers (BIL, SGOV, SHV, JPST, ICSH) and 1-3 year treasury for slightly longer horizons. Discuss credit quality (Treasury > IG corp > anything else for this use), duration (shorter when the cash is needed sooner), and intraday liquidity. For taxable accounts, mention federal-only tax exemption on direct treasuries. Strongly warn against any product with meaningful duration risk, credit risk, or drawdown history — chasing 50 bps of extra yield is not worth a 5% drawdown when the cash is needed in 6 months.",
-      "keyConsiderations": [
-        "Duration short enough that a rate spike cannot break the price (typically under 2 years, often under 1).",
-        "Credit quality — Treasury or AAA / IG corporate; no high-yield, no bank loans, no preferred.",
-        "Intraday liquidity for unplanned cash needs.",
-        "Bid-ask tightness — even a few basis points add up at cash-management scale.",
-        "Distribution-character tax treatment in taxable accounts (treasury interest is state-tax-exempt)."
-      ],
-      "redFlags": [
-        "Any duration over ~2 years — defeats the cash-management purpose.",
-        "Sub-investment-grade credit exposure or floating-rate bank loans — drawdown risk in stress.",
-        "Wide bid-ask that erodes the yield advantage over a high-yield savings account.",
-        "Target-maturity or auto-renewing structures whose maturity may not align with the cash-need date."
-      ]
-    },
-    {
-      "key": "pre-retiree-de-risker",
-      "name": "Pre-Retiree (De-Risking 3-10 Years Out)",
-      "shortDescription": "Investor 3-10 years from retirement — still accumulating, not yet drawing income, but in the fragile pre-retirement window where a major drawdown is hardest to recover from.",
-      "profile": {
-        "investmentHorizon": "Medium (1-5y)",
-        "riskTolerance": "Low-Moderate",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "None",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Investor in their 50s-60s within 3-10 years of retirement. Still earning and contributing, not yet drawing — but the funded ratio of the retirement plan is now sensitive to a single bad year. Often shifting from equity-heavy accumulation toward more bonds, more diversification, and downside-protected structures."
-      },
-      "analysisAngle": "Sequence-of-returns risk in the pre-retirement window — a 40% loss at age 60 with 5 years to retirement is far harder to recover than the same loss at 30. The investor has stopped being a pure accumulator but hasn't started drawing income. Focus on drawdown depth and recovery time vs benchmark, glide-path appropriate for the target retirement year, gradual fixed-income tilt, and downside-protected products (defined outcome, derivative income) that allow continued equity participation with capped downside. Distinct from retirement-income-seeker, who is already drawing income, and from long-term-wealth-builder, whose recovery window is multi-decade.",
-      "keyConsiderations": [
-        "Worst-12-month and worst-3-year drawdown — must be survivable without delaying retirement.",
-        "Gradual equity-to-bond glide path matched to the target retirement year.",
-        "Downside-protected structures (defined-outcome buffers, covered-call income) that allow continued equity participation.",
-        "Mandate stability — strategy or benchmark changes mid-glide disrupt the de-risking plan.",
-        "Tax efficiency — large balances at this stage make capital-gain distributions hurt more."
-      ],
-      "redFlags": [
-        "High-volatility growth, sector, or theme funds inappropriate for the shortened recovery window.",
-        "Long-duration bond exposure when rates may rise — 2022-style drawdown is hardest to recover from in this window.",
-        "Leveraged-inverse exposure — daily-decay risk during the de-risking phase.",
-        "Concentrated sector bets that worked in accumulation but no longer fit the time horizon."
+      "key": "retail-individual",
+      "name": "Retail / Individual Investor",
+      "shortDescription": "Person investing personal savings in a brokerage or tax-advantaged retirement account — DIY or self-directed, with goals ranging from a first index fund to active trading. Distinct from HNW because portfolio scale typically sits below $5M and direct-indexing / SMA / private-allocation infrastructure is not in play; distinct from intermediated channels (advisor, hedge fund) because the investor makes their own selection.",
+      "etfInvestorGoals": [
+        {
+          "key": "simple-broad-market-start",
+          "name": "Simple Broad-Market Start",
+          "shortDescription": "Beginner who wants the simplest, lowest-cost path to broad-market exposure without complexity — typically a single S&P 500 / total-market fund or a target-date fund.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Someone in their 20s-30s opening their first brokerage or Roth IRA, who has heard of the S&P 500 but not much else, contributing monthly into a 'set it and forget it' allocation."
+          },
+          "analysisAngle": "Frame everything in plain language. Default to the simplest, cheapest, most diversified option (broad-market index ETF or target-date fund). Spell out fee impact in dollar terms over 30 years. Explicitly warn against complex / leveraged / single-theme products even if recent performance has been strong.",
+          "keyConsiderations": [
+            "Expense ratio under 0.10% materially compounds over decades.",
+            "Broad diversification (500+ holdings) so no single stock can wreck the portfolio.",
+            "Issuer reputation (Vanguard, iShares, SPDR, Schwab, Fidelity) over chasing performance.",
+            "Tradability and liquidity — no surprises selling during a downturn."
+          ],
+          "redFlags": [
+            "Daily-reset leveraged or inverse exposure.",
+            "Concentrated single-theme funds (one sector or one country).",
+            "K-1 reporting or unusual non-1099 distributions.",
+            "Sub-3-year track record from a niche issuer."
+          ]
+        },
+        {
+          "key": "multi-decade-buy-and-hold",
+          "name": "Multi-Decade Buy-and-Hold Compounding",
+          "shortDescription": "Investor with a 15-30+ year horizon focused on cumulative compounding and minimizing fee drag — willing to ride out drawdowns to maximize the terminal balance.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Mid-career professional (30s-50s) saving consistently into a 401(k) and a taxable brokerage, willing to ride out drawdowns, optimizing for the 30-year terminal balance."
+          },
+          "analysisAngle": "Emphasize cumulative compounding over decades — even tiny fee differences become large. Focus on mandate stability (a fund that quietly changes its benchmark breaks the multi-decade thesis), tracking quality, drawdown depth and recovery time, and tax efficiency in taxable accounts. Discourage strategy churn and chasing recent outperformance.",
+          "keyConsiderations": [
+            "Fee drag compounding over 20-30 years vs the cheapest peer.",
+            "Mandate and benchmark stability across multiple market cycles.",
+            "Drawdown depth and recovery time in 2008, 2020, 2022.",
+            "Tax efficiency for taxable-account holdings (low capital-gain distributions).",
+            "Coverage of US large/mid/small + international + emerging markets."
+          ],
+          "redFlags": [
+            "Recent benchmark or strategy changes that break the historical record.",
+            "Material AUM decline combined with thin volume (closure risk).",
+            "Frequent capital-gain distributions in passive-style funds.",
+            "Headline fee well above category median without demonstrated alpha."
+          ]
+        },
+        {
+          "key": "growth-tilted-accumulation",
+          "name": "Growth-Tilted Accumulation",
+          "shortDescription": "Younger or aggressive investor with a long horizon and high risk tolerance, willing to accept large drawdowns in pursuit of higher long-run growth — overweight to growth, small-cap, EM, and innovation themes.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor in 20s-40s with stable income, no near-term withdrawal needs, comfortable seeing 30-50% drawdowns and able to stay invested through them."
+          },
+          "analysisAngle": "Volatility tolerance is the unlock — focus on whether the fund's drawdown depth and recovery time are acceptable for someone NOT yet near withdrawal. Discuss factor tilt (growth vs value, large vs small), sector concentration, top-holding exposure, and historical drawdown vs benchmark. Don't penalize narrower mandates as long as concentration risk is disclosed.",
+          "keyConsiderations": [
+            "Drawdown depth vs benchmark and recovery time.",
+            "Factor tilt — growth vs value, large vs small.",
+            "Sector and top-holding concentration risk.",
+            "Methodology stability so the historical return profile remains relevant.",
+            "Foreign and emerging-market exposure for higher long-term growth."
+          ],
+          "redFlags": [
+            "Sub-3-year history with no comparable issuer track record on similar strategies.",
+            "Headline fee above active-thematic peer median without demonstrated alpha.",
+            "Persistent benchmark drift from the stated index."
+          ]
+        },
+        {
+          "key": "pre-retirement-de-risking",
+          "name": "Pre-Retirement De-Risking (3-10 Years Out)",
+          "shortDescription": "Investor 3-10 years from retirement, still accumulating but in the fragile pre-retirement window — gliding equity exposure down and bond allocation up to protect against a late-cycle drawdown.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor in 50s-early 60s within 3-10 years of stopping wages, with a meaningful nest egg already accumulated and limited capacity to recover from a major drawdown right before retirement."
+          },
+          "analysisAngle": "Sequence-of-returns risk on the upcoming withdrawal years dominates everything. Focus on shifting the equity / bond mix down the glide path, drawdown floor, duration positioning of the bond sleeve, and tax-aware location of holdings (bonds in tax-deferred, equities in taxable). Discourage chasing late-cycle equity returns.",
+          "keyConsiderations": [
+            "Glide-path equity / bond mix appropriate for current years-to-retirement.",
+            "Drawdown floor — what's the worst the bond and equity sleeves did together?",
+            "Duration positioning relative to the rate outlook.",
+            "Tax-location of holdings (bonds in tax-deferred, equities in taxable).",
+            "Avoidance of new high-volatility positions this close to drawdown."
+          ],
+          "redFlags": [
+            "Long-duration bond exposure when rate outlook is rising.",
+            "New large equity-concentration positions inside the de-risking window.",
+            "Aggressive target-date dated 10+ years past expected retirement."
+          ]
+        },
+        {
+          "key": "retirement-income-with-preservation",
+          "name": "Retirement Income with Capital Preservation",
+          "shortDescription": "Pre-retiree or retiree prioritizing capital preservation and steady income over growth — drawing from the portfolio to fund living expenses.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor 60+ either approaching or in retirement, with a known annual withdrawal need, who cannot afford a large drawdown right before drawing income."
+          },
+          "analysisAngle": "Sequence-of-returns risk is the dominant concern. Focus on duration risk, distribution stability and character, drawdown floor, and whether the fund's worst 12-month drawdown is survivable for someone drawing income from it. Distribution character (qualified vs ROC) matters for tax planning.",
+          "keyConsiderations": [
+            "Worst-12-month drawdown an income-drawing investor could survive.",
+            "Distribution stability and character (qualified, ROC, ordinary income).",
+            "Duration and interest-rate sensitivity for bond holdings.",
+            "Manager continuity for active income strategies.",
+            "Glide path appropriate for the investor's current retirement phase."
+          ],
+          "redFlags": [
+            "Distribution funded substantially by ROC without disclosure.",
+            "Long-duration bond exposure when rates may rise.",
+            "Headline yield from concentrated low-rated credit.",
+            "Recent dividend cuts or skipped distributions."
+          ]
+        },
+        {
+          "key": "after-tax-optimization-retail",
+          "name": "After-Tax Optimization at Top Retail Bracket",
+          "shortDescription": "High-earner W-2 investor in a top federal (and often state) bracket with significant taxable-account holdings — needs ETFs that minimize taxable distributions and maximize after-tax compounding.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "High earner in 30s-60s in the top federal bracket and often a high-tax state (CA, NY, NJ, MA), with significant taxable-account holdings beyond what tax-advantaged accounts can shelter."
+          },
+          "analysisAngle": "After-tax return at the marginal rate is the only return that matters. Always compute tax-equivalent yield for muni comparisons (32% federal baseline; note state-tax benefits for in-state munis). Penalize high-turnover funds, K-1 reporting, and ROC-heavy distributions in taxable contexts. Favor passive index funds with low capital-gain distribution history.",
+          "keyConsiderations": [
+            "Tax-equivalent yield at the investor's marginal bracket.",
+            "Capital-gain distribution history in passive vs active products.",
+            "Distribution character (qualified, ordinary, ROC, K-1).",
+            "State-tax exemption for in-state muni holdings.",
+            "AMT exposure for private-activity-bond muni funds."
+          ],
+          "redFlags": [
+            "K-1 tax reporting (commodity pools, MLPs) without an offsetting benefit.",
+            "Material recent capital-gain distributions in a passive-style fund.",
+            "Headline yield largely composed of short-term gain or undisclosed ROC.",
+            "High-yield muni exposure that the fund label doesn't make obvious."
+          ]
+        },
+        {
+          "key": "high-current-yield-income",
+          "name": "High Current Yield Income",
+          "shortDescription": "Investor prioritizing current cash flow — willing to accept credit risk and complexity in exchange for above-market yield from credit, preferred, or derivative-income wrappers.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor of any age (often 40s-70s) deliberately tilting toward yield — supplementing wages, funding lifestyle, or building a yield-only portfolio. Comfortable with credit risk and willing to study distribution mechanics."
+          },
+          "analysisAngle": "Yield without distribution-character analysis is meaningless. Decompose every distribution into qualified, ordinary, short-term gain, and ROC. For credit funds focus on default risk and downside in March 2020 / Oct 2022 stress. For derivative-income funds focus on whether the strategy gave up upside that wasn't fully replaced by income.",
+          "keyConsiderations": [
+            "Distribution character (qualified vs ordinary vs ROC).",
+            "Sustainability of the headline yield through credit cycles.",
+            "Downside in credit-stress windows (March 2020, Oct 2022).",
+            "Underlying credit quality and concentration.",
+            "Capture-ratio analysis for derivative-income funds."
+          ],
+          "redFlags": [
+            "Yield largely funded by ROC without clear disclosure.",
+            "Concentrated low-rated issuer exposure inside a generically named credit fund.",
+            "Active credit fund failing to beat its passive peer net of fees.",
+            "Declining distribution trend masked by NAV-eroding payouts."
+          ]
+        },
+        {
+          "key": "sector-thematic-conviction",
+          "name": "Sector / Thematic Conviction Expression",
+          "shortDescription": "Investor with a directional view on a specific sector, theme, region, or asset — using ETFs to implement the thesis cheaply and liquidly without picking individual stocks.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "High",
+            "primaryGoal": "Thematic Exposure",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor who has formed a view ('AI will dominate the next decade', 'energy is mispriced', 'India's demographic tailwind is real') and wants the cleanest, cheapest ETF to implement that thesis without picking individual stocks."
+          },
+          "analysisAngle": "Theme purity is the test — is the fund actually delivering the exposure its name promises? Focus on top-holding concentration, methodology specifics, peer comparison within the sector or theme, and tracking fidelity vs the most recognized benchmark. Concentration is not a flaw here — it's the point — but it must be disclosed.",
+          "keyConsiderations": [
+            "Top-holding concentration and whether it matches the stated thesis.",
+            "Methodology — passive index vs rules-based vs active selection.",
+            "Peer comparison within the same sector or theme.",
+            "Tracking fidelity vs the recognized benchmark in the space.",
+            "Liquidity for entering and exiting full-conviction positions."
+          ],
+          "redFlags": [
+            "Theme drift — fund name and top holdings don't align.",
+            "Sub-3-year history on a strategy with no comparable issuer track record.",
+            "Headline fee well above peers in the same theme without methodology advantage.",
+            "Thin AUM with declining trend — closure risk during the holding period."
+          ]
+        },
+        {
+          "key": "inflation-real-asset-hedge",
+          "name": "Inflation & Real-Asset Hedge",
+          "shortDescription": "Investor concerned about inflation, currency debasement, or rising costs of living — using real assets (commodities, gold, real estate, infrastructure) and inflation-linked instruments (TIPS) to preserve purchasing power.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor of any age worried about CPI / monetary debasement / cost-of-living risk who allocates a meaningful sleeve to real assets and inflation-linked instruments rather than only nominal stocks and bonds."
+          },
+          "analysisAngle": "The test is real-return correlation across inflation regimes — TIPS hedge measured CPI directly, gold and commodities hedge different inflation drivers, real estate and infrastructure provide pricing power. Discuss the tradeoff: pure real-asset funds underperform in disinflation, so sizing matters. Watch for funds that LABEL as inflation-hedging but historically tracked equities.",
+          "keyConsiderations": [
+            "Real-return correlation in measured inflation regimes.",
+            "Composition tradeoff (commodities vs equity-heavy real assets vs TIPS).",
+            "Single-commodity concentration risk.",
+            "K-1 vs 1099 tax structure for commodity pools.",
+            "Behavior in disinflationary periods (drawdown if inflation rolls over)."
+          ],
+          "redFlags": [
+            "Commodity exposure delivered via equity proxies that track stocks more than spot.",
+            "K-1 reporting without offsetting yield or hedging benefit.",
+            "Fund labeled 'inflation hedge' with high beta to the equity market."
+          ]
+        },
+        {
+          "key": "esg-impact-alignment",
+          "name": "ESG / SRI / Impact Alignment",
+          "shortDescription": "Investor whose primary selection criterion is ESG, sustainability, or mission alignment — willing to accept some return or fee tradeoff in exchange for a portfolio that matches their values.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Investor of any age who screens for environmental, social, and governance criteria — may exclude fossil fuels, weapons, tobacco; may overweight renewable energy, gender-diverse boards, or community development."
+          },
+          "analysisAngle": "Screen quality is the central question — is this an actual ESG / SRI / impact fund or a labeling exercise? Focus on the screen methodology (third-party rating provider vs self-graded), exclusion rigor, sector tilt vs the unscreened parent index, and tracking-error implications. Compare fees to non-ESG equivalents — a 30+ bp premium needs justification.",
+          "keyConsiderations": [
+            "Screen methodology — third-party rated vs self-graded.",
+            "Exclusion rigor and transparency of holdings.",
+            "Sector tilt vs the unscreened parent index.",
+            "Tracking error implications of the screen.",
+            "Fee premium vs the unscreened equivalent."
+          ],
+          "redFlags": [
+            "Self-graded ESG screens with weak or vague criteria (greenwashing risk).",
+            "Holdings that contradict the fund's stated ESG mission.",
+            "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ]
+        }
       ]
     },
     {
       "key": "high-net-worth-individual",
       "name": "High-Net-Worth Individual / Family Office",
-      "shortDescription": "Wealthy individual or single-family office investing $5M-$500M+ across asset classes — uses ETFs for tax-efficient beta, satellite exposures, and overlays alongside private investments. Different HNW investors emphasize different goals: efficient public-equity beta in taxable accounts, state-tax-exempt muni income at the top federal/state bracket, or diversifying real-asset and alternatives overlays alongside their private allocations.",
-      "goals": [
+      "shortDescription": "Wealthy individual, single-family office, or multi-family office client investing $5M-$500M+ across asset classes. Distinct from retail because of scale (direct indexing / SMA / UMA infrastructure available), top federal+state+NIIT bracket, access to private allocations, and intergenerational planning. Distinct from institutional because the capital is family-owned (not subject to IPS / regulatory mandates).",
+      "etfInvestorGoals": [
         {
           "key": "tax-efficient-public-equity-sleeve",
           "name": "Tax-Efficient Public-Equity Beta Sleeve",
-          "shortDescription": "High-net-worth or family-office investor seeking tax-efficient compounding of US and international equity exposure inside taxable accounts — ETFs are the wrapper for the public-equity beta sleeve while private allocations carry the alpha mandate.",
+          "shortDescription": "Tax-efficient compounding of US and international equity exposure inside taxable accounts — ETFs are the wrapper for the public-equity beta sleeve while private allocations carry the alpha mandate.",
           "profile": {
             "investmentHorizon": "Very Long (15y+)",
             "riskTolerance": "Moderate-High",
@@ -459,7 +316,7 @@
             "taxSensitivity": "High",
             "typicalInvestor": "HNW investor in a top federal bracket who is also a high-tax-state resident; significant taxable-account fixed-income that needs to maximize after-tax yield via in-state muni exposure."
           },
-          "analysisAngle": "TEY at the explicit federal + state + NIIT bracket is the comparison metric. State-specific muni funds add the state-tax exemption — for a CA resident in the top bracket the math frequently dominates national muni and taxable IG. AMT exposure on private-activity-bond muni funds must be flagged. Credit quality and concentration matter — high-yield muni introduces real default risk that the muni label doesn't make obvious.",
+          "analysisAngle": "TEY at the explicit federal + state + NIIT bracket is the comparison metric. State-specific muni funds add the state-tax exemption — for a CA resident in the top bracket the math frequently dominates national muni and taxable IG. AMT exposure on private-activity-bond muni funds must be flagged. High-yield muni introduces real default risk that the muni label doesn't make obvious.",
           "keyConsiderations": [
             "Tax-equivalent yield at federal + state + NIIT bracket for in-state vs national muni.",
             "AMT exposure on private-activity-bond muni funds.",
@@ -476,7 +333,7 @@
         {
           "key": "real-asset-and-alternatives-overlay",
           "name": "Real-Asset and Alternatives Overlay",
-          "shortDescription": "HNW or family-office investor adding diversifying real-asset, defined-outcome, derivative-income, or commodity exposure on top of a public-equity + muni core — often complementing direct private real estate or commodity holdings.",
+          "shortDescription": "Diversifying real-asset, defined-outcome, derivative-income, or commodity exposure on top of a public-equity + muni core — often complementing direct private real estate or commodity holdings.",
           "profile": {
             "investmentHorizon": "Long (5-15y)",
             "riskTolerance": "Moderate-High",
@@ -485,7 +342,7 @@
             "taxSensitivity": "High",
             "typicalInvestor": "HNW investor or family office whose constructed portfolio already covers public-equity beta and tax-efficient fixed income, looking for inflation hedges, downside structure, or uncorrelated return streams via accessible ETF wrappers."
           },
-          "analysisAngle": "Sizing matters — these are diversifying sleeves, not core holdings. Defined-outcome and derivative-income funds must be evaluated on the upside-cap vs income-payout tradeoff. Commodity and precious-metals funds must be checked for K-1 vs 1099 reporting since K-1 creates real friction at HNW scale. Real-asset equity proxies (REITs, infrastructure, natural resources) carry equity-correlation risk that should be disclosed. Discuss complement to private allocations, not substitute.",
+          "analysisAngle": "Sizing matters — these are diversifying sleeves, not core holdings. Defined-outcome and derivative-income funds must be evaluated on the upside-cap vs income-payout tradeoff. Commodity and precious-metals funds must be checked for K-1 vs 1099 reporting since K-1 creates real friction at HNW scale. Real-asset equity proxies carry equity-correlation risk that should be disclosed.",
           "keyConsiderations": [
             "K-1 vs 1099 reporting (commodity pools, MLPs).",
             "Upside-cap vs income-payout tradeoff for defined-outcome and derivative-income funds.",
@@ -498,25 +355,206 @@
             "Unhedged single-currency or single-commodity concentration sized larger than satellite.",
             "K-1 reporting without offsetting tax or hedging benefit."
           ]
+        },
+        {
+          "key": "concentrated-position-diversification",
+          "name": "Concentrated-Position Diversification",
+          "shortDescription": "Founder, executive, or HNW investor with a large single-stock or single-sector position seeking structured diversification via defined-outcome / options-based ETFs without immediate taxable sale.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "Founder, executive, or HNW investor whose net worth is dominated by a concentrated single-stock holding (often with a low cost basis triggering large taxable gains on sale) and who is seeking diversification without immediately realizing the gain."
+          },
+          "analysisAngle": "The concentration risk vs the tax cost of selling is the central tradeoff. Defined-outcome ETFs (buffered equity), covered-call wrappers, and exchange funds offer different paths. Discuss the upside-cap, downside-floor, and rolling-window mechanics of defined-outcome products. For options-based hedges, discuss roll cost and how the strategy behaves across volatility regimes.",
+          "keyConsiderations": [
+            "Outcome-period mechanics (entry / exit window) of defined-outcome ETFs.",
+            "Upside-cap and downside-floor levels relative to current concentration.",
+            "Roll cost of options overlays across volatility regimes.",
+            "Tax-cost vs concentration-risk tradeoff of immediate sale.",
+            "Issuer counterparty exposure for derivative-based structures."
+          ],
+          "redFlags": [
+            "Defined-outcome fund where the cap and floor have already been breached mid-cycle.",
+            "Counterparty / credit exposure that adds risk beyond the concentrated position.",
+            "Methodology that doesn't explain how downside protection is funded."
+          ]
+        },
+        {
+          "key": "foreign-tax-credit-international",
+          "name": "Foreign-Tax-Credit Pickup on International",
+          "shortDescription": "International equity exposure held in taxable accounts to capture the foreign-tax credit — typically worth ~30-50 bp of after-tax pickup vs holding in tax-deferred.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor in a top bracket holding international equity exposure in taxable accounts to use the foreign-tax credit, which is wasted in tax-deferred accounts."
+          },
+          "analysisAngle": "FTC pickup is asset-location optimization, not security selection. Confirm the fund pays foreign withholding tax that flows through as creditable. Discuss treaty rates by region (developed vs EM differs). Compare to holding the same exposure in tax-deferred where the FTC is wasted. Avoid funds with unusual tax-pass-through structure that interferes with the credit.",
+          "keyConsiderations": [
+            "Confirmed foreign-withholding-tax pass-through to the holder.",
+            "Treaty-rate differences across regions (developed Europe, Japan, EM).",
+            "Comparison vs holding the same exposure in tax-deferred (FTC wasted).",
+            "Total foreign-tax exposure as a fraction of dividend yield.",
+            "Wrapper structures that interfere with FTC creditability."
+          ],
+          "redFlags": [
+            "Wrapper or fund structure that fails to pass foreign tax through to the holder.",
+            "Unusually low foreign-tax footprint suggesting mostly US-domiciled holdings."
+          ]
+        },
+        {
+          "key": "derivative-income-yield-supplement",
+          "name": "Derivative-Income Yield Supplement",
+          "shortDescription": "HNW investor or retiree using covered-call or option-overwrite ETFs (JEPI, JEPQ, QYLD) to supplement income from the public-equity sleeve, accepting an upside cap.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "HNW investor or retiree seeking enhanced current yield from the equity sleeve via covered-call or option-overwrite strategies — accepts that the strategy gives up some upside in exchange for monthly income."
+          },
+          "analysisAngle": "The capture ratio is the honest test — does the strategy deliver upside-capped equity returns plus durable monthly income? Decompose distribution into qualified dividend, ordinary income, and ROC; ROC is tax-deferred but lowers basis. Compare to a simple low-cost index + manual covered-call write.",
+          "keyConsiderations": [
+            "Capture ratio (% of upside captured vs % of downside) over 3-5 years.",
+            "Distribution character (qualified, ordinary, ROC).",
+            "Implied vol environment in which the strategy works best.",
+            "Total cost vs a manual covered-call equivalent.",
+            "Manager continuity for actively managed overwrite strategies."
+          ],
+          "redFlags": [
+            "Distribution funded mostly by ROC without explicit disclosure.",
+            "Capture ratio that gives up most upside without delivering matching income.",
+            "Strategy that significantly underperforms the underlying index in flat markets."
+          ]
+        },
+        {
+          "key": "liquid-beta-sleeve-alongside-privates",
+          "name": "Liquid-Beta Sleeve Alongside Private Allocations",
+          "shortDescription": "Public-market beta sleeve providing liquid US, international, and EM equity + IG bond exposure alongside an illiquid PE / hedge-fund / direct-real-estate book — also serves as the rebalancing buffer.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor or family office whose alpha mandate sits in private allocations; the public ETF sleeve provides liquid beta and the rebalancing reservoir to fund capital calls, distributions, and tax payments."
+          },
+          "analysisAngle": "This is a building-block role — the ETFs serve as cheap, transparent, scalable beta exposure. Tracking fidelity to the policy benchmark, AUM/capacity, bid-ask, and tax efficiency dominate. Discuss benchmark fit (S&P 500 vs Russell 1000 vs MSCI USA), and explicitly call out that the ETF must have enough liquidity to fund capital calls without market impact.",
+          "keyConsiderations": [
+            "Tracking fidelity to the chosen policy benchmark.",
+            "Bid-ask depth for funding capital calls without market impact.",
+            "Tax efficiency for the taxable-account public sleeve.",
+            "Benchmark family compatibility (S&P, Russell, MSCI, FTSE).",
+            "AUM scale appropriate for HNW position sizes."
+          ],
+          "redFlags": [
+            "Fund too small to absorb HNW position sizes without market impact.",
+            "Wrong benchmark family forcing tracking-error commentary.",
+            "Distribution mechanics that complicate capital-call funding."
+          ]
+        },
+        {
+          "key": "intergenerational-multi-decade-compounding",
+          "name": "Intergenerational Multi-Decade Compounding",
+          "shortDescription": "Family-office investor optimizing for multi-generational wealth preservation — fees, mandate stability, and tax efficiency matter over 30-50 years across generations.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "Single- or multi-family office investing across generations — the relevant horizon is 30-50 years and the next generation, not the next decade. Tax-aware estate planning and step-up-in-basis at death are part of the design."
+          },
+          "analysisAngle": "Fee drag and mandate stability over 30-50 years are the structural decisions. Discuss step-up-in-basis at death (favors holding low-basis appreciated positions until death rather than realizing). Estate / trust / GRAT structures interact with selection. Issuer operational stability over multiple decades matters more than near-term performance.",
+          "keyConsiderations": [
+            "Fee drag compounding over 30-50 years and across generations.",
+            "Mandate and benchmark stability across multiple decades.",
+            "Step-up-in-basis at death — favors holding low-basis appreciated positions.",
+            "Issuer operational stability over multi-decade horizons.",
+            "Compatibility with estate / trust / GRAT structures."
+          ],
+          "redFlags": [
+            "Recent benchmark or strategy changes that break the multi-decade record.",
+            "Issuer concentration risk that wouldn't survive a multi-decade test.",
+            "High-turnover strategies that destroy step-up-in-basis tax planning."
+          ]
+        },
+        {
+          "key": "hnw-inflation-real-asset-hedge",
+          "name": "Inflation Hedge as Diversifying Sleeve",
+          "shortDescription": "HNW investor adding a sized real-asset / inflation-hedge sleeve alongside private real estate — sizing matters since pure real-asset exposure underperforms in disinflation.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor or family office that already holds direct private real estate and wants a liquid ETF inflation hedge sleeve — typically 5-15% of the public-market portfolio."
+          },
+          "analysisAngle": "Real-return correlation in measured inflation regimes is the test. Discuss the composition tradeoff (commodities vs equity-heavy real assets vs TIPS) — for HNW, the equity-heavy real-asset proxies (REITs, infra) often duplicate exposure already held privately. K-1 reporting on commodity pools must be evaluated against the HNW reporting burden. Sizing relative to the existing private real-estate sleeve is critical.",
+          "keyConsiderations": [
+            "Sizing relative to the existing private real-estate / private-commodity sleeves.",
+            "Real-return correlation in measured inflation regimes.",
+            "K-1 reporting burden at HNW reporting scale.",
+            "Composition tradeoff (commodities vs equity-heavy real assets vs TIPS).",
+            "Overlap with directly held private real assets."
+          ],
+          "redFlags": [
+            "Commodity exposure delivered via equity proxies that track stocks more than spot.",
+            "K-1 reporting without offsetting hedging benefit.",
+            "Material overlap with directly held private real assets."
+          ]
+        },
+        {
+          "key": "hnw-esg-mission-aligned",
+          "name": "Family-Mission-Aligned Portfolio Construction",
+          "shortDescription": "Family office building a portfolio aligned with explicit family values — environmental, social-impact, religious, or community-development — while preserving expected return and risk profile.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "Family office, foundation, or HNW family with explicit values-based investment guidelines — often documented in a family Investment Policy Statement that screens out specific industries (fossil fuels, weapons, tobacco) or overweights specific themes (renewable energy, women-led companies, community development)."
+          },
+          "analysisAngle": "Screen rigor and transparency dominate — family-office-grade due diligence should not accept self-graded screens. Discuss screen methodology (third-party rated like MSCI ESG or Sustainalytics), exclusion list transparency, and tracking-error implications vs the unscreened parent index. Compare expected return / risk profile to the unscreened equivalent.",
+          "keyConsiderations": [
+            "Screen methodology — third-party rated vs self-graded.",
+            "Exclusion-list transparency and rigor.",
+            "Tracking-error implications vs the unscreened parent index.",
+            "Sector tilt introduced by the screen.",
+            "Fee premium vs the unscreened equivalent."
+          ],
+          "redFlags": [
+            "Self-graded ESG screens with weak or vague criteria.",
+            "Holdings that contradict the fund's stated mission alignment.",
+            "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ]
         }
       ]
     },
     {
-      "key": "pension-endowment-foundation",
-      "name": "Pension / Endowment / Foundation (incl. Union Pensions)",
-      "shortDescription": "Long-horizon institutional pool — corporate or public pension, Taft-Hartley / union pension, university endowment, charitable foundation, sovereign wealth fund — governed by an Investment Policy Statement with defined liabilities or spending mandates. Different mandates drive different goals: liability-driven investing (LDI) for defined-benefit pensions, sustainable spending-policy support for endowments and foundations, and a liquid-beta sleeve to complement illiquid private allocations.",
-      "goals": [
+      "key": "pension-endowment-foundation-sovereign",
+      "name": "Pension / Endowment / Foundation / Sovereign Wealth Fund",
+      "shortDescription": "Long-horizon, tax-exempt institutional pool governed by an Investment Policy Statement: corporate or public defined-benefit pension, Taft-Hartley / union pension, university endowment, charitable foundation, sovereign wealth fund. Distinct from corporate treasury because the mandate is long-horizon investment (not operating cash) and equity / private-asset allocation is part of the strategy. Distinct from HNW because the capital is institutional / fiduciary.",
+      "etfInvestorGoals": [
         {
           "key": "pension-liability-driven-investing",
-          "name": "Liability-Driven Investing (LDI)",
-          "shortDescription": "Defined-benefit pension plan (corporate, public, or Taft-Hartley union) matching long-duration nominal or real liabilities with treasuries, STRIPS, and TIPS — duration matching matters more than nominal yield.",
+          "name": "Pension Liability-Driven Investing (LDI)",
+          "shortDescription": "Defined-benefit pension plan matching long-duration nominal or real liabilities with treasuries, STRIPS, and TIPS — duration matching matters more than nominal yield.",
           "profile": {
             "investmentHorizon": "Very Long (15y+)",
             "riskTolerance": "Low-Moderate",
             "primaryGoal": "Capital Preservation",
             "incomeNeed": "High",
             "taxSensitivity": "Low",
-            "typicalInvestor": "Defined-benefit pension plan (corporate, public, or multi-employer / Taft-Hartley union) with a known actuarial liability stream, funded-ratio focused, governed by an IPS that specifies duration target and surplus risk tolerance."
+            "typicalInvestor": "Defined-benefit pension plan (corporate, public, multi-employer / Taft-Hartley union) with a known actuarial liability stream, funded-ratio focused, governed by an IPS that specifies duration target and surplus risk tolerance."
           },
           "analysisAngle": "Duration matching is the primary lens. Long treasuries, STRIPS, and long-TIPS are the workhorse instruments. Discuss key-rate-duration profile, convexity, and the surplus-volatility tradeoff. Securities-lending revenue and institutional-share-class fees change the math — avoid retail fee commentary. Capacity matters: the fund must absorb $50-500M allocations without market impact.",
           "keyConsiderations": [
@@ -524,17 +562,17 @@
             "Securities-lending revenue (institutional pools earn back basis points).",
             "Capacity to absorb $50-500M allocations without market impact.",
             "Liability-discount-curve sensitivity and surplus volatility.",
-            "Counterparty / collateral structure for treasury STRIPS or futures-based duration."
+            "Counterparty / collateral structure for STRIPS or futures-based duration."
           ],
           "redFlags": [
             "Fund too small for institutional-scale allocation without dominant-holder risk.",
-            "Methodology drift that breaks IPS benchmark consistency over multiple years.",
+            "Methodology drift that breaks IPS benchmark consistency.",
             "Concentration / closure risk from a single large investor's outflow."
           ]
         },
         {
           "key": "endowment-foundation-spending-policy-support",
-          "name": "Spending-Policy Support",
+          "name": "Endowment / Foundation Spending-Policy Support",
           "shortDescription": "University endowment or charitable foundation distributing ~5% per year while preserving real capital across generations — needs a portfolio that sustainably supports spending without eroding the corpus.",
           "profile": {
             "investmentHorizon": "Very Long (15y+)",
@@ -544,24 +582,24 @@
             "taxSensitivity": "Low",
             "typicalInvestor": "University endowment ($500M-$50B+), private foundation, or community foundation. Spending policy is the binding constraint (typically 4-5% rolling-average); IPS often includes ESG / SRI / mission-aligned screens; large allocations to private equity and real assets are typical."
           },
-          "analysisAngle": "The portfolio must sustainably distribute ~5%/year while preserving real (inflation-adjusted) capital — this is a real-return mandate. ETFs are typically the liquid-beta sleeve and rebalancing buffer alongside the illiquid private book. Discuss real-return coverage, ESG / SRI screen compatibility, capacity, and securities-lending revenue. Avoid retail-style fee comparisons.",
+          "analysisAngle": "The portfolio must sustainably distribute ~5%/year while preserving real (inflation-adjusted) capital — this is a real-return mandate. ETFs are typically the liquid-beta sleeve and rebalancing buffer alongside the illiquid private book. Discuss real-return coverage, ESG / SRI screen compatibility, capacity, and securities-lending revenue.",
           "keyConsiderations": [
             "Long-run real return coverage of the spending rate.",
-            "ESG / SRI / mission-aligned screen compatibility (foundations especially).",
+            "ESG / SRI / mission-aligned screen compatibility.",
             "Capacity for institutional-scale allocations without dominant-holder risk.",
             "Liquid-beta provision alongside illiquid private allocations.",
             "Rebalancing-band depth — can the ETF be sold at scale to fund distributions?"
           ],
           "redFlags": [
-            "ESG-labeled funds with weak self-graded screens (greenwashing risk for foundations).",
+            "ESG-labeled funds with weak self-graded screens (greenwashing risk).",
             "Methodology drift breaking IPS benchmark consistency.",
             "Insufficient liquidity to fund the annual distribution at scale."
           ]
         },
         {
           "key": "institutional-liquid-beta-sleeve",
-          "name": "Liquid-Beta Sleeve Alongside Privates",
-          "shortDescription": "Pension, endowment, foundation, or sovereign wealth fund needing a low-cost liquid index sleeve providing US, international, and EM equity beta + investment-grade core fixed income alongside an illiquid private-allocation book.",
+          "name": "Institutional Liquid-Beta Sleeve",
+          "shortDescription": "Pension, endowment, foundation, or sovereign wealth fund needing a low-cost liquid index sleeve providing US, international, and EM equity beta + IG core fixed income alongside an illiquid private-allocation book.",
           "profile": {
             "investmentHorizon": "Very Long (15y+)",
             "riskTolerance": "Moderate",
@@ -583,25 +621,422 @@
             "Limited capacity making the institution a dominant holder.",
             "Issuer or fund-family operational concerns at institutional scale."
           ]
+        },
+        {
+          "key": "ips-mandated-esg-sri-screened",
+          "name": "IPS-Mandated ESG / SRI / Mission-Aligned Screening",
+          "shortDescription": "Institutional pool whose IPS requires ESG, SRI, Taft-Hartley labor-friendly, or mission-aligned screens — needs ETFs that meet the screen with documented third-party-rated methodology.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension plan (especially Taft-Hartley with labor screens), university endowment with student-pressure-driven divestment, charitable foundation with mission alignment, or sovereign wealth fund with national policy constraints. IPS spells out the screen explicitly."
+          },
+          "analysisAngle": "Screen rigor at institutional level requires third-party-rated methodology with auditable exclusion lists. Self-graded screens are unacceptable for fiduciary use. Discuss screen provider (MSCI ESG, Sustainalytics, ISS), exclusion-list overlap with the IPS, sector tilt vs the unscreened benchmark, and tracking-error attribution. Capacity must accommodate institutional allocation sizes.",
+          "keyConsiderations": [
+            "Screen methodology — third-party rated, auditable exclusion list.",
+            "Screen-provider overlap with the IPS-mandated criteria.",
+            "Sector tilt and tracking error vs the unscreened parent index.",
+            "Capacity for institutional allocation sizes.",
+            "Documentation suitable for fiduciary review."
+          ],
+          "redFlags": [
+            "Self-graded ESG screens unsuitable for fiduciary use.",
+            "Exclusion-list gaps that the IPS specifically prohibits.",
+            "Capacity insufficient for the institutional allocation size."
+          ]
+        },
+        {
+          "key": "crisis-alpha-diversifier",
+          "name": "Crisis-Alpha Diversifier",
+          "shortDescription": "Institutional pool adding managed-futures, market-neutral, or multistrategy exposure to deliver positive returns or low correlation in equity bear markets — judged on portfolio-level resilience, not standalone return.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension or endowment CIO adding a diversifying alt sleeve — wants the fund to deliver positive return or low correlation precisely when equities are in drawdown, accepting underperformance in equity bull markets."
+          },
+          "analysisAngle": "Standalone return is the wrong metric — judge by correlation to equities in drawdowns, drawdown reduction in 2008/2020/2022, and risk-adjusted return at the portfolio level. Managed-futures, market-neutral, long-short, and multi-strategy funds must demonstrate they delivered on the diversification mandate.",
+          "keyConsiderations": [
+            "Correlation to broad equities, especially in equity drawdowns.",
+            "Drawdown reduction in March 2020 / 2022 / prior crises.",
+            "Mandate adherence — does the fund actually do what it says?",
+            "Risk-adjusted return (Sharpe, Sortino) vs cheap passive alternatives.",
+            "Liquidity and fee level commensurate with the diversification benefit."
+          ],
+          "redFlags": [
+            "Strategy that quietly tracks equities in bull markets but fails in bear markets.",
+            "Fee at or above peer median with no demonstrated low correlation.",
+            "Mandate drift — recent strategy or benchmark change."
+          ]
+        },
+        {
+          "key": "institutional-real-asset-inflation-hedge",
+          "name": "Institutional Real-Asset / Inflation Hedge",
+          "shortDescription": "Pension or endowment adding TIPS, commodities, real estate, or infrastructure exposure to defend real spending power against inflation — sized as a portfolio sleeve, often complementing direct private real-asset allocations.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension or endowment CIO building a real-asset sleeve to defend the real value of liabilities (pension) or spending policy (endowment). Often complemented by direct private real estate, farmland, or infrastructure holdings."
+          },
+          "analysisAngle": "Real-return correlation across inflation regimes drives selection. TIPS hedge measured CPI directly; commodities and gold hedge different drivers; equity-real-asset proxies (REITs, infra) carry equity beta that should be netted against the institutional equity allocation. Discuss overlap with directly held private real assets to avoid duplicate exposure.",
+          "keyConsiderations": [
+            "Real-return correlation in measured inflation regimes.",
+            "Overlap with directly held private real estate / infrastructure / farmland.",
+            "Composition tradeoff (commodities vs TIPS vs equity-heavy real assets).",
+            "Capacity for institutional-scale allocations.",
+            "Operational compatibility with the institution's custodian and reporting."
+          ],
+          "redFlags": [
+            "Material overlap with directly held private real assets.",
+            "Commodity exposure delivered via equity proxies that track stocks more than spot.",
+            "Capacity insufficient for the institutional allocation size."
+          ]
+        },
+        {
+          "key": "emerging-markets-international-at-scale",
+          "name": "Global / EM Diversification at Institutional Scale",
+          "shortDescription": "Institutional pool building developed-international and EM equity exposure at $50M-$5B allocation sizes — needs ETFs with capacity, tracking fidelity, and operational stability to handle the scale.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension, endowment, foundation, or sovereign wealth fund whose IPS targets a defined developed-international and EM equity weight — typically 15-30% of the equity allocation, sized in the hundreds of millions to billions."
+          },
+          "analysisAngle": "Capacity and tracking fidelity dominate. Discuss benchmark family (MSCI EAFE vs FTSE Developed; MSCI EM vs FTSE EM) and explicit currency-hedging methodology if applicable. Discuss country-tier allocation (frontier inclusion, China A-share inclusion). Operational reliability — settlement across time zones, tax-treaty structure — matters at this scale.",
+          "keyConsiderations": [
+            "Benchmark family compatibility (MSCI vs FTSE) with the IPS.",
+            "Capacity for $50M-$5B allocations without market impact.",
+            "Currency-hedging methodology if the fund hedges.",
+            "Country-tier inclusion (frontier, China A-share) vs the IPS target.",
+            "Operational reliability for cross-time-zone settlement and tax treaties."
+          ],
+          "redFlags": [
+            "Wrong benchmark family forcing attribution mismatch.",
+            "Limited capacity at institutional scale.",
+            "Currency-hedging methodology that materially deviates from the underlying spot."
+          ]
+        },
+        {
+          "key": "institutional-investment-grade-core-fixed-income",
+          "name": "Institutional Investment-Grade Core Fixed Income",
+          "shortDescription": "Institutional pool building IG bond exposure (treasury, agency, IG corporate, securitized) at scale as the fixed-income beta sleeve — alternative to a separate-account mandate.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension, endowment, or foundation building IG bond exposure at scale — typically choosing between an Aggregate-index ETF, a separate-account mandate, and a custom core-plus structure."
+          },
+          "analysisAngle": "ETF wrapper vs separate-account is the central comparison. Discuss tracking fidelity to the Bloomberg Aggregate (or chosen benchmark), securities-lending revenue, capacity, and the marginal cost vs a similarly sized separate account. Discuss treasury / agency / corporate / securitized weights vs the IPS target.",
+          "keyConsiderations": [
+            "Tracking fidelity to the Bloomberg Aggregate (or chosen benchmark).",
+            "Securities-lending revenue offset.",
+            "Capacity for institutional allocations.",
+            "Treasury / agency / corporate / securitized weights vs the IPS target.",
+            "Marginal cost vs an equivalent separate-account mandate."
+          ],
+          "redFlags": [
+            "Significant tracking error vs the chosen IPS benchmark.",
+            "Insufficient capacity at institutional scale.",
+            "Sector or duration tilt that drifts from the IPS target."
+          ]
+        },
+        {
+          "key": "securities-lending-revenue-offset",
+          "name": "Securities-Lending Revenue Offset",
+          "shortDescription": "Institutional pool optimizing the all-in cost of an ETF holding by capturing securities-lending revenue back from the fund — relevant for any IPS-mandated allocation where a sec-lending kickback materially offsets the headline fee.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Institutional pool (pension, endowment, foundation, sovereign) sized large enough to capture material securities-lending revenue back from the issuer or from a separately managed lending program."
+          },
+          "analysisAngle": "All-in net cost = headline fee minus sec-lending revenue retained by the fund. Discuss the issuer's lending program, revenue split with the fund, counterparty controls, and the typical sec-lending economics for the underlying universe (small-cap and EM lend richer than large-cap US). For some funds the sec-lending revenue exceeds the expense ratio.",
+          "keyConsiderations": [
+            "Issuer's sec-lending program and revenue split with the fund.",
+            "Counterparty and collateral controls inside the lending program.",
+            "Typical lending economics for the underlying universe (small-cap, EM lend richer).",
+            "Net all-in fee after sec-lending revenue is credited to the fund.",
+            "Lending policy transparency and reporting."
+          ],
+          "redFlags": [
+            "Opaque or poorly disclosed sec-lending program.",
+            "Counterparty exposure inside the lending program that is not capital-charge offset.",
+            "Lending revenue retained by the issuer rather than credited to the fund."
+          ]
+        },
+        {
+          "key": "tactical-rate-duration-overlay",
+          "name": "Tactical Rate / Duration Overlay",
+          "shortDescription": "Institutional pool using long treasury (TLT) or short treasury (SHY) ETFs as a tactical overlay to adjust portfolio duration around the IPS target — usually a CIO-driven tactical decision.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Institutional CIO or PM using treasury ETFs as a quick tactical overlay to add or subtract portfolio duration vs the IPS-mandated mix — typically a multi-quarter to multi-year overlay."
+          },
+          "analysisAngle": "Tactical sizing relative to the strategic mix is the core question. Discuss bid-ask, AUM, options-market liquidity (for hedging the overlay), and the simplicity advantage vs futures-based alternatives. For long treasury, discuss convexity and the value as an equity-bear-market hedge. For short treasury, discuss the cost in a flat-curve regime.",
+          "keyConsiderations": [
+            "Bid-ask depth for institutional-block trades.",
+            "Options-market liquidity for hedging the overlay.",
+            "Convexity vs futures-based alternatives.",
+            "Performance as an equity-bear-market hedge.",
+            "Sizing relative to the strategic IPS mix."
+          ],
+          "redFlags": [
+            "Insufficient bid-ask depth for institutional-block trades.",
+            "Limited options market making the overlay hard to hedge.",
+            "Material premium-discount drift in stress windows."
+          ]
+        }
+      ]
+    },
+    {
+      "key": "insurance-bank-corporate-treasury",
+      "name": "Insurance General Account / Bank / Corporate Treasury",
+      "shortDescription": "Regulated balance-sheet investor — insurance company general account, bank treasury, or corporate operating-cash treasury — constrained by external regulation (NAIC for insurers, Basel III / HQLA for banks) or board-approved IPS to investment-grade short-to-intermediate-duration fixed income. Distinct from pension/endowment because the mandate is balance-sheet preservation (not long-horizon investment) and equity exposure is typically prohibited.",
+      "etfInvestorGoals": [
+        {
+          "key": "operating-cash-management-ultra-short",
+          "name": "Operating-Cash Management (Ultra-Short)",
+          "shortDescription": "Corporate treasury or insurance operating-cash sleeve held in sub-1-year treasury or ultra-short bond ETFs (BIL, ICSH, JPST, GSY) — balances cash yield against same-day-liquidity needs.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Low",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Corporate treasury team or insurance operating-cash desk parking funds for known near-term needs (payroll, capex, claims settlement). Uses sub-1y treasury or ultra-short ETFs as a step up from money-market funds."
+          },
+          "analysisAngle": "Ultra-short duration and IG-only credit are the constraints. Discuss yield pickup vs Treasury bills and money-market funds, NAV stability ($ of NAV variance per $100), and same-day liquidity. Bid-ask matters at corporate scale. Avoid duration creep — funds labeled 'ultra-short' but holding 18+ month paper miss the mandate.",
+          "keyConsiderations": [
+            "Effective duration well under 1 year (target ~0.3 years for true ultra-short).",
+            "IG-only credit composition with no high-yield drift.",
+            "NAV stability ($ NAV variance per $100 invested).",
+            "Bid-ask depth for corporate-scale block trades.",
+            "Yield pickup vs Treasury bills and money-market funds."
+          ],
+          "redFlags": [
+            "Duration creep — fund labeled 'ultra-short' holding 18+ month paper.",
+            "Material credit-quality drift below IG.",
+            "NAV instability beyond expected ultra-short range."
+          ]
+        },
+        {
+          "key": "regulated-investment-grade-core-fixed-income",
+          "name": "Regulated Investment-Grade Core Fixed Income",
+          "shortDescription": "Insurance general account, bank treasury, or large-corporate treasury holding IG core bond exposure (treasury, IG corporate, agency MBS) inside NAIC / Basel / IPS constraints.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Low",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Insurance general account, bank treasury (Available-for-Sale book), or corporate treasury holding IG core bond exposure inside an IPS that limits to IG and target duration ≤ 3-5 years."
+          },
+          "analysisAngle": "Regulatory constraints dominate every decision. For insurers, NAIC ratings drive RBC charges; for banks, HQLA classification and Basel III apply; for corporates, the IPS limits to IG short-to-intermediate. Focus on look-through credit quality, duration profile, NAIC / Basel treatment of the wrapper, and AUM/liquidity at mandate scale. Avoid yield-pickup strategies — these holders are constrained.",
+          "keyConsiderations": [
+            "Underlying credit quality (95%+ IG for most policies).",
+            "Duration profile compatible with policy (often ≤ 3-5 years).",
+            "NAIC / Basel / IPS look-through treatment of the wrapper.",
+            "AUM and bid-ask depth at mandate scale ($50-500M positions).",
+            "Distribution mechanics — monthly cash flow and accrual treatment."
+          ],
+          "redFlags": [
+            "Any sub-investment-grade exposure inside the wrapper.",
+            "Long duration exposure incompatible with the policy.",
+            "Unclear regulatory look-through treatment."
+          ]
+        },
+        {
+          "key": "hqla-eligible-short-government",
+          "name": "HQLA-Eligible Short Government Exposure",
+          "shortDescription": "Bank treasury holding short-term US treasury ETFs (SHY, BIL, GBIL) as part of the High-Quality Liquid Assets (HQLA) buffer required under Basel III LCR.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Low",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Bank treasury team building the HQLA buffer required for Basel III LCR (Liquidity Coverage Ratio) compliance — wants treasury exposure with full HQLA Level-1 treatment via the wrapper."
+          },
+          "analysisAngle": "HQLA Level-1 treatment of the ETF wrapper is the gating question. Confirm look-through with regulator. Discuss bid-ask at bank-block scale, duration positioning vs LCR runoff assumptions, and pure-treasury composition (no agency / IG corporate). Securities-lending policy — borrowed-out shares may not count as HQLA.",
+          "keyConsiderations": [
+            "HQLA Level-1 look-through treatment confirmed with regulator.",
+            "Bid-ask depth at bank-block trade size.",
+            "Pure-treasury composition (no agency or IG corporate dilution).",
+            "Securities-lending policy — borrowed-out shares may not count toward HQLA.",
+            "Duration positioning vs LCR 30-day runoff assumptions."
+          ],
+          "redFlags": [
+            "Wrapper structure that loses HQLA Level-1 treatment under regulator look-through.",
+            "Securities-lending program that pulls shares out of HQLA buffer.",
+            "Composition drift away from pure treasury into agency or IG corporate."
+          ]
+        },
+        {
+          "key": "insurance-after-tax-muni-yield",
+          "name": "Insurance General-Account After-Tax Muni Yield",
+          "shortDescription": "Insurance general account (especially P&C) holding muni bond ETFs to capture after-tax yield where the IPS permits — competes against IG corporate and Treasury after the corporate-tax adjustment.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "Insurance general account (typically P&C insurer) where the IPS allows muni allocation and the after-tax muni yield exceeds the after-tax taxable IG alternative."
+          },
+          "analysisAngle": "After-corporate-tax yield is the comparison metric — adjust both muni and IG corporate yields to after-tax-of-21% federal. Discuss credit-tier mix, single-state concentration risk, AMT exposure on private-activity bonds (corporate AMT was repealed but state-level treatment varies), and NAIC treatment of muni inside the wrapper.",
+          "keyConsiderations": [
+            "After-corporate-tax yield vs IG corporate alternative.",
+            "Credit-tier mix — IG-only vs HY-muni tilt.",
+            "Single-state concentration risk for state-specific muni funds.",
+            "AMT or state-tax treatment of private-activity bonds.",
+            "NAIC look-through treatment of the muni-fund wrapper."
+          ],
+          "redFlags": [
+            "High-yield muni exposure inside a generically named muni fund.",
+            "Single-state concentration with documented credit distress.",
+            "Unclear NAIC treatment of the muni wrapper."
+          ]
+        },
+        {
+          "key": "insurance-intermediate-liability-matching",
+          "name": "Insurance Intermediate-Duration Liability Matching",
+          "shortDescription": "Insurance general account matching intermediate-duration liability cash flows with intermediate treasury, IG corporate, and securitized exposure — duration target typically 3-7 years.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Insurance general account (life insurer or long-tail P&C) building intermediate-duration fixed-income exposure to match liability cash flows that extend 3-7 years out, inside NAIC RBC constraints."
+          },
+          "analysisAngle": "Duration matching to the liability profile is the test. Discuss key-rate-duration profile, IG composition (treasury / agency / IG corporate / securitized weights), NAIC RBC charge per asset class, and the wrapper's RBC look-through treatment. Capacity matters at insurance-allocation scale ($100M-$1B positions).",
+          "keyConsiderations": [
+            "Key-rate-duration profile vs the liability cash flow.",
+            "IG composition mix (treasury / agency / IG corporate / securitized).",
+            "NAIC RBC charge per asset class inside the wrapper.",
+            "Capacity at insurance-allocation scale ($100M-$1B positions).",
+            "Wrapper structure compatible with liability accounting."
+          ],
+          "redFlags": [
+            "Duration mismatch with the targeted liability profile.",
+            "Material drift below IG composition.",
+            "Insufficient capacity for insurance-scale allocations."
+          ]
+        },
+        {
+          "key": "inflation-protected-fixed-income-treasury",
+          "name": "Inflation-Protected Fixed Income (TIPS)",
+          "shortDescription": "Insurance or treasury holding TIPS exposure to defend the real value of nominal liabilities or to hedge inflation-linked claim costs — typically intermediate-duration TIPS (TIP, SCHP).",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Insurance general account hedging inflation-linked claim costs (e.g., medical or auto bodily-injury reserves) or corporate treasury hedging inflation-sensitive liabilities. Uses TIPS for direct CPI linkage."
+          },
+          "analysisAngle": "Direct CPI linkage is the hedging mechanism. Discuss real yield vs nominal, breakeven inflation vs market-implied, NAIC treatment of TIPS inside the wrapper, and the asymmetric tax treatment of inflation accruals (taxable when accrued). For short-duration TIPS, discuss the lower duration risk vs reduced inflation pickup.",
+          "keyConsiderations": [
+            "Real yield vs nominal-yield-curve equivalent.",
+            "Breakeven inflation vs market-implied expectations.",
+            "NAIC look-through treatment of TIPS inside the wrapper.",
+            "Inflation-accrual tax treatment for taxable holders.",
+            "Duration positioning vs the inflation-linked liability."
+          ],
+          "redFlags": [
+            "Wrapper that obscures the inflation-accrual tax treatment.",
+            "Duration that mismatches the inflation-linked liability.",
+            "Insufficient capacity for insurance-scale allocations."
+          ]
+        },
+        {
+          "key": "money-market-cash-equivalent",
+          "name": "Money-Market / Cash-Equivalent Wrapper",
+          "shortDescription": "Treasury team using money-market ETFs (PULS, GSY) for the most conservative cash sleeve — alternative to a money-market fund where the ETF wrapper offers intra-day pricing and same-day liquidity.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Low",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Corporate treasury or insurance team parking funds in the most conservative cash sleeve — typically choosing between a prime money-market fund and a money-market ETF wrapper."
+          },
+          "analysisAngle": "ETF vs prime money-market fund is the central comparison. Discuss intra-day pricing, same-day liquidity, NAV stability, yield differential vs the equivalent prime MMF, and SEC 2a-7 treatment if any. For corporates with same-day-liquidity needs, the ETF wrapper's intraday tradability is the differentiator.",
+          "keyConsiderations": [
+            "Intra-day pricing and same-day liquidity vs prime MMF.",
+            "NAV stability ($ NAV variance per $100 invested).",
+            "Yield differential vs the equivalent prime MMF.",
+            "Composition (treasury / agency / IG corporate paper).",
+            "Bid-ask depth for treasury-block trades."
+          ],
+          "redFlags": [
+            "NAV instability beyond expected money-market range.",
+            "Yield drag relative to a prime MMF without offsetting liquidity benefit.",
+            "Composition drift toward longer-duration paper."
+          ]
+        },
+        {
+          "key": "permitted-floating-rate-bank-loan",
+          "name": "Permitted Floating-Rate Bank-Loan Sleeve",
+          "shortDescription": "Treasury or insurance permitting a small floating-rate / bank-loan sleeve as a rising-rate hedge for the IG fixed-income book — IPS-permitted only.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Treasury or insurance team whose IPS allows a small (often 5-10% cap) floating-rate / bank-loan sleeve as a rising-rate hedge complement to the duration-bearing IG core."
+          },
+          "analysisAngle": "Floating-rate income that benefits in rising-rate regimes is the appeal. Discuss credit quality of the loan portfolio (typically below IG — IPS must explicitly permit), default-rate context, secondary-market liquidity in stress, and NAIC / regulatory treatment. Below-IG composition usually needs explicit IPS permission.",
+          "keyConsiderations": [
+            "Credit quality of the loan portfolio (typically below IG).",
+            "Default-rate context vs historical loan-market cycles.",
+            "Secondary-market liquidity in stress (loans are OTC).",
+            "NAIC or regulatory treatment of the wrapper.",
+            "IPS-permitted allocation cap and explicit below-IG permission."
+          ],
+          "redFlags": [
+            "Below-IG exposure where IPS doesn't explicitly permit it.",
+            "Material loan-market liquidity stress in a recent down cycle.",
+            "Wrapper structure that fails NAIC or Basel look-through."
+          ]
         }
       ]
     },
     {
       "key": "financial-advisor-ria",
-      "name": "Financial Advisor / RIA",
-      "shortDescription": "Registered Investment Advisor or financial planner constructing model portfolios across many client accounts — selects ETFs as building blocks rather than as standalone hero positions. Goals depend on the client tier: low-cost passive building blocks for the core models, wash-sale-safe partner pairs for client-level tax-loss harvesting, and income-and-conservative tier models for retiree clients.",
-      "goals": [
+      "name": "Financial Advisor / RIA / Wealth Manager",
+      "shortDescription": "Registered Investment Advisor, fee-only financial planner, wealth manager, or wirehouse advisor managing client AUM through model portfolios — typically $50M-$5B in client AUM split into 3-5 risk-tier models, rebalanced quarterly. Distinct from retail because the advisor is the buyer making product decisions across many client accounts; distinct from HNW because the underlying capital belongs to many different clients with different tax / risk profiles.",
+      "etfInvestorGoals": [
         {
           "key": "passive-core-model-building-blocks",
           "name": "Passive Core Model-Portfolio Building Blocks",
-          "shortDescription": "Independent RIA or financial planner constructing risk-tier model portfolios across many client accounts — needs cheap, broad, well-tracked passive ETFs as the workhorse holdings.",
+          "shortDescription": "Cheap, broad, well-tracked passive ETFs as the workhorse holdings in risk-tier model portfolios — fact-sheet clarity, tight bid-ask, and TAMP availability matter.",
           "profile": {
             "investmentHorizon": "Long (5-15y)",
             "riskTolerance": "Moderate",
             "primaryGoal": "Diversification / Hedging",
             "incomeNeed": "Modest",
             "taxSensitivity": "Moderate",
-            "typicalInvestor": "Independent RIA or fee-only planner managing $50M-$5B in client AUM, using 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalancing quarterly. Selects ETFs as building blocks rather than standalone hero positions."
+            "typicalInvestor": "Independent RIA or fee-only planner managing $50M-$5B in client AUM, using 3-5 risk-tier models, rebalancing quarterly. Selects ETFs as building blocks rather than standalone hero positions."
           },
           "analysisAngle": "Selection logic optimizes for use as a building block — fact-sheet clarity for client meetings, bid-ask tightness across client-block trades, fee compounding on top of the advisor's own AUM fee. Issuer brand, analyst coverage, and rep support matter for due-diligence defensibility. Active or thematic funds complicate the simple 'we use low-cost passive' narrative the advisor is selling.",
           "keyConsiderations": [
@@ -644,9 +1079,9 @@
           ]
         },
         {
-          "key": "retiree-income-tier-models",
+          "key": "retiree-tier-income-models",
           "name": "Retiree-Tier Income & Conservative Models",
-          "shortDescription": "Advisor constructing income and conservative-tier model portfolios for retiree clients — needs sustainable income, lower drawdown floor, and an intuitive risk story for client conversations.",
+          "shortDescription": "Advisor constructing income and conservative-tier model portfolios for retiree clients — sustainable income, lower drawdown floor, and intuitive risk story for client conversations.",
           "profile": {
             "investmentHorizon": "Long (5-15y)",
             "riskTolerance": "Low-Moderate",
@@ -657,7 +1092,7 @@
           },
           "analysisAngle": "Distribution character matters as much as headline yield for client communication. Drawdown floor — 'what's the worst 12-month decline?' — is the question retiree clients ask. Derivative-income funds (JEPI / JEPQ-style) are common in this tier; advisors must understand the upside-cap tradeoff and explain it clearly. Sequence-of-returns risk is the dominant concern.",
           "keyConsiderations": [
-            "Distribution character (qualified dividend / ordinary income / ROC) for client tax communication.",
+            "Distribution character (qualified, ordinary, ROC) for client tax communication.",
             "Worst-12-month drawdown a retiree client could survive.",
             "Capture-ratio analysis for derivative-income funds (upside-cap vs income payout).",
             "Duration risk in the bond sleeve.",
@@ -667,6 +1102,455 @@
             "Distribution funded substantially by ROC without clear advisor-facing disclosure.",
             "Long-duration bond exposure incompatible with retiree drawdown tolerance.",
             "Active fund failing to beat its passive peer net of fees over 5+ years."
+          ]
+        },
+        {
+          "key": "conservative-tier-short-duration-bonds",
+          "name": "Conservative-Tier Short-Duration Bond Sleeves",
+          "shortDescription": "Advisor building short-duration IG bond sleeves for near-retiree or conservative-tier models — reduces duration risk and drawdown floor for clients close to or in withdrawal.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA building conservative-tier or near-retiree model portfolios — wants short-duration IG exposure as the bond sleeve to limit drawdown if rates spike or equities sell off."
+          },
+          "analysisAngle": "Short duration limits drawdown when rates rise or equities sell off — that's the role. Discuss effective duration (target ~1-3 years), credit quality (IG-only), and yield pickup vs cash. Distribution mechanics for client tax planning. Bid-ask matters across many client accounts.",
+          "keyConsiderations": [
+            "Effective duration in the 1-3 year target range.",
+            "IG-only credit composition.",
+            "Yield pickup vs cash and money-market funds.",
+            "Distribution mechanics for client tax planning.",
+            "Bid-ask depth for cross-account client-block trades."
+          ],
+          "redFlags": [
+            "Duration creep beyond the conservative-tier target.",
+            "Credit-quality drift below IG.",
+            "Wide bid-ask amplified across many client accounts."
+          ]
+        },
+        {
+          "key": "growth-tier-international-emerging-markets",
+          "name": "Growth-Tier International & Emerging-Markets Tilt",
+          "shortDescription": "Advisor building international and EM equity sleeves for growth-tier client models — captures higher long-run growth and diversifies US-only concentration.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA building growth-tier or aggressive-tier client models — wants meaningful international and EM equity exposure for diversification and long-run growth."
+          },
+          "analysisAngle": "Diversification benefit and long-run growth are the rationale. Discuss benchmark family (MSCI vs FTSE), country-tier inclusion (China A-share, frontier), currency-hedged vs unhedged variants, and foreign-tax-credit pickup if held in client taxable accounts. Bid-ask matters across many accounts.",
+          "keyConsiderations": [
+            "Benchmark family compatibility with the model's policy mix.",
+            "Country-tier inclusion (China A-share, frontier).",
+            "Currency-hedged vs unhedged variant choice.",
+            "Foreign-tax-credit pickup in taxable client accounts.",
+            "Bid-ask depth for cross-account client-block trades."
+          ],
+          "redFlags": [
+            "Wrong benchmark family creating attribution mismatch.",
+            "Material premium-discount drift in EM during stress windows.",
+            "Wrapper structure that loses foreign-tax-credit creditability."
+          ]
+        },
+        {
+          "key": "sector-thematic-satellite-tilt",
+          "name": "Sector / Thematic Satellite Tilt",
+          "shortDescription": "Advisor adding sector or thematic ETFs as satellite tilts in client models to differentiate the offering from a pure passive-index portfolio — REITs, infrastructure, broad tech, or specific themes.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Thematic Exposure",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA wanting to differentiate the model offering from pure passive-index by adding 5-15% in sector or thematic satellite tilts (REITs, infrastructure, broad tech, specific themes)."
+          },
+          "analysisAngle": "Satellite sizing (typically 5-15% per tilt) is the design constraint. Discuss the diversification or alpha thesis behind each tilt, methodology rigor (passive index vs rules-based vs active), tracking-error attribution vs the policy benchmark, and bid-ask at cross-account scale. Discuss the client-communication story — why this tilt is in the model.",
+          "keyConsiderations": [
+            "Satellite sizing (typically 5-15%) appropriate for the tier.",
+            "Diversification or alpha thesis behind the tilt.",
+            "Methodology rigor (passive index vs rules-based vs active).",
+            "Tracking-error attribution vs the policy benchmark.",
+            "Bid-ask depth for cross-account scale."
+          ],
+          "redFlags": [
+            "Theme drift — fund name and top holdings don't align.",
+            "Headline fee well above peers in the same theme without methodology advantage.",
+            "Closure risk that would force a cross-account taxable transition."
+          ]
+        },
+        {
+          "key": "esg-sri-client-model-variant",
+          "name": "ESG / SRI Client-Model Variant",
+          "shortDescription": "Advisor building an ESG or SRI variant of the standard model portfolio for clients who request values-aligned investing — needs ETFs with documented third-party-rated screens.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA building an ESG / SRI client-model variant alongside the standard model — typically maintains the same risk profile but substitutes screened ETFs for the unscreened equivalents."
+          },
+          "analysisAngle": "Screen rigor and tracking-error attribution are the central questions. Third-party-rated methodology (MSCI ESG, Sustainalytics) is the advisor's defensibility anchor. Discuss exclusion-list transparency, sector tilt vs the unscreened parent index, fee premium, and the client-communication story — why this screen, what's excluded, what tradeoff is accepted.",
+          "keyConsiderations": [
+            "Screen methodology — third-party rated, auditable exclusion list.",
+            "Sector tilt vs the unscreened parent index.",
+            "Tracking-error attribution and risk-profile preservation vs the standard model.",
+            "Fee premium vs the unscreened equivalent.",
+            "Client-communication story for the screen rationale."
+          ],
+          "redFlags": [
+            "Self-graded ESG screens with weak or vague criteria.",
+            "Holdings that contradict the fund's stated mission.",
+            "Material fee premium without methodology advantage."
+          ]
+        },
+        {
+          "key": "muni-sleeve-high-bracket-clients",
+          "name": "Muni Sleeve for High-Bracket Client Sub-Models",
+          "shortDescription": "Advisor building muni bond ETF sleeves for high-bracket clients holding in taxable accounts — competes against IG corporate alternative on after-tax basis.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "RIA building a muni bond sleeve for high-bracket client sub-models held in taxable accounts — typically substitutes muni for the taxable IG bond sleeve when after-tax muni yield wins."
+          },
+          "analysisAngle": "Tax-equivalent yield vs taxable IG alternative drives selection. Discuss bracket assumptions (federal + state + NIIT), state-specific vs national muni, AMT exposure on private-activity bonds, and credit-tier mix. Bid-ask depth at cross-account scale matters. Distinguish IG muni from HY muni explicitly in client communication.",
+          "keyConsiderations": [
+            "Tax-equivalent yield at the client's marginal bracket.",
+            "State-specific vs national muni choice for in-state-resident clients.",
+            "AMT exposure on private-activity-bond muni funds.",
+            "Credit-tier mix (IG-only vs HY-muni tilt).",
+            "Bid-ask depth at cross-account client-block scale."
+          ],
+          "redFlags": [
+            "High-yield muni exposure inside a generically named muni fund.",
+            "Single-state muni with documented credit distress.",
+            "Wide bid-ask amplified across many client accounts."
+          ]
+        },
+        {
+          "key": "inflation-real-asset-diversification-sleeve",
+          "name": "Inflation / Real-Asset Diversification Sleeve",
+          "shortDescription": "Advisor adding a real-asset sleeve (TIPS, REITs, commodities, infrastructure) as a diversifier in moderate / aggressive client models — typically 5-10% of the portfolio.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA adding a 5-10% real-asset / inflation-hedge sleeve to moderate or aggressive client models for diversification and inflation defense."
+          },
+          "analysisAngle": "Sized as a diversifying sleeve, not a core holding. Discuss the composition tradeoff (TIPS for measured CPI, commodities for unanticipated inflation, REITs for equity-correlated real-asset exposure). Watch for K-1 reporting on commodity pools — many advisors avoid K-1s entirely for client simplicity. Tracking-error attribution vs the policy benchmark.",
+          "keyConsiderations": [
+            "Composition tradeoff (TIPS, commodities, REITs, infrastructure).",
+            "K-1 vs 1099 reporting (advisors often avoid K-1 for client simplicity).",
+            "Real-return correlation in measured inflation regimes.",
+            "Tracking-error attribution vs the policy benchmark.",
+            "Sizing relative to the diversification benefit."
+          ],
+          "redFlags": [
+            "K-1 reporting for client accounts where the advisor avoids K-1s.",
+            "Fund labeled inflation-hedge but historically tracking equity beta.",
+            "Material commodity-spot vs equity-proxy mismatch."
+          ]
+        },
+        {
+          "key": "defined-outcome-derivative-income-retiree",
+          "name": "Defined-Outcome / Derivative-Income for Retiree Tier",
+          "shortDescription": "Advisor adding buffered-equity (defined-outcome) or covered-call (derivative-income) ETFs to retiree-tier models for downside protection or yield supplement — explains upside-cap tradeoff to clients.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA building retiree-tier models that include defined-outcome (buffered) ETFs for downside protection or covered-call ETFs for yield supplement — accepts the upside cap as the tradeoff."
+          },
+          "analysisAngle": "Upside-cap vs downside-floor tradeoff is the central client conversation. For defined-outcome, discuss outcome-period mechanics (entry / exit window) and what happens if the cap is breached mid-cycle. For covered-call, discuss capture ratio, distribution character, and whether the income is durable. Both require careful client-communication discipline.",
+          "keyConsiderations": [
+            "Upside-cap vs downside-floor tradeoff for defined-outcome funds.",
+            "Outcome-period mechanics (entry / exit window).",
+            "Capture ratio for covered-call funds.",
+            "Distribution character (qualified, ordinary, ROC) for client tax communication.",
+            "Issuer counterparty exposure for derivative-based structures."
+          ],
+          "redFlags": [
+            "Defined-outcome fund where the cap and floor have already been breached mid-cycle.",
+            "Capture ratio that gives up most upside without delivering matching income.",
+            "Distribution funded mostly by ROC without explicit disclosure."
+          ]
+        }
+      ]
+    },
+    {
+      "key": "hedge-fund-asset-manager-trading-desk",
+      "name": "Hedge Fund / Asset Manager / Trading Desk",
+      "shortDescription": "Professional trading entity using ETFs as efficient wrappers for short-term beta, hedging, basket trades, transition management, and pair trades — hedge fund PM, proprietary trading desk, mutual fund manager, fund-of-funds allocator. Distinct from RIA / wealth manager because the holding period is hours to weeks (not years), tax considerations are minimal (pass-through), and ETF selection optimizes for liquidity / borrow / options-market depth rather than long-term portfolio fit.",
+      "etfInvestorGoals": [
+        {
+          "key": "short-term-equity-beta-wrapper",
+          "name": "Short-Term Equity Beta Wrapper",
+          "shortDescription": "SPY / QQQ / IWM as short-horizon equity beta wrappers for transition management, beta exposure between trades, or expressing a directional equity view.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund PM, mutual fund transition manager, or proprietary trading desk needing efficient equity-beta wrapper exposure for hours to weeks."
+          },
+          "analysisAngle": "Bid-ask, dollar volume, and options-market depth dominate. SPY / IVV / VOO compete on liquidity and borrow availability; QQQ vs QQQM differs on options market. Discuss creation-redemption efficiency and AP friction, and securities-borrow availability for the short-side trade. Premium / discount drift in stress windows (March 2020) is a real cost.",
+          "keyConsiderations": [
+            "Average daily dollar volume in $hundreds of millions.",
+            "Options-market depth for hedging overlays.",
+            "Securities-borrow availability and cost for short positions.",
+            "Creation-redemption baskets and AP friction during stress.",
+            "Premium / discount drift in stress windows."
+          ],
+          "redFlags": [
+            "Options market thin or non-existent.",
+            "High borrow cost or limited shortable supply.",
+            "Wide premium / discount drift during normal conditions."
+          ]
+        },
+        {
+          "key": "sector-relative-value-pair-trade",
+          "name": "Sector Relative-Value Pair Trade",
+          "shortDescription": "Long / short pair trades expressed via sector ETFs (e.g., long XLK / short XLE) — relies on tight bid-ask, deep options markets, and reliable shortable inventory.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund PM (long-short, multi-strategy) or proprietary desk expressing a sector relative-value view via long one sector ETF and short another — typically holds for days to months."
+          },
+          "analysisAngle": "Both legs of the pair must have tight bid-ask, deep options, and reliable borrow. Sector-fund methodology differences (XLK vs VGT) can change the trade thesis if the funds tilt to different sub-sectors. Discuss top-holding overlap with the index target. Borrow cost on the short leg is the marginal cost.",
+          "keyConsiderations": [
+            "Bid-ask tightness on both legs of the pair.",
+            "Options-market depth on both sides for hedging.",
+            "Securities-borrow availability and cost on the short leg.",
+            "Methodology overlap between competing sector funds (XLK vs VGT).",
+            "Top-holding overlap with the trade thesis."
+          ],
+          "redFlags": [
+            "Borrow cost on the short leg that erodes the trade economics.",
+            "Methodology mismatch between the two sector funds invalidating the thesis.",
+            "Material option-market thinness on either leg."
+          ]
+        },
+        {
+          "key": "credit-spread-expression",
+          "name": "Credit-Spread Expression",
+          "shortDescription": "HYG / JNK / LQD as the standard wrappers for credit-spread directional bets — long HYG / short LQD for spread tightening, vice versa for widening.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund credit PM, macro PM, or proprietary desk expressing a credit-spread view via HY vs IG ETFs — holds for days to months, often with options overlays."
+          },
+          "analysisAngle": "Bid-ask of HY ETFs in stress is the central friction — HYG can move to -2% premium / discount in March 2020 / Oct 2022. Discuss options-market depth (HYG has the deepest), borrow availability, and the underlying-bond illiquidity that the ETF wrapper actually traverses through creation-redemption. CDX vs ETF as expression mechanism comparison.",
+          "keyConsiderations": [
+            "HY ETF bid-ask behavior in credit-stress windows.",
+            "Options-market depth for hedging the position.",
+            "Borrow availability for the short leg.",
+            "Underlying-bond liquidity flowing through creation-redemption.",
+            "CDX index alternative as a competing expression mechanism."
+          ],
+          "redFlags": [
+            "Material premium / discount drift in HY ETF during normal conditions.",
+            "Options market thin on the HY ETF leg.",
+            "High borrow cost on the short leg."
+          ]
+        },
+        {
+          "key": "rate-duration-tactical-bet",
+          "name": "Rate / Duration Tactical Bet",
+          "shortDescription": "TLT / IEF / SHY for tactical rate / duration / curve bets — long TLT for falling rates, short TLT for rising, butterfly trades for curve shape.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Macro PM or proprietary rates desk expressing a rate / duration / curve view via treasury ETFs — typically for days to months, often with futures overlays."
+          },
+          "analysisAngle": "Treasury futures vs ETF as expression is the central comparison — futures have lower frictions but less convex options markets; TLT options are deep. Discuss key-rate-duration profile, convexity at long-end, and bid-ask. For curve trades, butterfly construction across SHY / IEF / TLT.",
+          "keyConsiderations": [
+            "Bid-ask depth for institutional-block trades.",
+            "Options-market depth for hedging or expressing volatility.",
+            "Key-rate-duration profile and convexity.",
+            "Treasury futures alternative comparison.",
+            "Curve-trade construction across multiple treasury ETFs."
+          ],
+          "redFlags": [
+            "Bid-ask widening in stress vs the underlying treasury market.",
+            "Options market thin on chosen treasury ETF.",
+            "Material premium / discount drift in stress windows."
+          ]
+        },
+        {
+          "key": "macro-fx-directional-bet",
+          "name": "Macro FX Directional Bet",
+          "shortDescription": "Single-currency ETFs (FXE / FXY / UUP) as wrappers for FX directional bets — alternative to FX forwards for desks without prime-broker FX access.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Macro PM or proprietary desk expressing an FX directional view — often used by smaller funds without direct FX-forward access via prime broker."
+          },
+          "analysisAngle": "FX-forward vs ETF as expression is the comparison — forwards have lower frictions but require prime-broker FX access. Discuss bid-ask, options-market depth (limited for most single-currency ETFs), and the carry / roll embedded in the ETF structure. For levered FX bets, leveraged-FX ETFs add daily-reset friction.",
+          "keyConsiderations": [
+            "Bid-ask depth at desk-block trade size.",
+            "Options-market depth for hedging.",
+            "Carry / roll embedded in the ETF structure.",
+            "FX-forward alternative comparison.",
+            "Daily-reset friction for leveraged-FX variants."
+          ],
+          "redFlags": [
+            "Bid-ask wide enough that round-trip cost dominates trade economics.",
+            "Limited options market on the chosen FX ETF.",
+            "Daily-reset decay in leveraged-FX variants over multi-day holds."
+          ]
+        },
+        {
+          "key": "macro-commodity-directional-bet",
+          "name": "Macro Commodity Directional Bet",
+          "shortDescription": "Commodity ETFs (USO / UNG / DBC / GLD / SLV) for macro directional bets on energy, metals, or broad commodities — alternative to futures for desks without commodity prime-brokerage.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Macro PM or proprietary desk expressing a commodity directional view — often used as an alternative to commodity futures for desks without commodity prime-brokerage access."
+          },
+          "analysisAngle": "Futures vs ETF as expression is the comparison. ETF wrappers carry roll cost (contango / backwardation), tax structure (K-1 vs 1099), and tracking error vs spot. Discuss options-market depth, borrow availability, and the contango-friction history of the chosen ETF. GLD / SLV are spot-backed; USO / UNG are futures-rolled.",
+          "keyConsiderations": [
+            "Roll cost in contango vs spot tracking.",
+            "K-1 vs 1099 tax structure (most commodity pools are K-1).",
+            "Options-market depth for hedging.",
+            "Borrow availability for the short side.",
+            "Spot-backed vs futures-rolled methodology choice."
+          ],
+          "redFlags": [
+            "Material contango friction eroding the trade thesis.",
+            "K-1 reporting where the desk's tax structure can't accept it.",
+            "Limited options market on the chosen commodity ETF."
+          ]
+        },
+        {
+          "key": "leveraged-tactical-short-term-hedge",
+          "name": "Leveraged Tactical Short-Term Hedge",
+          "shortDescription": "Daily-leveraged ETFs (TQQQ, SOXL, FAS) for short-horizon tactical hedging or capital-efficient directional bets — explicit understanding of daily-reset path dependency.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund PM or proprietary desk using daily-leveraged ETFs for capital-efficient tactical bets — explicit understanding that the products are unsuitable for multi-week holds."
+          },
+          "analysisAngle": "Daily-reset path dependency drives every judgment. Suitable for hours to days, NOT weeks. Discuss bid-ask, options-market depth, embedded swap-financing cost, and leverage-fidelity (does 3x deliver 3x intraday?). Capital-efficiency vs futures or options as alternative expressions.",
+          "keyConsiderations": [
+            "Daily-leverage fidelity (does 3x deliver 3x intraday?).",
+            "Embedded swap-financing cost on top of the headline expense ratio.",
+            "Bid-ask spread at desk-block trade size.",
+            "Options-market depth for hedging the leveraged position.",
+            "Capital-efficiency vs futures / options alternatives."
+          ],
+          "redFlags": [
+            "Documented tracking failures on the daily-leverage objective.",
+            "Wide bid-ask combined with thin volume.",
+            "Marketing that downplays daily-reset risk."
+          ]
+        },
+        {
+          "key": "inverse-hedge-exposure",
+          "name": "Inverse Hedge Exposure",
+          "shortDescription": "Inverse ETFs (SH, SDS, SQQQ) for short-term tactical hedging of long portfolios without locating shortable shares — useful for funds without unfettered short access.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund or fund-of-funds desk that needs short-side exposure without locating shortable inventory — uses inverse ETFs for tactical portfolio hedging over hours to weeks."
+          },
+          "analysisAngle": "Avoids the locate-borrow problem inherent in shorting. Daily-reset path dependency still applies. Discuss bid-ask, options-market depth, and beta-to-underlying over the intended hedge horizon (hours: tracks 1-to-1; days: starts to drift; weeks: significant decay). Vs short futures or short ETF alternatives.",
+          "keyConsiderations": [
+            "Beta-to-underlying over the intended hedge horizon.",
+            "Bid-ask spread at desk-block trade size.",
+            "Daily-reset path dependency over the hedge horizon.",
+            "Options-market depth on the inverse ETF.",
+            "Short-futures or short-ETF alternative comparison."
+          ],
+          "redFlags": [
+            "Documented tracking failures on the daily-inverse objective.",
+            "Wide bid-ask defeating the hedge economics.",
+            "Material daily-reset decay over the intended hedge horizon."
+          ]
+        },
+        {
+          "key": "crypto-digital-asset-tactical-position",
+          "name": "Crypto / Digital-Asset Tactical Position",
+          "shortDescription": "Spot-bitcoin (IBIT, FBTC) or spot-ether ETFs as wrappers for short-term tactical crypto positions — alternative to direct spot-crypto exposure for funds without crypto custody infrastructure.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund macro PM or crypto-focused fund taking tactical spot-bitcoin or spot-ether exposure via the ETF wrapper — alternative to direct crypto custody."
+          },
+          "analysisAngle": "Spot-crypto vs ETF wrapper is the comparison. ETF avoids custody / cold-storage operational risk but adds custodian counterparty exposure. Discuss bid-ask, options-market depth (rapidly developing for IBIT / FBTC), creation-redemption efficiency, and basis vs spot crypto. Trading hours mismatch with 24/7 spot crypto.",
+          "keyConsiderations": [
+            "Custodian counterparty inside the ETF wrapper.",
+            "Bid-ask depth at desk-block trade size.",
+            "Options-market depth (rapidly developing for spot-BTC ETFs).",
+            "Basis vs underlying spot crypto.",
+            "Trading-hours mismatch (24/7 spot vs ETF market hours)."
+          ],
+          "redFlags": [
+            "Material basis vs spot crypto in normal conditions.",
+            "Custodian concentration risk inside the ETF wrapper.",
+            "Limited options market for the chosen spot-crypto ETF."
+          ]
+        },
+        {
+          "key": "transition-management-basket-wrapper",
+          "name": "Transition-Management Basket Wrapper",
+          "shortDescription": "Mutual fund manager or institutional transition desk using broad ETFs (SPY, AGG, EFA, EEM) as temporary beta wrappers during portfolio reorgs or fund manager transitions.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Mutual fund transition manager, institutional pension transition desk, or fund-of-funds allocator using broad ETFs as temporary beta wrappers during portfolio reorgs (manager transitions, mandate changes, reorganizations)."
+          },
+          "analysisAngle": "Speed and tracking fidelity dominate — the ETF replaces the in-transit portfolio for days to weeks while underlying-security trades settle. Discuss bid-ask, dollar volume, tracking fidelity vs the policy benchmark, and creation-redemption efficiency for in-and-out volume. Standard transition workhorses are SPY (US equity), AGG (core bond), EFA (developed international), EEM (EM).",
+          "keyConsiderations": [
+            "Tracking fidelity vs the policy benchmark being replaced.",
+            "Average daily dollar volume sufficient for transition-block trades.",
+            "Creation-redemption efficiency for rapid in-and-out volume.",
+            "Bid-ask cost of the round-trip transition.",
+            "Issuer operational reliability for transition-scale trades."
+          ],
+          "redFlags": [
+            "Tracking error vs the benchmark being replaced.",
+            "Insufficient dollar volume for transition-block trades.",
+            "AP friction during the transition period."
           ]
         }
       ]

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,21 +1,18 @@
 {
-  "description": "Target investor groups taxonomy — investor archetypes used to frame ETF analysis from the perspective of the people most likely to consider buying the fund. Each group describes the investor's profile (experience, horizon, risk tolerance, primary goal, income need, tax sensitivity, account preference), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and the ETF groups + specific Morningstar categories from etf-analysis-categories.json that fit their goals. Groups are NOT mutually exclusive — a single ETF can be relevant to several investor groups (e.g. a TIPS fund fits both retirement-income-seeker and inflation-real-asset-hedger). The goal-label list mirrors the Phase-2 taxonomy in tasks/koala-gains/etfs.md (e.g. 'Fixed income with low risk', 'High yield with moderate or high risk', 'Single-country thematic exposure').",
+  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Each group describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and the ETF groups + specific Morningstar categories from etf-analysis-categories.json that fit. Groups are NOT mutually exclusive — a single ETF can be relevant to several investor groups (e.g. a TIPS fund fits both retirement-income-seeker and inflation-real-asset-hedger, and HNW investors often overlap with tax-sensitive-high-earner). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
   "investorGroups": [
     {
       "key": "first-time-investor",
       "name": "First-Time / Beginner Investor",
       "shortDescription": "New to investing, wants the simplest possible exposure to broad markets without making fund-selection mistakes that compound over decades.",
       "profile": {
-        "experienceLevel": "Beginner",
         "investmentHorizon": "Long (5-15y)",
         "riskTolerance": "Moderate",
         "primaryGoal": "Wealth Accumulation",
         "incomeNeed": "None",
         "taxSensitivity": "Low",
-        "accountTypePreference": "Tax-Advantaged",
         "typicalInvestor": "Someone in their 20s or 30s opening a brokerage or Roth IRA for the first time, contributing monthly, with little appetite for picking individual sub-categories or sectors."
       },
-      "goalLabels": ["Simple broad-market exposure", "Low-cost long-term growth", "One-fund retirement glide path"],
       "analysisAngle": "Default to the simplest, cheapest, most diversified option. Explain the fund as if the reader has never bought an ETF before. Always anchor to the boring baseline (a total-market or S&P 500 fund, or a target-date fund) and explain whether this fund adds anything over that baseline that justifies the additional complexity. Avoid jargon; if a term like 'duration' or 'tracking error' is used, define it inline.",
       "keyConsiderations": [
         "Expense ratio under ~0.10% for passive broad-equity, under ~0.20% for target-date.",
@@ -32,8 +29,16 @@
         "AUM under $100M with declining trend (real closure risk)."
       ],
       "etfGroupFit": [
-        { "groupKey": "broad-equity", "fit": "primary", "rationale": "Total-market and S&P 500 trackers are the canonical first-purchase ETF." },
-        { "groupKey": "allocation-target-date", "fit": "primary", "rationale": "A single target-date fund is the simplest one-decision retirement portfolio." },
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Total-market and S&P 500 trackers are the canonical first-purchase ETF."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "primary",
+          "rationale": "A single target-date fund is the simplest one-decision retirement portfolio."
+        },
         {
           "groupKey": "fixed-income-core",
           "fit": "secondary",
@@ -49,23 +54,43 @@
           "fit": "occasional",
           "rationale": "Credit risk is hard to evaluate as a beginner — better to wait until the broad base is established."
         },
-        { "groupKey": "muni", "fit": "occasional", "rationale": "Tax benefits rarely matter for beginners in low-bracket or tax-advantaged accounts." },
+        {
+          "groupKey": "muni",
+          "fit": "occasional",
+          "rationale": "Tax benefits rarely matter for beginners in low-bracket or tax-advantaged accounts."
+        },
         {
           "groupKey": "alt-strategies",
           "fit": "avoid",
           "rationale": "Complex strategies are easy to misunderstand and create surprise tax or distribution outcomes."
         },
-        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Daily reset and decay make these unsuitable for any beginner buy-and-hold context." }
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Daily reset and decay make these unsuitable for any beginner buy-and-hold context."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Large Blend", "group": "broad-equity", "rationale": "S&P 500 / total-market trackers — the textbook first-purchase ETF." },
-        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Adds developed ex-US exposure with one fund." },
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "S&P 500 / total-market trackers — the textbook first-purchase ETF."
+        },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Adds developed ex-US exposure with one fund."
+        },
         {
           "category": "Target-Date 2050",
           "group": "allocation-target-date",
           "rationale": "Single-fund retirement glide path for an investor in their 30s — no rebalancing decisions required."
         },
-        { "category": "Target-Date 2065+", "group": "allocation-target-date", "rationale": "Single-fund glide path for a younger first-time investor." },
+        {
+          "category": "Target-Date 2065+",
+          "group": "allocation-target-date",
+          "rationale": "Single-fund glide path for a younger first-time investor."
+        },
         {
           "category": "Intermediate Core Bond",
           "group": "fixed-income-core",
@@ -78,16 +103,13 @@
       "name": "Long-Term Wealth Builder (Buy & Hold)",
       "shortDescription": "Multi-decade horizon, comfortable with equity volatility, focused on cumulative compounding and minimizing fee drag over 20-30+ years.",
       "profile": {
-        "experienceLevel": "Intermediate",
         "investmentHorizon": "Very Long (15y+)",
         "riskTolerance": "Moderate-High",
         "primaryGoal": "Wealth Accumulation",
         "incomeNeed": "None",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Working-age investor 5-30 years from retirement, dollar-cost-averaging into a core portfolio, cares more about the next 25 years than the next 25 weeks."
       },
-      "goalLabels": ["Core long-term equity growth", "Diversified global exposure", "Low-cost compounding"],
       "analysisAngle": "Frame everything in cumulative-compounding terms: a 0.30% fee gap is ~9% of an ending balance over 30 years. Emphasize tracking fidelity, mandate stability, and downside drawdown / recovery time. De-emphasize 1-year performance; weight 5-year and 10-year risk-adjusted return. Note dividend reinvestment and the practical difference between a total-return and price index.",
       "keyConsiderations": [
         "Cumulative fee drag over 20-30 years vs the lowest-cost peer.",
@@ -133,18 +155,38 @@
           "fit": "occasional",
           "rationale": "Credit adds yield but historically underperforms equity over very long horizons."
         },
-        { "groupKey": "muni", "fit": "occasional", "rationale": "Only relevant for high-bracket investors funding a taxable bond sleeve." },
-        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Daily-reset decay makes these structurally unsuitable for buy-and-hold." }
+        {
+          "groupKey": "muni",
+          "fit": "occasional",
+          "rationale": "Only relevant for high-bracket investors funding a taxable bond sleeve."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Daily-reset decay makes these structurally unsuitable for buy-and-hold."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Large Blend", "group": "broad-equity", "rationale": "Core US large-cap exposure — the historical engine of long-run equity returns." },
-        { "category": "Mid-Cap Blend", "group": "broad-equity", "rationale": "Mid-cap completes the US-equity base alongside large-cap." },
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "Core US large-cap exposure — the historical engine of long-run equity returns."
+        },
+        {
+          "category": "Mid-Cap Blend",
+          "group": "broad-equity",
+          "rationale": "Mid-cap completes the US-equity base alongside large-cap."
+        },
         {
           "category": "Small Blend",
           "group": "broad-equity",
           "rationale": "Small-cap captures the size premium for long horizons that can absorb volatility."
         },
-        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Developed ex-US is a long-run diversifier when US valuations stretch." },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Developed ex-US is a long-run diversifier when US valuations stretch."
+        },
         {
           "category": "Diversified Emerging Mkts",
           "group": "broad-equity",
@@ -167,16 +209,13 @@
       "name": "Growth-Focused Accumulator",
       "shortDescription": "Younger investor with a long horizon and high risk tolerance, willing to accept large drawdowns in pursuit of higher long-run growth — overweight to growth, small-cap, EM, and innovation themes.",
       "profile": {
-        "experienceLevel": "Intermediate",
         "investmentHorizon": "Very Long (15y+)",
         "riskTolerance": "High",
         "primaryGoal": "Wealth Accumulation",
         "incomeNeed": "None",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "20s-30s investor with stable income, no near-term capital needs, willing to accept 30-50% peak-to-trough drawdowns in exchange for higher expected returns over 20+ years."
       },
-      "goalLabels": ["Aggressive equity growth", "Innovation / theme tilt", "High volatility tolerance"],
       "analysisAngle": "Emphasize factor tilt (growth, small-cap, momentum), top-holding concentration, and drawdown / recovery behavior — this investor needs to know *how* painful the down years will be and how long recovery has historically taken. Reinforce that past bull-run leadership does not guarantee future leadership; address sequence risk only lightly because the horizon is long.",
       "keyConsiderations": [
         "Factor exposure (growth vs blend vs value tilt) and how it has driven returns.",
@@ -217,13 +256,33 @@
           "fit": "occasional",
           "rationale": "Only for tactical sub-week trades; unsuitable as a growth holding due to decay."
         },
-        { "groupKey": "fixed-income-core", "fit": "occasional", "rationale": "Small allocation only; bonds dilute the growth tilt this investor wants." },
-        { "groupKey": "fixed-income-credit", "fit": "avoid", "rationale": "Yield doesn't compound like equity over multi-decade horizons." },
-        { "groupKey": "muni", "fit": "avoid", "rationale": "Tax-exempt income is irrelevant for an accumulator with no income need." }
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "occasional",
+          "rationale": "Small allocation only; bonds dilute the growth tilt this investor wants."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "avoid",
+          "rationale": "Yield doesn't compound like equity over multi-decade horizons."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "avoid",
+          "rationale": "Tax-exempt income is irrelevant for an accumulator with no income need."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Large Growth", "group": "broad-equity", "rationale": "Core US large-cap growth exposure — the cleanest expression of US growth tilt." },
-        { "category": "Mid-Cap Growth", "group": "broad-equity", "rationale": "Mid-cap growth blends scaling-stage businesses with public-market liquidity." },
+        {
+          "category": "Large Growth",
+          "group": "broad-equity",
+          "rationale": "Core US large-cap growth exposure — the cleanest expression of US growth tilt."
+        },
+        {
+          "category": "Mid-Cap Growth",
+          "group": "broad-equity",
+          "rationale": "Mid-cap growth blends scaling-stage businesses with public-market liquidity."
+        },
         {
           "category": "Small Growth",
           "group": "broad-equity",
@@ -234,7 +293,11 @@
           "group": "broad-equity",
           "rationale": "EM for long-horizon investors who can tolerate currency and policy regime risk."
         },
-        { "category": "India Equity", "group": "broad-equity", "rationale": "Single-country growth bet for investors with a structural EM thesis." },
+        {
+          "category": "India Equity",
+          "group": "broad-equity",
+          "rationale": "Single-country growth bet for investors with a structural EM thesis."
+        },
         {
           "category": "Technology",
           "group": "sector-thematic-equity",
@@ -250,7 +313,11 @@
           "group": "sector-thematic-equity",
           "rationale": "Equity exposure to crypto-economy companies for investors with conviction but not direct-asset risk tolerance."
         },
-        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot digital-asset ETFs for highest-growth-tilt sleeves." }
+        {
+          "category": "Digital Assets",
+          "group": "alt-strategies",
+          "rationale": "Spot digital-asset ETFs for highest-growth-tilt sleeves."
+        }
       ]
     },
     {
@@ -258,16 +325,13 @@
       "name": "Retirement Income Seeker",
       "shortDescription": "At or near retirement, drawing from the portfolio for living expenses. Prioritizes capital preservation, predictable income, and shallow drawdowns over absolute return.",
       "profile": {
-        "experienceLevel": "Intermediate",
         "investmentHorizon": "Medium (1-5y)",
         "riskTolerance": "Low-Moderate",
         "primaryGoal": "Capital Preservation",
         "incomeNeed": "High",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Investor in their 60s-70s living off portfolio distributions, where a single deep drawdown in the wrong year can permanently impair retirement consumption (sequence-of-returns risk)."
       },
-      "goalLabels": ["Capital preservation", "Steady income", "Fixed income with low risk", "Retirement glide path"],
       "analysisAngle": "Lead with downside: worst calendar year, worst drawdown, recovery time, and distribution stability. Income consistency matters more than headline yield — a fund that paid every quarter through 2008 and 2020 is more useful than one with a higher headline yield and an erratic record. Address sequence-of-returns risk explicitly: a 30% drawdown in year 1 of retirement is fundamentally different from year 20.",
       "keyConsiderations": [
         "Distribution stability and history — quarterly/monthly consistency through stress periods.",
@@ -319,7 +383,11 @@
           "fit": "occasional",
           "rationale": "Real estate and utilities can supplement income; growth-tilted sectors don't fit."
         },
-        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Volatility decay and path dependency are incompatible with capital preservation." }
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Volatility decay and path dependency are incompatible with capital preservation."
+        }
       ],
       "highlightedCategories": [
         {
@@ -332,13 +400,21 @@
           "group": "fixed-income-core",
           "rationale": "Low-duration income with limited rate sensitivity — useful when rate path is uncertain."
         },
-        { "category": "Ultrashort Bond", "group": "fixed-income-core", "rationale": "Cash-like ballast for distributions and near-term spending." },
+        {
+          "category": "Ultrashort Bond",
+          "group": "fixed-income-core",
+          "rationale": "Cash-like ballast for distributions and near-term spending."
+        },
         {
           "category": "Inflation-Protected Bond",
           "group": "fixed-income-core",
           "rationale": "TIPS protect real purchasing power across the multi-decade retirement horizon."
         },
-        { "category": "Target-Date Retirement", "group": "allocation-target-date", "rationale": "Designed exactly for the in-retirement glide path." },
+        {
+          "category": "Target-Date Retirement",
+          "group": "allocation-target-date",
+          "rationale": "Designed exactly for the in-retirement glide path."
+        },
         {
           "category": "Conservative Allocation",
           "group": "allocation-target-date",
@@ -366,16 +442,13 @@
       "name": "Tax-Sensitive High-Income Investor",
       "shortDescription": "High federal-bracket investor (often in a high-tax state) for whom after-tax return is the only return that matters. Heavy use of muni bonds and tax-efficient passive equity.",
       "profile": {
-        "experienceLevel": "Experienced",
         "investmentHorizon": "Long (5-15y)",
         "riskTolerance": "Moderate",
         "primaryGoal": "Tax Optimization",
         "incomeNeed": "Modest",
         "taxSensitivity": "High",
-        "accountTypePreference": "Taxable",
         "typicalInvestor": "Top federal-bracket professional or business owner in a high-tax state (CA, NY, NJ, MA), with a large taxable account where every percent of tax drag compounds."
       },
-      "goalLabels": ["Tax-equivalent yield", "Tax-efficient equity", "State-specific muni exposure"],
       "analysisAngle": "State the marginal tax assumption explicitly (e.g. 37% federal + 13.3% CA = ~46% combined). For muni funds compute tax-equivalent yield (TEY = SEC yield / (1 − marginal rate)) and compare to taxable peers of similar duration / credit quality. Flag distribution character (qualified dividend vs ROC vs ordinary) and surface K-1 reporting wherever it appears. For equity sleeves, prefer low-turnover passive index funds over high-turnover active.",
       "keyConsiderations": [
         "Tax-equivalent yield at the investor's marginal rate vs taxable bond peers.",
@@ -408,7 +481,11 @@
           "fit": "secondary",
           "rationale": "Useful only when the underlying holdings are tax-efficient passive sleeves."
         },
-        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasuries are state-tax exempt — meaningful for high-state-tax investors." },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "Treasuries are state-tax exempt — meaningful for high-state-tax investors."
+        },
         {
           "groupKey": "sector-thematic-equity",
           "fit": "occasional",
@@ -431,11 +508,31 @@
         }
       ],
       "highlightedCategories": [
-        { "category": "Muni National Interm", "group": "muni", "rationale": "Default national tax-exempt sleeve for federal high-bracket investors." },
-        { "category": "Muni National Long", "group": "muni", "rationale": "Higher TEY for investors who can absorb the duration risk." },
-        { "category": "High Yield Muni", "group": "muni", "rationale": "Boosts TEY when the investor accepts credit risk; flag the credit-quality slip." },
-        { "category": "Muni California Long", "group": "muni", "rationale": "Triple-exempt yield for California residents in the top brackets." },
-        { "category": "Muni New York Long", "group": "muni", "rationale": "Triple-exempt yield for New York residents (especially NYC)." },
+        {
+          "category": "Muni National Interm",
+          "group": "muni",
+          "rationale": "Default national tax-exempt sleeve for federal high-bracket investors."
+        },
+        {
+          "category": "Muni National Long",
+          "group": "muni",
+          "rationale": "Higher TEY for investors who can absorb the duration risk."
+        },
+        {
+          "category": "High Yield Muni",
+          "group": "muni",
+          "rationale": "Boosts TEY when the investor accepts credit risk; flag the credit-quality slip."
+        },
+        {
+          "category": "Muni California Long",
+          "group": "muni",
+          "rationale": "Triple-exempt yield for California residents in the top brackets."
+        },
+        {
+          "category": "Muni New York Long",
+          "group": "muni",
+          "rationale": "Triple-exempt yield for New York residents (especially NYC)."
+        },
         {
           "category": "Large Blend",
           "group": "broad-equity",
@@ -463,16 +560,13 @@
       "name": "Income / High-Yield Seeker",
       "shortDescription": "Wants the highest sustainable cash distribution the portfolio can produce, accepting credit risk, derivative complexity, or sector concentration to get there.",
       "profile": {
-        "experienceLevel": "Intermediate",
         "investmentHorizon": "Medium (1-5y)",
         "riskTolerance": "Moderate-High",
         "primaryGoal": "Income Generation",
         "incomeNeed": "High",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Investor whose portfolio purpose is producing monthly or quarterly cash — semi-retired, FIRE, or someone funding a specific spending program — willing to underweight pure capital appreciation in exchange for distributable yield."
       },
-      "goalLabels": ["High yield with moderate or high risk", "Monthly income", "Credit-driven income", "Equity-income tilt"],
       "analysisAngle": "Lead with distribution yield, distribution frequency, and the *sustainability* of the distribution. Decompose the yield into character (qualified dividend / ordinary income / ROC / short-term gain) and the source of return (coupon, option premium, credit spread, REIT FFO). Stress-test distributions against credit drawdowns (2008, 2020, 2022) and option-premium compression in low-vol regimes. A high yield that proved unstable is worse than a lower yield that proved durable.",
       "keyConsiderations": [
         "Trailing 12-month distribution yield AND SEC yield (the gap reveals optical yield).",
@@ -510,7 +604,11 @@
           "fit": "secondary",
           "rationale": "Long bond, corporate bond, and TIPS deliver investment-grade income with manageable credit risk."
         },
-        { "groupKey": "muni", "fit": "secondary", "rationale": "Tax-equivalent yield matters when the investor is in a high bracket." },
+        {
+          "groupKey": "muni",
+          "fit": "secondary",
+          "rationale": "Tax-equivalent yield matters when the investor is in a high bracket."
+        },
         {
           "groupKey": "broad-equity",
           "fit": "occasional",
@@ -528,8 +626,16 @@
         }
       ],
       "highlightedCategories": [
-        { "category": "High Yield Bond", "group": "fixed-income-credit", "rationale": "Core taxable high-yield exposure (HYG / JNK style)." },
-        { "category": "Bank Loan", "group": "fixed-income-credit", "rationale": "Floating-rate income that holds up in rising-rate environments." },
+        {
+          "category": "High Yield Bond",
+          "group": "fixed-income-credit",
+          "rationale": "Core taxable high-yield exposure (HYG / JNK style)."
+        },
+        {
+          "category": "Bank Loan",
+          "group": "fixed-income-credit",
+          "rationale": "Floating-rate income that holds up in rising-rate environments."
+        },
         {
           "category": "Preferred Stock",
           "group": "fixed-income-credit",
@@ -550,9 +656,21 @@
           "group": "alt-strategies",
           "rationale": "Covered-call funds (JEPI / QYLD / SPYI) deliver high monthly distributions from option premium."
         },
-        { "category": "Defined Outcome", "group": "alt-strategies", "rationale": "Buffered structured-payoff funds with defined income and downside profile." },
-        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT income from rents — ordinary income but historically sustainable." },
-        { "category": "Utilities", "group": "sector-thematic-equity", "rationale": "Regulated-utility dividend stream, mostly qualified." },
+        {
+          "category": "Defined Outcome",
+          "group": "alt-strategies",
+          "rationale": "Buffered structured-payoff funds with defined income and downside profile."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REIT income from rents — ordinary income but historically sustainable."
+        },
+        {
+          "category": "Utilities",
+          "group": "sector-thematic-equity",
+          "rationale": "Regulated-utility dividend stream, mostly qualified."
+        },
         {
           "category": "Energy Limited Partnership",
           "group": "sector-thematic-equity",
@@ -563,7 +681,11 @@
           "group": "fixed-income-core",
           "rationale": "Long-duration IG paper for investors who want yield and accept rate risk."
         },
-        { "category": "Corporate Bond", "group": "fixed-income-core", "rationale": "IG corporate income without meaningful credit blow-up risk." }
+        {
+          "category": "Corporate Bond",
+          "group": "fixed-income-core",
+          "rationale": "IG corporate income without meaningful credit blow-up risk."
+        }
       ]
     },
     {
@@ -571,16 +693,13 @@
       "name": "Sector / Thematic Conviction Investor",
       "shortDescription": "Has a directional view on a specific sector, theme, region, or commodity and wants the cleanest expression of that thesis.",
       "profile": {
-        "experienceLevel": "Experienced",
         "investmentHorizon": "Medium (1-5y)",
         "riskTolerance": "High",
         "primaryGoal": "Thematic Exposure",
         "incomeNeed": "None",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Investor who has formed a specific view (AI infrastructure will outperform, India will outgrow EM, gold will benefit from real-rate path) and wants a single ETF that expresses that view rather than picking individual stocks."
       },
-      "goalLabels": ["Sector tilt", "Thematic exposure", "Single-country thematic exposure", "Commodity / real-asset exposure"],
       "analysisAngle": "Focus on theme purity — does the fund actually own the names that match its label? Decompose top holdings, methodology, and how the index defines the theme. Compare against the obvious peers in the same theme (XLK vs VGT vs IYW for tech; KWEB vs MCHI vs FXI for China). Surface concentration, weighting methodology (cap vs equal vs revenue), and rebalancing cadence. Avoid over-weighting historical returns — themes rotate and recent leadership is a poor predictor.",
       "keyConsiderations": [
         "Methodology — what does the index actually screen for, and how strict is the filter?",
@@ -597,7 +716,11 @@
         "AUM under $50M with declining trend (closure risk in a specialty fund is high)."
       ],
       "etfGroupFit": [
-        { "groupKey": "sector-thematic-equity", "fit": "primary", "rationale": "Every category in this group is exactly a sector or thematic expression." },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "primary",
+          "rationale": "Every category in this group is exactly a sector or thematic expression."
+        },
         {
           "groupKey": "alt-strategies",
           "fit": "primary",
@@ -613,32 +736,108 @@
           "fit": "occasional",
           "rationale": "Acceptable only as a short-term tactical expression, never as the long-form thematic holding."
         },
-        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "EM debt and certain credit themes can express a macro view." },
-        { "groupKey": "fixed-income-core", "fit": "occasional", "rationale": "Duration / curve tilts (long government, TIPS) can express macro themes." },
-        { "groupKey": "muni", "fit": "occasional", "rationale": "State-specific muni funds are technically thematic on state-fiscal health." },
-        { "groupKey": "allocation-target-date", "fit": "avoid", "rationale": "Multi-asset blends dilute any single thematic view." }
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "EM debt and certain credit themes can express a macro view."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "occasional",
+          "rationale": "Duration / curve tilts (long government, TIPS) can express macro themes."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "occasional",
+          "rationale": "State-specific muni funds are technically thematic on state-fiscal health."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "avoid",
+          "rationale": "Multi-asset blends dilute any single thematic view."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Technology", "group": "sector-thematic-equity", "rationale": "Cleanest US-tech thematic expression." },
-        { "category": "Health", "group": "sector-thematic-equity", "rationale": "Healthcare sector tilt — defensive growth with distinct regulatory risk." },
-        { "category": "Financial", "group": "sector-thematic-equity", "rationale": "Bank, broker, and insurance tilt — rate- and cycle-sensitive." },
-        { "category": "Equity Energy", "group": "sector-thematic-equity", "rationale": "Equity expression of the energy thesis (vs commodity exposure)." },
-        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT thematic exposure to commercial real estate." },
-        { "category": "Equity Precious Metals", "group": "sector-thematic-equity", "rationale": "Gold-mining equities — leveraged play on the gold price." },
-        { "category": "Infrastructure", "group": "sector-thematic-equity", "rationale": "Listed infrastructure thematic — utilities, pipelines, transport." },
-        { "category": "Equity Digital Assets", "group": "sector-thematic-equity", "rationale": "Equity exposure to crypto-economy companies." },
-        { "category": "China Region", "group": "broad-equity", "rationale": "Single-country China thematic exposure." },
-        { "category": "India Equity", "group": "broad-equity", "rationale": "Single-country India growth thesis." },
-        { "category": "Japan Stock", "group": "broad-equity", "rationale": "Single-country Japan thematic — corporate governance / yen thesis." },
-        { "category": "Latin America Stock", "group": "broad-equity", "rationale": "Regional EM tilt with commodity sensitivity." },
-        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot crypto exposure for direct thematic conviction." },
-        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity thematic plays (gold, silver, oil, ag)." },
+        {
+          "category": "Technology",
+          "group": "sector-thematic-equity",
+          "rationale": "Cleanest US-tech thematic expression."
+        },
+        {
+          "category": "Health",
+          "group": "sector-thematic-equity",
+          "rationale": "Healthcare sector tilt — defensive growth with distinct regulatory risk."
+        },
+        {
+          "category": "Financial",
+          "group": "sector-thematic-equity",
+          "rationale": "Bank, broker, and insurance tilt — rate- and cycle-sensitive."
+        },
+        {
+          "category": "Equity Energy",
+          "group": "sector-thematic-equity",
+          "rationale": "Equity expression of the energy thesis (vs commodity exposure)."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REIT thematic exposure to commercial real estate."
+        },
+        {
+          "category": "Equity Precious Metals",
+          "group": "sector-thematic-equity",
+          "rationale": "Gold-mining equities — leveraged play on the gold price."
+        },
+        {
+          "category": "Infrastructure",
+          "group": "sector-thematic-equity",
+          "rationale": "Listed infrastructure thematic — utilities, pipelines, transport."
+        },
+        {
+          "category": "Equity Digital Assets",
+          "group": "sector-thematic-equity",
+          "rationale": "Equity exposure to crypto-economy companies."
+        },
+        {
+          "category": "China Region",
+          "group": "broad-equity",
+          "rationale": "Single-country China thematic exposure."
+        },
+        {
+          "category": "India Equity",
+          "group": "broad-equity",
+          "rationale": "Single-country India growth thesis."
+        },
+        {
+          "category": "Japan Stock",
+          "group": "broad-equity",
+          "rationale": "Single-country Japan thematic — corporate governance / yen thesis."
+        },
+        {
+          "category": "Latin America Stock",
+          "group": "broad-equity",
+          "rationale": "Regional EM tilt with commodity sensitivity."
+        },
+        {
+          "category": "Digital Assets",
+          "group": "alt-strategies",
+          "rationale": "Spot crypto exposure for direct thematic conviction."
+        },
+        {
+          "category": "Commodities Focused",
+          "group": "alt-strategies",
+          "rationale": "Single-commodity thematic plays (gold, silver, oil, ag)."
+        },
         {
           "category": "Commodities Precious Metals",
           "group": "alt-strategies",
           "rationale": "Direct precious-metals exposure for inflation / debasement views."
         },
-        { "category": "Single Currency", "group": "alt-strategies", "rationale": "Direct FX expression for macro currency views." }
+        {
+          "category": "Single Currency",
+          "group": "alt-strategies",
+          "rationale": "Direct FX expression for macro currency views."
+        }
       ]
     },
     {
@@ -646,16 +845,13 @@
       "name": "Active Trader / Tactical Speculator",
       "shortDescription": "Holds positions for hours to weeks, uses ETFs as expression vehicles for short-term directional or hedging trades. Tolerates structural decay in exchange for liquidity and leverage.",
       "profile": {
-        "experienceLevel": "Experienced",
         "investmentHorizon": "Short (<1y)",
         "riskTolerance": "Very High",
         "primaryGoal": "Speculation / Trading",
         "incomeNeed": "None",
         "taxSensitivity": "Low",
-        "accountTypePreference": "Taxable",
         "typicalInvestor": "Active trader running directional or pairs trades, hedging an existing book, or expressing tactical macro views with daily-leveraged or single-currency / single-commodity products."
       },
-      "goalLabels": ["Short-term tactical exposure", "Leveraged directional bet", "Hedging overlay"],
       "analysisAngle": "Focus on intraday liquidity, bid-ask spread, daily volume, and daily-leverage tracking fidelity. For leveraged products, hammer the holding-period warning: 2-3% all-in annual decay (financing + volatility drag + expense ratio) means these are not buy-and-hold. Address pair-trade construction (TQQQ vs SQQQ, TLT vs TBT) and the impact of overnight gap risk. Tax efficiency is largely irrelevant — short-term gains are short-term gains.",
       "keyConsiderations": [
         "Average daily dollar volume — must support entry/exit at intended size without slippage.",
@@ -687,31 +883,83 @@
           "fit": "secondary",
           "rationale": "Narrow sector ETFs are useful for sector-rotation trades and short-term hedges."
         },
-        { "groupKey": "broad-equity", "fit": "secondary", "rationale": "Single-country / regional funds enable macro-tactical bets on specific economies." },
-        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasury-duration ETFs (TLT, IEF) are standard rate-bet expression vehicles." },
-        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "HY-credit ETFs can express risk-on / risk-off tactical views." },
-        { "groupKey": "muni", "fit": "avoid", "rationale": "Wide bid-ask and slow underlying market make muni ETFs unsuitable for short-term trading." },
-        { "groupKey": "allocation-target-date", "fit": "avoid", "rationale": "Multi-asset blends are too diluted for any tactical thesis." }
+        {
+          "groupKey": "broad-equity",
+          "fit": "secondary",
+          "rationale": "Single-country / regional funds enable macro-tactical bets on specific economies."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "Treasury-duration ETFs (TLT, IEF) are standard rate-bet expression vehicles."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "HY-credit ETFs can express risk-on / risk-off tactical views."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "avoid",
+          "rationale": "Wide bid-ask and slow underlying market make muni ETFs unsuitable for short-term trading."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "avoid",
+          "rationale": "Multi-asset blends are too diluted for any tactical thesis."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Trading--Leveraged Equity", "group": "leveraged-inverse", "rationale": "TQQQ / SPXL — canonical 3x equity tactical long." },
+        {
+          "category": "Trading--Leveraged Equity",
+          "group": "leveraged-inverse",
+          "rationale": "TQQQ / SPXL — canonical 3x equity tactical long."
+        },
         {
           "category": "Trading--Inverse Equity",
           "group": "leveraged-inverse",
           "rationale": "SQQQ / SPXS — canonical short-side equity expression for hedging or directional shorts."
         },
-        { "category": "Trading--Leveraged Debt", "group": "leveraged-inverse", "rationale": "TMF — leveraged long-duration Treasury bet." },
-        { "category": "Trading--Inverse Debt", "group": "leveraged-inverse", "rationale": "TBT / TBF — short long-duration Treasury (rate hike bet)." },
-        { "category": "Trading--Leveraged Commodities", "group": "leveraged-inverse", "rationale": "BOIL / UCO — leveraged commodity trades." },
+        {
+          "category": "Trading--Leveraged Debt",
+          "group": "leveraged-inverse",
+          "rationale": "TMF — leveraged long-duration Treasury bet."
+        },
+        {
+          "category": "Trading--Inverse Debt",
+          "group": "leveraged-inverse",
+          "rationale": "TBT / TBF — short long-duration Treasury (rate hike bet)."
+        },
+        {
+          "category": "Trading--Leveraged Commodities",
+          "group": "leveraged-inverse",
+          "rationale": "BOIL / UCO — leveraged commodity trades."
+        },
         {
           "category": "Multi-Asset Leveraged",
           "group": "leveraged-inverse",
           "rationale": "Risk-parity-style leveraged multi-asset for sophisticated tactical use."
         },
-        { "category": "Single Currency", "group": "alt-strategies", "rationale": "Direct USD / yen / euro expression for macro tactical FX." },
-        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity tactical plays (oil, gas, ag)." },
-        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot crypto for short-term directional bets." },
-        { "category": "Long Government", "group": "fixed-income-core", "rationale": "TLT — the standard tactical duration vehicle without leverage." }
+        {
+          "category": "Single Currency",
+          "group": "alt-strategies",
+          "rationale": "Direct USD / yen / euro expression for macro tactical FX."
+        },
+        {
+          "category": "Commodities Focused",
+          "group": "alt-strategies",
+          "rationale": "Single-commodity tactical plays (oil, gas, ag)."
+        },
+        {
+          "category": "Digital Assets",
+          "group": "alt-strategies",
+          "rationale": "Spot crypto for short-term directional bets."
+        },
+        {
+          "category": "Long Government",
+          "group": "fixed-income-core",
+          "rationale": "TLT — the standard tactical duration vehicle without leverage."
+        }
       ]
     },
     {
@@ -719,16 +967,13 @@
       "name": "All-Weather Diversifier / Risk-Off Hedger",
       "shortDescription": "Cares about portfolio-level outcomes more than any one fund's return. Prioritizes low correlation, drawdown reduction, and risk-adjusted return; allocates to alternatives and balanced sleeves.",
       "profile": {
-        "experienceLevel": "Experienced",
         "investmentHorizon": "Long (5-15y)",
         "riskTolerance": "Moderate",
         "primaryGoal": "Diversification / Hedging",
         "incomeNeed": "Modest",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Sophisticated investor (often someone with finance background or working with an advisor) building a portfolio that holds up across regimes — not just bull markets — and willing to accept lower expected return for shallower drawdowns."
       },
-      "goalLabels": ["Low-correlation diversifier", "Drawdown reduction", "All-weather portfolio sleeve", "Risk-off hedge"],
       "analysisAngle": "Focus on correlation to S&P 500 and to a 60/40 benchmark, drawdown depth in 2008 / 2020 / 2022, and whether the strategy actually delivered its mandate (low correlation, downside protection, uncorrelated returns) — not whether it beat the S&P. Emphasize that the right yardstick for an alt strategy is mandate adherence in stress, not absolute return in a bull market. Address how this fund interacts with a typical equity-heavy portfolio.",
       "keyConsiderations": [
         "Realized correlation to S&P 500 across full cycle and in stress periods.",
@@ -755,33 +1000,73 @@
           "fit": "primary",
           "rationale": "Managed futures, market neutral, long-short, and multistrategy are the canonical low-correlation diversifiers."
         },
-        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasuries and TIPS provide the classic risk-off ballast in a 60/40 portfolio." },
-        { "groupKey": "broad-equity", "fit": "secondary", "rationale": "Foreign and EM equity diversify the US-equity risk concentration." },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "Treasuries and TIPS provide the classic risk-off ballast in a 60/40 portfolio."
+        },
+        {
+          "groupKey": "broad-equity",
+          "fit": "secondary",
+          "rationale": "Foreign and EM equity diversify the US-equity risk concentration."
+        },
         {
           "groupKey": "sector-thematic-equity",
           "fit": "occasional",
           "rationale": "Real estate, gold-mining, and infrastructure can serve as thematic diversifiers but carry sector risk."
         },
-        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "Credit correlates with equity in stress — limited diversification value." },
-        { "groupKey": "muni", "fit": "occasional", "rationale": "Useful when the diversifier need is also tax-efficient." },
-        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Volatility decay makes these unsuitable as portfolio diversifiers." }
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Credit correlates with equity in stress — limited diversification value."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "occasional",
+          "rationale": "Useful when the diversifier need is also tax-efficient."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Volatility decay makes these unsuitable as portfolio diversifiers."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Tactical Allocation", "group": "allocation-target-date", "rationale": "Active multi-asset that tilts across regimes." },
-        { "category": "Moderate Allocation", "group": "allocation-target-date", "rationale": "Static 60/40-style blend as a single-ticker portfolio." },
+        {
+          "category": "Tactical Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Active multi-asset that tilts across regimes."
+        },
+        {
+          "category": "Moderate Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Static 60/40-style blend as a single-ticker portfolio."
+        },
         {
           "category": "Global Moderate Allocation",
           "group": "allocation-target-date",
           "rationale": "Globally diversified balanced blend reducing US-equity concentration."
         },
-        { "category": "Global Allocation", "group": "allocation-target-date", "rationale": "Flexible cross-asset, cross-region single-ticker allocation." },
+        {
+          "category": "Global Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Flexible cross-asset, cross-region single-ticker allocation."
+        },
         {
           "category": "Systematic Trend",
           "group": "alt-strategies",
           "rationale": "Managed-futures trend-following — historically uncorrelated and positive in 2008 / 2022."
         },
-        { "category": "Equity Market Neutral", "group": "alt-strategies", "rationale": "Long/short construction targeting near-zero net market exposure." },
-        { "category": "Long-Short Equity", "group": "alt-strategies", "rationale": "Reduces beta vs long-only equity while retaining stock-selection alpha." },
+        {
+          "category": "Equity Market Neutral",
+          "group": "alt-strategies",
+          "rationale": "Long/short construction targeting near-zero net market exposure."
+        },
+        {
+          "category": "Long-Short Equity",
+          "group": "alt-strategies",
+          "rationale": "Reduces beta vs long-only equity while retaining stock-selection alpha."
+        },
         {
           "category": "Multistrategy",
           "group": "alt-strategies",
@@ -802,8 +1087,16 @@
           "group": "fixed-income-core",
           "rationale": "TIPS hedge inflation regimes that hurt nominal bonds and growth equity."
         },
-        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Developed-ex-US diversifies US-equity concentration." },
-        { "category": "Diversified Emerging Mkts", "group": "broad-equity", "rationale": "EM equity diversifies developed-market regime risk." }
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Developed-ex-US diversifies US-equity concentration."
+        },
+        {
+          "category": "Diversified Emerging Mkts",
+          "group": "broad-equity",
+          "rationale": "EM equity diversifies developed-market regime risk."
+        }
       ]
     },
     {
@@ -811,16 +1104,13 @@
       "name": "Inflation & Real-Asset Hedger",
       "shortDescription": "Worried about CPI / debasement / cost-of-living erosion of purchasing power. Allocates to commodities, real estate, infrastructure, energy equities, gold, and TIPS.",
       "profile": {
-        "experienceLevel": "Intermediate",
         "investmentHorizon": "Long (5-15y)",
         "riskTolerance": "Moderate-High",
         "primaryGoal": "Diversification / Hedging",
         "incomeNeed": "Modest",
         "taxSensitivity": "Moderate",
-        "accountTypePreference": "Either",
         "typicalInvestor": "Investor explicitly worried about inflation regimes (post-2021 type), sustained debasement, or cost-of-living erosion of the bond and growth-equity portion of their portfolio."
       },
-      "goalLabels": ["Inflation hedge", "Real-asset exposure", "Commodity / real-estate tilt", "Debasement hedge"],
       "analysisAngle": "Focus on real-return correlation and inflation beta. Distinguish *direct* inflation hedges (commodities, TIPS, gold) from *equity-style* real-asset proxies (REITs, infrastructure, energy equities, MLPs) — the equity proxies have meaningful equity-market beta and are imperfect hedges in pure inflation shocks. Address regime sensitivity: gold and commodities perform very differently across stagflation, demand-pull, and rate-hike inflation. Surface tax / K-1 complications for commodity pools and MLPs.",
       "keyConsiderations": [
         "Direct vs proxy inflation exposure — physical commodities vs producer equities have different betas.",
@@ -847,40 +1137,88 @@
           "fit": "primary",
           "rationale": "Real estate, natural resources, infrastructure, energy, and MLPs are the equity-style real-asset proxies."
         },
-        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "TIPS and short-term TIPS are the direct inflation-linked Treasury hedge." },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "TIPS and short-term TIPS are the direct inflation-linked Treasury hedge."
+        },
         {
           "groupKey": "broad-equity",
           "fit": "occasional",
           "rationale": "Value tilt and EM equity historically perform better than growth in inflation regimes."
         },
-        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "Bank loans (floating rate) can hold up in rising-rate inflation regimes." },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Bank loans (floating rate) can hold up in rising-rate inflation regimes."
+        },
         {
           "groupKey": "allocation-target-date",
           "fit": "occasional",
           "rationale": "Most allocation funds underweight real assets; check the actual inflation hedge sleeve."
         },
-        { "groupKey": "muni", "fit": "avoid", "rationale": "Long-duration nominal munis lose to inflation; not a hedge." },
-        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Decay structure makes these unsuitable for a multi-year inflation hedge." }
+        {
+          "groupKey": "muni",
+          "fit": "avoid",
+          "rationale": "Long-duration nominal munis lose to inflation; not a hedge."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Decay structure makes these unsuitable for a multi-year inflation hedge."
+        }
       ],
       "highlightedCategories": [
-        { "category": "Commodities Broad Basket", "group": "alt-strategies", "rationale": "Diversified commodity exposure — the direct inflation hedge." },
-        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity exposure for specific supply / demand views." },
-        { "category": "Commodities Precious Metals", "group": "alt-strategies", "rationale": "Direct gold / silver exposure — the classic debasement hedge." },
+        {
+          "category": "Commodities Broad Basket",
+          "group": "alt-strategies",
+          "rationale": "Diversified commodity exposure — the direct inflation hedge."
+        },
+        {
+          "category": "Commodities Focused",
+          "group": "alt-strategies",
+          "rationale": "Single-commodity exposure for specific supply / demand views."
+        },
+        {
+          "category": "Commodities Precious Metals",
+          "group": "alt-strategies",
+          "rationale": "Direct gold / silver exposure — the classic debasement hedge."
+        },
         {
           "category": "Digital Assets",
           "group": "alt-strategies",
           "rationale": "Bitcoin as the modern debasement hedge for investors who accept the volatility."
         },
-        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT income inflation pass-through, with equity-market beta caveat." },
-        { "category": "Global Real Estate", "group": "sector-thematic-equity", "rationale": "Diversifies single-country property regulatory risk." },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REIT income inflation pass-through, with equity-market beta caveat."
+        },
+        {
+          "category": "Global Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "Diversifies single-country property regulatory risk."
+        },
         {
           "category": "Natural Resources",
           "group": "sector-thematic-equity",
           "rationale": "Diversified resource-equity exposure (mining, energy, agriculture)."
         },
-        { "category": "Equity Energy", "group": "sector-thematic-equity", "rationale": "Energy-equity tilt for oil-price inflation regimes." },
-        { "category": "Equity Precious Metals", "group": "sector-thematic-equity", "rationale": "Gold-miner equity leverage to the gold price." },
-        { "category": "Infrastructure", "group": "sector-thematic-equity", "rationale": "Listed infrastructure with regulated inflation pass-through." },
+        {
+          "category": "Equity Energy",
+          "group": "sector-thematic-equity",
+          "rationale": "Energy-equity tilt for oil-price inflation regimes."
+        },
+        {
+          "category": "Equity Precious Metals",
+          "group": "sector-thematic-equity",
+          "rationale": "Gold-miner equity leverage to the gold price."
+        },
+        {
+          "category": "Infrastructure",
+          "group": "sector-thematic-equity",
+          "rationale": "Listed infrastructure with regulated inflation pass-through."
+        },
         {
           "category": "Energy Limited Partnership",
           "group": "sector-thematic-equity",
@@ -895,6 +1233,551 @@
           "category": "Short-Term Inflation-Protected Bond",
           "group": "fixed-income-core",
           "rationale": "TIPS without long-duration real-rate risk — purer near-term inflation hedge."
+        }
+      ]
+    },
+    {
+      "key": "high-net-worth-individual",
+      "name": "High-Net-Worth Individual / Family Office",
+      "shortDescription": "Wealthy individual or single-family office investing $5M-$500M+ across asset classes — uses ETFs for tax-efficient beta, satellite exposures, and overlays alongside private investments.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "High",
+        "typicalInvestor": "HNW individual ($5M-$50M investable), single-family office ($50M-$500M+), or multi-family office client. Already holds direct stocks, private equity, real estate, and may use a CIO or external advisor; uses ETFs for the public-market beta sleeve while alternatives carry the alpha mandate."
+      },
+      "analysisAngle": "Tax efficiency at the marginal rate (top federal + state + NIIT) is paramount — tax-loss harvesting, lot-level optimization, and avoidance of cap-gain distributions matter as much as gross return. Frame ETFs as the efficient-beta or thematic-tilt sleeve in a portfolio whose alpha mandate sits in privates. At >$1M position sizes, direct indexing often beats an index ETF for tax-loss harvesting, so the ETF must justify its wrapper. Currency hedging, concentrated-stock diversification overlays, and access to alternatives (commodities, gold, defined outcome) are common use cases.",
+      "keyConsiderations": [
+        "After-tax return at the top federal + state + NIIT bracket, not headline yield/return.",
+        "Capital-gain distribution history (passive ETFs near zero; active and thematic can surprise).",
+        "Tax-loss harvesting partner pairs (e.g., VTI ↔ ITOT, IEFA ↔ VEA) to allow wash-sale-safe swaps.",
+        "Direct-indexing breakeven — does the ETF still win after harvesting potential is considered?",
+        "Wrapper cost stacking when held inside a SMA / UMA — fee on top of fee."
+      ],
+      "redFlags": [
+        "Material recent capital-gain distributions in a passive-style fund.",
+        "K-1 reporting (commodity pools, MLPs) without an offsetting alpha or hedging benefit.",
+        "Distribution character largely ROC or short-term gain without disclosure.",
+        "ETF that is strictly worse than direct indexing for a $1M+ position with harvesting needs."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Tax-efficient passive beta — large-blend, foreign-blend, EM as the public-equity core."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "primary",
+          "rationale": "State-specific and national muni for the taxable fixed-income sleeve at top brackets."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "Thematic tilts (real estate, infrastructure, healthcare) as satellites around the core."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Defined outcome, derivative income, gold, and commodities provide diversification and downside structure."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Preferred and EM debt as small income sleeves; muni usually wins after-tax."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "occasional",
+          "rationale": "Use only inside tax-deferred accounts; muni dominates in taxable."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "occasional",
+          "rationale": "Rare — HNW investors typically construct their own asset allocation rather than use packaged glide paths."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Short-term capital gains taxed at marginal rate; structurally bad for after-tax wealth."
+        }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "Tax-efficient US large-cap core for the public-equity sleeve (VOO, VTI, ITOT)."
+        },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Developed-international exposure with foreign-tax-credit pickup in taxable accounts."
+        },
+        {
+          "category": "Muni California Long",
+          "group": "muni",
+          "rationale": "Triple-tax-free for high-bracket California-resident HNWs."
+        },
+        {
+          "category": "Muni New York Long",
+          "group": "muni",
+          "rationale": "State-tax exemption stack for NY residents in top brackets."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REIT income and inflation-hedge as a portfolio satellite."
+        },
+        {
+          "category": "Defined Outcome",
+          "group": "alt-strategies",
+          "rationale": "Buffered-equity structures for concentrated-position diversification with downside protection."
+        },
+        {
+          "category": "Equity Precious Metals",
+          "group": "sector-thematic-equity",
+          "rationale": "Gold-mining equity as a tactical real-asset sleeve."
+        }
+      ]
+    },
+    {
+      "key": "pension-endowment-foundation",
+      "name": "Pension Fund / Endowment / Foundation (incl. Union Pensions)",
+      "shortDescription": "Long-horizon institutional pool — corporate or public pension, Taft-Hartley / union pension, university endowment, charitable foundation — governed by an Investment Policy Statement with defined liabilities or spending mandates.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Low",
+        "typicalInvestor": "Defined-benefit corporate or public pension plan, Taft-Hartley union pension, university endowment ($500M-$50B+), private foundation, or sovereign wealth fund. Tax-exempt; constrained by an IPS that often includes ESG / SRI / labor-friendly screens; focused on long-term funded ratio (pensions) or sustainable spending policy ~5% (endowments/foundations)."
+      },
+      "analysisAngle": "Liability-driven investing (LDI) for pensions — duration matching matters more than nominal yield. For endowments and foundations, the spending policy is the binding constraint: distribute ~5% per year while preserving real capital across generations. ETFs are typically the liquid-beta sleeve (US equity, international, EM, treasuries, TIPS) and the liquidity buffer alongside illiquid private allocations (PE, real assets, hedge funds). Discuss IPS fit, governance overhead, and securities-lending revenue potential. Avoid retail-style fee commentary — institutional share classes, separate accounts, and rebates change the math; what matters is total cost-to-strategy and capacity.",
+      "keyConsiderations": [
+        "AUM and securities-lending revenue potential — institutional pools earn back basis points.",
+        "Tracking quality and benchmark fidelity for IPS-mandated benchmarks.",
+        "Liability-matching duration profile (pensions) or spending-policy support (endowments/foundations).",
+        "ESG / SRI / Taft-Hartley screen compatibility if the IPS requires it.",
+        "Capacity — can the fund absorb a $50-500M allocation without market impact or becoming a dominant holder?"
+      ],
+      "redFlags": [
+        "Fund too small for institutional-scale allocation without becoming a dominant holder.",
+        "Methodology drift that breaks IPS benchmark consistency over multiple years.",
+        "ESG-labeled funds with weak or self-graded underlying screens (greenwashing risk for foundations).",
+        "Concentration / closure risk from a single large investor's outflow."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Cap-weighted US, international, and EM index ETFs for the equity-beta sleeve."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "primary",
+          "rationale": "Long treasuries and TIPS for liability-matching duration; intermediate core for general fixed-income beta."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Managed futures, market-neutral, and commodities as overlays — often preferred via SMA but ETF wrappers are used for liquidity sleeves."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "Real estate, infrastructure, and natural resources as inflation-hedge and real-asset sleeves."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "secondary",
+          "rationale": "High-yield, EM debt, and bank loans as a return-seeking credit sleeve when the IPS allows."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "occasional",
+          "rationale": "Rare — institutions construct their own glide path; target-date funds appear only inside DC plan menus offered to participants."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "avoid",
+          "rationale": "Tax-exempt status erases the muni advantage; taxable bonds with higher pre-tax yield dominate."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "IPS guidelines almost universally prohibit daily-reset leveraged products."
+        }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "Standard US-equity beta benchmark exposure (S&P 500 / total-market)."
+        },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Developed-international beta for the policy benchmark mix."
+        },
+        {
+          "category": "Diversified Emerging Mkts",
+          "group": "broad-equity",
+          "rationale": "EM equity sleeve typical in institutional policy mixes."
+        },
+        {
+          "category": "Long Government",
+          "group": "fixed-income-core",
+          "rationale": "Long treasuries are the standard LDI duration-matching instrument for pensions."
+        },
+        {
+          "category": "Inflation-Protected Bond",
+          "group": "fixed-income-core",
+          "rationale": "TIPS for real-liability matching and real-return mandates."
+        },
+        {
+          "category": "Intermediate Core Bond",
+          "group": "fixed-income-core",
+          "rationale": "Aggregate-index core fixed-income beta for the policy mix."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "Liquid REIT sleeve as a complement to direct private real-estate holdings."
+        },
+        {
+          "category": "Systematic Trend",
+          "group": "alt-strategies",
+          "rationale": "Managed-futures trend overlay used as a crisis-alpha diversifier."
+        }
+      ]
+    },
+    {
+      "key": "financial-advisor-ria",
+      "name": "Financial Advisor / RIA Building Client Portfolios",
+      "shortDescription": "Registered Investment Advisor or financial planner constructing model portfolios across many clients — selects ETFs as building blocks for risk-tier models rather than as standalone positions.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Independent RIA, fee-only financial planner, or wirehouse advisor managing $50M-$5B in client AUM across model portfolios. Builds 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalances quarterly, and answers to clients across the wealth spectrum."
+      },
+      "analysisAngle": "Selection logic optimizes for use as a model-portfolio building block, not a standalone hero position. Focus on: TAMP / model-portfolio platform availability (Schwab, Fidelity, Pershing, Envestnet), bid-ask tightness (block trades across hundreds of accounts amplify spread cost), tax-lot fungibility for client-level tax-loss harvesting (e.g., VTI ↔ ITOT pairs), and clean fact-sheet documentation for client meetings. The advisor's own AUM fee sits on top of the ETF fee, so the all-in cost story is what the end client sees and judges. Issuer relationships, rep support, and analyst coverage matter for due-diligence defensibility.",
+      "keyConsiderations": [
+        "Fact-sheet clarity for client-meeting presentation and due-diligence files.",
+        "Bid-ask tightness amplified across hundreds of client accounts.",
+        "Compatibility with major TAMP / custody platforms and model-portfolio software.",
+        "Tax-loss harvesting partner pairs (VTI ↔ ITOT, SPY ↔ IVV ↔ VOO, IEFA ↔ VEA).",
+        "Issuer relationship and wholesaler support for ongoing due diligence."
+      ],
+      "redFlags": [
+        "Wide bid-ask amplified across many client accounts becomes real client-level slippage.",
+        "Niche issuer with no analyst coverage or rep relationship — hard to defend in due diligence.",
+        "Active strategy that complicates the simple 'we use low-cost passive' value-prop.",
+        "Closure risk that would force a cross-account taxable transition for hundreds of clients."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Diversified equity index ETFs are the workhorse building block of every risk-tier model."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "primary",
+          "rationale": "Investment-grade core, short-term, and TIPS form the bond sleeve of every model."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "REITs and select sector tilts as model satellites."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "secondary",
+          "rationale": "Used for high-bracket client sub-models holding in taxable accounts."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "secondary",
+          "rationale": "Multisector and preferred sleeves to add yield in income-tilted models."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Managed futures and market-neutral as small uncorrelated sleeves; derivative income for retiree models."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "occasional",
+          "rationale": "Advisors usually construct their own allocation rather than outsource it to a target-date fund."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Daily-reset products do not belong in a long-term advisory model portfolio."
+        }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "Core US-equity building block — VTI / ITOT / SPY / IVV / VOO are the standard model picks."
+        },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Developed-international building block (VEA, IEFA, IXUS)."
+        },
+        {
+          "category": "Diversified Emerging Mkts",
+          "group": "broad-equity",
+          "rationale": "EM equity sleeve for growth-tier models."
+        },
+        {
+          "category": "Intermediate Core Bond",
+          "group": "fixed-income-core",
+          "rationale": "Standard bond building block (AGG, BND)."
+        },
+        {
+          "category": "Short-Term Bond",
+          "group": "fixed-income-core",
+          "rationale": "Lower-duration bond sleeve for conservative-tier models."
+        },
+        {
+          "category": "Muni National Interm",
+          "group": "muni",
+          "rationale": "Default muni building block for high-bracket client sub-models."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REIT satellite found in most diversified models."
+        },
+        {
+          "category": "Derivative Income",
+          "group": "alt-strategies",
+          "rationale": "Covered-call income for retiree-tier income models (JEPI, JEPQ-style)."
+        }
+      ]
+    },
+    {
+      "key": "institutional-trading-desk",
+      "name": "Institutional Trading Desk / Hedge Fund / Asset Manager",
+      "shortDescription": "Professional trading desk using ETFs as efficient wrappers for short-term beta, hedging, basket trades, transition management, or pair trades.",
+      "profile": {
+        "investmentHorizon": "Short (<1y)",
+        "riskTolerance": "Very High",
+        "primaryGoal": "Speculation / Trading",
+        "incomeNeed": "None",
+        "taxSensitivity": "Low",
+        "typicalInvestor": "Hedge fund PM (long-short, macro, multi-strategy), proprietary trading desk, mutual fund manager doing transition management, or fund-of-funds allocator. Holds ETFs for hours to weeks, often with options overlays; pass-through tax structure means short-term gains aren't a concern."
+      },
+      "analysisAngle": "ETFs are wrappers — judged purely on cleanliness of exposure, liquidity, and shortable inventory. Focus on: bid-ask in bps, average daily dollar volume in $hundreds of millions, options-market liquidity (open interest, IV surface tightness), securities-borrow availability and cost for short positions, and creation-redemption efficiency for AP arbitrage. Tax considerations are minimal. For sector / single-country / leveraged products, the question is implementation efficiency vs the alternative (futures, swaps, baskets of underlyings).",
+      "keyConsiderations": [
+        "Average daily dollar volume in $hundreds of millions — supports block trades without slippage.",
+        "Options-market depth and IV surface tightness for hedging overlays.",
+        "Securities-borrow availability and cost for short positions.",
+        "Creation/redemption baskets and AP friction during stress windows.",
+        "Premium/discount drift in stress windows (March 2020, Oct 2022)."
+      ],
+      "redFlags": [
+        "Options market thin or non-existent — no efficient hedging path.",
+        "High borrow cost or limited shortable supply for short-side strategies.",
+        "Wide premium/discount during normal conditions (AP friction or low primary-market activity).",
+        "AUM small enough that a normal block trade visibly moves the price."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "S&P 500, NDX, Russell 2000 wrappers (SPY, QQQ, IWM) are the standard equity-beta vehicles for desks."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "primary",
+          "rationale": "Sector ETFs (XLK, XLE, XLF) are the standard relative-value pair-trade vehicles."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "secondary",
+          "rationale": "Daily-leveraged and inverse products for tactical hedging and short-term directional bets."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Single-currency, commodities, and digital-asset ETFs for macro directional bets."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "secondary",
+          "rationale": "HYG / JNK / LQD as standard credit-spread expression vehicles."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "TLT / IEF / SHY for rate / duration tactical bets and curve trades."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "avoid",
+          "rationale": "Diversified retail-targeted vehicles with no trading utility."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "avoid",
+          "rationale": "OTC-underlying friction and limited options market make munis unsuitable for trading desks."
+        }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "SPY / IVV / VOO — the deepest ETF-options markets and primary beta-expression vehicles."
+        },
+        {
+          "category": "Trading--Leveraged Equity",
+          "group": "leveraged-inverse",
+          "rationale": "TQQQ, SOXL for short-term leveraged directional bets."
+        },
+        {
+          "category": "Trading--Inverse Equity",
+          "group": "leveraged-inverse",
+          "rationale": "SQQQ, SH for short-term inverse hedges or directional shorts."
+        },
+        {
+          "category": "Technology",
+          "group": "sector-thematic-equity",
+          "rationale": "XLK / VGT for sector relative-value pair trades."
+        },
+        {
+          "category": "Equity Energy",
+          "group": "sector-thematic-equity",
+          "rationale": "XLE for energy sector pair trades and macro commodity bets."
+        },
+        {
+          "category": "High Yield Bond",
+          "group": "fixed-income-credit",
+          "rationale": "HYG / JNK as the standard credit-spread expression instrument."
+        },
+        {
+          "category": "Long Government",
+          "group": "fixed-income-core",
+          "rationale": "TLT for rate / duration tactical bets and curve trades."
+        },
+        {
+          "category": "Single Currency",
+          "group": "alt-strategies",
+          "rationale": "Single-currency ETFs for macro FX directional bets."
+        }
+      ]
+    },
+    {
+      "key": "insurance-corporate-treasury",
+      "name": "Insurance General Account / Corporate Treasury",
+      "shortDescription": "Regulated balance-sheet investor with strict capital-preservation and liability-matching constraints — uses ETFs sparingly for liquid investment-grade fixed-income exposure inside policy limits.",
+      "profile": {
+        "investmentHorizon": "Medium (1-5y)",
+        "riskTolerance": "Low",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Insurance company general account (life or P&C), bank treasury, or large-corporate operating-cash treasury team. Constrained by NAIC ratings (insurers), Basel / HQLA / regulatory capital (banks), or board-approved investment policy (corporates) — usually limited to investment-grade short-duration."
+      },
+      "analysisAngle": "Regulatory constraints dominate every decision — for insurers, NAIC ratings drive risk-based capital charges; for banks, HQLA classification and Basel III constraints apply; for corporate treasuries, the policy almost always limits to investment-grade short-duration. ETFs are used sparingly because the underlying bond ratings flow through to the holder for many regulatory frameworks, and look-through treatment varies. Focus on: underlying credit quality (95%+ IG), duration ≤ 3 years for treasury use, NAIC / Basel look-through treatment, and AUM/liquidity for unwinding without slippage. Do NOT discuss yield-pickup strategies — these holders are constrained from chasing yield and will reject the analysis if it ignores their guardrails.",
+      "keyConsiderations": [
+        "Underlying credit quality (95%+ investment grade for most policies).",
+        "Duration profile compatible with the policy (often ≤ 3 years for operating treasury).",
+        "NAIC / Basel / look-through treatment of the wrapper for capital-charge calculation.",
+        "AUM and bid-ask depth sized for the mandate (often $50-500M positions).",
+        "Distribution mechanics — monthly cash flow for treasury, accrual treatment for accounting."
+      ],
+      "redFlags": [
+        "Any sub-investment-grade exposure inside the wrapper — immediate policy violation for many holders.",
+        "Long duration exposure incompatible with operating-cash mandate.",
+        "Unclear regulatory look-through treatment — risk team can't approve.",
+        "Thin liquidity that would force NAV-discount selling under outflow stress."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "primary",
+          "rationale": "Treasuries, ultrashort, short-term IG corporate, and IG core are the entire usable universe for most policies."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "secondary",
+          "rationale": "Insurance general accounts can use muni for after-tax yield where the policy permits."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "avoid",
+          "rationale": "High-yield, EM debt, preferred, and bank-loan products are typically prohibited by IG-only policies."
+        },
+        {
+          "groupKey": "broad-equity",
+          "fit": "avoid",
+          "rationale": "Most insurance / treasury policies prohibit equity exposure inside the operating account."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "avoid",
+          "rationale": "Equity exposure of any kind is typically prohibited."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "avoid",
+          "rationale": "Strategy complexity and capital-charge uncertainty rule these out."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "avoid",
+          "rationale": "Embedded equity exposure violates IG-only mandates."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Derivative-driven structures with capital-charge uncertainty — disallowed almost universally."
+        }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Ultrashort Bond",
+          "group": "fixed-income-core",
+          "rationale": "Operating-cash management — ICSH, JPST, GSY for sub-1-year duration."
+        },
+        {
+          "category": "Short-Term Bond",
+          "group": "fixed-income-core",
+          "rationale": "1-3 year IG corporate / treasury exposure for treasury sleeves."
+        },
+        {
+          "category": "Short Government",
+          "group": "fixed-income-core",
+          "rationale": "Short-duration treasury exposure (SHY) — HQLA-eligible for bank treasuries."
+        },
+        {
+          "category": "Intermediate Government",
+          "group": "fixed-income-core",
+          "rationale": "Treasury IEF for slightly longer-duration insurance general-account use."
+        },
+        {
+          "category": "Corporate Bond",
+          "group": "fixed-income-core",
+          "rationale": "IG corporate exposure (LQD) for general-account yield pickup over treasuries."
+        },
+        {
+          "category": "Money Market-Taxable",
+          "group": "fixed-income-core",
+          "rationale": "Money-market wrappers for the most conservative cash sleeves."
+        },
+        {
+          "category": "Muni National Short",
+          "group": "muni",
+          "rationale": "Short-duration muni for after-tax yield where policy permits."
         }
       ]
     }

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,5 +1,5 @@
 {
-  "description": "ETF investor taxonomy used to write ETF analyses from the perspective of who the potential investors are. Two-level structure: top level is investor type (EtfInvestor — name, shortDescription, etfInvestorGoals[]); second level is goals an investor of that type pursues when buying ETFs (each goal has profile, analysisAngle, keyConsiderations, redFlags). 6 investor types: retail individual, HNW / family office, pension / endowment / foundation / sovereign, insurance / bank / corporate treasury, financial advisor / RIA / wealth manager, hedge fund / asset manager / trading desk. Types are intentionally non-overlapping (each defined by a distinct funding source / governance / regulatory context). Goals can recur across types (e.g., inflation hedge appears in retail, HNW, and pension) but each instance is framed for that type's specific perspective. Conforms to EtfInvestorTaxonomyConfig in src/types/etf/etf-analysis-types.ts.",
+  "description": "ETF investor taxonomy used to write ETF analyses from the perspective of who the potential investors are. Two-level structure: top level is investor type (EtfInvestor — name, shortDescription, etfInvestorGoals[]); second level is goals an investor of that type pursues when buying ETFs (each goal has profile, analysisAngle, keyConsiderations, redFlags). 6 investor types — retail individual, HNW / family office, pension / endowment / foundation / sovereign, insurance / bank / corporate treasury, financial advisor / RIA / wealth manager, hedge fund / asset manager / trading desk — intentionally non-overlapping (each defined by a distinct funding source / governance / regulatory context). Goals are limited to realistic, commonly seen ETF use-cases for each type; goals can recur across types (e.g., real-asset hedge appears in retail-via-ETFs, HNW overlay, and pension/endowment) but each instance is framed for that type's specific perspective. Conforms to EtfInvestorTaxonomyConfig in src/types/etf/etf-analysis-types.ts.",
   "investors": [
     {
       "key": "retail-individual",
@@ -139,33 +139,6 @@
           ]
         },
         {
-          "key": "after-tax-optimization-retail",
-          "name": "After-Tax Optimization at Top Retail Bracket",
-          "shortDescription": "High-earner W-2 investor in a top federal (and often state) bracket with significant taxable-account holdings — needs ETFs that minimize taxable distributions and maximize after-tax compounding.",
-          "profile": {
-            "investmentHorizon": "Long (5-15y)",
-            "riskTolerance": "Moderate",
-            "primaryGoal": "Tax Optimization",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "High",
-            "typicalInvestor": "High earner in 30s-60s in the top federal bracket and often a high-tax state (CA, NY, NJ, MA), with significant taxable-account holdings beyond what tax-advantaged accounts can shelter."
-          },
-          "analysisAngle": "After-tax return at the marginal rate is the only return that matters. Always compute tax-equivalent yield for muni comparisons (32% federal baseline; note state-tax benefits for in-state munis). Penalize high-turnover funds, K-1 reporting, and ROC-heavy distributions in taxable contexts. Favor passive index funds with low capital-gain distribution history.",
-          "keyConsiderations": [
-            "Tax-equivalent yield at the investor's marginal bracket.",
-            "Capital-gain distribution history in passive vs active products.",
-            "Distribution character (qualified, ordinary, ROC, K-1).",
-            "State-tax exemption for in-state muni holdings.",
-            "AMT exposure for private-activity-bond muni funds."
-          ],
-          "redFlags": [
-            "K-1 tax reporting (commodity pools, MLPs) without an offsetting benefit.",
-            "Material recent capital-gain distributions in a passive-style fund.",
-            "Headline yield largely composed of short-term gain or undisclosed ROC.",
-            "High-yield muni exposure that the fund label doesn't make obvious."
-          ]
-        },
-        {
           "key": "high-current-yield-income",
           "name": "High Current Yield Income",
           "shortDescription": "Investor prioritizing current cash flow — willing to accept credit risk and complexity in exchange for above-market yield from credit, preferred, or derivative-income wrappers.",
@@ -220,32 +193,6 @@
           ]
         },
         {
-          "key": "inflation-real-asset-hedge",
-          "name": "Inflation & Real-Asset Hedge",
-          "shortDescription": "Investor concerned about inflation, currency debasement, or rising costs of living — using real assets (commodities, gold, real estate, infrastructure) and inflation-linked instruments (TIPS) to preserve purchasing power.",
-          "profile": {
-            "investmentHorizon": "Long (5-15y)",
-            "riskTolerance": "Moderate-High",
-            "primaryGoal": "Capital Preservation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "Moderate",
-            "typicalInvestor": "Investor of any age worried about CPI / monetary debasement / cost-of-living risk who allocates a meaningful sleeve to real assets and inflation-linked instruments rather than only nominal stocks and bonds."
-          },
-          "analysisAngle": "The test is real-return correlation across inflation regimes — TIPS hedge measured CPI directly, gold and commodities hedge different inflation drivers, real estate and infrastructure provide pricing power. Discuss the tradeoff: pure real-asset funds underperform in disinflation, so sizing matters. Watch for funds that LABEL as inflation-hedging but historically tracked equities.",
-          "keyConsiderations": [
-            "Real-return correlation in measured inflation regimes.",
-            "Composition tradeoff (commodities vs equity-heavy real assets vs TIPS).",
-            "Single-commodity concentration risk.",
-            "K-1 vs 1099 tax structure for commodity pools.",
-            "Behavior in disinflationary periods (drawdown if inflation rolls over)."
-          ],
-          "redFlags": [
-            "Commodity exposure delivered via equity proxies that track stocks more than spot.",
-            "K-1 reporting without offsetting yield or hedging benefit.",
-            "Fund labeled 'inflation hedge' with high beta to the equity market."
-          ]
-        },
-        {
           "key": "esg-impact-alignment",
           "name": "ESG / SRI / Impact Alignment",
           "shortDescription": "Investor whose primary selection criterion is ESG, sustainability, or mission alignment — willing to accept some return or fee tradeoff in exchange for a portfolio that matches their values.",
@@ -269,6 +216,32 @@
             "Self-graded ESG screens with weak or vague criteria (greenwashing risk).",
             "Holdings that contradict the fund's stated ESG mission.",
             "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ]
+        },
+        {
+          "key": "retail-leveraged-or-active-trading",
+          "name": "Leveraged or Active Trading (Retail)",
+          "shortDescription": "Self-directed retail trader using leveraged (TQQQ, SOXL, FAS), inverse (SQQQ, SH), or active sector ETFs for short-horizon directional bets — typically days to weeks.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Self-directed retail trader using a brokerage app (Robinhood, Fidelity, Schwab) for short-term directional bets — comfortable with daily-leveraged products and inverse ETFs, often holding for days to a few weeks."
+          },
+          "analysisAngle": "Path-dependency decay is the central warning — leveraged products are unsuitable for any multi-week hold regardless of how cheap the sticker fee. Discuss bid-ask, daily-leverage fidelity, embedded swap-financing cost on top of the headline expense ratio, and the documented decay over multi-week holds. Reinforce explicitly: these are trading vehicles, not buy-and-hold.",
+          "keyConsiderations": [
+            "Daily-leverage fidelity (does 3x deliver 3x intraday?).",
+            "Bid-ask spread for retail-block trades.",
+            "All-in cost (expense ratio + embedded swap-financing).",
+            "Documented decay over multi-week holds (volatility drag).",
+            "Options market for hedging the position."
+          ],
+          "redFlags": [
+            "Marketing or fund material that downplays daily-reset risk.",
+            "Headline expense ratio above leveraged-peer norms.",
+            "Wide bid-ask combined with thin volume."
           ]
         }
       ]
@@ -383,31 +356,6 @@
           ]
         },
         {
-          "key": "foreign-tax-credit-international",
-          "name": "Foreign-Tax-Credit Pickup on International",
-          "shortDescription": "International equity exposure held in taxable accounts to capture the foreign-tax credit — typically worth ~30-50 bp of after-tax pickup vs holding in tax-deferred.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Moderate-High",
-            "primaryGoal": "Tax Optimization",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "High",
-            "typicalInvestor": "HNW investor in a top bracket holding international equity exposure in taxable accounts to use the foreign-tax credit, which is wasted in tax-deferred accounts."
-          },
-          "analysisAngle": "FTC pickup is asset-location optimization, not security selection. Confirm the fund pays foreign withholding tax that flows through as creditable. Discuss treaty rates by region (developed vs EM differs). Compare to holding the same exposure in tax-deferred where the FTC is wasted. Avoid funds with unusual tax-pass-through structure that interferes with the credit.",
-          "keyConsiderations": [
-            "Confirmed foreign-withholding-tax pass-through to the holder.",
-            "Treaty-rate differences across regions (developed Europe, Japan, EM).",
-            "Comparison vs holding the same exposure in tax-deferred (FTC wasted).",
-            "Total foreign-tax exposure as a fraction of dividend yield.",
-            "Wrapper structures that interfere with FTC creditability."
-          ],
-          "redFlags": [
-            "Wrapper or fund structure that fails to pass foreign tax through to the holder.",
-            "Unusually low foreign-tax footprint suggesting mostly US-domiciled holdings."
-          ]
-        },
-        {
           "key": "derivative-income-yield-supplement",
           "name": "Derivative-Income Yield Supplement",
           "shortDescription": "HNW investor or retiree using covered-call or option-overwrite ETFs (JEPI, JEPQ, QYLD) to supplement income from the public-equity sleeve, accepting an upside cap.",
@@ -460,58 +408,6 @@
           ]
         },
         {
-          "key": "intergenerational-multi-decade-compounding",
-          "name": "Intergenerational Multi-Decade Compounding",
-          "shortDescription": "Family-office investor optimizing for multi-generational wealth preservation — fees, mandate stability, and tax efficiency matter over 30-50 years across generations.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Moderate-High",
-            "primaryGoal": "Wealth Accumulation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "High",
-            "typicalInvestor": "Single- or multi-family office investing across generations — the relevant horizon is 30-50 years and the next generation, not the next decade. Tax-aware estate planning and step-up-in-basis at death are part of the design."
-          },
-          "analysisAngle": "Fee drag and mandate stability over 30-50 years are the structural decisions. Discuss step-up-in-basis at death (favors holding low-basis appreciated positions until death rather than realizing). Estate / trust / GRAT structures interact with selection. Issuer operational stability over multiple decades matters more than near-term performance.",
-          "keyConsiderations": [
-            "Fee drag compounding over 30-50 years and across generations.",
-            "Mandate and benchmark stability across multiple decades.",
-            "Step-up-in-basis at death — favors holding low-basis appreciated positions.",
-            "Issuer operational stability over multi-decade horizons.",
-            "Compatibility with estate / trust / GRAT structures."
-          ],
-          "redFlags": [
-            "Recent benchmark or strategy changes that break the multi-decade record.",
-            "Issuer concentration risk that wouldn't survive a multi-decade test.",
-            "High-turnover strategies that destroy step-up-in-basis tax planning."
-          ]
-        },
-        {
-          "key": "hnw-inflation-real-asset-hedge",
-          "name": "Inflation Hedge as Diversifying Sleeve",
-          "shortDescription": "HNW investor adding a sized real-asset / inflation-hedge sleeve alongside private real estate — sizing matters since pure real-asset exposure underperforms in disinflation.",
-          "profile": {
-            "investmentHorizon": "Long (5-15y)",
-            "riskTolerance": "Moderate",
-            "primaryGoal": "Diversification / Hedging",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "High",
-            "typicalInvestor": "HNW investor or family office that already holds direct private real estate and wants a liquid ETF inflation hedge sleeve — typically 5-15% of the public-market portfolio."
-          },
-          "analysisAngle": "Real-return correlation in measured inflation regimes is the test. Discuss the composition tradeoff (commodities vs equity-heavy real assets vs TIPS) — for HNW, the equity-heavy real-asset proxies (REITs, infra) often duplicate exposure already held privately. K-1 reporting on commodity pools must be evaluated against the HNW reporting burden. Sizing relative to the existing private real-estate sleeve is critical.",
-          "keyConsiderations": [
-            "Sizing relative to the existing private real-estate / private-commodity sleeves.",
-            "Real-return correlation in measured inflation regimes.",
-            "K-1 reporting burden at HNW reporting scale.",
-            "Composition tradeoff (commodities vs equity-heavy real assets vs TIPS).",
-            "Overlap with directly held private real assets."
-          ],
-          "redFlags": [
-            "Commodity exposure delivered via equity proxies that track stocks more than spot.",
-            "K-1 reporting without offsetting hedging benefit.",
-            "Material overlap with directly held private real assets."
-          ]
-        },
-        {
           "key": "hnw-esg-mission-aligned",
           "name": "Family-Mission-Aligned Portfolio Construction",
           "shortDescription": "Family office building a portfolio aligned with explicit family values — environmental, social-impact, religious, or community-development — while preserving expected return and risk profile.",
@@ -535,6 +431,32 @@
             "Self-graded ESG screens with weak or vague criteria.",
             "Holdings that contradict the fund's stated mission alignment.",
             "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ]
+        },
+        {
+          "key": "multi-generational-trust-portfolio",
+          "name": "Multi-Generational Trust Portfolio Construction",
+          "shortDescription": "Family-office investor managing wealth through generation-skipping trusts, GRATs, IDGTs, or dynasty trusts — needs ETFs whose mandate stability and tax efficiency hold across 30-50+ year horizons.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "Family office or HNW family using trust structures (generation-skipping, GRAT, IDGT, dynasty trust) to transfer wealth across generations — relevant horizon is 30-50+ years and the trustee's fiduciary duty drives selection."
+          },
+          "analysisAngle": "Mandate stability over 30-50+ years is the structural bet — a fund that quietly changes its benchmark mid-trust breaks the rationale. Discuss step-up-in-basis at death (favors holding low-basis appreciated positions until trust unwinds vs realizing during life). Trustee fiduciary duty and prudent-investor-rule compatibility matter. Issuer operational stability over multi-decade horizons is the other anchor.",
+          "keyConsiderations": [
+            "Mandate and benchmark stability over multi-decade trust horizons.",
+            "Trustee fiduciary duty and prudent-investor-rule compatibility.",
+            "Issuer operational stability over 30-50+ years.",
+            "Tax efficiency for held-to-trust-termination positions.",
+            "Step-up-in-basis interaction with trust structure (varies by trust type)."
+          ],
+          "redFlags": [
+            "Recent benchmark or strategy changes that break the multi-decade record.",
+            "Issuer operational concerns over long horizons.",
+            "High-turnover strategy that breaks tax-deferral within the trust."
           ]
         }
       ]
@@ -727,81 +649,29 @@
           ]
         },
         {
-          "key": "institutional-investment-grade-core-fixed-income",
-          "name": "Institutional Investment-Grade Core Fixed Income",
-          "shortDescription": "Institutional pool building IG bond exposure (treasury, agency, IG corporate, securitized) at scale as the fixed-income beta sleeve — alternative to a separate-account mandate.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Low-Moderate",
-            "primaryGoal": "Capital Preservation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Pension, endowment, or foundation building IG bond exposure at scale — typically choosing between an Aggregate-index ETF, a separate-account mandate, and a custom core-plus structure."
-          },
-          "analysisAngle": "ETF wrapper vs separate-account is the central comparison. Discuss tracking fidelity to the Bloomberg Aggregate (or chosen benchmark), securities-lending revenue, capacity, and the marginal cost vs a similarly sized separate account. Discuss treasury / agency / corporate / securitized weights vs the IPS target.",
-          "keyConsiderations": [
-            "Tracking fidelity to the Bloomberg Aggregate (or chosen benchmark).",
-            "Securities-lending revenue offset.",
-            "Capacity for institutional allocations.",
-            "Treasury / agency / corporate / securitized weights vs the IPS target.",
-            "Marginal cost vs an equivalent separate-account mandate."
-          ],
-          "redFlags": [
-            "Significant tracking error vs the chosen IPS benchmark.",
-            "Insufficient capacity at institutional scale.",
-            "Sector or duration tilt that drifts from the IPS target."
-          ]
-        },
-        {
-          "key": "securities-lending-revenue-offset",
-          "name": "Securities-Lending Revenue Offset",
-          "shortDescription": "Institutional pool optimizing the all-in cost of an ETF holding by capturing securities-lending revenue back from the fund — relevant for any IPS-mandated allocation where a sec-lending kickback materially offsets the headline fee.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Moderate",
-            "primaryGoal": "Wealth Accumulation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Institutional pool (pension, endowment, foundation, sovereign) sized large enough to capture material securities-lending revenue back from the issuer or from a separately managed lending program."
-          },
-          "analysisAngle": "All-in net cost = headline fee minus sec-lending revenue retained by the fund. Discuss the issuer's lending program, revenue split with the fund, counterparty controls, and the typical sec-lending economics for the underlying universe (small-cap and EM lend richer than large-cap US). For some funds the sec-lending revenue exceeds the expense ratio.",
-          "keyConsiderations": [
-            "Issuer's sec-lending program and revenue split with the fund.",
-            "Counterparty and collateral controls inside the lending program.",
-            "Typical lending economics for the underlying universe (small-cap, EM lend richer).",
-            "Net all-in fee after sec-lending revenue is credited to the fund.",
-            "Lending policy transparency and reporting."
-          ],
-          "redFlags": [
-            "Opaque or poorly disclosed sec-lending program.",
-            "Counterparty exposure inside the lending program that is not capital-charge offset.",
-            "Lending revenue retained by the issuer rather than credited to the fund."
-          ]
-        },
-        {
-          "key": "tactical-rate-duration-overlay",
-          "name": "Tactical Rate / Duration Overlay",
-          "shortDescription": "Institutional pool using long treasury (TLT) or short treasury (SHY) ETFs as a tactical overlay to adjust portfolio duration around the IPS target — usually a CIO-driven tactical decision.",
+          "key": "public-private-allocation-rebalancing-buffer",
+          "name": "Public/Private Allocation Rebalancing Buffer",
+          "shortDescription": "Institutional pool using broad index ETFs as the liquid 'rebalancing reservoir' that absorbs private-side capital calls or distributions without forcing a strategic-mix shift.",
           "profile": {
             "investmentHorizon": "Medium (1-5y)",
             "riskTolerance": "Moderate",
             "primaryGoal": "Diversification / Hedging",
-            "incomeNeed": "None",
+            "incomeNeed": "Modest",
             "taxSensitivity": "Low",
-            "typicalInvestor": "Institutional CIO or PM using treasury ETFs as a quick tactical overlay to add or subtract portfolio duration vs the IPS-mandated mix — typically a multi-quarter to multi-year overlay."
+            "typicalInvestor": "Institutional CIO managing a portfolio with 30-60% private allocations (PE, real estate, credit) — uses public ETF positions as the liquid buffer that absorbs private-side capital calls and distributions without forcing a strategic-mix shift."
           },
-          "analysisAngle": "Tactical sizing relative to the strategic mix is the core question. Discuss bid-ask, AUM, options-market liquidity (for hedging the overlay), and the simplicity advantage vs futures-based alternatives. For long treasury, discuss convexity and the value as an equity-bear-market hedge. For short treasury, discuss the cost in a flat-curve regime.",
+          "analysisAngle": "Liquidity at scale is the central requirement — the ETF must absorb $50-500M in/out trades without market impact. Discuss bid-ask, dollar volume, premium-discount drift in stress, and capacity headroom. Tracking fidelity to the strategic-mix benchmark matters because the buffer should NOT introduce attribution mismatch when held longer than expected.",
           "keyConsiderations": [
-            "Bid-ask depth for institutional-block trades.",
-            "Options-market liquidity for hedging the overlay.",
-            "Convexity vs futures-based alternatives.",
-            "Performance as an equity-bear-market hedge.",
-            "Sizing relative to the strategic IPS mix."
+            "Bid-ask depth for $50-500M institutional-block trades.",
+            "Average daily dollar volume sufficient for rapid in-and-out.",
+            "Premium-discount drift in stress windows (March 2020 / Oct 2022).",
+            "Tracking fidelity to the strategic-mix benchmark.",
+            "Capacity headroom — would a single trade make the institution a dominant holder?"
           ],
           "redFlags": [
-            "Insufficient bid-ask depth for institutional-block trades.",
-            "Limited options market making the overlay hard to hedge.",
-            "Material premium-discount drift in stress windows."
+            "Insufficient dollar volume for institutional-block trades.",
+            "Material premium-discount drift during normal conditions.",
+            "Capacity that would make the institution a dominant holder."
           ]
         }
       ]
@@ -968,55 +838,29 @@
           ]
         },
         {
-          "key": "money-market-cash-equivalent",
-          "name": "Money-Market / Cash-Equivalent Wrapper",
-          "shortDescription": "Treasury team using money-market ETFs (PULS, GSY) for the most conservative cash sleeve — alternative to a money-market fund where the ETF wrapper offers intra-day pricing and same-day liquidity.",
-          "profile": {
-            "investmentHorizon": "Short (<1y)",
-            "riskTolerance": "Low",
-            "primaryGoal": "Capital Preservation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "Moderate",
-            "typicalInvestor": "Corporate treasury or insurance team parking funds in the most conservative cash sleeve — typically choosing between a prime money-market fund and a money-market ETF wrapper."
-          },
-          "analysisAngle": "ETF vs prime money-market fund is the central comparison. Discuss intra-day pricing, same-day liquidity, NAV stability, yield differential vs the equivalent prime MMF, and SEC 2a-7 treatment if any. For corporates with same-day-liquidity needs, the ETF wrapper's intraday tradability is the differentiator.",
-          "keyConsiderations": [
-            "Intra-day pricing and same-day liquidity vs prime MMF.",
-            "NAV stability ($ NAV variance per $100 invested).",
-            "Yield differential vs the equivalent prime MMF.",
-            "Composition (treasury / agency / IG corporate paper).",
-            "Bid-ask depth for treasury-block trades."
-          ],
-          "redFlags": [
-            "NAV instability beyond expected money-market range.",
-            "Yield drag relative to a prime MMF without offsetting liquidity benefit.",
-            "Composition drift toward longer-duration paper."
-          ]
-        },
-        {
-          "key": "permitted-floating-rate-bank-loan",
-          "name": "Permitted Floating-Rate Bank-Loan Sleeve",
-          "shortDescription": "Treasury or insurance permitting a small floating-rate / bank-loan sleeve as a rising-rate hedge for the IG fixed-income book — IPS-permitted only.",
+          "key": "short-corporate-credit-yield-pickup",
+          "name": "Short-Corporate-Credit Yield Pickup over Treasury",
+          "shortDescription": "Treasury or insurance team adding a short-duration IG corporate bond ETF (VCSH, IGSB) sleeve to capture the modest credit-spread pickup over treasury within an IG-only IPS.",
           "profile": {
             "investmentHorizon": "Medium (1-5y)",
-            "riskTolerance": "Moderate",
+            "riskTolerance": "Low-Moderate",
             "primaryGoal": "Income Generation",
             "incomeNeed": "Modest",
             "taxSensitivity": "Moderate",
-            "typicalInvestor": "Treasury or insurance team whose IPS allows a small (often 5-10% cap) floating-rate / bank-loan sleeve as a rising-rate hedge complement to the duration-bearing IG core."
+            "typicalInvestor": "Corporate treasury, insurance general account, or bank treasury that holds a baseline of treasury exposure and adds a short-duration IG corporate sleeve to capture the credit-spread pickup over comparable-duration treasury — keeps the IPS's IG-only mandate."
           },
-          "analysisAngle": "Floating-rate income that benefits in rising-rate regimes is the appeal. Discuss credit quality of the loan portfolio (typically below IG — IPS must explicitly permit), default-rate context, secondary-market liquidity in stress, and NAIC / regulatory treatment. Below-IG composition usually needs explicit IPS permission.",
+          "analysisAngle": "The yield pickup vs comparable-duration treasury is the entire rationale. Discuss the typical IG corporate spread over treasury (30-100 bp), credit-tier mix inside the IG bucket (A vs BBB tilt), and the spread behavior in credit-stress windows. Confirm the wrapper is NAIC / Basel acceptable. The sleeve becomes a real cost in stress when spreads widen.",
           "keyConsiderations": [
-            "Credit quality of the loan portfolio (typically below IG).",
-            "Default-rate context vs historical loan-market cycles.",
-            "Secondary-market liquidity in stress (loans are OTC).",
-            "NAIC or regulatory treatment of the wrapper.",
-            "IPS-permitted allocation cap and explicit below-IG permission."
+            "Yield pickup vs comparable-duration treasury (typical 30-100 bp).",
+            "Credit-tier mix inside the IG bucket (A vs BBB tilt).",
+            "Spread behavior in credit-stress windows (March 2020, Oct 2022).",
+            "NAIC / Basel look-through treatment of the wrapper.",
+            "Duration matched to the comparable treasury sleeve."
           ],
           "redFlags": [
-            "Below-IG exposure where IPS doesn't explicitly permit it.",
-            "Material loan-market liquidity stress in a recent down cycle.",
-            "Wrapper structure that fails NAIC or Basel look-through."
+            "Material BBB tilt that increases downgrade-to-HY risk.",
+            "Spread behavior worse than peers in past credit stress.",
+            "Unclear NAIC / Basel look-through treatment."
           ]
         }
       ]
@@ -1398,32 +1242,6 @@
           ]
         },
         {
-          "key": "macro-fx-directional-bet",
-          "name": "Macro FX Directional Bet",
-          "shortDescription": "Single-currency ETFs (FXE / FXY / UUP) as wrappers for FX directional bets — alternative to FX forwards for desks without prime-broker FX access.",
-          "profile": {
-            "investmentHorizon": "Short (<1y)",
-            "riskTolerance": "Very High",
-            "primaryGoal": "Speculation / Trading",
-            "incomeNeed": "None",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Macro PM or proprietary desk expressing an FX directional view — often used by smaller funds without direct FX-forward access via prime broker."
-          },
-          "analysisAngle": "FX-forward vs ETF as expression is the comparison — forwards have lower frictions but require prime-broker FX access. Discuss bid-ask, options-market depth (limited for most single-currency ETFs), and the carry / roll embedded in the ETF structure. For levered FX bets, leveraged-FX ETFs add daily-reset friction.",
-          "keyConsiderations": [
-            "Bid-ask depth at desk-block trade size.",
-            "Options-market depth for hedging.",
-            "Carry / roll embedded in the ETF structure.",
-            "FX-forward alternative comparison.",
-            "Daily-reset friction for leveraged-FX variants."
-          ],
-          "redFlags": [
-            "Bid-ask wide enough that round-trip cost dominates trade economics.",
-            "Limited options market on the chosen FX ETF.",
-            "Daily-reset decay in leveraged-FX variants over multi-day holds."
-          ]
-        },
-        {
           "key": "macro-commodity-directional-bet",
           "name": "Macro Commodity Directional Bet",
           "shortDescription": "Commodity ETFs (USO / UNG / DBC / GLD / SLV) for macro directional bets on energy, metals, or broad commodities — alternative to futures for desks without commodity prime-brokerage.",
@@ -1525,32 +1343,6 @@
             "Material basis vs spot crypto in normal conditions.",
             "Custodian concentration risk inside the ETF wrapper.",
             "Limited options market for the chosen spot-crypto ETF."
-          ]
-        },
-        {
-          "key": "transition-management-basket-wrapper",
-          "name": "Transition-Management Basket Wrapper",
-          "shortDescription": "Mutual fund manager or institutional transition desk using broad ETFs (SPY, AGG, EFA, EEM) as temporary beta wrappers during portfolio reorgs or fund manager transitions.",
-          "profile": {
-            "investmentHorizon": "Short (<1y)",
-            "riskTolerance": "Moderate-High",
-            "primaryGoal": "Diversification / Hedging",
-            "incomeNeed": "None",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Mutual fund transition manager, institutional pension transition desk, or fund-of-funds allocator using broad ETFs as temporary beta wrappers during portfolio reorgs (manager transitions, mandate changes, reorganizations)."
-          },
-          "analysisAngle": "Speed and tracking fidelity dominate — the ETF replaces the in-transit portfolio for days to weeks while underlying-security trades settle. Discuss bid-ask, dollar volume, tracking fidelity vs the policy benchmark, and creation-redemption efficiency for in-and-out volume. Standard transition workhorses are SPY (US equity), AGG (core bond), EFA (developed international), EEM (EM).",
-          "keyConsiderations": [
-            "Tracking fidelity vs the policy benchmark being replaced.",
-            "Average daily dollar volume sufficient for transition-block trades.",
-            "Creation-redemption efficiency for rapid in-and-out volume.",
-            "Bid-ask cost of the round-trip transition.",
-            "Issuer operational reliability for transition-scale trades."
-          ],
-          "redFlags": [
-            "Tracking error vs the benchmark being replaced.",
-            "Insufficient dollar volume for transition-block trades.",
-            "AP friction during the transition period."
           ]
         }
       ]

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -333,52 +333,6 @@
           ]
         },
         {
-          "key": "esg-impact-alignment",
-          "name": "ESG / SRI / Impact Alignment",
-          "shortDescription": "Investor whose primary selection criterion is ESG, sustainability, or mission alignment — willing to accept some return or fee tradeoff in exchange for a portfolio that matches their values.",
-          "profile": {
-            "investmentHorizon": "Long (5-15y)",
-            "riskTolerance": "Moderate",
-            "primaryGoal": "Wealth Accumulation",
-            "incomeNeed": "None",
-            "taxSensitivity": "Moderate",
-            "typicalInvestor": "Investor of any age who screens for environmental, social, and governance criteria — may exclude fossil fuels, weapons, tobacco; may overweight renewable energy, gender-diverse boards, or community development."
-          },
-          "analysisAngle": "Screen quality is the central question — is this an actual ESG / SRI / impact fund or a labeling exercise? Focus on the screen methodology (third-party rating provider vs self-graded), exclusion rigor, sector tilt vs the unscreened parent index, and tracking-error implications. Compare fees to non-ESG equivalents — a 30+ bp premium needs justification.",
-          "keyConsiderations": [
-            "Screen methodology — third-party rated vs self-graded.",
-            "Exclusion rigor and transparency of holdings.",
-            "Sector tilt vs the unscreened parent index.",
-            "Tracking error implications of the screen.",
-            "Fee premium vs the unscreened equivalent."
-          ],
-          "redFlags": [
-            "Self-graded ESG screens with weak or vague criteria (greenwashing risk).",
-            "Holdings that contradict the fund's stated ESG mission.",
-            "Material fee premium vs the unscreened equivalent without methodology advantage."
-          ],
-          "etfs": [
-            {
-              "symbol": "ESGV",
-              "name": "Vanguard ESG US Stock ETF",
-              "exchange": "BATS",
-              "why": "Low-fee (0.09%) FTSE-screened ESG US large/mid/small exposure with broad diversification."
-            },
-            {
-              "symbol": "ESGU",
-              "name": "iShares ESG Aware MSCI USA ETF",
-              "exchange": "NASDAQ",
-              "why": "MSCI ESG-rated US large/mid-cap exposure with documented third-party screen — defensible methodology."
-            },
-            {
-              "symbol": "ICLN",
-              "name": "iShares Global Clean Energy ETF",
-              "exchange": "NASDAQ",
-              "why": "Pure-thematic global renewable-energy exposure for impact-focused investors wanting visible mission alignment."
-            }
-          ]
-        },
-        {
           "key": "retail-leveraged-or-active-trading",
           "name": "Leveraged or Active Trading (Retail)",
           "shortDescription": "Self-directed retail trader using leveraged (TQQQ, SOXL, FAS), inverse (SQQQ, SH), or active sector ETFs for short-horizon directional bets — typically days to weeks.",
@@ -421,6 +375,98 @@
               "name": "ProShares UltraPro Short QQQ",
               "exchange": "NASDAQ",
               "why": "3x daily-inverse Nasdaq 100 for retail short-side bets without locating shares to borrow."
+            }
+          ]
+        },
+        {
+          "key": "short-medium-term-savings-goal",
+          "name": "Short-to-Medium-Term Savings Goal",
+          "shortDescription": "Saver working toward a known major purchase 2-7 years out (house down payment, wedding, car) — needs return above cash without exposing the spend date to a 30%+ equity drawdown.",
+          "profile": {
+            "investmentHorizon": "Medium (1-5y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Saver in 20s-40s working toward a known goal (down payment, wedding, car) on a 2-7 year horizon — needs return above cash without exposing the spend date to a major drawdown."
+          },
+          "analysisAngle": "The known spend date dominates everything. Risk capacity is high enough to take some equity exposure but not enough for a 50% equity drawdown right before the goal date. Focus on conservative balanced funds, short-duration bonds, and TIPS for inflation defense. Discourage all-equity allocations for sub-5y horizons regardless of recent performance.",
+          "keyConsiderations": [
+            "Worst-12-month drawdown an investor could survive without delaying the goal.",
+            "Glide-path positioning — equity weight should decline as the spend date approaches.",
+            "Inflation defense for the savings target value (especially housing-cost-inflated goals).",
+            "Tax efficiency in taxable brokerage accounts where most non-retirement savings sits.",
+            "Liquidity at the spend date — bid-ask, T+1 settlement, no surprise distributions."
+          ],
+          "redFlags": [
+            "100% equity allocation for sub-3-year horizons.",
+            "Long-duration bond exposure when the spend date is near.",
+            "High-yield credit dressed as 'short-term bond' delivering surprise drawdown."
+          ],
+          "etfs": [
+            {
+              "symbol": "AOK",
+              "name": "iShares Core Conservative Allocation ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pre-built ~30/70 stock/bond mix providing modest growth above cash while limiting drawdown ahead of a known spend date."
+            },
+            {
+              "symbol": "BSV",
+              "name": "Vanguard Short-Term Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-duration IG bond exposure at 0.04% — workhorse for the bond sleeve as the spend date approaches."
+            },
+            {
+              "symbol": "VTIP",
+              "name": "Vanguard Short-Term Inflation-Protected Securities ETF",
+              "exchange": "NASDAQ",
+              "why": "Direct CPI linkage to defend the real value of the savings target against inflation through the holding window."
+            }
+          ]
+        },
+        {
+          "key": "retail-crypto-allocation",
+          "name": "Retail Crypto Allocation via ETF",
+          "shortDescription": "Self-directed retail investor wanting a small (1-5%) bitcoin/ether sleeve as a portfolio satellite — uses spot-crypto ETFs to avoid wallet/custody operational risk inside a brokerage account.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Retail investor convinced bitcoin/ether deserves a small portfolio sleeve as a long-term asymmetric bet — wants the convenience of the brokerage wrapper instead of self-custody or exchange wallets."
+          },
+          "analysisAngle": "Position sizing is the central discipline — 1-5% is the financial-planner consensus for a portfolio satellite, not a core holding. ETF wrapper avoids self-custody risk but adds custodian counterparty and management-fee drag vs spot. Discuss issuer scale, custodian (Coinbase Prime is dominant), and fee level. Frame crypto as a speculative long-term asymmetric bet — not a yield play and not a core holding.",
+          "keyConsiderations": [
+            "Position sizing — 1-5% as a satellite, not a core holding.",
+            "Issuer/custodian counterparty exposure inside the wrapper.",
+            "Fee level vs spot-crypto holding cost.",
+            "Tax treatment in taxable brokerage account vs IRA placement.",
+            "Volatility tolerance — crypto routinely sees 50-80% drawdowns."
+          ],
+          "redFlags": [
+            "Position sizing above 10% turning the satellite into a core risk.",
+            "Futures-based crypto wrapper carrying contango friction vs a spot-backed alternative.",
+            "Concentrated custodian exposure inside a single ETF wrapper."
+          ],
+          "etfs": [
+            {
+              "symbol": "IBIT",
+              "name": "iShares Bitcoin Trust ETF",
+              "exchange": "NASDAQ",
+              "why": "Largest spot-bitcoin ETF with the deepest liquidity and rapidly developing options market — default retail spot-BTC choice."
+            },
+            {
+              "symbol": "FBTC",
+              "name": "Fidelity Wise Origin Bitcoin Fund",
+              "exchange": "BATS",
+              "why": "Fidelity spot-bitcoin alternative offering issuer/custodian diversification away from BlackRock."
+            },
+            {
+              "symbol": "ETHA",
+              "name": "iShares Ethereum Trust ETF",
+              "exchange": "NASDAQ",
+              "why": "BlackRock spot-ether ETF — primary spot-ETH wrapper for retail wanting Ethereum exposure alongside bitcoin."
             }
           ]
         }
@@ -708,52 +754,6 @@
           ]
         },
         {
-          "key": "hnw-esg-mission-aligned",
-          "name": "Family-Mission-Aligned Portfolio Construction",
-          "shortDescription": "Family office building a portfolio aligned with explicit family values — environmental, social-impact, religious, or community-development — while preserving expected return and risk profile.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Moderate-High",
-            "primaryGoal": "Wealth Accumulation",
-            "incomeNeed": "Modest",
-            "taxSensitivity": "High",
-            "typicalInvestor": "Family office, foundation, or HNW family with explicit values-based investment guidelines — often documented in a family Investment Policy Statement that screens out specific industries (fossil fuels, weapons, tobacco) or overweights specific themes (renewable energy, women-led companies, community development)."
-          },
-          "analysisAngle": "Screen rigor and transparency dominate — family-office-grade due diligence should not accept self-graded screens. Discuss screen methodology (third-party rated like MSCI ESG or Sustainalytics), exclusion list transparency, and tracking-error implications vs the unscreened parent index. Compare expected return / risk profile to the unscreened equivalent.",
-          "keyConsiderations": [
-            "Screen methodology — third-party rated vs self-graded.",
-            "Exclusion-list transparency and rigor.",
-            "Tracking-error implications vs the unscreened parent index.",
-            "Sector tilt introduced by the screen.",
-            "Fee premium vs the unscreened equivalent."
-          ],
-          "redFlags": [
-            "Self-graded ESG screens with weak or vague criteria.",
-            "Holdings that contradict the fund's stated mission alignment.",
-            "Material fee premium vs the unscreened equivalent without methodology advantage."
-          ],
-          "etfs": [
-            {
-              "symbol": "ESGV",
-              "name": "Vanguard ESG US Stock ETF",
-              "exchange": "BATS",
-              "why": "Vanguard’s screened US equity at 0.09% — broad diversification with FTSE ESG screen suitable for family-IPS use."
-            },
-            {
-              "symbol": "ESGU",
-              "name": "iShares ESG Aware MSCI USA ETF",
-              "exchange": "NASDAQ",
-              "why": "MSCI ESG-rated US large/mid-cap with documented third-party screen — defensible for family-office due-diligence files."
-            },
-            {
-              "symbol": "ESGD",
-              "name": "iShares ESG Aware MSCI EAFE ETF",
-              "exchange": "NASDAQ",
-              "why": "MSCI ESG-rated developed-international exposure to apply the same screen across the international sleeve."
-            }
-          ]
-        },
-        {
           "key": "multi-generational-trust-portfolio",
           "name": "Multi-Generational Trust Portfolio Construction",
           "shortDescription": "Family-office investor managing wealth through generation-skipping trusts, GRATs, IDGTs, or dynasty trusts — needs ETFs whose mandate stability and tax efficiency hold across 30-50+ year horizons.",
@@ -796,6 +796,52 @@
               "name": "Vanguard Total International Stock ETF",
               "exchange": "NASDAQ",
               "why": "Broad ex-US equity exposure at 0.05% to round out the multi-generational global equity sleeve."
+            }
+          ]
+        },
+        {
+          "key": "charitable-giving-daf-funding",
+          "name": "Charitable Giving / DAF Appreciated-Securities Funding",
+          "shortDescription": "HNW or family-office donor funding a Donor-Advised Fund (Schwab/Fidelity/Vanguard Charitable) with long-term-held appreciated ETF shares — gets the FMV deduction while extinguishing the embedded capital gain.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "None",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor or family office with appreciated long-term-held ETF positions in taxable accounts who funds a DAF (Schwab Charitable, Fidelity Charitable, Vanguard Charitable) annually — captures the FMV deduction while avoiding the capital gain."
+          },
+          "analysisAngle": "The optimal donation candidate is a long-term-held ETF with the largest unrealized gain — donor receives the FMV deduction (subject to AGI limits) while extinguishing the embedded gain. Discuss long-term-held qualification, AGI deduction limits (30% for appreciated public securities), and basis-reset by repurchasing the same ETF after the gift. DAF sponsors accept all major ETF shares in-kind, making this nearly frictionless.",
+          "keyConsiderations": [
+            "Long-term-held qualification (12+ months) for FMV deduction vs basis-only.",
+            "Embedded unrealized gain — bigger gain = more tax-leakage avoided.",
+            "AGI deduction limit (30% for appreciated public securities, 5-year carryforward).",
+            "Cost-basis reset by repurchasing the same ETF after the gift (not a wash-sale).",
+            "DAF sponsor support for in-kind ETF transfers (Schwab/Fidelity/Vanguard all accept)."
+          ],
+          "redFlags": [
+            "Donating short-term-held positions (only basis is deductible — wastes the strategy).",
+            "Donating positions with embedded losses (better to sell, harvest the loss, donate cash).",
+            "Hitting the AGI deduction limit and losing deduction value beyond carryforward window."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Common HNW long-term-held position carrying frequent material unrealized gains — DAF sponsors accept in-kind transfer."
+            },
+            {
+              "symbol": "SPY",
+              "name": "SPDR S&P 500 ETF Trust",
+              "exchange": "NYSEARCA",
+              "why": "Universally accepted by every DAF sponsor with frictionless in-kind transfer mechanics — the most liquid donation vehicle."
+            },
+            {
+              "symbol": "QQQ",
+              "name": "Invesco QQQ Trust",
+              "exchange": "NASDAQ",
+              "why": "Tech-heavy positions accumulated over the past decade often carry the largest unrealized gains — high-impact DAF funding vehicle."
             }
           ]
         }
@@ -991,52 +1037,6 @@
           ]
         },
         {
-          "key": "crisis-alpha-diversifier",
-          "name": "Crisis-Alpha Diversifier",
-          "shortDescription": "Institutional pool adding managed-futures, market-neutral, or multistrategy exposure to deliver positive returns or low correlation in equity bear markets — judged on portfolio-level resilience, not standalone return.",
-          "profile": {
-            "investmentHorizon": "Very Long (15y+)",
-            "riskTolerance": "Moderate",
-            "primaryGoal": "Diversification / Hedging",
-            "incomeNeed": "None",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Pension or endowment CIO adding a diversifying alt sleeve — wants the fund to deliver positive return or low correlation precisely when equities are in drawdown, accepting underperformance in equity bull markets."
-          },
-          "analysisAngle": "Standalone return is the wrong metric — judge by correlation to equities in drawdowns, drawdown reduction in 2008/2020/2022, and risk-adjusted return at the portfolio level. Managed-futures, market-neutral, long-short, and multi-strategy funds must demonstrate they delivered on the diversification mandate.",
-          "keyConsiderations": [
-            "Correlation to broad equities, especially in equity drawdowns.",
-            "Drawdown reduction in March 2020 / 2022 / prior crises.",
-            "Mandate adherence — does the fund actually do what it says?",
-            "Risk-adjusted return (Sharpe, Sortino) vs cheap passive alternatives.",
-            "Liquidity and fee level commensurate with the diversification benefit."
-          ],
-          "redFlags": [
-            "Strategy that quietly tracks equities in bull markets but fails in bear markets.",
-            "Fee at or above peer median with no demonstrated low correlation.",
-            "Mandate drift — recent strategy or benchmark change."
-          ],
-          "etfs": [
-            {
-              "symbol": "DBMF",
-              "name": "iMGP DBi Managed Futures Strategy ETF",
-              "exchange": "NYSEARCA",
-              "why": "Replicates a managed-futures hedge-fund composite — designed to deliver positive return in equity drawdowns."
-            },
-            {
-              "symbol": "QAI",
-              "name": "NYLI Hedge Multi-Strategy Tracker ETF",
-              "exchange": "NYSEARCA",
-              "why": "Multi-strategy hedge-fund replicator providing low-correlation institutional alts exposure in a liquid wrapper."
-            },
-            {
-              "symbol": "MNA",
-              "name": "NYLI Merger Arbitrage ETF",
-              "exchange": "NYSEARCA",
-              "why": "Merger-arbitrage strategy delivering structurally low equity-correlation returns suitable for the diversifier sleeve."
-            }
-          ]
-        },
-        {
           "key": "institutional-real-asset-inflation-hedge",
           "name": "Institutional Real-Asset / Inflation Hedge",
           "shortDescription": "Pension or endowment adding TIPS, commodities, real estate, or infrastructure exposure to defend real spending power against inflation — sized as a portfolio sleeve, often complementing direct private real-asset allocations.",
@@ -1171,6 +1171,52 @@
               "name": "iShares Core US Aggregate Bond ETF",
               "exchange": "NYSEARCA",
               "why": "IG core bond exposure at $110B+ AUM — bond-side rebalancing buffer when private-credit calls land."
+            }
+          ]
+        },
+        {
+          "key": "cash-equitization-transition-management",
+          "name": "Cash Equitization & Transition Management",
+          "shortDescription": "Institutional CIO using SPY / IVV / AGG as bridge exposure during manager transitions, contribution timing gaps, or to neutralize the cash-drag on uninvested funds pending strategic deployment.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Institutional CIO, transition manager, or asset-allocation team needing same-day broad-market beta exposure for cash sitting in custody — typically held days to weeks during manager hire/fire transitions or contribution-timing gaps."
+          },
+          "analysisAngle": "The role is to neutralize uninvested-cash drag against the policy benchmark for a defined short window. Bid-ask, dollar volume, and policy-benchmark fidelity dominate; securities-lending revenue and fee compounding barely matter at short horizons. The fund must absorb $50M-$1B in/out without market impact and unwind cleanly when the strategic allocation is funded.",
+          "keyConsiderations": [
+            "Bid-ask depth for $50M-$1B institutional-block in-and-out trades.",
+            "Policy-benchmark fidelity (S&P 500 vs Russell 1000 vs MSCI USA depending on IPS).",
+            "Premium-discount drift in stress windows when transitions land at bad times.",
+            "Unwind mechanics — same-day liquidity to fund the strategic allocation when ready.",
+            "Operational compatibility with custodian and external transition manager."
+          ],
+          "redFlags": [
+            "Insufficient dollar volume making the institution a dominant short-term holder.",
+            "Wrong benchmark family creating attribution mismatch on the bridge sleeve.",
+            "Premium-discount drift during the brief holding period."
+          ],
+          "etfs": [
+            {
+              "symbol": "SPY",
+              "name": "SPDR S&P 500 ETF Trust",
+              "exchange": "NYSEARCA",
+              "why": "Largest, most-liquid S&P 500 wrapper at $400B+ AUM — institutional-default cash-equitization vehicle with deepest bid-ask."
+            },
+            {
+              "symbol": "IVV",
+              "name": "iShares Core S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "iShares S&P 500 alternative at $500B+ AUM — same liquidity profile with alternative-issuer custody."
+            },
+            {
+              "symbol": "AGG",
+              "name": "iShares Core US Aggregate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "IG core bond exposure at $110B+ AUM — bond-side equitization for fixed-income manager transitions."
             }
           ]
         }
@@ -1500,6 +1546,52 @@
               "name": "iShares 0-5 Year Investment Grade Corporate Bond ETF",
               "exchange": "NASDAQ",
               "why": "Even shorter 0-5y IG corporate for treasuries wanting minimal duration alongside the credit-spread pickup."
+            }
+          ]
+        },
+        {
+          "key": "agency-mbs-mortgage-allocation",
+          "name": "Agency MBS Allocation",
+          "shortDescription": "Insurance general account or bank treasury holding agency MBS exposure (MBB, VMBS, SPMB) for the mortgage sleeve of an IG fixed-income mandate — captures the spread-and-prepayment dynamic of agency mortgages.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Insurance general account, bank treasury (Available-for-Sale book), or large corporate treasury holding agency-MBS exposure as the mortgage-securitized sleeve of a diversified IG fixed-income mandate."
+          },
+          "analysisAngle": "Agency MBS carries explicit (Ginnie Mae) or implicit (Fannie/Freddie) government guarantee, so credit risk is minimal — the entire risk is prepayment/extension and option-adjusted spread. Discuss effective duration (changes materially with rate moves), negative convexity from the prepayment option, HQLA Level-2A treatment for banks, and NAIC RBC charge for insurers (typically very favorable). Capacity matters at insurance/bank allocation scale.",
+          "keyConsiderations": [
+            "Effective duration profile — varies with rate environment due to prepayment.",
+            "Negative convexity from prepayment option — extension risk in rising-rate regimes.",
+            "HQLA Level-2A treatment for bank-treasury holders.",
+            "NAIC RBC treatment for insurance holders (typically very favorable for agency MBS).",
+            "Capacity for $100M+ allocation sizes without market impact."
+          ],
+          "redFlags": [
+            "Material non-agency MBS exposure inside a generically named 'MBS' fund.",
+            "Convexity-mismatch surprises in fast-moving rate regimes.",
+            "Insufficient capacity for institution-scale allocations."
+          ],
+          "etfs": [
+            {
+              "symbol": "MBB",
+              "name": "iShares MBS ETF",
+              "exchange": "NASDAQ",
+              "why": "Largest agency-MBS ETF at $35B+ AUM — institutional-scale liquidity for insurance/bank mortgage allocation."
+            },
+            {
+              "symbol": "VMBS",
+              "name": "Vanguard Mortgage-Backed Securities ETF",
+              "exchange": "NASDAQ",
+              "why": "Vanguard's agency-MBS wrapper at 0.04% — alternative-issuer with similar mandate to MBB for fund-issuer diversification."
+            },
+            {
+              "symbol": "SPMB",
+              "name": "SPDR Portfolio Mortgage Backed Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "SPDR low-fee (0.04%) agency-MBS exposure — third-issuer alternative diversifying across MBB and VMBS."
             }
           ]
         }
@@ -1969,6 +2061,52 @@
               "why": "Covered-call equity overlay for the derivative-income piece of retiree models — flagship income-supplement vehicle."
             }
           ]
+        },
+        {
+          "key": "client-cash-sweep-alternative-yield",
+          "name": "Client Cash-Sweep Alternative for Higher Yield",
+          "shortDescription": "Advisor moving client cash from default brokerage sweep accounts (paying ~0.5%) into ultra-short Treasury or money-market ETFs (SGOV, JPST, BOXX) yielding ~4-5% — captures 300-400 bp without taking duration risk.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Low",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "RIA seeing client cash sitting in custodian sweep accounts paying <1% while Treasury bills yield 4-5%+ — moves cash into liquid ultra-short ETFs to capture the yield without duration risk. Critical post-2023 as client awareness of sweep underpayment grew (with related lawsuits at major custodians)."
+          },
+          "analysisAngle": "The yield gap between custodian sweep (~0.5%) and Treasury yield (~4-5%) is the entire rationale — capturing it across many client accounts is a clear advisor value-add. Discuss SGOV/BIL/USFR for treasury-only exposure (state-tax-exempt income for clients), JPST for slightly higher yield with modest credit, and BOXX as a tax-deferred alternative using box-spread mechanics. Same-day liquidity matters for cash-equivalent classification in client portfolio reporting.",
+          "keyConsiderations": [
+            "Yield pickup vs custodian sweep account — typically 300-400 bp in current rate environment.",
+            "Treasury exposure for state-tax exemption in client taxable accounts (SGOV, BIL, USFR).",
+            "BOXX as a capital-gain-only structure for after-tax yield maximization in taxable accounts.",
+            "Same-day liquidity for cash-classification in client portfolio reporting.",
+            "Bid-ask depth for cross-account client-block trades."
+          ],
+          "redFlags": [
+            "Duration creep in 'cash-equivalent' wrappers extending past ~6 months.",
+            "Material BBB or HY drift in funds labeled 'ultra-short'.",
+            "Wrapper structure that loses cash-equivalent classification on the custodian platform."
+          ],
+          "etfs": [
+            {
+              "symbol": "SGOV",
+              "name": "iShares 0-3 Month Treasury Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pure 0-3 month Treasury exposure — cleanest cash-sweep alternative with state-tax-exempt income and minimal NAV variance."
+            },
+            {
+              "symbol": "JPST",
+              "name": "JPMorgan Ultra-Short Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "Active ultra-short IG fund delivering modest yield pickup over T-bills with daily liquidity for advisor block trades."
+            },
+            {
+              "symbol": "BOXX",
+              "name": "Alpha Architect 1-3 Month Box ETF",
+              "exchange": "BATS",
+              "why": "Box-spread structure converting yield into capital gains — top-bracket-client favorite for after-tax yield maximization."
+            }
+          ]
         }
       ]
     },
@@ -2254,52 +2392,6 @@
           ]
         },
         {
-          "key": "inverse-hedge-exposure",
-          "name": "Inverse Hedge Exposure",
-          "shortDescription": "Inverse ETFs (SH, SDS, SQQQ) for short-term tactical hedging of long portfolios without locating shortable shares — useful for funds without unfettered short access.",
-          "profile": {
-            "investmentHorizon": "Short (<1y)",
-            "riskTolerance": "Very High",
-            "primaryGoal": "Diversification / Hedging",
-            "incomeNeed": "None",
-            "taxSensitivity": "Low",
-            "typicalInvestor": "Hedge fund or fund-of-funds desk that needs short-side exposure without locating shortable inventory — uses inverse ETFs for tactical portfolio hedging over hours to weeks."
-          },
-          "analysisAngle": "Avoids the locate-borrow problem inherent in shorting. Daily-reset path dependency still applies. Discuss bid-ask, options-market depth, and beta-to-underlying over the intended hedge horizon (hours: tracks 1-to-1; days: starts to drift; weeks: significant decay). Vs short futures or short ETF alternatives.",
-          "keyConsiderations": [
-            "Beta-to-underlying over the intended hedge horizon.",
-            "Bid-ask spread at desk-block trade size.",
-            "Daily-reset path dependency over the hedge horizon.",
-            "Options-market depth on the inverse ETF.",
-            "Short-futures or short-ETF alternative comparison."
-          ],
-          "redFlags": [
-            "Documented tracking failures on the daily-inverse objective.",
-            "Wide bid-ask defeating the hedge economics.",
-            "Material daily-reset decay over the intended hedge horizon."
-          ],
-          "etfs": [
-            {
-              "symbol": "SH",
-              "name": "ProShares Short S&P 500",
-              "exchange": "NYSEARCA",
-              "why": "1x daily-inverse S&P 500 — cleanest inverse-hedge vehicle with minimal daily-reset decay over short windows."
-            },
-            {
-              "symbol": "SDS",
-              "name": "ProShares UltraShort S&P 500",
-              "exchange": "NYSEARCA",
-              "why": "2x daily-inverse S&P 500 — capital-efficient inverse hedge accepting modest decay for higher beta-to-underlying."
-            },
-            {
-              "symbol": "SQQQ",
-              "name": "ProShares UltraPro Short QQQ",
-              "exchange": "NASDAQ",
-              "why": "3x daily-inverse Nasdaq 100 — capital-efficient hedge for tech-tilt portfolios needing concentrated short exposure."
-            }
-          ]
-        },
-        {
           "key": "crypto-digital-asset-tactical-position",
           "name": "Crypto / Digital-Asset Tactical Position",
           "shortDescription": "Spot-bitcoin (IBIT, FBTC) or spot-ether ETFs as wrappers for short-term tactical crypto positions — alternative to direct spot-crypto exposure for funds without crypto custody infrastructure.",
@@ -2342,6 +2434,98 @@
               "name": "iShares Ethereum Trust ETF",
               "exchange": "NASDAQ",
               "why": "BlackRock’s spot-ether ETF — primary spot-ETH wrapper for tactical Ethereum directional positions."
+            }
+          ]
+        },
+        {
+          "key": "volatility-vix-tactical-expression",
+          "name": "Volatility / VIX Tactical Expression",
+          "shortDescription": "VXX, UVXY (long-vol) or SVXY (short-vol) for tactical VIX-direction views or dedicated tail-risk hedges — explicit volatility exposure rather than implicit option overlays.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Hedge fund volatility PM, macro PM, or proprietary desk expressing a VIX-direction view or hedging tail risk via dedicated vol products — typically held hours to days due to severe roll cost in contango."
+          },
+          "analysisAngle": "VIX-futures roll cost is the central friction — the VIX futures curve is normally in contango, so long-vol products (VXX, UVXY) bleed in stable markets while short-vol (SVXY) earns the carry. Daily-reset path dependency applies to the leveraged and inverse versions. Discuss bid-ask, options-market depth, and the front-month vs constant-maturity exposure choice. VIX futures direct is the alternative for desks with futures access.",
+          "keyConsiderations": [
+            "Roll cost in contango — typical 5-10% per month drag on long-vol positions.",
+            "Daily-reset path dependency for leveraged/inverse versions (UVXY, SVXY).",
+            "Bid-ask spread at desk-block trade size.",
+            "Options-market depth for hedging or expressing vol-of-vol.",
+            "VIX futures direct as the alternative for desks with futures access."
+          ],
+          "redFlags": [
+            "Multi-week holds on long-vol products in stable-market regimes.",
+            "Leveraged/inverse vol products held beyond a few days.",
+            "Material premium-discount drift in stress events when the hedge is needed most."
+          ],
+          "etfs": [
+            {
+              "symbol": "VXX",
+              "name": "iPath Series B S&P 500 VIX Short-Term Futures ETN",
+              "exchange": "BATS",
+              "why": "Standard front-month VIX expression — workhorse for short-horizon long-vol bets and tactical equity tail hedges."
+            },
+            {
+              "symbol": "UVXY",
+              "name": "ProShares Ultra VIX Short-Term Futures ETF",
+              "exchange": "BATS",
+              "why": "1.5x leveraged VIX exposure for capital-efficient long-vol bets — extreme decay outside hours-to-days holds."
+            },
+            {
+              "symbol": "SVXY",
+              "name": "ProShares Short VIX Short-Term Futures ETF",
+              "exchange": "BATS",
+              "why": "Short-vol exposure capturing the contango carry — high-conviction tactical bet on calm markets with severe stress-event risk."
+            }
+          ]
+        },
+        {
+          "key": "single-country-regional-tactical-bet",
+          "name": "Single-Country / Regional Tactical Bet",
+          "shortDescription": "Single-country ETFs (FXI, EWJ, EWZ, INDA) for tactical macro views — China stimulus, Japan reflation, Brazil commodity-cycle, India growth — without setting up local-market trading infrastructure.",
+          "profile": {
+            "investmentHorizon": "Short (<1y)",
+            "riskTolerance": "Very High",
+            "primaryGoal": "Speculation / Trading",
+            "incomeNeed": "None",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Macro hedge fund PM or asset-manager regional desk taking a tactical single-country position — uses US-listed country ETFs as alternative to setting up local-market broker relationships and currency-hedging infrastructure."
+          },
+          "analysisAngle": "Bid-ask depth, options-market availability, and reliable shortable inventory determine viability for desk-block trades. Currency exposure is typically unhedged — that's an additional macro variable embedded in the trade. Discuss tax-treaty structure (FTC pass-through), settlement timing across time zones, and creation-redemption efficiency during local-market closures. China-exposure ETFs (FXI vs KWEB) carry methodology differences worth flagging (state-owned vs internet-platform tilts).",
+          "keyConsiderations": [
+            "Bid-ask depth and average daily dollar volume at desk-block scale.",
+            "Options-market depth for hedging or expressing volatility.",
+            "Borrow availability and cost on the short leg for pair construction.",
+            "Currency exposure (typically unhedged) as an embedded macro variable.",
+            "Methodology differences between competing single-country ETFs (FXI vs KWEB for China)."
+          ],
+          "redFlags": [
+            "Wide bid-ask combined with thin options market on the chosen wrapper.",
+            "High borrow cost or limited shortable supply for the short leg.",
+            "Material premium-discount drift during local-market closures."
+          ],
+          "etfs": [
+            {
+              "symbol": "FXI",
+              "name": "iShares China Large-Cap ETF",
+              "exchange": "NASDAQ",
+              "why": "Standard cap-weighted China large-cap exposure — workhorse for state-owned-enterprise China bets with deep options market."
+            },
+            {
+              "symbol": "EWJ",
+              "name": "iShares MSCI Japan ETF",
+              "exchange": "NYSEARCA",
+              "why": "Standard MSCI Japan exposure — workhorse for Japan reflation and yield-curve-control trades with deep desk liquidity."
+            },
+            {
+              "symbol": "EWZ",
+              "name": "iShares MSCI Brazil ETF",
+              "exchange": "NYSEARCA",
+              "why": "Standard MSCI Brazil exposure — commodity-cycle and Latin-America-macro tactical wrapper with reliable shortable inventory."
             }
           ]
         }

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,0 +1,902 @@
+{
+  "description": "Target investor groups taxonomy — investor archetypes used to frame ETF analysis from the perspective of the people most likely to consider buying the fund. Each group describes the investor's profile (experience, horizon, risk tolerance, primary goal, income need, tax sensitivity, account preference), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and the ETF groups + specific Morningstar categories from etf-analysis-categories.json that fit their goals. Groups are NOT mutually exclusive — a single ETF can be relevant to several investor groups (e.g. a TIPS fund fits both retirement-income-seeker and inflation-real-asset-hedger). The goal-label list mirrors the Phase-2 taxonomy in tasks/koala-gains/etfs.md (e.g. 'Fixed income with low risk', 'High yield with moderate or high risk', 'Single-country thematic exposure').",
+  "investorGroups": [
+    {
+      "key": "first-time-investor",
+      "name": "First-Time / Beginner Investor",
+      "shortDescription": "New to investing, wants the simplest possible exposure to broad markets without making fund-selection mistakes that compound over decades.",
+      "profile": {
+        "experienceLevel": "Beginner",
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "None",
+        "taxSensitivity": "Low",
+        "accountTypePreference": "Tax-Advantaged",
+        "typicalInvestor": "Someone in their 20s or 30s opening a brokerage or Roth IRA for the first time, contributing monthly, with little appetite for picking individual sub-categories or sectors."
+      },
+      "goalLabels": ["Simple broad-market exposure", "Low-cost long-term growth", "One-fund retirement glide path"],
+      "analysisAngle": "Default to the simplest, cheapest, most diversified option. Explain the fund as if the reader has never bought an ETF before. Always anchor to the boring baseline (a total-market or S&P 500 fund, or a target-date fund) and explain whether this fund adds anything over that baseline that justifies the additional complexity. Avoid jargon; if a term like 'duration' or 'tracking error' is used, define it inline.",
+      "keyConsiderations": [
+        "Expense ratio under ~0.10% for passive broad-equity, under ~0.20% for target-date.",
+        "Fund size large enough that closure is not a concern (>$1B AUM ideal).",
+        "Mandate stability — no recent benchmark or category changes.",
+        "Tracking error vs the index is small and consistent.",
+        "Distribution character is simple (qualified dividends, no surprise capital-gain distributions)."
+      ],
+      "redFlags": [
+        "Daily-leveraged or inverse structure (path-dependent, not for buy-and-hold).",
+        "Single-country, single-sector, single-currency, or single-stock concentration.",
+        "K-1 tax reporting for a beginner taxable account.",
+        "Expense ratio above ~0.50% for what is fundamentally an index product.",
+        "AUM under $100M with declining trend (real closure risk)."
+      ],
+      "etfGroupFit": [
+        { "groupKey": "broad-equity", "fit": "primary", "rationale": "Total-market and S&P 500 trackers are the canonical first-purchase ETF." },
+        { "groupKey": "allocation-target-date", "fit": "primary", "rationale": "A single target-date fund is the simplest one-decision retirement portfolio." },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "A small treasury or aggregate-bond sleeve adds resilience once the equity base is in place."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "occasional",
+          "rationale": "Only after a broad-market base exists; a sector fund is a satellite, not a starter holding."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Credit risk is hard to evaluate as a beginner — better to wait until the broad base is established."
+        },
+        { "groupKey": "muni", "fit": "occasional", "rationale": "Tax benefits rarely matter for beginners in low-bracket or tax-advantaged accounts." },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "avoid",
+          "rationale": "Complex strategies are easy to misunderstand and create surprise tax or distribution outcomes."
+        },
+        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Daily reset and decay make these unsuitable for any beginner buy-and-hold context." }
+      ],
+      "highlightedCategories": [
+        { "category": "Large Blend", "group": "broad-equity", "rationale": "S&P 500 / total-market trackers — the textbook first-purchase ETF." },
+        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Adds developed ex-US exposure with one fund." },
+        {
+          "category": "Target-Date 2050",
+          "group": "allocation-target-date",
+          "rationale": "Single-fund retirement glide path for an investor in their 30s — no rebalancing decisions required."
+        },
+        { "category": "Target-Date 2065+", "group": "allocation-target-date", "rationale": "Single-fund glide path for a younger first-time investor." },
+        {
+          "category": "Intermediate Core Bond",
+          "group": "fixed-income-core",
+          "rationale": "The plain-vanilla bond sleeve when a beginner adds fixed income to an equity base."
+        }
+      ]
+    },
+    {
+      "key": "long-term-wealth-builder",
+      "name": "Long-Term Wealth Builder (Buy & Hold)",
+      "shortDescription": "Multi-decade horizon, comfortable with equity volatility, focused on cumulative compounding and minimizing fee drag over 20-30+ years.",
+      "profile": {
+        "experienceLevel": "Intermediate",
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "None",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Working-age investor 5-30 years from retirement, dollar-cost-averaging into a core portfolio, cares more about the next 25 years than the next 25 weeks."
+      },
+      "goalLabels": ["Core long-term equity growth", "Diversified global exposure", "Low-cost compounding"],
+      "analysisAngle": "Frame everything in cumulative-compounding terms: a 0.30% fee gap is ~9% of an ending balance over 30 years. Emphasize tracking fidelity, mandate stability, and downside drawdown / recovery time. De-emphasize 1-year performance; weight 5-year and 10-year risk-adjusted return. Note dividend reinvestment and the practical difference between a total-return and price index.",
+      "keyConsiderations": [
+        "Cumulative fee drag over 20-30 years vs the lowest-cost peer.",
+        "Tracking error consistency across market regimes.",
+        "Drawdown depth and recovery time in 2008, 2020, 2022.",
+        "Tax efficiency — capital-gain distribution history for taxable accounts.",
+        "Issuer scale and operational stability over decades."
+      ],
+      "redFlags": [
+        "Mandate or benchmark changes mid-life (breaks the historical record).",
+        "Manager or strategy churn within an active core holding.",
+        "Persistent tracking error well above peer median for a passive fund.",
+        "Repeated capital-gain distributions in a passive equity ETF held in a taxable account."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Diversified equity across cap, style, and geography is the core of a multi-decade portfolio."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "primary",
+          "rationale": "Long-dated target-date funds embed equity-heavy glide paths designed exactly for this horizon."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "REITs, infrastructure, and broad-tech can supplement a core; narrow themes are satellite, not core."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "A small bond sleeve becomes more relevant as the horizon shortens past 10 years."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "occasional",
+          "rationale": "Most alt strategies dilute long-run equity premium; only useful as small uncorrelated sleeves."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Credit adds yield but historically underperforms equity over very long horizons."
+        },
+        { "groupKey": "muni", "fit": "occasional", "rationale": "Only relevant for high-bracket investors funding a taxable bond sleeve." },
+        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Daily-reset decay makes these structurally unsuitable for buy-and-hold." }
+      ],
+      "highlightedCategories": [
+        { "category": "Large Blend", "group": "broad-equity", "rationale": "Core US large-cap exposure — the historical engine of long-run equity returns." },
+        { "category": "Mid-Cap Blend", "group": "broad-equity", "rationale": "Mid-cap completes the US-equity base alongside large-cap." },
+        {
+          "category": "Small Blend",
+          "group": "broad-equity",
+          "rationale": "Small-cap captures the size premium for long horizons that can absorb volatility."
+        },
+        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Developed ex-US is a long-run diversifier when US valuations stretch." },
+        {
+          "category": "Diversified Emerging Mkts",
+          "group": "broad-equity",
+          "rationale": "EM equity for long-horizon investors comfortable with regime volatility."
+        },
+        {
+          "category": "Real Estate",
+          "group": "sector-thematic-equity",
+          "rationale": "REITs add a long-run income + appreciation stream uncorrelated with the S&P."
+        },
+        {
+          "category": "Target-Date 2045",
+          "group": "allocation-target-date",
+          "rationale": "Auto-rebalancing glide path for a buy-and-hold investor near mid-career."
+        }
+      ]
+    },
+    {
+      "key": "growth-accumulator",
+      "name": "Growth-Focused Accumulator",
+      "shortDescription": "Younger investor with a long horizon and high risk tolerance, willing to accept large drawdowns in pursuit of higher long-run growth — overweight to growth, small-cap, EM, and innovation themes.",
+      "profile": {
+        "experienceLevel": "Intermediate",
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "High",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "None",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "20s-30s investor with stable income, no near-term capital needs, willing to accept 30-50% peak-to-trough drawdowns in exchange for higher expected returns over 20+ years."
+      },
+      "goalLabels": ["Aggressive equity growth", "Innovation / theme tilt", "High volatility tolerance"],
+      "analysisAngle": "Emphasize factor tilt (growth, small-cap, momentum), top-holding concentration, and drawdown / recovery behavior — this investor needs to know *how* painful the down years will be and how long recovery has historically taken. Reinforce that past bull-run leadership does not guarantee future leadership; address sequence risk only lightly because the horizon is long.",
+      "keyConsiderations": [
+        "Factor exposure (growth vs blend vs value tilt) and how it has driven returns.",
+        "Top-10 holdings concentration — a 'growth' fund that is 50% mega-cap tech is concentrated, not diversified.",
+        "Volatility (std dev) and beta vs the S&P 500.",
+        "Worst 1-year and worst peak-to-trough drawdown, plus recovery time.",
+        "Theme purity — does the fund actually own the names that describe it?"
+      ],
+      "redFlags": [
+        "Thematic fund chasing a recently-hot theme with under 2 years of history.",
+        "Concentration so extreme that 5 holdings drive most of the return.",
+        "High turnover combined with a high expense ratio in a taxable account.",
+        "Daily-leveraged structure used as a 'growth' substitute (decay erases the edge)."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Growth, small-cap, EM, and foreign-growth sub-categories deliver higher expected return at the cost of higher volatility."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "primary",
+          "rationale": "Tech, communications, consumer cyclical, and digital-asset equities give targeted growth tilt."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Spot digital-asset and commodities-focused funds can serve as small high-growth satellites."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "secondary",
+          "rationale": "Aggressive-allocation and far-dated target-date funds align with the high-equity tilt."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "occasional",
+          "rationale": "Only for tactical sub-week trades; unsuitable as a growth holding due to decay."
+        },
+        { "groupKey": "fixed-income-core", "fit": "occasional", "rationale": "Small allocation only; bonds dilute the growth tilt this investor wants." },
+        { "groupKey": "fixed-income-credit", "fit": "avoid", "rationale": "Yield doesn't compound like equity over multi-decade horizons." },
+        { "groupKey": "muni", "fit": "avoid", "rationale": "Tax-exempt income is irrelevant for an accumulator with no income need." }
+      ],
+      "highlightedCategories": [
+        { "category": "Large Growth", "group": "broad-equity", "rationale": "Core US large-cap growth exposure — the cleanest expression of US growth tilt." },
+        { "category": "Mid-Cap Growth", "group": "broad-equity", "rationale": "Mid-cap growth blends scaling-stage businesses with public-market liquidity." },
+        {
+          "category": "Small Growth",
+          "group": "broad-equity",
+          "rationale": "Small growth captures the highest-volatility, highest-upside corner of US equity."
+        },
+        {
+          "category": "Diversified Emerging Mkts",
+          "group": "broad-equity",
+          "rationale": "EM for long-horizon investors who can tolerate currency and policy regime risk."
+        },
+        { "category": "India Equity", "group": "broad-equity", "rationale": "Single-country growth bet for investors with a structural EM thesis." },
+        {
+          "category": "Technology",
+          "group": "sector-thematic-equity",
+          "rationale": "Direct exposure to the secular-growth sector that has driven US-equity returns for two decades."
+        },
+        {
+          "category": "Communications",
+          "group": "sector-thematic-equity",
+          "rationale": "Captures internet platforms, media, and telecom — adjacent to tech without identical concentration."
+        },
+        {
+          "category": "Equity Digital Assets",
+          "group": "sector-thematic-equity",
+          "rationale": "Equity exposure to crypto-economy companies for investors with conviction but not direct-asset risk tolerance."
+        },
+        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot digital-asset ETFs for highest-growth-tilt sleeves." }
+      ]
+    },
+    {
+      "key": "retirement-income-seeker",
+      "name": "Retirement Income Seeker",
+      "shortDescription": "At or near retirement, drawing from the portfolio for living expenses. Prioritizes capital preservation, predictable income, and shallow drawdowns over absolute return.",
+      "profile": {
+        "experienceLevel": "Intermediate",
+        "investmentHorizon": "Medium (1-5y)",
+        "riskTolerance": "Low-Moderate",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "High",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Investor in their 60s-70s living off portfolio distributions, where a single deep drawdown in the wrong year can permanently impair retirement consumption (sequence-of-returns risk)."
+      },
+      "goalLabels": ["Capital preservation", "Steady income", "Fixed income with low risk", "Retirement glide path"],
+      "analysisAngle": "Lead with downside: worst calendar year, worst drawdown, recovery time, and distribution stability. Income consistency matters more than headline yield — a fund that paid every quarter through 2008 and 2020 is more useful than one with a higher headline yield and an erratic record. Address sequence-of-returns risk explicitly: a 30% drawdown in year 1 of retirement is fundamentally different from year 20.",
+      "keyConsiderations": [
+        "Distribution stability and history — quarterly/monthly consistency through stress periods.",
+        "Duration risk and sensitivity to a sudden rate move.",
+        "Worst peak-to-trough drawdown and time-to-recover (a retiree may not have the time).",
+        "Income character — qualified dividends vs ordinary income vs return-of-capital.",
+        "Sequence-of-returns risk — a deep drawdown in year 1-3 of retirement is uniquely damaging."
+      ],
+      "redFlags": [
+        "Daily-leveraged or inverse structure (any holding period).",
+        "Concentrated single-sector or single-country bets.",
+        "High-yield distribution that is largely ROC (lowers cost basis silently).",
+        "Long-duration bond fund without an explicit duration tolerance discussion.",
+        "Active manager with under 3 years tenure on a fund used for income."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "primary",
+          "rationale": "Investment-grade core, short-term Treasuries, TIPS, and money market are the income / preservation backbone of a retirement portfolio."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "primary",
+          "rationale": "Retirement-dated and conservative-allocation funds are designed for exactly this glide-path."
+        },
+        {
+          "groupKey": "muni",
+          "fit": "secondary",
+          "rationale": "Tax-equivalent yield is meaningful when retirement income pushes the investor into a high bracket."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "secondary",
+          "rationale": "Derivative-income (covered-call) and defined-outcome buffer funds trade upside for income / downside protection."
+        },
+        {
+          "groupKey": "broad-equity",
+          "fit": "secondary",
+          "rationale": "A modest equity sleeve (especially large value / dividend-tilted) hedges longevity risk without excess drawdown."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Some HY / preferred / multisector exposure can boost yield, but credit drawdowns hurt retirees disproportionately."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "occasional",
+          "rationale": "Real estate and utilities can supplement income; growth-tilted sectors don't fit."
+        },
+        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Volatility decay and path dependency are incompatible with capital preservation." }
+      ],
+      "highlightedCategories": [
+        {
+          "category": "Intermediate Core Bond",
+          "group": "fixed-income-core",
+          "rationale": "The default investment-grade core for a retirement income portfolio."
+        },
+        {
+          "category": "Short-Term Bond",
+          "group": "fixed-income-core",
+          "rationale": "Low-duration income with limited rate sensitivity — useful when rate path is uncertain."
+        },
+        { "category": "Ultrashort Bond", "group": "fixed-income-core", "rationale": "Cash-like ballast for distributions and near-term spending." },
+        {
+          "category": "Inflation-Protected Bond",
+          "group": "fixed-income-core",
+          "rationale": "TIPS protect real purchasing power across the multi-decade retirement horizon."
+        },
+        { "category": "Target-Date Retirement", "group": "allocation-target-date", "rationale": "Designed exactly for the in-retirement glide path." },
+        {
+          "category": "Conservative Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Static conservative blend for investors who want one ticker handling drawdown management."
+        },
+        {
+          "category": "Moderate Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Slightly more equity for early-retirement years where longevity risk dominates sequence risk."
+        },
+        {
+          "category": "Derivative Income",
+          "group": "alt-strategies",
+          "rationale": "Covered-call funds (e.g. JEPI-style) trade upside for steady monthly income."
+        },
+        {
+          "category": "Defined Outcome",
+          "group": "alt-strategies",
+          "rationale": "Buffered funds cap upside in exchange for explicit downside protection — useful near retirement."
+        }
+      ]
+    },
+    {
+      "key": "tax-sensitive-high-earner",
+      "name": "Tax-Sensitive High-Income Investor",
+      "shortDescription": "High federal-bracket investor (often in a high-tax state) for whom after-tax return is the only return that matters. Heavy use of muni bonds and tax-efficient passive equity.",
+      "profile": {
+        "experienceLevel": "Experienced",
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Tax Optimization",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "High",
+        "accountTypePreference": "Taxable",
+        "typicalInvestor": "Top federal-bracket professional or business owner in a high-tax state (CA, NY, NJ, MA), with a large taxable account where every percent of tax drag compounds."
+      },
+      "goalLabels": ["Tax-equivalent yield", "Tax-efficient equity", "State-specific muni exposure"],
+      "analysisAngle": "State the marginal tax assumption explicitly (e.g. 37% federal + 13.3% CA = ~46% combined). For muni funds compute tax-equivalent yield (TEY = SEC yield / (1 − marginal rate)) and compare to taxable peers of similar duration / credit quality. Flag distribution character (qualified dividend vs ROC vs ordinary) and surface K-1 reporting wherever it appears. For equity sleeves, prefer low-turnover passive index funds over high-turnover active.",
+      "keyConsiderations": [
+        "Tax-equivalent yield at the investor's marginal rate vs taxable bond peers.",
+        "AMT treatment for private-activity-bond muni funds.",
+        "State tax exemption — in-state muni funds give triple-exempt yield in high-tax states.",
+        "Distribution character (qualified dividends, return-of-capital, ordinary income).",
+        "Capital-gain distribution history — a passive ETF should essentially never pay one.",
+        "K-1 vs 1099 reporting for any commodity / MLP / certain alt-strategy funds."
+      ],
+      "redFlags": [
+        "Repeated capital-gain distributions from an ETF marketed as passive.",
+        "K-1 reporting in a fund being considered for a taxable buy-and-hold sleeve.",
+        "Derivative-income fund whose 'yield' is largely return-of-capital without disclosure.",
+        "High-turnover active equity ETF in a taxable account.",
+        "Non-AMT-aware muni allocation for an investor exposed to AMT."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "muni",
+          "fit": "primary",
+          "rationale": "Federally tax-exempt income is the entire reason this group exists; in-state funds add state-tax exemption."
+        },
+        {
+          "groupKey": "broad-equity",
+          "fit": "primary",
+          "rationale": "Low-turnover passive index ETFs are the most tax-efficient way to hold equity in a taxable account."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "secondary",
+          "rationale": "Useful only when the underlying holdings are tax-efficient passive sleeves."
+        },
+        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasuries are state-tax exempt — meaningful for high-state-tax investors." },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "occasional",
+          "rationale": "Acceptable when low-turnover and passive; methodology rebalancing can still cause cap-gain distributions."
+        },
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "occasional",
+          "rationale": "Yield is taxable at ordinary rates — usually loses to muni TEY at this bracket."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "avoid",
+          "rationale": "K-1 reporting, ROC distributions, and high turnover create tax surprises that erode the after-tax return."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "High realized short-term gains taxed at ordinary rates — the worst possible structure for taxable accounts."
+        }
+      ],
+      "highlightedCategories": [
+        { "category": "Muni National Interm", "group": "muni", "rationale": "Default national tax-exempt sleeve for federal high-bracket investors." },
+        { "category": "Muni National Long", "group": "muni", "rationale": "Higher TEY for investors who can absorb the duration risk." },
+        { "category": "High Yield Muni", "group": "muni", "rationale": "Boosts TEY when the investor accepts credit risk; flag the credit-quality slip." },
+        { "category": "Muni California Long", "group": "muni", "rationale": "Triple-exempt yield for California residents in the top brackets." },
+        { "category": "Muni New York Long", "group": "muni", "rationale": "Triple-exempt yield for New York residents (especially NYC)." },
+        {
+          "category": "Large Blend",
+          "group": "broad-equity",
+          "rationale": "Total-market and S&P 500 ETFs are highly tax-efficient and rarely distribute capital gains."
+        },
+        {
+          "category": "Foreign Large Blend",
+          "group": "broad-equity",
+          "rationale": "Passive ex-US exposure with foreign-tax-credit pass-through in taxable accounts."
+        },
+        {
+          "category": "Short Government",
+          "group": "fixed-income-core",
+          "rationale": "Treasuries are state-tax exempt — meaningful in high-state-tax jurisdictions."
+        },
+        {
+          "category": "Long Government",
+          "group": "fixed-income-core",
+          "rationale": "State-tax-exempt long-duration government for investors balancing duration and state-tax savings."
+        }
+      ]
+    },
+    {
+      "key": "income-yield-seeker",
+      "name": "Income / High-Yield Seeker",
+      "shortDescription": "Wants the highest sustainable cash distribution the portfolio can produce, accepting credit risk, derivative complexity, or sector concentration to get there.",
+      "profile": {
+        "experienceLevel": "Intermediate",
+        "investmentHorizon": "Medium (1-5y)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Income Generation",
+        "incomeNeed": "High",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Investor whose portfolio purpose is producing monthly or quarterly cash — semi-retired, FIRE, or someone funding a specific spending program — willing to underweight pure capital appreciation in exchange for distributable yield."
+      },
+      "goalLabels": ["High yield with moderate or high risk", "Monthly income", "Credit-driven income", "Equity-income tilt"],
+      "analysisAngle": "Lead with distribution yield, distribution frequency, and the *sustainability* of the distribution. Decompose the yield into character (qualified dividend / ordinary income / ROC / short-term gain) and the source of return (coupon, option premium, credit spread, REIT FFO). Stress-test distributions against credit drawdowns (2008, 2020, 2022) and option-premium compression in low-vol regimes. A high yield that proved unstable is worse than a lower yield that proved durable.",
+      "keyConsiderations": [
+        "Trailing 12-month distribution yield AND SEC yield (the gap reveals optical yield).",
+        "Distribution character — qualified vs ordinary vs ROC vs short-term gain.",
+        "Distribution stability through 2008, 2020 March, 2022.",
+        "Credit quality mix (HY vs IG, AAA muni vs BB) — yield premium reflects real default risk.",
+        "Concentration risk — REIT, utility, energy MLP, EM debt all carry single-factor exposure.",
+        "For derivative-income funds: cap on upside, behavior in sustained bull markets."
+      ],
+      "redFlags": [
+        "Headline yield meaningfully above SEC yield without disclosed ROC accounting.",
+        "Distribution cut history that the fund's marketing buries.",
+        "Single-issuer or single-country concentration that is not visible from the yield.",
+        "Covered-call strategy whose total return has lagged the underlying by more than the option-premium income.",
+        "High-yield muni labeled as 'muni' but functioning as a credit play."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "fixed-income-credit",
+          "fit": "primary",
+          "rationale": "High-yield, bank loan, EM debt, preferred, and multisector are the canonical taxable-income vehicles."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "primary",
+          "rationale": "Derivative-income and defined-outcome funds engineer high distribution rates by selling options."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "REITs, utilities, energy LPs, and infrastructure deliver equity income and inflation pass-through."
+        },
+        {
+          "groupKey": "fixed-income-core",
+          "fit": "secondary",
+          "rationale": "Long bond, corporate bond, and TIPS deliver investment-grade income with manageable credit risk."
+        },
+        { "groupKey": "muni", "fit": "secondary", "rationale": "Tax-equivalent yield matters when the investor is in a high bracket." },
+        {
+          "groupKey": "broad-equity",
+          "fit": "occasional",
+          "rationale": "Large value and dividend-tilted blends deliver modest but qualified-dividend income."
+        },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "occasional",
+          "rationale": "Conservative allocation funds blend income sleeves but are not income-optimized by design."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "avoid",
+          "rationale": "Not an income vehicle; daily-reset structure is incompatible with distribution stability."
+        }
+      ],
+      "highlightedCategories": [
+        { "category": "High Yield Bond", "group": "fixed-income-credit", "rationale": "Core taxable high-yield exposure (HYG / JNK style)." },
+        { "category": "Bank Loan", "group": "fixed-income-credit", "rationale": "Floating-rate income that holds up in rising-rate environments." },
+        {
+          "category": "Preferred Stock",
+          "group": "fixed-income-credit",
+          "rationale": "Equity-like instruments paying high stated yields, mostly from financial issuers."
+        },
+        {
+          "category": "Emerging Markets Bond",
+          "group": "fixed-income-credit",
+          "rationale": "Sovereign and quasi-sovereign EM credit with materially higher yields than US IG."
+        },
+        {
+          "category": "Multisector Bond",
+          "group": "fixed-income-credit",
+          "rationale": "Active credit allocation across HY, IG, and EM — manager flexibility for income generation."
+        },
+        {
+          "category": "Derivative Income",
+          "group": "alt-strategies",
+          "rationale": "Covered-call funds (JEPI / QYLD / SPYI) deliver high monthly distributions from option premium."
+        },
+        { "category": "Defined Outcome", "group": "alt-strategies", "rationale": "Buffered structured-payoff funds with defined income and downside profile." },
+        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT income from rents — ordinary income but historically sustainable." },
+        { "category": "Utilities", "group": "sector-thematic-equity", "rationale": "Regulated-utility dividend stream, mostly qualified." },
+        {
+          "category": "Energy Limited Partnership",
+          "group": "sector-thematic-equity",
+          "rationale": "MLP distributions with K-1 reporting — high yield but tax-complex."
+        },
+        {
+          "category": "Long-Term Bond",
+          "group": "fixed-income-core",
+          "rationale": "Long-duration IG paper for investors who want yield and accept rate risk."
+        },
+        { "category": "Corporate Bond", "group": "fixed-income-core", "rationale": "IG corporate income without meaningful credit blow-up risk." }
+      ]
+    },
+    {
+      "key": "sector-thematic-conviction",
+      "name": "Sector / Thematic Conviction Investor",
+      "shortDescription": "Has a directional view on a specific sector, theme, region, or commodity and wants the cleanest expression of that thesis.",
+      "profile": {
+        "experienceLevel": "Experienced",
+        "investmentHorizon": "Medium (1-5y)",
+        "riskTolerance": "High",
+        "primaryGoal": "Thematic Exposure",
+        "incomeNeed": "None",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Investor who has formed a specific view (AI infrastructure will outperform, India will outgrow EM, gold will benefit from real-rate path) and wants a single ETF that expresses that view rather than picking individual stocks."
+      },
+      "goalLabels": ["Sector tilt", "Thematic exposure", "Single-country thematic exposure", "Commodity / real-asset exposure"],
+      "analysisAngle": "Focus on theme purity — does the fund actually own the names that match its label? Decompose top holdings, methodology, and how the index defines the theme. Compare against the obvious peers in the same theme (XLK vs VGT vs IYW for tech; KWEB vs MCHI vs FXI for China). Surface concentration, weighting methodology (cap vs equal vs revenue), and rebalancing cadence. Avoid over-weighting historical returns — themes rotate and recent leadership is a poor predictor.",
+      "keyConsiderations": [
+        "Methodology — what does the index actually screen for, and how strict is the filter?",
+        "Theme purity — top-10 holdings vs the stated thesis.",
+        "Peer comparison within the same theme (multiple ETFs often exist).",
+        "Concentration — how much of return is driven by the top 5 names?",
+        "Weighting scheme (market-cap vs equal-weight vs revenue-weight) materially changes risk profile.",
+        "Rebalancing cadence and turnover — high-rebalance themes generate cap gains in taxable accounts."
+      ],
+      "redFlags": [
+        "Theme name that does not match the actual top holdings (e.g. an 'AI' fund holding mostly mega-cap tech).",
+        "Single-stock exposure above ~25% (turns the fund into a single-stock proxy).",
+        "Recent inception (<2 years) for a niche theme without issuer track record.",
+        "AUM under $50M with declining trend (closure risk in a specialty fund is high)."
+      ],
+      "etfGroupFit": [
+        { "groupKey": "sector-thematic-equity", "fit": "primary", "rationale": "Every category in this group is exactly a sector or thematic expression." },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "primary",
+          "rationale": "Spot digital assets, commodities, and single-currency funds are pure thematic real-asset / FX expressions."
+        },
+        {
+          "groupKey": "broad-equity",
+          "fit": "secondary",
+          "rationale": "Single-country and regional funds (China, India, Japan, Latin America) are equity-thematic by definition."
+        },
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "occasional",
+          "rationale": "Acceptable only as a short-term tactical expression, never as the long-form thematic holding."
+        },
+        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "EM debt and certain credit themes can express a macro view." },
+        { "groupKey": "fixed-income-core", "fit": "occasional", "rationale": "Duration / curve tilts (long government, TIPS) can express macro themes." },
+        { "groupKey": "muni", "fit": "occasional", "rationale": "State-specific muni funds are technically thematic on state-fiscal health." },
+        { "groupKey": "allocation-target-date", "fit": "avoid", "rationale": "Multi-asset blends dilute any single thematic view." }
+      ],
+      "highlightedCategories": [
+        { "category": "Technology", "group": "sector-thematic-equity", "rationale": "Cleanest US-tech thematic expression." },
+        { "category": "Health", "group": "sector-thematic-equity", "rationale": "Healthcare sector tilt — defensive growth with distinct regulatory risk." },
+        { "category": "Financial", "group": "sector-thematic-equity", "rationale": "Bank, broker, and insurance tilt — rate- and cycle-sensitive." },
+        { "category": "Equity Energy", "group": "sector-thematic-equity", "rationale": "Equity expression of the energy thesis (vs commodity exposure)." },
+        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT thematic exposure to commercial real estate." },
+        { "category": "Equity Precious Metals", "group": "sector-thematic-equity", "rationale": "Gold-mining equities — leveraged play on the gold price." },
+        { "category": "Infrastructure", "group": "sector-thematic-equity", "rationale": "Listed infrastructure thematic — utilities, pipelines, transport." },
+        { "category": "Equity Digital Assets", "group": "sector-thematic-equity", "rationale": "Equity exposure to crypto-economy companies." },
+        { "category": "China Region", "group": "broad-equity", "rationale": "Single-country China thematic exposure." },
+        { "category": "India Equity", "group": "broad-equity", "rationale": "Single-country India growth thesis." },
+        { "category": "Japan Stock", "group": "broad-equity", "rationale": "Single-country Japan thematic — corporate governance / yen thesis." },
+        { "category": "Latin America Stock", "group": "broad-equity", "rationale": "Regional EM tilt with commodity sensitivity." },
+        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot crypto exposure for direct thematic conviction." },
+        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity thematic plays (gold, silver, oil, ag)." },
+        {
+          "category": "Commodities Precious Metals",
+          "group": "alt-strategies",
+          "rationale": "Direct precious-metals exposure for inflation / debasement views."
+        },
+        { "category": "Single Currency", "group": "alt-strategies", "rationale": "Direct FX expression for macro currency views." }
+      ]
+    },
+    {
+      "key": "active-trader-speculator",
+      "name": "Active Trader / Tactical Speculator",
+      "shortDescription": "Holds positions for hours to weeks, uses ETFs as expression vehicles for short-term directional or hedging trades. Tolerates structural decay in exchange for liquidity and leverage.",
+      "profile": {
+        "experienceLevel": "Experienced",
+        "investmentHorizon": "Short (<1y)",
+        "riskTolerance": "Very High",
+        "primaryGoal": "Speculation / Trading",
+        "incomeNeed": "None",
+        "taxSensitivity": "Low",
+        "accountTypePreference": "Taxable",
+        "typicalInvestor": "Active trader running directional or pairs trades, hedging an existing book, or expressing tactical macro views with daily-leveraged or single-currency / single-commodity products."
+      },
+      "goalLabels": ["Short-term tactical exposure", "Leveraged directional bet", "Hedging overlay"],
+      "analysisAngle": "Focus on intraday liquidity, bid-ask spread, daily volume, and daily-leverage tracking fidelity. For leveraged products, hammer the holding-period warning: 2-3% all-in annual decay (financing + volatility drag + expense ratio) means these are not buy-and-hold. Address pair-trade construction (TQQQ vs SQQQ, TLT vs TBT) and the impact of overnight gap risk. Tax efficiency is largely irrelevant — short-term gains are short-term gains.",
+      "keyConsiderations": [
+        "Average daily dollar volume — must support entry/exit at intended size without slippage.",
+        "Bid-ask spread in bps — direct round-trip cost for high-frequency trading.",
+        "Daily-leverage tracking fidelity vs the stated multiplier.",
+        "Underlying market hours — single-currency and commodity ETFs may gap on overnight underlying moves.",
+        "Volatility decay magnitude in the recent regime.",
+        "Suitability for pair trades (matched leverage long/short pairs)."
+      ],
+      "redFlags": [
+        "Wide bid-ask that erodes round-trip economics.",
+        "Thin volume that prevents large-order exits without market impact.",
+        "Persistent tracking gap vs the daily-leverage objective.",
+        "Marketing language that downplays the daily-reset / decay mechanism."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "leveraged-inverse",
+          "fit": "primary",
+          "rationale": "Daily-leveraged and inverse funds are the direct expression vehicle for short-term tactical bets."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "primary",
+          "rationale": "Single-currency, commodity, and digital-asset funds give clean tactical exposure to macro factors."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "secondary",
+          "rationale": "Narrow sector ETFs are useful for sector-rotation trades and short-term hedges."
+        },
+        { "groupKey": "broad-equity", "fit": "secondary", "rationale": "Single-country / regional funds enable macro-tactical bets on specific economies." },
+        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasury-duration ETFs (TLT, IEF) are standard rate-bet expression vehicles." },
+        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "HY-credit ETFs can express risk-on / risk-off tactical views." },
+        { "groupKey": "muni", "fit": "avoid", "rationale": "Wide bid-ask and slow underlying market make muni ETFs unsuitable for short-term trading." },
+        { "groupKey": "allocation-target-date", "fit": "avoid", "rationale": "Multi-asset blends are too diluted for any tactical thesis." }
+      ],
+      "highlightedCategories": [
+        { "category": "Trading--Leveraged Equity", "group": "leveraged-inverse", "rationale": "TQQQ / SPXL — canonical 3x equity tactical long." },
+        {
+          "category": "Trading--Inverse Equity",
+          "group": "leveraged-inverse",
+          "rationale": "SQQQ / SPXS — canonical short-side equity expression for hedging or directional shorts."
+        },
+        { "category": "Trading--Leveraged Debt", "group": "leveraged-inverse", "rationale": "TMF — leveraged long-duration Treasury bet." },
+        { "category": "Trading--Inverse Debt", "group": "leveraged-inverse", "rationale": "TBT / TBF — short long-duration Treasury (rate hike bet)." },
+        { "category": "Trading--Leveraged Commodities", "group": "leveraged-inverse", "rationale": "BOIL / UCO — leveraged commodity trades." },
+        {
+          "category": "Multi-Asset Leveraged",
+          "group": "leveraged-inverse",
+          "rationale": "Risk-parity-style leveraged multi-asset for sophisticated tactical use."
+        },
+        { "category": "Single Currency", "group": "alt-strategies", "rationale": "Direct USD / yen / euro expression for macro tactical FX." },
+        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity tactical plays (oil, gas, ag)." },
+        { "category": "Digital Assets", "group": "alt-strategies", "rationale": "Spot crypto for short-term directional bets." },
+        { "category": "Long Government", "group": "fixed-income-core", "rationale": "TLT — the standard tactical duration vehicle without leverage." }
+      ]
+    },
+    {
+      "key": "all-weather-diversifier",
+      "name": "All-Weather Diversifier / Risk-Off Hedger",
+      "shortDescription": "Cares about portfolio-level outcomes more than any one fund's return. Prioritizes low correlation, drawdown reduction, and risk-adjusted return; allocates to alternatives and balanced sleeves.",
+      "profile": {
+        "experienceLevel": "Experienced",
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Sophisticated investor (often someone with finance background or working with an advisor) building a portfolio that holds up across regimes — not just bull markets — and willing to accept lower expected return for shallower drawdowns."
+      },
+      "goalLabels": ["Low-correlation diversifier", "Drawdown reduction", "All-weather portfolio sleeve", "Risk-off hedge"],
+      "analysisAngle": "Focus on correlation to S&P 500 and to a 60/40 benchmark, drawdown depth in 2008 / 2020 / 2022, and whether the strategy actually delivered its mandate (low correlation, downside protection, uncorrelated returns) — not whether it beat the S&P. Emphasize that the right yardstick for an alt strategy is mandate adherence in stress, not absolute return in a bull market. Address how this fund interacts with a typical equity-heavy portfolio.",
+      "keyConsiderations": [
+        "Realized correlation to S&P 500 across full cycle and in stress periods.",
+        "Maximum drawdown vs an equity benchmark — did it cut drawdown materially?",
+        "Mandate delivery — did the strategy do what it said (managed-futures up in 2022, market-neutral flat through 2020)?",
+        "Risk-adjusted return (Sharpe / Sortino) vs both peers and a passive blend.",
+        "Fee justification — alt-strategy fees only earn their keep if the diversification is real.",
+        "Capacity / scaling — has the strategy degraded as AUM grew?"
+      ],
+      "redFlags": [
+        "Strategy that quietly tracks equities in stress (correlation spike when it matters most).",
+        "High fees on a 'multi-strategy' fund that just delivers equity beta.",
+        "Manager change without succession plan in an active alt sleeve.",
+        "Mandate drift — fund relabels from 'market neutral' to 'long-short' (different risk profile)."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "primary",
+          "rationale": "Static balanced, tactical, and global allocation funds are pre-built diversified sleeves."
+        },
+        {
+          "groupKey": "alt-strategies",
+          "fit": "primary",
+          "rationale": "Managed futures, market neutral, long-short, and multistrategy are the canonical low-correlation diversifiers."
+        },
+        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "Treasuries and TIPS provide the classic risk-off ballast in a 60/40 portfolio." },
+        { "groupKey": "broad-equity", "fit": "secondary", "rationale": "Foreign and EM equity diversify the US-equity risk concentration." },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "occasional",
+          "rationale": "Real estate, gold-mining, and infrastructure can serve as thematic diversifiers but carry sector risk."
+        },
+        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "Credit correlates with equity in stress — limited diversification value." },
+        { "groupKey": "muni", "fit": "occasional", "rationale": "Useful when the diversifier need is also tax-efficient." },
+        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Volatility decay makes these unsuitable as portfolio diversifiers." }
+      ],
+      "highlightedCategories": [
+        { "category": "Tactical Allocation", "group": "allocation-target-date", "rationale": "Active multi-asset that tilts across regimes." },
+        { "category": "Moderate Allocation", "group": "allocation-target-date", "rationale": "Static 60/40-style blend as a single-ticker portfolio." },
+        {
+          "category": "Global Moderate Allocation",
+          "group": "allocation-target-date",
+          "rationale": "Globally diversified balanced blend reducing US-equity concentration."
+        },
+        { "category": "Global Allocation", "group": "allocation-target-date", "rationale": "Flexible cross-asset, cross-region single-ticker allocation." },
+        {
+          "category": "Systematic Trend",
+          "group": "alt-strategies",
+          "rationale": "Managed-futures trend-following — historically uncorrelated and positive in 2008 / 2022."
+        },
+        { "category": "Equity Market Neutral", "group": "alt-strategies", "rationale": "Long/short construction targeting near-zero net market exposure." },
+        { "category": "Long-Short Equity", "group": "alt-strategies", "rationale": "Reduces beta vs long-only equity while retaining stock-selection alpha." },
+        {
+          "category": "Multistrategy",
+          "group": "alt-strategies",
+          "rationale": "Combines uncorrelated alt sleeves into one ticker for portfolio-level diversification."
+        },
+        {
+          "category": "Macro Trading",
+          "group": "alt-strategies",
+          "rationale": "Macro-discretionary or systematic — distinct return drivers from equity / credit."
+        },
+        {
+          "category": "Long Government",
+          "group": "fixed-income-core",
+          "rationale": "Long-duration Treasury — classic risk-off equity hedge in deflation regimes."
+        },
+        {
+          "category": "Inflation-Protected Bond",
+          "group": "fixed-income-core",
+          "rationale": "TIPS hedge inflation regimes that hurt nominal bonds and growth equity."
+        },
+        { "category": "Foreign Large Blend", "group": "broad-equity", "rationale": "Developed-ex-US diversifies US-equity concentration." },
+        { "category": "Diversified Emerging Mkts", "group": "broad-equity", "rationale": "EM equity diversifies developed-market regime risk." }
+      ]
+    },
+    {
+      "key": "inflation-real-asset-hedger",
+      "name": "Inflation & Real-Asset Hedger",
+      "shortDescription": "Worried about CPI / debasement / cost-of-living erosion of purchasing power. Allocates to commodities, real estate, infrastructure, energy equities, gold, and TIPS.",
+      "profile": {
+        "experienceLevel": "Intermediate",
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "accountTypePreference": "Either",
+        "typicalInvestor": "Investor explicitly worried about inflation regimes (post-2021 type), sustained debasement, or cost-of-living erosion of the bond and growth-equity portion of their portfolio."
+      },
+      "goalLabels": ["Inflation hedge", "Real-asset exposure", "Commodity / real-estate tilt", "Debasement hedge"],
+      "analysisAngle": "Focus on real-return correlation and inflation beta. Distinguish *direct* inflation hedges (commodities, TIPS, gold) from *equity-style* real-asset proxies (REITs, infrastructure, energy equities, MLPs) — the equity proxies have meaningful equity-market beta and are imperfect hedges in pure inflation shocks. Address regime sensitivity: gold and commodities perform very differently across stagflation, demand-pull, and rate-hike inflation. Surface tax / K-1 complications for commodity pools and MLPs.",
+      "keyConsiderations": [
+        "Direct vs proxy inflation exposure — physical commodities vs producer equities have different betas.",
+        "Inflation beta in actual inflation regimes (2021-2023, 2008 commodity spike).",
+        "Real-rate sensitivity — TIPS lose value when real rates rise even if breakevens hold.",
+        "K-1 vs 1099 reporting for commodity pools, MLPs, and certain alt funds.",
+        "Concentration — a 'commodities' fund may be 80% energy.",
+        "Equity-market beta of REITs, infrastructure, and natural-resource equities (they are not pure inflation hedges)."
+      ],
+      "redFlags": [
+        "Long-duration nominal bond fund being marketed as part of an inflation portfolio.",
+        "Single-commodity fund being used as the broad inflation hedge.",
+        "Equity REIT being treated as a pure inflation hedge despite high equity-market beta.",
+        "Gold-mining ETF treated as gold (mining equities can decouple sharply from spot)."
+      ],
+      "etfGroupFit": [
+        {
+          "groupKey": "alt-strategies",
+          "fit": "primary",
+          "rationale": "Commodities, precious metals, and digital-asset funds are the most direct real-asset / debasement hedges."
+        },
+        {
+          "groupKey": "sector-thematic-equity",
+          "fit": "primary",
+          "rationale": "Real estate, natural resources, infrastructure, energy, and MLPs are the equity-style real-asset proxies."
+        },
+        { "groupKey": "fixed-income-core", "fit": "secondary", "rationale": "TIPS and short-term TIPS are the direct inflation-linked Treasury hedge." },
+        {
+          "groupKey": "broad-equity",
+          "fit": "occasional",
+          "rationale": "Value tilt and EM equity historically perform better than growth in inflation regimes."
+        },
+        { "groupKey": "fixed-income-credit", "fit": "occasional", "rationale": "Bank loans (floating rate) can hold up in rising-rate inflation regimes." },
+        {
+          "groupKey": "allocation-target-date",
+          "fit": "occasional",
+          "rationale": "Most allocation funds underweight real assets; check the actual inflation hedge sleeve."
+        },
+        { "groupKey": "muni", "fit": "avoid", "rationale": "Long-duration nominal munis lose to inflation; not a hedge." },
+        { "groupKey": "leveraged-inverse", "fit": "avoid", "rationale": "Decay structure makes these unsuitable for a multi-year inflation hedge." }
+      ],
+      "highlightedCategories": [
+        { "category": "Commodities Broad Basket", "group": "alt-strategies", "rationale": "Diversified commodity exposure — the direct inflation hedge." },
+        { "category": "Commodities Focused", "group": "alt-strategies", "rationale": "Single-commodity exposure for specific supply / demand views." },
+        { "category": "Commodities Precious Metals", "group": "alt-strategies", "rationale": "Direct gold / silver exposure — the classic debasement hedge." },
+        {
+          "category": "Digital Assets",
+          "group": "alt-strategies",
+          "rationale": "Bitcoin as the modern debasement hedge for investors who accept the volatility."
+        },
+        { "category": "Real Estate", "group": "sector-thematic-equity", "rationale": "REIT income inflation pass-through, with equity-market beta caveat." },
+        { "category": "Global Real Estate", "group": "sector-thematic-equity", "rationale": "Diversifies single-country property regulatory risk." },
+        {
+          "category": "Natural Resources",
+          "group": "sector-thematic-equity",
+          "rationale": "Diversified resource-equity exposure (mining, energy, agriculture)."
+        },
+        { "category": "Equity Energy", "group": "sector-thematic-equity", "rationale": "Energy-equity tilt for oil-price inflation regimes." },
+        { "category": "Equity Precious Metals", "group": "sector-thematic-equity", "rationale": "Gold-miner equity leverage to the gold price." },
+        { "category": "Infrastructure", "group": "sector-thematic-equity", "rationale": "Listed infrastructure with regulated inflation pass-through." },
+        {
+          "category": "Energy Limited Partnership",
+          "group": "sector-thematic-equity",
+          "rationale": "MLPs tied to commodity throughput and inflation pass-through (K-1 caveat)."
+        },
+        {
+          "category": "Inflation-Protected Bond",
+          "group": "fixed-income-core",
+          "rationale": "Direct CPI-linked Treasury exposure — the classic real-yield hedge."
+        },
+        {
+          "category": "Short-Term Inflation-Protected Bond",
+          "group": "fixed-income-core",
+          "rationale": "TIPS without long-duration real-rate risk — purer near-term inflation hedge."
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,5 +1,5 @@
 {
-  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Each entry is an audience + goal pair (e.g., 'HNW: State-Tax-Exempt Muni Income', 'Pension: Liability-Driven Investing', 'RIA: Tax-Loss-Harvesting Partner Pairs') rather than a generic audience label, so retail and institutional channels are both captured at the level of the specific outcome they're trying to achieve. Note: the word 'group' here is a generic 'investor archetype'; it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, and red flags that disqualify a fund for them. Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
+  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Two shapes appear in the investorGroups array: (1) flat goal-persona entries with key/name/shortDescription/profile/analysisAngle/keyConsiderations/redFlags (used for retail goals like first-time-investor, growth-accumulator, retirement-income-seeker, plus single-purpose institutional ones like institutional-trading-desk and insurance-corporate-treasury); and (2) audience entries with key/name/shortDescription/goals[], where the goals[] array holds nested goal-persona entries — used for broad audiences (HNW / family office, pension / endowment / foundation, RIA / financial advisor) that have multiple distinct goals worth analyzing separately. Note: the word 'group' here is a generic 'investor archetype'; it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
   "investorGroups": [
     {
       "key": "first-time-investor",
@@ -417,237 +417,258 @@
       ]
     },
     {
-      "key": "hnw-tax-efficient-public-equity-sleeve",
-      "name": "HNW: Tax-Efficient Public-Equity Beta Sleeve",
-      "shortDescription": "High-net-worth or family-office investor seeking tax-efficient compounding of US and international equity exposure inside taxable accounts — ETFs are the wrapper for the public-equity beta sleeve while private allocations carry the alpha mandate.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "High",
-        "typicalInvestor": "HNW individual ($5M-$50M investable) or single-family office at the top federal + state + NIIT bracket; alpha mandate sits in PE / hedge funds / direct real estate; ETFs serve only as the efficient-beta sleeve."
-      },
-      "analysisAngle": "After-tax return at the top marginal rate is the only metric that matters. Capital-gain distribution history must be near zero. At >$1M positions, direct indexing with daily harvesting often beats an index ETF — the ETF must justify its wrapper. Foreign-tax-credit pickup is a real consideration for international sleeves held in taxable accounts.",
-      "keyConsiderations": [
-        "Capital-gain distribution history (passive ETFs near zero; thematic and active can surprise).",
-        "After-tax return at top federal + state + NIIT bracket, not headline return.",
-        "Foreign-tax-credit pickup for international ETFs held in taxable accounts.",
-        "Direct-indexing breakeven analysis for $1M+ positions.",
-        "Wrapper cost stacking when the ETF sits inside a SMA / UMA."
-      ],
-      "redFlags": [
-        "Material recent capital-gain distributions in a passive-style fund.",
-        "Active or thematic strategy with high turnover dragging after-tax return.",
-        "Distribution character largely ROC or short-term gain without disclosure."
+      "key": "high-net-worth-individual",
+      "name": "High-Net-Worth Individual / Family Office",
+      "shortDescription": "Wealthy individual or single-family office investing $5M-$500M+ across asset classes — uses ETFs for tax-efficient beta, satellite exposures, and overlays alongside private investments. Different HNW investors emphasize different goals: efficient public-equity beta in taxable accounts, state-tax-exempt muni income at the top federal/state bracket, or diversifying real-asset and alternatives overlays alongside their private allocations.",
+      "goals": [
+        {
+          "key": "tax-efficient-public-equity-sleeve",
+          "name": "Tax-Efficient Public-Equity Beta Sleeve",
+          "shortDescription": "High-net-worth or family-office investor seeking tax-efficient compounding of US and international equity exposure inside taxable accounts — ETFs are the wrapper for the public-equity beta sleeve while private allocations carry the alpha mandate.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Wealth Accumulation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW individual ($5M-$50M investable) or single-family office at the top federal + state + NIIT bracket; alpha mandate sits in PE / hedge funds / direct real estate; ETFs serve only as the efficient-beta sleeve."
+          },
+          "analysisAngle": "After-tax return at the top marginal rate is the only metric that matters. Capital-gain distribution history must be near zero. At >$1M positions, direct indexing with daily harvesting often beats an index ETF — the ETF must justify its wrapper. Foreign-tax-credit pickup is a real consideration for international sleeves held in taxable accounts.",
+          "keyConsiderations": [
+            "Capital-gain distribution history (passive ETFs near zero; thematic and active can surprise).",
+            "After-tax return at top federal + state + NIIT bracket, not headline return.",
+            "Foreign-tax-credit pickup for international ETFs held in taxable accounts.",
+            "Direct-indexing breakeven analysis for $1M+ positions.",
+            "Wrapper cost stacking when the ETF sits inside a SMA / UMA."
+          ],
+          "redFlags": [
+            "Material recent capital-gain distributions in a passive-style fund.",
+            "Active or thematic strategy with high turnover dragging after-tax return.",
+            "Distribution character largely ROC or short-term gain without disclosure."
+          ]
+        },
+        {
+          "key": "state-tax-exempt-muni-income",
+          "name": "State-Tax-Exempt Muni Income",
+          "shortDescription": "High-bracket resident of a high-tax state (CA, NY, NJ, MA, IL) seeking muni income with state-tax exemption stacked on top of the federal exemption — AMT awareness for private-activity-bond exposure.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor in a top federal bracket who is also a high-tax-state resident; significant taxable-account fixed-income that needs to maximize after-tax yield via in-state muni exposure."
+          },
+          "analysisAngle": "TEY at the explicit federal + state + NIIT bracket is the comparison metric. State-specific muni funds add the state-tax exemption — for a CA resident in the top bracket the math frequently dominates national muni and taxable IG. AMT exposure on private-activity-bond muni funds must be flagged. Credit quality and concentration matter — high-yield muni introduces real default risk that the muni label doesn't make obvious.",
+          "keyConsiderations": [
+            "Tax-equivalent yield at federal + state + NIIT bracket for in-state vs national muni.",
+            "AMT exposure on private-activity-bond muni funds.",
+            "Single-jurisdiction credit risk in state-specific muni (pension stress, revenue shock).",
+            "Issuer credit-tier mix — IG-only vs HY-muni tilt.",
+            "Duration positioning relative to rate outlook."
+          ],
+          "redFlags": [
+            "High-yield muni exposure inside a generically named muni fund without disclosure.",
+            "Private-activity-bond concentration triggering AMT for high-bracket investors.",
+            "Single-state muni with documented pension or revenue-base distress."
+          ]
+        },
+        {
+          "key": "real-asset-and-alternatives-overlay",
+          "name": "Real-Asset and Alternatives Overlay",
+          "shortDescription": "HNW or family-office investor adding diversifying real-asset, defined-outcome, derivative-income, or commodity exposure on top of a public-equity + muni core — often complementing direct private real estate or commodity holdings.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate-High",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "High",
+            "typicalInvestor": "HNW investor or family office whose constructed portfolio already covers public-equity beta and tax-efficient fixed income, looking for inflation hedges, downside structure, or uncorrelated return streams via accessible ETF wrappers."
+          },
+          "analysisAngle": "Sizing matters — these are diversifying sleeves, not core holdings. Defined-outcome and derivative-income funds must be evaluated on the upside-cap vs income-payout tradeoff. Commodity and precious-metals funds must be checked for K-1 vs 1099 reporting since K-1 creates real friction at HNW scale. Real-asset equity proxies (REITs, infrastructure, natural resources) carry equity-correlation risk that should be disclosed. Discuss complement to private allocations, not substitute.",
+          "keyConsiderations": [
+            "K-1 vs 1099 reporting (commodity pools, MLPs).",
+            "Upside-cap vs income-payout tradeoff for defined-outcome and derivative-income funds.",
+            "Equity-correlation in 'real asset' equity proxies during stress.",
+            "Sizing relative to existing private real-estate / private-PE allocations.",
+            "Currency-hedging methodology for non-USD alts."
+          ],
+          "redFlags": [
+            "Fund labeled 'inflation hedge' but historically tracking equity beta.",
+            "Unhedged single-currency or single-commodity concentration sized larger than satellite.",
+            "K-1 reporting without offsetting tax or hedging benefit."
+          ]
+        }
       ]
     },
     {
-      "key": "hnw-state-tax-exempt-muni-income",
-      "name": "HNW: State-Tax-Exempt Muni Income",
-      "shortDescription": "High-bracket resident of a high-tax state (CA, NY, NJ, MA, IL) seeking muni income with state-tax exemption stacked on top of the federal exemption — AMT awareness for private-activity-bond exposure.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Tax Optimization",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "High",
-        "typicalInvestor": "HNW investor in a top federal bracket who is also a high-tax-state resident; significant taxable-account fixed-income that needs to maximize after-tax yield via in-state muni exposure."
-      },
-      "analysisAngle": "TEY at the explicit federal + state + NIIT bracket is the comparison metric. State-specific muni funds add the state-tax exemption — for a CA resident in the top bracket the math frequently dominates national muni and taxable IG. AMT exposure on private-activity-bond muni funds must be flagged. Credit quality and concentration matter — high-yield muni introduces real default risk that the muni label doesn't make obvious.",
-      "keyConsiderations": [
-        "Tax-equivalent yield at federal + state + NIIT bracket for in-state vs national muni.",
-        "AMT exposure on private-activity-bond muni funds.",
-        "Single-jurisdiction credit risk in state-specific muni (pension stress, revenue shock).",
-        "Issuer credit-tier mix — IG-only vs HY-muni tilt.",
-        "Duration positioning relative to rate outlook."
-      ],
-      "redFlags": [
-        "High-yield muni exposure inside a generically named muni fund without disclosure.",
-        "Private-activity-bond concentration triggering AMT for high-bracket investors.",
-        "Single-state muni with documented pension or revenue-base distress."
+      "key": "pension-endowment-foundation",
+      "name": "Pension / Endowment / Foundation (incl. Union Pensions)",
+      "shortDescription": "Long-horizon institutional pool — corporate or public pension, Taft-Hartley / union pension, university endowment, charitable foundation, sovereign wealth fund — governed by an Investment Policy Statement with defined liabilities or spending mandates. Different mandates drive different goals: liability-driven investing (LDI) for defined-benefit pensions, sustainable spending-policy support for endowments and foundations, and a liquid-beta sleeve to complement illiquid private allocations.",
+      "goals": [
+        {
+          "key": "pension-liability-driven-investing",
+          "name": "Liability-Driven Investing (LDI)",
+          "shortDescription": "Defined-benefit pension plan (corporate, public, or Taft-Hartley union) matching long-duration nominal or real liabilities with treasuries, STRIPS, and TIPS — duration matching matters more than nominal yield.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Defined-benefit pension plan (corporate, public, or multi-employer / Taft-Hartley union) with a known actuarial liability stream, funded-ratio focused, governed by an IPS that specifies duration target and surplus risk tolerance."
+          },
+          "analysisAngle": "Duration matching is the primary lens. Long treasuries, STRIPS, and long-TIPS are the workhorse instruments. Discuss key-rate-duration profile, convexity, and the surplus-volatility tradeoff. Securities-lending revenue and institutional-share-class fees change the math — avoid retail fee commentary. Capacity matters: the fund must absorb $50-500M allocations without market impact.",
+          "keyConsiderations": [
+            "Key-rate-duration and convexity profile vs the liability stream.",
+            "Securities-lending revenue (institutional pools earn back basis points).",
+            "Capacity to absorb $50-500M allocations without market impact.",
+            "Liability-discount-curve sensitivity and surplus volatility.",
+            "Counterparty / collateral structure for treasury STRIPS or futures-based duration."
+          ],
+          "redFlags": [
+            "Fund too small for institutional-scale allocation without dominant-holder risk.",
+            "Methodology drift that breaks IPS benchmark consistency over multiple years.",
+            "Concentration / closure risk from a single large investor's outflow."
+          ]
+        },
+        {
+          "key": "endowment-foundation-spending-policy-support",
+          "name": "Spending-Policy Support",
+          "shortDescription": "University endowment or charitable foundation distributing ~5% per year while preserving real capital across generations — needs a portfolio that sustainably supports spending without eroding the corpus.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Capital Preservation",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "University endowment ($500M-$50B+), private foundation, or community foundation. Spending policy is the binding constraint (typically 4-5% rolling-average); IPS often includes ESG / SRI / mission-aligned screens; large allocations to private equity and real assets are typical."
+          },
+          "analysisAngle": "The portfolio must sustainably distribute ~5%/year while preserving real (inflation-adjusted) capital — this is a real-return mandate. ETFs are typically the liquid-beta sleeve and rebalancing buffer alongside the illiquid private book. Discuss real-return coverage, ESG / SRI screen compatibility, capacity, and securities-lending revenue. Avoid retail-style fee comparisons.",
+          "keyConsiderations": [
+            "Long-run real return coverage of the spending rate.",
+            "ESG / SRI / mission-aligned screen compatibility (foundations especially).",
+            "Capacity for institutional-scale allocations without dominant-holder risk.",
+            "Liquid-beta provision alongside illiquid private allocations.",
+            "Rebalancing-band depth — can the ETF be sold at scale to fund distributions?"
+          ],
+          "redFlags": [
+            "ESG-labeled funds with weak self-graded screens (greenwashing risk for foundations).",
+            "Methodology drift breaking IPS benchmark consistency.",
+            "Insufficient liquidity to fund the annual distribution at scale."
+          ]
+        },
+        {
+          "key": "institutional-liquid-beta-sleeve",
+          "name": "Liquid-Beta Sleeve Alongside Privates",
+          "shortDescription": "Pension, endowment, foundation, or sovereign wealth fund needing a low-cost liquid index sleeve providing US, international, and EM equity beta + investment-grade core fixed income alongside an illiquid private-allocation book.",
+          "profile": {
+            "investmentHorizon": "Very Long (15y+)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Low",
+            "typicalInvestor": "Pension plan, endowment, foundation, or sovereign wealth fund whose IPS calls for a defined liquid-beta exposure mix to complement private equity, private real estate, and private credit. Typically uses institutional ETF share classes or separate accounts."
+          },
+          "analysisAngle": "This is a building-block role — the ETFs serve as cheap, transparent, scalable beta exposure for the IPS-mandated mix. Tracking fidelity to the policy benchmark, AUM/capacity, and securities-lending revenue dominate. Discuss policy benchmark fit (e.g., S&P 500 vs Russell 1000 vs MSCI USA) — the wrong benchmark family breaks attribution.",
+          "keyConsiderations": [
+            "Tracking fidelity to the IPS-mandated benchmark.",
+            "Securities-lending revenue offset against the institutional fee.",
+            "Capacity for institutional allocation sizes without market impact.",
+            "Benchmark family compatibility (S&P, Russell, MSCI, FTSE) with the IPS.",
+            "Operational stability — issuer custody, counterparty, settlement reliability."
+          ],
+          "redFlags": [
+            "Wrong benchmark family forcing attribution adjustments.",
+            "Limited capacity making the institution a dominant holder.",
+            "Issuer or fund-family operational concerns at institutional scale."
+          ]
+        }
       ]
     },
     {
-      "key": "hnw-real-asset-and-alternatives-overlay",
-      "name": "HNW: Real-Asset and Alternatives Overlay",
-      "shortDescription": "HNW or family-office investor adding diversifying real-asset, defined-outcome, derivative-income, or commodity exposure on top of a public-equity + muni core — often complementing direct private real estate or commodity holdings.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "High",
-        "typicalInvestor": "HNW investor or family office whose constructed portfolio already covers public-equity beta and tax-efficient fixed income, looking for inflation hedges, downside structure, or uncorrelated return streams via accessible ETF wrappers."
-      },
-      "analysisAngle": "Sizing matters — these are diversifying sleeves, not core holdings. Defined-outcome and derivative-income funds must be evaluated on the upside-cap vs income-payout tradeoff. Commodity and precious-metals funds must be checked for K-1 vs 1099 reporting since K-1 creates real friction at HNW scale. Real-asset equity proxies (REITs, infrastructure, natural resources) carry equity-correlation risk that should be disclosed. Discuss complement to private allocations, not substitute.",
-      "keyConsiderations": [
-        "K-1 vs 1099 reporting (commodity pools, MLPs).",
-        "Upside-cap vs income-payout tradeoff for defined-outcome and derivative-income funds.",
-        "Equity-correlation in 'real asset' equity proxies during stress.",
-        "Sizing relative to existing private real-estate / private-PE allocations.",
-        "Currency-hedging methodology for non-USD alts."
-      ],
-      "redFlags": [
-        "Fund labeled 'inflation hedge' but historically tracking equity beta.",
-        "Unhedged single-currency or single-commodity concentration sized larger than satellite.",
-        "K-1 reporting without offsetting tax or hedging benefit."
-      ]
-    },
-    {
-      "key": "pef-pension-liability-driven-investing",
-      "name": "Pension: Liability-Driven Investing (LDI)",
-      "shortDescription": "Defined-benefit pension plan (corporate, public, or Taft-Hartley union) matching long-duration nominal or real liabilities with treasuries, STRIPS, and TIPS — duration matching matters more than nominal yield.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Low-Moderate",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "High",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Defined-benefit pension plan (corporate, public, or multi-employer / Taft-Hartley union) with a known actuarial liability stream, funded-ratio focused, governed by an IPS that specifies duration target and surplus risk tolerance."
-      },
-      "analysisAngle": "Duration matching is the primary lens. Long treasuries, STRIPS, and long-TIPS are the workhorse instruments. Discuss key-rate-duration profile, convexity, and the surplus-volatility tradeoff. Securities-lending revenue and institutional-share-class fees change the math — avoid retail fee commentary. Capacity matters: the fund must absorb $50-500M allocations without market impact.",
-      "keyConsiderations": [
-        "Key-rate-duration and convexity profile vs the liability stream.",
-        "Securities-lending revenue (institutional pools earn back basis points).",
-        "Capacity to absorb $50-500M allocations without market impact.",
-        "Liability-discount-curve sensitivity and surplus volatility.",
-        "Counterparty / collateral structure for treasury STRIPS or futures-based duration."
-      ],
-      "redFlags": [
-        "Fund too small for institutional-scale allocation without dominant-holder risk.",
-        "Methodology drift that breaks IPS benchmark consistency over multiple years.",
-        "Concentration / closure risk from a single large investor's outflow."
-      ]
-    },
-    {
-      "key": "pef-endowment-foundation-spending-policy-support",
-      "name": "Endowment / Foundation: Spending-Policy Support",
-      "shortDescription": "University endowment or charitable foundation distributing ~5% per year while preserving real capital across generations — needs a portfolio that sustainably supports spending without eroding the corpus.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "University endowment ($500M-$50B+), private foundation, or community foundation. Spending policy is the binding constraint (typically 4-5% rolling-average); IPS often includes ESG / SRI / mission-aligned screens; large allocations to private equity and real assets are typical."
-      },
-      "analysisAngle": "The portfolio must sustainably distribute ~5%/year while preserving real (inflation-adjusted) capital — this is a real-return mandate. ETFs are typically the liquid-beta sleeve and rebalancing buffer alongside the illiquid private book. Discuss real-return coverage, ESG / SRI screen compatibility, capacity, and securities-lending revenue. Avoid retail-style fee comparisons.",
-      "keyConsiderations": [
-        "Long-run real return coverage of the spending rate.",
-        "ESG / SRI / mission-aligned screen compatibility (foundations especially).",
-        "Capacity for institutional-scale allocations without dominant-holder risk.",
-        "Liquid-beta provision alongside illiquid private allocations.",
-        "Rebalancing-band depth — can the ETF be sold at scale to fund distributions?"
-      ],
-      "redFlags": [
-        "ESG-labeled funds with weak self-graded screens (greenwashing risk for foundations).",
-        "Methodology drift breaking IPS benchmark consistency.",
-        "Insufficient liquidity to fund the annual distribution at scale."
-      ]
-    },
-    {
-      "key": "pef-institutional-liquid-beta-sleeve",
-      "name": "Institutional: Liquid-Beta Sleeve Alongside Privates",
-      "shortDescription": "Pension, endowment, foundation, or sovereign wealth fund needing a low-cost liquid index sleeve providing US, international, and EM equity beta + investment-grade core fixed income alongside an illiquid private-allocation book.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Pension plan, endowment, foundation, or sovereign wealth fund whose IPS calls for a defined liquid-beta exposure mix to complement private equity, private real estate, and private credit. Typically uses institutional ETF share classes or separate accounts."
-      },
-      "analysisAngle": "This is a building-block role — the ETFs serve as cheap, transparent, scalable beta exposure for the IPS-mandated mix. Tracking fidelity to the policy benchmark, AUM/capacity, and securities-lending revenue dominate. Discuss policy benchmark fit (e.g., S&P 500 vs Russell 1000 vs MSCI USA) — the wrong benchmark family breaks attribution.",
-      "keyConsiderations": [
-        "Tracking fidelity to the IPS-mandated benchmark.",
-        "Securities-lending revenue offset against the institutional fee.",
-        "Capacity for institutional allocation sizes without market impact.",
-        "Benchmark family compatibility (S&P, Russell, MSCI, FTSE) with the IPS.",
-        "Operational stability — issuer custody, counterparty, settlement reliability."
-      ],
-      "redFlags": [
-        "Wrong benchmark family forcing attribution adjustments.",
-        "Limited capacity making the institution a dominant holder.",
-        "Issuer or fund-family operational concerns at institutional scale."
-      ]
-    },
-    {
-      "key": "ria-passive-core-model-building-blocks",
-      "name": "RIA: Passive Core Model-Portfolio Building Blocks",
-      "shortDescription": "Independent RIA or financial planner constructing risk-tier model portfolios across many client accounts — needs cheap, broad, well-tracked passive ETFs as the workhorse holdings.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Independent RIA or fee-only planner managing $50M-$5B in client AUM, using 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalancing quarterly. Selects ETFs as building blocks rather than standalone hero positions."
-      },
-      "analysisAngle": "Selection logic optimizes for use as a building block — fact-sheet clarity for client meetings, bid-ask tightness across client-block trades, fee compounding on top of the advisor's own AUM fee. Issuer brand, analyst coverage, and rep support matter for due-diligence defensibility. Active or thematic funds complicate the simple 'we use low-cost passive' narrative the advisor is selling.",
-      "keyConsiderations": [
-        "Bid-ask tightness amplified across many client-block trades.",
-        "Fact-sheet clarity for client meetings and due-diligence files.",
-        "Compatibility with major TAMP / custody platforms (Schwab, Fidelity, Pershing, Envestnet).",
-        "All-in cost story (ETF fee + advisor AUM fee) for the end-client narrative.",
-        "Issuer scale and rep support for ongoing due diligence."
-      ],
-      "redFlags": [
-        "Niche issuer with no analyst coverage or wholesaler relationship.",
-        "Active or thematic strategy that complicates the model-portfolio thesis.",
-        "Closure risk that would force a cross-account taxable transition for many clients."
-      ]
-    },
-    {
-      "key": "ria-tax-loss-harvesting-partner-pairs",
-      "name": "RIA: Tax-Loss-Harvesting Partner Pairs",
-      "shortDescription": "Advisor needs wash-sale-safe ETF pairs (e.g., VTI ↔ ITOT, IEFA ↔ VEA, SPY ↔ IVV ↔ VOO) to enable client-level tax-loss harvesting on a rolling basis without losing market exposure.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Tax Optimization",
-        "incomeNeed": "None",
-        "taxSensitivity": "High",
-        "typicalInvestor": "RIA or financial planner systematically harvesting losses in taxable client accounts — needs ETFs that track materially different indices to satisfy IRS wash-sale rules while delivering nearly identical exposure."
-      },
-      "analysisAngle": "The test is benchmark differentiation — two ETFs tracking the same benchmark are wash-sale violations; tracking different benchmarks is the safe path. Discuss the canonical TLH pairs and the differentiation rationale (S&P 500 vs CRSP US Total Market vs Russell 1000). Tracking-error similarity to keep portfolio risk constant during the swap matters as much as the differentiation itself.",
-      "keyConsiderations": [
-        "Benchmark differentiation sufficient to satisfy wash-sale rules.",
-        "Tracking-error similarity to keep portfolio risk profile constant during the swap.",
-        "Bid-ask cost of the round-trip swap.",
-        "Both sides of the pair must have sufficient AUM and liquidity for client-block trades.",
-        "Documented TLH-pair fact sheets for due-diligence and client communication."
-      ],
-      "redFlags": [
-        "Fund tracking the same index as the existing holding (wash-sale violation risk).",
-        "Material tracking-error difference that materially shifts portfolio risk during the swap.",
-        "One side of the pair has thin AUM or wide bid-ask, defeating the harvest math."
-      ]
-    },
-    {
-      "key": "ria-retiree-income-tier-models",
-      "name": "RIA: Retiree-Tier Income & Conservative Models",
-      "shortDescription": "Advisor constructing income and conservative-tier model portfolios for retiree clients — needs sustainable income, lower drawdown floor, and an intuitive risk story for client conversations.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Low-Moderate",
-        "primaryGoal": "Income Generation",
-        "incomeNeed": "High",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "RIA or planner managing retiree client portfolios with defined withdrawal needs, building income-tier or conservative-tier models that prioritize distribution stability and downside protection over growth."
-      },
-      "analysisAngle": "Distribution character matters as much as headline yield for client communication. Drawdown floor — 'what's the worst 12-month decline?' — is the question retiree clients ask. Derivative-income funds (JEPI / JEPQ-style) are common in this tier; advisors must understand the upside-cap tradeoff and explain it clearly. Sequence-of-returns risk is the dominant concern.",
-      "keyConsiderations": [
-        "Distribution character (qualified dividend / ordinary income / ROC) for client tax communication.",
-        "Worst-12-month drawdown a retiree client could survive.",
-        "Capture-ratio analysis for derivative-income funds (upside-cap vs income payout).",
-        "Duration risk in the bond sleeve.",
-        "Manager continuity for active income strategies."
-      ],
-      "redFlags": [
-        "Distribution funded substantially by ROC without clear advisor-facing disclosure.",
-        "Long-duration bond exposure incompatible with retiree drawdown tolerance.",
-        "Active fund failing to beat its passive peer net of fees over 5+ years."
+      "key": "financial-advisor-ria",
+      "name": "Financial Advisor / RIA",
+      "shortDescription": "Registered Investment Advisor or financial planner constructing model portfolios across many client accounts — selects ETFs as building blocks rather than as standalone hero positions. Goals depend on the client tier: low-cost passive building blocks for the core models, wash-sale-safe partner pairs for client-level tax-loss harvesting, and income-and-conservative tier models for retiree clients.",
+      "goals": [
+        {
+          "key": "passive-core-model-building-blocks",
+          "name": "Passive Core Model-Portfolio Building Blocks",
+          "shortDescription": "Independent RIA or financial planner constructing risk-tier model portfolios across many client accounts — needs cheap, broad, well-tracked passive ETFs as the workhorse holdings.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Diversification / Hedging",
+            "incomeNeed": "Modest",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "Independent RIA or fee-only planner managing $50M-$5B in client AUM, using 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalancing quarterly. Selects ETFs as building blocks rather than standalone hero positions."
+          },
+          "analysisAngle": "Selection logic optimizes for use as a building block — fact-sheet clarity for client meetings, bid-ask tightness across client-block trades, fee compounding on top of the advisor's own AUM fee. Issuer brand, analyst coverage, and rep support matter for due-diligence defensibility. Active or thematic funds complicate the simple 'we use low-cost passive' narrative the advisor is selling.",
+          "keyConsiderations": [
+            "Bid-ask tightness amplified across many client-block trades.",
+            "Fact-sheet clarity for client meetings and due-diligence files.",
+            "Compatibility with major TAMP / custody platforms (Schwab, Fidelity, Pershing, Envestnet).",
+            "All-in cost story (ETF fee + advisor AUM fee) for the end-client narrative.",
+            "Issuer scale and rep support for ongoing due diligence."
+          ],
+          "redFlags": [
+            "Niche issuer with no analyst coverage or wholesaler relationship.",
+            "Active or thematic strategy that complicates the model-portfolio thesis.",
+            "Closure risk that would force a cross-account taxable transition for many clients."
+          ]
+        },
+        {
+          "key": "tax-loss-harvesting-partner-pairs",
+          "name": "Tax-Loss-Harvesting Partner Pairs",
+          "shortDescription": "Advisor needs wash-sale-safe ETF pairs (e.g., VTI ↔ ITOT, IEFA ↔ VEA, SPY ↔ IVV ↔ VOO) to enable client-level tax-loss harvesting on a rolling basis without losing market exposure.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Moderate",
+            "primaryGoal": "Tax Optimization",
+            "incomeNeed": "None",
+            "taxSensitivity": "High",
+            "typicalInvestor": "RIA or financial planner systematically harvesting losses in taxable client accounts — needs ETFs that track materially different indices to satisfy IRS wash-sale rules while delivering nearly identical exposure."
+          },
+          "analysisAngle": "The test is benchmark differentiation — two ETFs tracking the same benchmark are wash-sale violations; tracking different benchmarks is the safe path. Discuss the canonical TLH pairs and the differentiation rationale (S&P 500 vs CRSP US Total Market vs Russell 1000). Tracking-error similarity to keep portfolio risk constant during the swap matters as much as the differentiation itself.",
+          "keyConsiderations": [
+            "Benchmark differentiation sufficient to satisfy wash-sale rules.",
+            "Tracking-error similarity to keep portfolio risk profile constant during the swap.",
+            "Bid-ask cost of the round-trip swap.",
+            "Both sides of the pair must have sufficient AUM and liquidity for client-block trades.",
+            "Documented TLH-pair fact sheets for due-diligence and client communication."
+          ],
+          "redFlags": [
+            "Fund tracking the same index as the existing holding (wash-sale violation risk).",
+            "Material tracking-error difference that materially shifts portfolio risk during the swap.",
+            "One side of the pair has thin AUM or wide bid-ask, defeating the harvest math."
+          ]
+        },
+        {
+          "key": "retiree-income-tier-models",
+          "name": "Retiree-Tier Income & Conservative Models",
+          "shortDescription": "Advisor constructing income and conservative-tier model portfolios for retiree clients — needs sustainable income, lower drawdown floor, and an intuitive risk story for client conversations.",
+          "profile": {
+            "investmentHorizon": "Long (5-15y)",
+            "riskTolerance": "Low-Moderate",
+            "primaryGoal": "Income Generation",
+            "incomeNeed": "High",
+            "taxSensitivity": "Moderate",
+            "typicalInvestor": "RIA or planner managing retiree client portfolios with defined withdrawal needs, building income-tier or conservative-tier models that prioritize distribution stability and downside protection over growth."
+          },
+          "analysisAngle": "Distribution character matters as much as headline yield for client communication. Drawdown floor — 'what's the worst 12-month decline?' — is the question retiree clients ask. Derivative-income funds (JEPI / JEPQ-style) are common in this tier; advisors must understand the upside-cap tradeoff and explain it clearly. Sequence-of-returns risk is the dominant concern.",
+          "keyConsiderations": [
+            "Distribution character (qualified dividend / ordinary income / ROC) for client tax communication.",
+            "Worst-12-month drawdown a retiree client could survive.",
+            "Capture-ratio analysis for derivative-income funds (upside-cap vs income payout).",
+            "Duration risk in the bond sleeve.",
+            "Manager continuity for active income strategies."
+          ],
+          "redFlags": [
+            "Distribution funded substantially by ROC without clear advisor-facing disclosure.",
+            "Long-duration bond exposure incompatible with retiree drawdown tolerance.",
+            "Active fund failing to beat its passive peer net of fees over 5+ years."
+          ]
+        }
       ]
     }
   ]

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,5 +1,5 @@
 {
-  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Note: the word 'group' here is a generic 'investor archetype' (e.g., 'investors expecting high dividends', 'pension funds', 'HNW family offices'); it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, red flags that disqualify a fund for them, and a short list of highlighted Morningstar categories that are commonly relevant. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
+  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Note: the word 'group' here is a generic 'investor archetype' (e.g., 'investors expecting high dividends', 'pension funds', 'HNW family offices'); it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, and red flags that disqualify a fund for them. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
   "investorGroups": [
     {
       "key": "first-time-investor",
@@ -27,33 +27,6 @@
         "K-1 tax reporting for a beginner taxable account.",
         "Expense ratio above ~0.50% for what is fundamentally an index product.",
         "AUM under $100M with declining trend (real closure risk)."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "S&P 500 / total-market trackers — the textbook first-purchase ETF."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Adds developed ex-US exposure with one fund."
-        },
-        {
-          "category": "Target-Date 2050",
-          "group": "allocation-target-date",
-          "rationale": "Single-fund retirement glide path for an investor in their 30s — no rebalancing decisions required."
-        },
-        {
-          "category": "Target-Date 2065+",
-          "group": "allocation-target-date",
-          "rationale": "Single-fund glide path for a younger first-time investor."
-        },
-        {
-          "category": "Intermediate Core Bond",
-          "group": "fixed-income-core",
-          "rationale": "The plain-vanilla bond sleeve when a beginner adds fixed income to an equity base."
-        }
       ]
     },
     {
@@ -81,43 +54,6 @@
         "Manager or strategy churn within an active core holding.",
         "Persistent tracking error well above peer median for a passive fund.",
         "Repeated capital-gain distributions in a passive equity ETF held in a taxable account."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "Core US large-cap exposure — the historical engine of long-run equity returns."
-        },
-        {
-          "category": "Mid-Cap Blend",
-          "group": "broad-equity",
-          "rationale": "Mid-cap completes the US-equity base alongside large-cap."
-        },
-        {
-          "category": "Small Blend",
-          "group": "broad-equity",
-          "rationale": "Small-cap captures the size premium for long horizons that can absorb volatility."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Developed ex-US is a long-run diversifier when US valuations stretch."
-        },
-        {
-          "category": "Diversified Emerging Mkts",
-          "group": "broad-equity",
-          "rationale": "EM equity for long-horizon investors comfortable with regime volatility."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REITs add a long-run income + appreciation stream uncorrelated with the S&P."
-        },
-        {
-          "category": "Target-Date 2045",
-          "group": "allocation-target-date",
-          "rationale": "Auto-rebalancing glide path for a buy-and-hold investor near mid-career."
-        }
       ]
     },
     {
@@ -145,53 +81,6 @@
         "Concentration so extreme that 5 holdings drive most of the return.",
         "High turnover combined with a high expense ratio in a taxable account.",
         "Daily-leveraged structure used as a 'growth' substitute (decay erases the edge)."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Growth",
-          "group": "broad-equity",
-          "rationale": "Core US large-cap growth exposure — the cleanest expression of US growth tilt."
-        },
-        {
-          "category": "Mid-Cap Growth",
-          "group": "broad-equity",
-          "rationale": "Mid-cap growth blends scaling-stage businesses with public-market liquidity."
-        },
-        {
-          "category": "Small Growth",
-          "group": "broad-equity",
-          "rationale": "Small growth captures the highest-volatility, highest-upside corner of US equity."
-        },
-        {
-          "category": "Diversified Emerging Mkts",
-          "group": "broad-equity",
-          "rationale": "EM for long-horizon investors who can tolerate currency and policy regime risk."
-        },
-        {
-          "category": "India Equity",
-          "group": "broad-equity",
-          "rationale": "Single-country growth bet for investors with a structural EM thesis."
-        },
-        {
-          "category": "Technology",
-          "group": "sector-thematic-equity",
-          "rationale": "Direct exposure to the secular-growth sector that has driven US-equity returns for two decades."
-        },
-        {
-          "category": "Communications",
-          "group": "sector-thematic-equity",
-          "rationale": "Captures internet platforms, media, and telecom — adjacent to tech without identical concentration."
-        },
-        {
-          "category": "Equity Digital Assets",
-          "group": "sector-thematic-equity",
-          "rationale": "Equity exposure to crypto-economy companies for investors with conviction but not direct-asset risk tolerance."
-        },
-        {
-          "category": "Digital Assets",
-          "group": "alt-strategies",
-          "rationale": "Spot digital-asset ETFs for highest-growth-tilt sleeves."
-        }
       ]
     },
     {
@@ -220,53 +109,6 @@
         "High-yield distribution that is largely ROC (lowers cost basis silently).",
         "Long-duration bond fund without an explicit duration tolerance discussion.",
         "Active manager with under 3 years tenure on a fund used for income."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Intermediate Core Bond",
-          "group": "fixed-income-core",
-          "rationale": "The default investment-grade core for a retirement income portfolio."
-        },
-        {
-          "category": "Short-Term Bond",
-          "group": "fixed-income-core",
-          "rationale": "Low-duration income with limited rate sensitivity — useful when rate path is uncertain."
-        },
-        {
-          "category": "Ultrashort Bond",
-          "group": "fixed-income-core",
-          "rationale": "Cash-like ballast for distributions and near-term spending."
-        },
-        {
-          "category": "Inflation-Protected Bond",
-          "group": "fixed-income-core",
-          "rationale": "TIPS protect real purchasing power across the multi-decade retirement horizon."
-        },
-        {
-          "category": "Target-Date Retirement",
-          "group": "allocation-target-date",
-          "rationale": "Designed exactly for the in-retirement glide path."
-        },
-        {
-          "category": "Conservative Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Static conservative blend for investors who want one ticker handling drawdown management."
-        },
-        {
-          "category": "Moderate Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Slightly more equity for early-retirement years where longevity risk dominates sequence risk."
-        },
-        {
-          "category": "Derivative Income",
-          "group": "alt-strategies",
-          "rationale": "Covered-call funds (e.g. JEPI-style) trade upside for steady monthly income."
-        },
-        {
-          "category": "Defined Outcome",
-          "group": "alt-strategies",
-          "rationale": "Buffered funds cap upside in exchange for explicit downside protection — useful near retirement."
-        }
       ]
     },
     {
@@ -296,53 +138,6 @@
         "Derivative-income fund whose 'yield' is largely return-of-capital without disclosure.",
         "High-turnover active equity ETF in a taxable account.",
         "Non-AMT-aware muni allocation for an investor exposed to AMT."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Muni National Interm",
-          "group": "muni",
-          "rationale": "Default national tax-exempt sleeve for federal high-bracket investors."
-        },
-        {
-          "category": "Muni National Long",
-          "group": "muni",
-          "rationale": "Higher TEY for investors who can absorb the duration risk."
-        },
-        {
-          "category": "High Yield Muni",
-          "group": "muni",
-          "rationale": "Boosts TEY when the investor accepts credit risk; flag the credit-quality slip."
-        },
-        {
-          "category": "Muni California Long",
-          "group": "muni",
-          "rationale": "Triple-exempt yield for California residents in the top brackets."
-        },
-        {
-          "category": "Muni New York Long",
-          "group": "muni",
-          "rationale": "Triple-exempt yield for New York residents (especially NYC)."
-        },
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "Total-market and S&P 500 ETFs are highly tax-efficient and rarely distribute capital gains."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Passive ex-US exposure with foreign-tax-credit pass-through in taxable accounts."
-        },
-        {
-          "category": "Short Government",
-          "group": "fixed-income-core",
-          "rationale": "Treasuries are state-tax exempt — meaningful in high-state-tax jurisdictions."
-        },
-        {
-          "category": "Long Government",
-          "group": "fixed-income-core",
-          "rationale": "State-tax-exempt long-duration government for investors balancing duration and state-tax savings."
-        }
       ]
     },
     {
@@ -372,68 +167,6 @@
         "Single-issuer or single-country concentration that is not visible from the yield.",
         "Covered-call strategy whose total return has lagged the underlying by more than the option-premium income.",
         "High-yield muni labeled as 'muni' but functioning as a credit play."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "High Yield Bond",
-          "group": "fixed-income-credit",
-          "rationale": "Core taxable high-yield exposure (HYG / JNK style)."
-        },
-        {
-          "category": "Bank Loan",
-          "group": "fixed-income-credit",
-          "rationale": "Floating-rate income that holds up in rising-rate environments."
-        },
-        {
-          "category": "Preferred Stock",
-          "group": "fixed-income-credit",
-          "rationale": "Equity-like instruments paying high stated yields, mostly from financial issuers."
-        },
-        {
-          "category": "Emerging Markets Bond",
-          "group": "fixed-income-credit",
-          "rationale": "Sovereign and quasi-sovereign EM credit with materially higher yields than US IG."
-        },
-        {
-          "category": "Multisector Bond",
-          "group": "fixed-income-credit",
-          "rationale": "Active credit allocation across HY, IG, and EM — manager flexibility for income generation."
-        },
-        {
-          "category": "Derivative Income",
-          "group": "alt-strategies",
-          "rationale": "Covered-call funds (JEPI / QYLD / SPYI) deliver high monthly distributions from option premium."
-        },
-        {
-          "category": "Defined Outcome",
-          "group": "alt-strategies",
-          "rationale": "Buffered structured-payoff funds with defined income and downside profile."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REIT income from rents — ordinary income but historically sustainable."
-        },
-        {
-          "category": "Utilities",
-          "group": "sector-thematic-equity",
-          "rationale": "Regulated-utility dividend stream, mostly qualified."
-        },
-        {
-          "category": "Energy Limited Partnership",
-          "group": "sector-thematic-equity",
-          "rationale": "MLP distributions with K-1 reporting — high yield but tax-complex."
-        },
-        {
-          "category": "Long-Term Bond",
-          "group": "fixed-income-core",
-          "rationale": "Long-duration IG paper for investors who want yield and accept rate risk."
-        },
-        {
-          "category": "Corporate Bond",
-          "group": "fixed-income-core",
-          "rationale": "IG corporate income without meaningful credit blow-up risk."
-        }
       ]
     },
     {
@@ -462,88 +195,6 @@
         "Single-stock exposure above ~25% (turns the fund into a single-stock proxy).",
         "Recent inception (<2 years) for a niche theme without issuer track record.",
         "AUM under $50M with declining trend (closure risk in a specialty fund is high)."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Technology",
-          "group": "sector-thematic-equity",
-          "rationale": "Cleanest US-tech thematic expression."
-        },
-        {
-          "category": "Health",
-          "group": "sector-thematic-equity",
-          "rationale": "Healthcare sector tilt — defensive growth with distinct regulatory risk."
-        },
-        {
-          "category": "Financial",
-          "group": "sector-thematic-equity",
-          "rationale": "Bank, broker, and insurance tilt — rate- and cycle-sensitive."
-        },
-        {
-          "category": "Equity Energy",
-          "group": "sector-thematic-equity",
-          "rationale": "Equity expression of the energy thesis (vs commodity exposure)."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REIT thematic exposure to commercial real estate."
-        },
-        {
-          "category": "Equity Precious Metals",
-          "group": "sector-thematic-equity",
-          "rationale": "Gold-mining equities — leveraged play on the gold price."
-        },
-        {
-          "category": "Infrastructure",
-          "group": "sector-thematic-equity",
-          "rationale": "Listed infrastructure thematic — utilities, pipelines, transport."
-        },
-        {
-          "category": "Equity Digital Assets",
-          "group": "sector-thematic-equity",
-          "rationale": "Equity exposure to crypto-economy companies."
-        },
-        {
-          "category": "China Region",
-          "group": "broad-equity",
-          "rationale": "Single-country China thematic exposure."
-        },
-        {
-          "category": "India Equity",
-          "group": "broad-equity",
-          "rationale": "Single-country India growth thesis."
-        },
-        {
-          "category": "Japan Stock",
-          "group": "broad-equity",
-          "rationale": "Single-country Japan thematic — corporate governance / yen thesis."
-        },
-        {
-          "category": "Latin America Stock",
-          "group": "broad-equity",
-          "rationale": "Regional EM tilt with commodity sensitivity."
-        },
-        {
-          "category": "Digital Assets",
-          "group": "alt-strategies",
-          "rationale": "Spot crypto exposure for direct thematic conviction."
-        },
-        {
-          "category": "Commodities Focused",
-          "group": "alt-strategies",
-          "rationale": "Single-commodity thematic plays (gold, silver, oil, ag)."
-        },
-        {
-          "category": "Commodities Precious Metals",
-          "group": "alt-strategies",
-          "rationale": "Direct precious-metals exposure for inflation / debasement views."
-        },
-        {
-          "category": "Single Currency",
-          "group": "alt-strategies",
-          "rationale": "Direct FX expression for macro currency views."
-        }
       ]
     },
     {
@@ -572,58 +223,6 @@
         "Thin volume that prevents large-order exits without market impact.",
         "Persistent tracking gap vs the daily-leverage objective.",
         "Marketing language that downplays the daily-reset / decay mechanism."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Trading--Leveraged Equity",
-          "group": "leveraged-inverse",
-          "rationale": "TQQQ / SPXL — canonical 3x equity tactical long."
-        },
-        {
-          "category": "Trading--Inverse Equity",
-          "group": "leveraged-inverse",
-          "rationale": "SQQQ / SPXS — canonical short-side equity expression for hedging or directional shorts."
-        },
-        {
-          "category": "Trading--Leveraged Debt",
-          "group": "leveraged-inverse",
-          "rationale": "TMF — leveraged long-duration Treasury bet."
-        },
-        {
-          "category": "Trading--Inverse Debt",
-          "group": "leveraged-inverse",
-          "rationale": "TBT / TBF — short long-duration Treasury (rate hike bet)."
-        },
-        {
-          "category": "Trading--Leveraged Commodities",
-          "group": "leveraged-inverse",
-          "rationale": "BOIL / UCO — leveraged commodity trades."
-        },
-        {
-          "category": "Multi-Asset Leveraged",
-          "group": "leveraged-inverse",
-          "rationale": "Risk-parity-style leveraged multi-asset for sophisticated tactical use."
-        },
-        {
-          "category": "Single Currency",
-          "group": "alt-strategies",
-          "rationale": "Direct USD / yen / euro expression for macro tactical FX."
-        },
-        {
-          "category": "Commodities Focused",
-          "group": "alt-strategies",
-          "rationale": "Single-commodity tactical plays (oil, gas, ag)."
-        },
-        {
-          "category": "Digital Assets",
-          "group": "alt-strategies",
-          "rationale": "Spot crypto for short-term directional bets."
-        },
-        {
-          "category": "Long Government",
-          "group": "fixed-income-core",
-          "rationale": "TLT — the standard tactical duration vehicle without leverage."
-        }
       ]
     },
     {
@@ -652,73 +251,6 @@
         "High fees on a 'multi-strategy' fund that just delivers equity beta.",
         "Manager change without succession plan in an active alt sleeve.",
         "Mandate drift — fund relabels from 'market neutral' to 'long-short' (different risk profile)."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Tactical Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Active multi-asset that tilts across regimes."
-        },
-        {
-          "category": "Moderate Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Static 60/40-style blend as a single-ticker portfolio."
-        },
-        {
-          "category": "Global Moderate Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Globally diversified balanced blend reducing US-equity concentration."
-        },
-        {
-          "category": "Global Allocation",
-          "group": "allocation-target-date",
-          "rationale": "Flexible cross-asset, cross-region single-ticker allocation."
-        },
-        {
-          "category": "Systematic Trend",
-          "group": "alt-strategies",
-          "rationale": "Managed-futures trend-following — historically uncorrelated and positive in 2008 / 2022."
-        },
-        {
-          "category": "Equity Market Neutral",
-          "group": "alt-strategies",
-          "rationale": "Long/short construction targeting near-zero net market exposure."
-        },
-        {
-          "category": "Long-Short Equity",
-          "group": "alt-strategies",
-          "rationale": "Reduces beta vs long-only equity while retaining stock-selection alpha."
-        },
-        {
-          "category": "Multistrategy",
-          "group": "alt-strategies",
-          "rationale": "Combines uncorrelated alt sleeves into one ticker for portfolio-level diversification."
-        },
-        {
-          "category": "Macro Trading",
-          "group": "alt-strategies",
-          "rationale": "Macro-discretionary or systematic — distinct return drivers from equity / credit."
-        },
-        {
-          "category": "Long Government",
-          "group": "fixed-income-core",
-          "rationale": "Long-duration Treasury — classic risk-off equity hedge in deflation regimes."
-        },
-        {
-          "category": "Inflation-Protected Bond",
-          "group": "fixed-income-core",
-          "rationale": "TIPS hedge inflation regimes that hurt nominal bonds and growth equity."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Developed-ex-US diversifies US-equity concentration."
-        },
-        {
-          "category": "Diversified Emerging Mkts",
-          "group": "broad-equity",
-          "rationale": "EM equity diversifies developed-market regime risk."
-        }
       ]
     },
     {
@@ -747,73 +279,6 @@
         "Single-commodity fund being used as the broad inflation hedge.",
         "Equity REIT being treated as a pure inflation hedge despite high equity-market beta.",
         "Gold-mining ETF treated as gold (mining equities can decouple sharply from spot)."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Commodities Broad Basket",
-          "group": "alt-strategies",
-          "rationale": "Diversified commodity exposure — the direct inflation hedge."
-        },
-        {
-          "category": "Commodities Focused",
-          "group": "alt-strategies",
-          "rationale": "Single-commodity exposure for specific supply / demand views."
-        },
-        {
-          "category": "Commodities Precious Metals",
-          "group": "alt-strategies",
-          "rationale": "Direct gold / silver exposure — the classic debasement hedge."
-        },
-        {
-          "category": "Digital Assets",
-          "group": "alt-strategies",
-          "rationale": "Bitcoin as the modern debasement hedge for investors who accept the volatility."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REIT income inflation pass-through, with equity-market beta caveat."
-        },
-        {
-          "category": "Global Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "Diversifies single-country property regulatory risk."
-        },
-        {
-          "category": "Natural Resources",
-          "group": "sector-thematic-equity",
-          "rationale": "Diversified resource-equity exposure (mining, energy, agriculture)."
-        },
-        {
-          "category": "Equity Energy",
-          "group": "sector-thematic-equity",
-          "rationale": "Energy-equity tilt for oil-price inflation regimes."
-        },
-        {
-          "category": "Equity Precious Metals",
-          "group": "sector-thematic-equity",
-          "rationale": "Gold-miner equity leverage to the gold price."
-        },
-        {
-          "category": "Infrastructure",
-          "group": "sector-thematic-equity",
-          "rationale": "Listed infrastructure with regulated inflation pass-through."
-        },
-        {
-          "category": "Energy Limited Partnership",
-          "group": "sector-thematic-equity",
-          "rationale": "MLPs tied to commodity throughput and inflation pass-through (K-1 caveat)."
-        },
-        {
-          "category": "Inflation-Protected Bond",
-          "group": "fixed-income-core",
-          "rationale": "Direct CPI-linked Treasury exposure — the classic real-yield hedge."
-        },
-        {
-          "category": "Short-Term Inflation-Protected Bond",
-          "group": "fixed-income-core",
-          "rationale": "TIPS without long-duration real-rate risk — purer near-term inflation hedge."
-        }
       ]
     },
     {
@@ -841,43 +306,6 @@
         "K-1 reporting (commodity pools, MLPs) without an offsetting alpha or hedging benefit.",
         "Distribution character largely ROC or short-term gain without disclosure.",
         "ETF that is strictly worse than direct indexing for a $1M+ position with harvesting needs."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "Tax-efficient US large-cap core for the public-equity sleeve (VOO, VTI, ITOT)."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Developed-international exposure with foreign-tax-credit pickup in taxable accounts."
-        },
-        {
-          "category": "Muni California Long",
-          "group": "muni",
-          "rationale": "Triple-tax-free for high-bracket California-resident HNWs."
-        },
-        {
-          "category": "Muni New York Long",
-          "group": "muni",
-          "rationale": "State-tax exemption stack for NY residents in top brackets."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REIT income and inflation-hedge as a portfolio satellite."
-        },
-        {
-          "category": "Defined Outcome",
-          "group": "alt-strategies",
-          "rationale": "Buffered-equity structures for concentrated-position diversification with downside protection."
-        },
-        {
-          "category": "Equity Precious Metals",
-          "group": "sector-thematic-equity",
-          "rationale": "Gold-mining equity as a tactical real-asset sleeve."
-        }
       ]
     },
     {
@@ -905,48 +333,6 @@
         "Methodology drift that breaks IPS benchmark consistency over multiple years.",
         "ESG-labeled funds with weak or self-graded underlying screens (greenwashing risk for foundations).",
         "Concentration / closure risk from a single large investor's outflow."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "Standard US-equity beta benchmark exposure (S&P 500 / total-market)."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Developed-international beta for the policy benchmark mix."
-        },
-        {
-          "category": "Diversified Emerging Mkts",
-          "group": "broad-equity",
-          "rationale": "EM equity sleeve typical in institutional policy mixes."
-        },
-        {
-          "category": "Long Government",
-          "group": "fixed-income-core",
-          "rationale": "Long treasuries are the standard LDI duration-matching instrument for pensions."
-        },
-        {
-          "category": "Inflation-Protected Bond",
-          "group": "fixed-income-core",
-          "rationale": "TIPS for real-liability matching and real-return mandates."
-        },
-        {
-          "category": "Intermediate Core Bond",
-          "group": "fixed-income-core",
-          "rationale": "Aggregate-index core fixed-income beta for the policy mix."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "Liquid REIT sleeve as a complement to direct private real-estate holdings."
-        },
-        {
-          "category": "Systematic Trend",
-          "group": "alt-strategies",
-          "rationale": "Managed-futures trend overlay used as a crisis-alpha diversifier."
-        }
       ]
     },
     {
@@ -974,48 +360,6 @@
         "Niche issuer with no analyst coverage or rep relationship — hard to defend in due diligence.",
         "Active strategy that complicates the simple 'we use low-cost passive' value-prop.",
         "Closure risk that would force a cross-account taxable transition for hundreds of clients."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "Core US-equity building block — VTI / ITOT / SPY / IVV / VOO are the standard model picks."
-        },
-        {
-          "category": "Foreign Large Blend",
-          "group": "broad-equity",
-          "rationale": "Developed-international building block (VEA, IEFA, IXUS)."
-        },
-        {
-          "category": "Diversified Emerging Mkts",
-          "group": "broad-equity",
-          "rationale": "EM equity sleeve for growth-tier models."
-        },
-        {
-          "category": "Intermediate Core Bond",
-          "group": "fixed-income-core",
-          "rationale": "Standard bond building block (AGG, BND)."
-        },
-        {
-          "category": "Short-Term Bond",
-          "group": "fixed-income-core",
-          "rationale": "Lower-duration bond sleeve for conservative-tier models."
-        },
-        {
-          "category": "Muni National Interm",
-          "group": "muni",
-          "rationale": "Default muni building block for high-bracket client sub-models."
-        },
-        {
-          "category": "Real Estate",
-          "group": "sector-thematic-equity",
-          "rationale": "REIT satellite found in most diversified models."
-        },
-        {
-          "category": "Derivative Income",
-          "group": "alt-strategies",
-          "rationale": "Covered-call income for retiree-tier income models (JEPI, JEPQ-style)."
-        }
       ]
     },
     {
@@ -1043,48 +387,6 @@
         "High borrow cost or limited shortable supply for short-side strategies.",
         "Wide premium/discount during normal conditions (AP friction or low primary-market activity).",
         "AUM small enough that a normal block trade visibly moves the price."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Large Blend",
-          "group": "broad-equity",
-          "rationale": "SPY / IVV / VOO — the deepest ETF-options markets and primary beta-expression vehicles."
-        },
-        {
-          "category": "Trading--Leveraged Equity",
-          "group": "leveraged-inverse",
-          "rationale": "TQQQ, SOXL for short-term leveraged directional bets."
-        },
-        {
-          "category": "Trading--Inverse Equity",
-          "group": "leveraged-inverse",
-          "rationale": "SQQQ, SH for short-term inverse hedges or directional shorts."
-        },
-        {
-          "category": "Technology",
-          "group": "sector-thematic-equity",
-          "rationale": "XLK / VGT for sector relative-value pair trades."
-        },
-        {
-          "category": "Equity Energy",
-          "group": "sector-thematic-equity",
-          "rationale": "XLE for energy sector pair trades and macro commodity bets."
-        },
-        {
-          "category": "High Yield Bond",
-          "group": "fixed-income-credit",
-          "rationale": "HYG / JNK as the standard credit-spread expression instrument."
-        },
-        {
-          "category": "Long Government",
-          "group": "fixed-income-core",
-          "rationale": "TLT for rate / duration tactical bets and curve trades."
-        },
-        {
-          "category": "Single Currency",
-          "group": "alt-strategies",
-          "rationale": "Single-currency ETFs for macro FX directional bets."
-        }
       ]
     },
     {
@@ -1112,43 +414,6 @@
         "Long duration exposure incompatible with operating-cash mandate.",
         "Unclear regulatory look-through treatment — risk team can't approve.",
         "Thin liquidity that would force NAV-discount selling under outflow stress."
-      ],
-      "highlightedCategories": [
-        {
-          "category": "Ultrashort Bond",
-          "group": "fixed-income-core",
-          "rationale": "Operating-cash management — ICSH, JPST, GSY for sub-1-year duration."
-        },
-        {
-          "category": "Short-Term Bond",
-          "group": "fixed-income-core",
-          "rationale": "1-3 year IG corporate / treasury exposure for treasury sleeves."
-        },
-        {
-          "category": "Short Government",
-          "group": "fixed-income-core",
-          "rationale": "Short-duration treasury exposure (SHY) — HQLA-eligible for bank treasuries."
-        },
-        {
-          "category": "Intermediate Government",
-          "group": "fixed-income-core",
-          "rationale": "Treasury IEF for slightly longer-duration insurance general-account use."
-        },
-        {
-          "category": "Corporate Bond",
-          "group": "fixed-income-core",
-          "rationale": "IG corporate exposure (LQD) for general-account yield pickup over treasuries."
-        },
-        {
-          "category": "Money Market-Taxable",
-          "group": "fixed-income-core",
-          "rationale": "Money-market wrappers for the most conservative cash sleeves."
-        },
-        {
-          "category": "Muni National Short",
-          "group": "muni",
-          "rationale": "Short-duration muni for after-tax yield where policy permits."
-        }
       ]
     }
   ]

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -1,5 +1,5 @@
 {
-  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Note: the word 'group' here is a generic 'investor archetype' (e.g., 'investors expecting high dividends', 'pension funds', 'HNW family offices'); it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, and red flags that disqualify a fund for them. Covers retail archetypes (beginner through high-yield seeker, sector-conviction, active trader, all-weather diversifier, inflation hedger) AND institutional / professional channels (HNW & family office, pension / endowment / foundation including union pensions, RIA / financial advisor, hedge-fund / trading desk, insurance general account / corporate treasury). Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
+  "description": "Target investor-group taxonomy used to write ETF analyses from the perspective of who the potential investors are — essentially an investor-goal / persona library. Each entry is an audience + goal pair (e.g., 'HNW: State-Tax-Exempt Muni Income', 'Pension: Liability-Driven Investing', 'RIA: Tax-Loss-Harvesting Partner Pairs') rather than a generic audience label, so retail and institutional channels are both captured at the level of the specific outcome they're trying to achieve. Note: the word 'group' here is a generic 'investor archetype'; it is NOT a mapping back to the 8 ETF category-groups defined in etf-analysis-categories.json. Determining which of these investor goals a given ETF actually satisfies is done during ETF analysis (Phase 2 of tasks/koala-gains/etfs.md), not pre-baked into this file. Each entry describes the investor's profile (horizon, risk tolerance, primary goal, income need, tax sensitivity), the analysis angle to take when writing for them, key things they care about, and red flags that disqualify a fund for them. Conforms to EtfTargetInvestorGroupsConfig in src/types/etf/etf-analysis-types.ts.",
   "investorGroups": [
     {
       "key": "first-time-investor",
@@ -282,87 +282,6 @@
       ]
     },
     {
-      "key": "high-net-worth-individual",
-      "name": "High-Net-Worth Individual / Family Office",
-      "shortDescription": "Wealthy individual or single-family office investing $5M-$500M+ across asset classes — uses ETFs for tax-efficient beta, satellite exposures, and overlays alongside private investments.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate-High",
-        "primaryGoal": "Wealth Accumulation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "High",
-        "typicalInvestor": "HNW individual ($5M-$50M investable), single-family office ($50M-$500M+), or multi-family office client. Already holds direct stocks, private equity, real estate, and may use a CIO or external advisor; uses ETFs for the public-market beta sleeve while alternatives carry the alpha mandate."
-      },
-      "analysisAngle": "Tax efficiency at the marginal rate (top federal + state + NIIT) is paramount — tax-loss harvesting, lot-level optimization, and avoidance of cap-gain distributions matter as much as gross return. Frame ETFs as the efficient-beta or thematic-tilt sleeve in a portfolio whose alpha mandate sits in privates. At >$1M position sizes, direct indexing often beats an index ETF for tax-loss harvesting, so the ETF must justify its wrapper. Currency hedging, concentrated-stock diversification overlays, and access to alternatives (commodities, gold, defined outcome) are common use cases.",
-      "keyConsiderations": [
-        "After-tax return at the top federal + state + NIIT bracket, not headline yield/return.",
-        "Capital-gain distribution history (passive ETFs near zero; active and thematic can surprise).",
-        "Tax-loss harvesting partner pairs (e.g., VTI ↔ ITOT, IEFA ↔ VEA) to allow wash-sale-safe swaps.",
-        "Direct-indexing breakeven — does the ETF still win after harvesting potential is considered?",
-        "Wrapper cost stacking when held inside a SMA / UMA — fee on top of fee."
-      ],
-      "redFlags": [
-        "Material recent capital-gain distributions in a passive-style fund.",
-        "K-1 reporting (commodity pools, MLPs) without an offsetting alpha or hedging benefit.",
-        "Distribution character largely ROC or short-term gain without disclosure.",
-        "ETF that is strictly worse than direct indexing for a $1M+ position with harvesting needs."
-      ]
-    },
-    {
-      "key": "pension-endowment-foundation",
-      "name": "Pension Fund / Endowment / Foundation (incl. Union Pensions)",
-      "shortDescription": "Long-horizon institutional pool — corporate or public pension, Taft-Hartley / union pension, university endowment, charitable foundation — governed by an Investment Policy Statement with defined liabilities or spending mandates.",
-      "profile": {
-        "investmentHorizon": "Very Long (15y+)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Capital Preservation",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Low",
-        "typicalInvestor": "Defined-benefit corporate or public pension plan, Taft-Hartley union pension, university endowment ($500M-$50B+), private foundation, or sovereign wealth fund. Tax-exempt; constrained by an IPS that often includes ESG / SRI / labor-friendly screens; focused on long-term funded ratio (pensions) or sustainable spending policy ~5% (endowments/foundations)."
-      },
-      "analysisAngle": "Liability-driven investing (LDI) for pensions — duration matching matters more than nominal yield. For endowments and foundations, the spending policy is the binding constraint: distribute ~5% per year while preserving real capital across generations. ETFs are typically the liquid-beta sleeve (US equity, international, EM, treasuries, TIPS) and the liquidity buffer alongside illiquid private allocations (PE, real assets, hedge funds). Discuss IPS fit, governance overhead, and securities-lending revenue potential. Avoid retail-style fee commentary — institutional share classes, separate accounts, and rebates change the math; what matters is total cost-to-strategy and capacity.",
-      "keyConsiderations": [
-        "AUM and securities-lending revenue potential — institutional pools earn back basis points.",
-        "Tracking quality and benchmark fidelity for IPS-mandated benchmarks.",
-        "Liability-matching duration profile (pensions) or spending-policy support (endowments/foundations).",
-        "ESG / SRI / Taft-Hartley screen compatibility if the IPS requires it.",
-        "Capacity — can the fund absorb a $50-500M allocation without market impact or becoming a dominant holder?"
-      ],
-      "redFlags": [
-        "Fund too small for institutional-scale allocation without becoming a dominant holder.",
-        "Methodology drift that breaks IPS benchmark consistency over multiple years.",
-        "ESG-labeled funds with weak or self-graded underlying screens (greenwashing risk for foundations).",
-        "Concentration / closure risk from a single large investor's outflow."
-      ]
-    },
-    {
-      "key": "financial-advisor-ria",
-      "name": "Financial Advisor / RIA Building Client Portfolios",
-      "shortDescription": "Registered Investment Advisor or financial planner constructing model portfolios across many clients — selects ETFs as building blocks for risk-tier models rather than as standalone positions.",
-      "profile": {
-        "investmentHorizon": "Long (5-15y)",
-        "riskTolerance": "Moderate",
-        "primaryGoal": "Diversification / Hedging",
-        "incomeNeed": "Modest",
-        "taxSensitivity": "Moderate",
-        "typicalInvestor": "Independent RIA, fee-only financial planner, or wirehouse advisor managing $50M-$5B in client AUM across model portfolios. Builds 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalances quarterly, and answers to clients across the wealth spectrum."
-      },
-      "analysisAngle": "Selection logic optimizes for use as a model-portfolio building block, not a standalone hero position. Focus on: TAMP / model-portfolio platform availability (Schwab, Fidelity, Pershing, Envestnet), bid-ask tightness (block trades across hundreds of accounts amplify spread cost), tax-lot fungibility for client-level tax-loss harvesting (e.g., VTI ↔ ITOT pairs), and clean fact-sheet documentation for client meetings. The advisor's own AUM fee sits on top of the ETF fee, so the all-in cost story is what the end client sees and judges. Issuer relationships, rep support, and analyst coverage matter for due-diligence defensibility.",
-      "keyConsiderations": [
-        "Fact-sheet clarity for client-meeting presentation and due-diligence files.",
-        "Bid-ask tightness amplified across hundreds of client accounts.",
-        "Compatibility with major TAMP / custody platforms and model-portfolio software.",
-        "Tax-loss harvesting partner pairs (VTI ↔ ITOT, SPY ↔ IVV ↔ VOO, IEFA ↔ VEA).",
-        "Issuer relationship and wholesaler support for ongoing due diligence."
-      ],
-      "redFlags": [
-        "Wide bid-ask amplified across many client accounts becomes real client-level slippage.",
-        "Niche issuer with no analyst coverage or rep relationship — hard to defend in due diligence.",
-        "Active strategy that complicates the simple 'we use low-cost passive' value-prop.",
-        "Closure risk that would force a cross-account taxable transition for hundreds of clients."
-      ]
-    },
-    {
       "key": "institutional-trading-desk",
       "name": "Institutional Trading Desk / Hedge Fund / Asset Manager",
       "shortDescription": "Professional trading desk using ETFs as efficient wrappers for short-term beta, hedging, basket trades, transition management, or pair trades.",
@@ -414,6 +333,321 @@
         "Long duration exposure incompatible with operating-cash mandate.",
         "Unclear regulatory look-through treatment — risk team can't approve.",
         "Thin liquidity that would force NAV-discount selling under outflow stress."
+      ]
+    },
+    {
+      "key": "esg-impact-investor",
+      "name": "ESG / Sustainable / Impact Investor",
+      "shortDescription": "Investor who screens for environmental, social, and governance criteria — willing to accept some return or fee tradeoff for portfolio alignment with values, climate goals, or impact mandates.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "None",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Retail investor, foundation, university endowment, religious institution, or impact-focused family office that explicitly excludes fossil fuels, weapons, tobacco, or other fails-to-screen issuers — or that actively allocates to climate-solutions, gender-lens, clean-energy, or community-development themes. Will accept measured return giveup or higher fees in exchange for screen integrity."
+      },
+      "analysisAngle": "Screen integrity is the primary test — does the methodology actually deliver what the label promises, and is it auditable? Many ESG-labeled ETFs have weak underlying screens (greenwashing risk) or hold companies that obviously violate the spirit of the label. Compare the methodology disclosure and actual top holdings against the stated mandate. Discuss the return / fee tradeoff vs the equivalent unscreened index. For impact-themed funds (clean energy, gender lens, community development) focus on whether the theme is implementable as a diversified portfolio or whether it becomes a concentrated single-sector bet in disguise.",
+      "keyConsiderations": [
+        "Methodology disclosure — exclusion list, integration approach, third-party rating provider, refresh cadence.",
+        "Actual top holdings vs the spirit of the screen (greenwashing detection).",
+        "Return and fee tradeoff vs the equivalent unscreened broad-market index.",
+        "Coverage breadth — does the screened universe still produce diversified factor and sector exposure?",
+        "Issuer's broader ESG record, including proxy voting on shareholder proposals."
+      ],
+      "redFlags": [
+        "Top holdings include obvious screen violators — greenwashing.",
+        "Third-party ESG rating relied on without underlying methodology transparency.",
+        "Headline fee well above the unscreened equivalent without screen-quality evidence to justify it.",
+        "Theme fund framed as broad ESG but delivering concentrated single-sector exposure (e.g., clean-energy ETFs that are functionally tech bets)."
+      ]
+    },
+    {
+      "key": "short-term-liquidity-parker",
+      "name": "Short-Term Liquidity Parker",
+      "shortDescription": "Investor with a known near-term cash need (months to ~2 years) — down payment, emergency fund, business reserves, deal pipeline — wanting yield without duration risk or drawdown.",
+      "profile": {
+        "investmentHorizon": "Short (<1y)",
+        "riskTolerance": "Low",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Retail saver with a near-term goal (home down payment in 12-24 months, kid's tuition, emergency fund), self-employed professional managing operating cash, or angel investor warehousing dry powder between deals. Wants the cash to earn meaningful yield but cannot afford a drawdown when the money is needed."
+      },
+      "analysisAngle": "Capital preservation and same-day liquidity dominate every other consideration — yield matters only after those two constraints are satisfied. Default recommendation is ultrashort treasury or money-market wrappers (BIL, SGOV, SHV, JPST, ICSH) and 1-3 year treasury for slightly longer horizons. Discuss credit quality (Treasury > IG corp > anything else for this use), duration (shorter when the cash is needed sooner), and intraday liquidity. For taxable accounts, mention federal-only tax exemption on direct treasuries. Strongly warn against any product with meaningful duration risk, credit risk, or drawdown history — chasing 50 bps of extra yield is not worth a 5% drawdown when the cash is needed in 6 months.",
+      "keyConsiderations": [
+        "Duration short enough that a rate spike cannot break the price (typically under 2 years, often under 1).",
+        "Credit quality — Treasury or AAA / IG corporate; no high-yield, no bank loans, no preferred.",
+        "Intraday liquidity for unplanned cash needs.",
+        "Bid-ask tightness — even a few basis points add up at cash-management scale.",
+        "Distribution-character tax treatment in taxable accounts (treasury interest is state-tax-exempt)."
+      ],
+      "redFlags": [
+        "Any duration over ~2 years — defeats the cash-management purpose.",
+        "Sub-investment-grade credit exposure or floating-rate bank loans — drawdown risk in stress.",
+        "Wide bid-ask that erodes the yield advantage over a high-yield savings account.",
+        "Target-maturity or auto-renewing structures whose maturity may not align with the cash-need date."
+      ]
+    },
+    {
+      "key": "pre-retiree-de-risker",
+      "name": "Pre-Retiree (De-Risking 3-10 Years Out)",
+      "shortDescription": "Investor 3-10 years from retirement — still accumulating, not yet drawing income, but in the fragile pre-retirement window where a major drawdown is hardest to recover from.",
+      "profile": {
+        "investmentHorizon": "Medium (1-5y)",
+        "riskTolerance": "Low-Moderate",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "None",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Investor in their 50s-60s within 3-10 years of retirement. Still earning and contributing, not yet drawing — but the funded ratio of the retirement plan is now sensitive to a single bad year. Often shifting from equity-heavy accumulation toward more bonds, more diversification, and downside-protected structures."
+      },
+      "analysisAngle": "Sequence-of-returns risk in the pre-retirement window — a 40% loss at age 60 with 5 years to retirement is far harder to recover than the same loss at 30. The investor has stopped being a pure accumulator but hasn't started drawing income. Focus on drawdown depth and recovery time vs benchmark, glide-path appropriate for the target retirement year, gradual fixed-income tilt, and downside-protected products (defined outcome, derivative income) that allow continued equity participation with capped downside. Distinct from retirement-income-seeker, who is already drawing income, and from long-term-wealth-builder, whose recovery window is multi-decade.",
+      "keyConsiderations": [
+        "Worst-12-month and worst-3-year drawdown — must be survivable without delaying retirement.",
+        "Gradual equity-to-bond glide path matched to the target retirement year.",
+        "Downside-protected structures (defined-outcome buffers, covered-call income) that allow continued equity participation.",
+        "Mandate stability — strategy or benchmark changes mid-glide disrupt the de-risking plan.",
+        "Tax efficiency — large balances at this stage make capital-gain distributions hurt more."
+      ],
+      "redFlags": [
+        "High-volatility growth, sector, or theme funds inappropriate for the shortened recovery window.",
+        "Long-duration bond exposure when rates may rise — 2022-style drawdown is hardest to recover from in this window.",
+        "Leveraged-inverse exposure — daily-decay risk during the de-risking phase.",
+        "Concentrated sector bets that worked in accumulation but no longer fit the time horizon."
+      ]
+    },
+    {
+      "key": "hnw-tax-efficient-public-equity-sleeve",
+      "name": "HNW: Tax-Efficient Public-Equity Beta Sleeve",
+      "shortDescription": "High-net-worth or family-office investor seeking tax-efficient compounding of US and international equity exposure inside taxable accounts — ETFs are the wrapper for the public-equity beta sleeve while private allocations carry the alpha mandate.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Wealth Accumulation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "High",
+        "typicalInvestor": "HNW individual ($5M-$50M investable) or single-family office at the top federal + state + NIIT bracket; alpha mandate sits in PE / hedge funds / direct real estate; ETFs serve only as the efficient-beta sleeve."
+      },
+      "analysisAngle": "After-tax return at the top marginal rate is the only metric that matters. Capital-gain distribution history must be near zero. At >$1M positions, direct indexing with daily harvesting often beats an index ETF — the ETF must justify its wrapper. Foreign-tax-credit pickup is a real consideration for international sleeves held in taxable accounts.",
+      "keyConsiderations": [
+        "Capital-gain distribution history (passive ETFs near zero; thematic and active can surprise).",
+        "After-tax return at top federal + state + NIIT bracket, not headline return.",
+        "Foreign-tax-credit pickup for international ETFs held in taxable accounts.",
+        "Direct-indexing breakeven analysis for $1M+ positions.",
+        "Wrapper cost stacking when the ETF sits inside a SMA / UMA."
+      ],
+      "redFlags": [
+        "Material recent capital-gain distributions in a passive-style fund.",
+        "Active or thematic strategy with high turnover dragging after-tax return.",
+        "Distribution character largely ROC or short-term gain without disclosure."
+      ]
+    },
+    {
+      "key": "hnw-state-tax-exempt-muni-income",
+      "name": "HNW: State-Tax-Exempt Muni Income",
+      "shortDescription": "High-bracket resident of a high-tax state (CA, NY, NJ, MA, IL) seeking muni income with state-tax exemption stacked on top of the federal exemption — AMT awareness for private-activity-bond exposure.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Tax Optimization",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "High",
+        "typicalInvestor": "HNW investor in a top federal bracket who is also a high-tax-state resident; significant taxable-account fixed-income that needs to maximize after-tax yield via in-state muni exposure."
+      },
+      "analysisAngle": "TEY at the explicit federal + state + NIIT bracket is the comparison metric. State-specific muni funds add the state-tax exemption — for a CA resident in the top bracket the math frequently dominates national muni and taxable IG. AMT exposure on private-activity-bond muni funds must be flagged. Credit quality and concentration matter — high-yield muni introduces real default risk that the muni label doesn't make obvious.",
+      "keyConsiderations": [
+        "Tax-equivalent yield at federal + state + NIIT bracket for in-state vs national muni.",
+        "AMT exposure on private-activity-bond muni funds.",
+        "Single-jurisdiction credit risk in state-specific muni (pension stress, revenue shock).",
+        "Issuer credit-tier mix — IG-only vs HY-muni tilt.",
+        "Duration positioning relative to rate outlook."
+      ],
+      "redFlags": [
+        "High-yield muni exposure inside a generically named muni fund without disclosure.",
+        "Private-activity-bond concentration triggering AMT for high-bracket investors.",
+        "Single-state muni with documented pension or revenue-base distress."
+      ]
+    },
+    {
+      "key": "hnw-real-asset-and-alternatives-overlay",
+      "name": "HNW: Real-Asset and Alternatives Overlay",
+      "shortDescription": "HNW or family-office investor adding diversifying real-asset, defined-outcome, derivative-income, or commodity exposure on top of a public-equity + muni core — often complementing direct private real estate or commodity holdings.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate-High",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "High",
+        "typicalInvestor": "HNW investor or family office whose constructed portfolio already covers public-equity beta and tax-efficient fixed income, looking for inflation hedges, downside structure, or uncorrelated return streams via accessible ETF wrappers."
+      },
+      "analysisAngle": "Sizing matters — these are diversifying sleeves, not core holdings. Defined-outcome and derivative-income funds must be evaluated on the upside-cap vs income-payout tradeoff. Commodity and precious-metals funds must be checked for K-1 vs 1099 reporting since K-1 creates real friction at HNW scale. Real-asset equity proxies (REITs, infrastructure, natural resources) carry equity-correlation risk that should be disclosed. Discuss complement to private allocations, not substitute.",
+      "keyConsiderations": [
+        "K-1 vs 1099 reporting (commodity pools, MLPs).",
+        "Upside-cap vs income-payout tradeoff for defined-outcome and derivative-income funds.",
+        "Equity-correlation in 'real asset' equity proxies during stress.",
+        "Sizing relative to existing private real-estate / private-PE allocations.",
+        "Currency-hedging methodology for non-USD alts."
+      ],
+      "redFlags": [
+        "Fund labeled 'inflation hedge' but historically tracking equity beta.",
+        "Unhedged single-currency or single-commodity concentration sized larger than satellite.",
+        "K-1 reporting without offsetting tax or hedging benefit."
+      ]
+    },
+    {
+      "key": "pef-pension-liability-driven-investing",
+      "name": "Pension: Liability-Driven Investing (LDI)",
+      "shortDescription": "Defined-benefit pension plan (corporate, public, or Taft-Hartley union) matching long-duration nominal or real liabilities with treasuries, STRIPS, and TIPS — duration matching matters more than nominal yield.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Low-Moderate",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "High",
+        "taxSensitivity": "Low",
+        "typicalInvestor": "Defined-benefit pension plan (corporate, public, or multi-employer / Taft-Hartley union) with a known actuarial liability stream, funded-ratio focused, governed by an IPS that specifies duration target and surplus risk tolerance."
+      },
+      "analysisAngle": "Duration matching is the primary lens. Long treasuries, STRIPS, and long-TIPS are the workhorse instruments. Discuss key-rate-duration profile, convexity, and the surplus-volatility tradeoff. Securities-lending revenue and institutional-share-class fees change the math — avoid retail fee commentary. Capacity matters: the fund must absorb $50-500M allocations without market impact.",
+      "keyConsiderations": [
+        "Key-rate-duration and convexity profile vs the liability stream.",
+        "Securities-lending revenue (institutional pools earn back basis points).",
+        "Capacity to absorb $50-500M allocations without market impact.",
+        "Liability-discount-curve sensitivity and surplus volatility.",
+        "Counterparty / collateral structure for treasury STRIPS or futures-based duration."
+      ],
+      "redFlags": [
+        "Fund too small for institutional-scale allocation without dominant-holder risk.",
+        "Methodology drift that breaks IPS benchmark consistency over multiple years.",
+        "Concentration / closure risk from a single large investor's outflow."
+      ]
+    },
+    {
+      "key": "pef-endowment-foundation-spending-policy-support",
+      "name": "Endowment / Foundation: Spending-Policy Support",
+      "shortDescription": "University endowment or charitable foundation distributing ~5% per year while preserving real capital across generations — needs a portfolio that sustainably supports spending without eroding the corpus.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Capital Preservation",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Low",
+        "typicalInvestor": "University endowment ($500M-$50B+), private foundation, or community foundation. Spending policy is the binding constraint (typically 4-5% rolling-average); IPS often includes ESG / SRI / mission-aligned screens; large allocations to private equity and real assets are typical."
+      },
+      "analysisAngle": "The portfolio must sustainably distribute ~5%/year while preserving real (inflation-adjusted) capital — this is a real-return mandate. ETFs are typically the liquid-beta sleeve and rebalancing buffer alongside the illiquid private book. Discuss real-return coverage, ESG / SRI screen compatibility, capacity, and securities-lending revenue. Avoid retail-style fee comparisons.",
+      "keyConsiderations": [
+        "Long-run real return coverage of the spending rate.",
+        "ESG / SRI / mission-aligned screen compatibility (foundations especially).",
+        "Capacity for institutional-scale allocations without dominant-holder risk.",
+        "Liquid-beta provision alongside illiquid private allocations.",
+        "Rebalancing-band depth — can the ETF be sold at scale to fund distributions?"
+      ],
+      "redFlags": [
+        "ESG-labeled funds with weak self-graded screens (greenwashing risk for foundations).",
+        "Methodology drift breaking IPS benchmark consistency.",
+        "Insufficient liquidity to fund the annual distribution at scale."
+      ]
+    },
+    {
+      "key": "pef-institutional-liquid-beta-sleeve",
+      "name": "Institutional: Liquid-Beta Sleeve Alongside Privates",
+      "shortDescription": "Pension, endowment, foundation, or sovereign wealth fund needing a low-cost liquid index sleeve providing US, international, and EM equity beta + investment-grade core fixed income alongside an illiquid private-allocation book.",
+      "profile": {
+        "investmentHorizon": "Very Long (15y+)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Low",
+        "typicalInvestor": "Pension plan, endowment, foundation, or sovereign wealth fund whose IPS calls for a defined liquid-beta exposure mix to complement private equity, private real estate, and private credit. Typically uses institutional ETF share classes or separate accounts."
+      },
+      "analysisAngle": "This is a building-block role — the ETFs serve as cheap, transparent, scalable beta exposure for the IPS-mandated mix. Tracking fidelity to the policy benchmark, AUM/capacity, and securities-lending revenue dominate. Discuss policy benchmark fit (e.g., S&P 500 vs Russell 1000 vs MSCI USA) — the wrong benchmark family breaks attribution.",
+      "keyConsiderations": [
+        "Tracking fidelity to the IPS-mandated benchmark.",
+        "Securities-lending revenue offset against the institutional fee.",
+        "Capacity for institutional allocation sizes without market impact.",
+        "Benchmark family compatibility (S&P, Russell, MSCI, FTSE) with the IPS.",
+        "Operational stability — issuer custody, counterparty, settlement reliability."
+      ],
+      "redFlags": [
+        "Wrong benchmark family forcing attribution adjustments.",
+        "Limited capacity making the institution a dominant holder.",
+        "Issuer or fund-family operational concerns at institutional scale."
+      ]
+    },
+    {
+      "key": "ria-passive-core-model-building-blocks",
+      "name": "RIA: Passive Core Model-Portfolio Building Blocks",
+      "shortDescription": "Independent RIA or financial planner constructing risk-tier model portfolios across many client accounts — needs cheap, broad, well-tracked passive ETFs as the workhorse holdings.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Diversification / Hedging",
+        "incomeNeed": "Modest",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "Independent RIA or fee-only planner managing $50M-$5B in client AUM, using 3-5 risk-tier models (Conservative / Moderate / Growth / Aggressive), rebalancing quarterly. Selects ETFs as building blocks rather than standalone hero positions."
+      },
+      "analysisAngle": "Selection logic optimizes for use as a building block — fact-sheet clarity for client meetings, bid-ask tightness across client-block trades, fee compounding on top of the advisor's own AUM fee. Issuer brand, analyst coverage, and rep support matter for due-diligence defensibility. Active or thematic funds complicate the simple 'we use low-cost passive' narrative the advisor is selling.",
+      "keyConsiderations": [
+        "Bid-ask tightness amplified across many client-block trades.",
+        "Fact-sheet clarity for client meetings and due-diligence files.",
+        "Compatibility with major TAMP / custody platforms (Schwab, Fidelity, Pershing, Envestnet).",
+        "All-in cost story (ETF fee + advisor AUM fee) for the end-client narrative.",
+        "Issuer scale and rep support for ongoing due diligence."
+      ],
+      "redFlags": [
+        "Niche issuer with no analyst coverage or wholesaler relationship.",
+        "Active or thematic strategy that complicates the model-portfolio thesis.",
+        "Closure risk that would force a cross-account taxable transition for many clients."
+      ]
+    },
+    {
+      "key": "ria-tax-loss-harvesting-partner-pairs",
+      "name": "RIA: Tax-Loss-Harvesting Partner Pairs",
+      "shortDescription": "Advisor needs wash-sale-safe ETF pairs (e.g., VTI ↔ ITOT, IEFA ↔ VEA, SPY ↔ IVV ↔ VOO) to enable client-level tax-loss harvesting on a rolling basis without losing market exposure.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Moderate",
+        "primaryGoal": "Tax Optimization",
+        "incomeNeed": "None",
+        "taxSensitivity": "High",
+        "typicalInvestor": "RIA or financial planner systematically harvesting losses in taxable client accounts — needs ETFs that track materially different indices to satisfy IRS wash-sale rules while delivering nearly identical exposure."
+      },
+      "analysisAngle": "The test is benchmark differentiation — two ETFs tracking the same benchmark are wash-sale violations; tracking different benchmarks is the safe path. Discuss the canonical TLH pairs and the differentiation rationale (S&P 500 vs CRSP US Total Market vs Russell 1000). Tracking-error similarity to keep portfolio risk constant during the swap matters as much as the differentiation itself.",
+      "keyConsiderations": [
+        "Benchmark differentiation sufficient to satisfy wash-sale rules.",
+        "Tracking-error similarity to keep portfolio risk profile constant during the swap.",
+        "Bid-ask cost of the round-trip swap.",
+        "Both sides of the pair must have sufficient AUM and liquidity for client-block trades.",
+        "Documented TLH-pair fact sheets for due-diligence and client communication."
+      ],
+      "redFlags": [
+        "Fund tracking the same index as the existing holding (wash-sale violation risk).",
+        "Material tracking-error difference that materially shifts portfolio risk during the swap.",
+        "One side of the pair has thin AUM or wide bid-ask, defeating the harvest math."
+      ]
+    },
+    {
+      "key": "ria-retiree-income-tier-models",
+      "name": "RIA: Retiree-Tier Income & Conservative Models",
+      "shortDescription": "Advisor constructing income and conservative-tier model portfolios for retiree clients — needs sustainable income, lower drawdown floor, and an intuitive risk story for client conversations.",
+      "profile": {
+        "investmentHorizon": "Long (5-15y)",
+        "riskTolerance": "Low-Moderate",
+        "primaryGoal": "Income Generation",
+        "incomeNeed": "High",
+        "taxSensitivity": "Moderate",
+        "typicalInvestor": "RIA or planner managing retiree client portfolios with defined withdrawal needs, building income-tier or conservative-tier models that prioritize distribution stability and downside protection over growth."
+      },
+      "analysisAngle": "Distribution character matters as much as headline yield for client communication. Drawdown floor — 'what's the worst 12-month decline?' — is the question retiree clients ask. Derivative-income funds (JEPI / JEPQ-style) are common in this tier; advisors must understand the upside-cap tradeoff and explain it clearly. Sequence-of-returns risk is the dominant concern.",
+      "keyConsiderations": [
+        "Distribution character (qualified dividend / ordinary income / ROC) for client tax communication.",
+        "Worst-12-month drawdown a retiree client could survive.",
+        "Capture-ratio analysis for derivative-income funds (upside-cap vs income payout).",
+        "Duration risk in the bond sleeve.",
+        "Manager continuity for active income strategies."
+      ],
+      "redFlags": [
+        "Distribution funded substantially by ROC without clear advisor-facing disclosure.",
+        "Long-duration bond exposure incompatible with retiree drawdown tolerance.",
+        "Active fund failing to beat its passive peer net of fees over 5+ years."
       ]
     }
   ]

--- a/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
+++ b/insights-ui/src/etf-analysis-data/etf-target-investor-groups.json
@@ -30,6 +30,26 @@
             "Concentrated single-theme funds (one sector or one country).",
             "K-1 reporting or unusual non-1099 distributions.",
             "Sub-3-year track record from a niche issuer."
+          ],
+          "etfs": [
+            {
+              "symbol": "VOO",
+              "name": "Vanguard S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "Lowest-fee S&P 500 wrapper at 0.03% — the canonical first index ETF for a beginner."
+            },
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Total US market in one ticker at 0.03% — broader than the S&P 500 with the same set-and-forget simplicity."
+            },
+            {
+              "symbol": "AOR",
+              "name": "iShares Core Growth Allocation ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pre-built ~60/40 stock/bond allocation in a single ticker — true single-fund target-date alternative."
+            }
           ]
         },
         {
@@ -57,6 +77,26 @@
             "Material AUM decline combined with thin volume (closure risk).",
             "Frequent capital-gain distributions in passive-style funds.",
             "Headline fee well above category median without demonstrated alpha."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "0.03% fee compounds to large savings over 30 years vs higher-fee peers, with a stable total-market mandate."
+            },
+            {
+              "symbol": "ITOT",
+              "name": "iShares Core S&P Total US Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Same total-US exposure at 0.03% with iShares’ multi-decade operational track record as a benchmark-stable mandate."
+            },
+            {
+              "symbol": "VXUS",
+              "name": "Vanguard Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "Adds developed-international plus EM at 0.05% — completes the global compounding sleeve over multi-decade horizons."
+            }
           ]
         },
         {
@@ -83,6 +123,26 @@
             "Sub-3-year history with no comparable issuer track record on similar strategies.",
             "Headline fee above active-thematic peer median without demonstrated alpha.",
             "Persistent benchmark drift from the stated index."
+          ],
+          "etfs": [
+            {
+              "symbol": "VUG",
+              "name": "Vanguard Growth ETF",
+              "exchange": "NYSEARCA",
+              "why": "Cheap large-cap growth tilt at 0.04% capturing the long-run growth factor without active-management fees."
+            },
+            {
+              "symbol": "QQQM",
+              "name": "Invesco NASDAQ 100 ETF",
+              "exchange": "NASDAQ",
+              "why": "Lower-fee QQQ alternative (0.15%) suited to buy-and-hold investors seeking innovation/tech tilt."
+            },
+            {
+              "symbol": "VWO",
+              "name": "Vanguard FTSE Emerging Markets ETF",
+              "exchange": "NYSEARCA",
+              "why": "EM equity exposure at 0.08% adding higher long-term growth potential from emerging economies."
+            }
           ]
         },
         {
@@ -109,6 +169,26 @@
             "Long-duration bond exposure when rate outlook is rising.",
             "New large equity-concentration positions inside the de-risking window.",
             "Aggressive target-date dated 10+ years past expected retirement."
+          ],
+          "etfs": [
+            {
+              "symbol": "AOM",
+              "name": "iShares Core Moderate Allocation ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pre-built ~40/60 stock/bond mix that fits the pre-retirement glide-path in a single holding."
+            },
+            {
+              "symbol": "BND",
+              "name": "Vanguard Total Bond Market ETF",
+              "exchange": "NASDAQ",
+              "why": "Cheap (0.03%) broad IG core bond fund to scale up as equity is gradually trimmed inside the de-risking window."
+            },
+            {
+              "symbol": "BSV",
+              "name": "Vanguard Short-Term Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-duration IG bond exposure that limits drawdown if rates spike during the fragile pre-retirement years."
+            }
           ]
         },
         {
@@ -136,6 +216,26 @@
             "Long-duration bond exposure when rates may rise.",
             "Headline yield from concentrated low-rated credit.",
             "Recent dividend cuts or skipped distributions."
+          ],
+          "etfs": [
+            {
+              "symbol": "AOK",
+              "name": "iShares Core Conservative Allocation ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pre-built ~30/70 stock/bond mix designed for retirees prioritizing preservation alongside steady distribution."
+            },
+            {
+              "symbol": "SCHD",
+              "name": "Schwab US Dividend Equity ETF",
+              "exchange": "NYSEARCA",
+              "why": "Quality-screened dividend equity sleeve with sustainable distribution character preferred for retiree taxable accounts."
+            },
+            {
+              "symbol": "BND",
+              "name": "Vanguard Total Bond Market ETF",
+              "exchange": "NASDAQ",
+              "why": "Diversified IG core bond exposure at 0.03% provides the preservation anchor inside the income portfolio."
+            }
           ]
         },
         {
@@ -163,6 +263,26 @@
             "Concentrated low-rated issuer exposure inside a generically named credit fund.",
             "Active credit fund failing to beat its passive peer net of fees.",
             "Declining distribution trend masked by NAV-eroding payouts."
+          ],
+          "etfs": [
+            {
+              "symbol": "JEPI",
+              "name": "JPMorgan Equity Premium Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "Equity-overlay covered-call strategy distributing high monthly income (~7-8%) — flagship retail yield-supplement vehicle."
+            },
+            {
+              "symbol": "HYG",
+              "name": "iShares iBoxx $ High Yield Corporate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Liquid US high-yield corporate bond exposure delivering above-market credit yield in a transparent wrapper."
+            },
+            {
+              "symbol": "PFF",
+              "name": "iShares Preferred and Income Securities ETF",
+              "exchange": "NASDAQ",
+              "why": "Diversified preferred-securities yield (~6%) with monthly distributions — broad issuer mix limits single-name risk."
+            }
           ]
         },
         {
@@ -190,6 +310,26 @@
             "Sub-3-year history on a strategy with no comparable issuer track record.",
             "Headline fee well above peers in the same theme without methodology advantage.",
             "Thin AUM with declining trend — closure risk during the holding period."
+          ],
+          "etfs": [
+            {
+              "symbol": "XLK",
+              "name": "Technology Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Cleanest cap-weighted US tech exposure at 0.09% — canonical AI/tech-thesis vehicle with deep liquidity."
+            },
+            {
+              "symbol": "XLE",
+              "name": "Energy Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Pure-play US energy exposure at 0.09% — standard wrapper for the energy mispricing thesis."
+            },
+            {
+              "symbol": "INDA",
+              "name": "iShares MSCI India ETF",
+              "exchange": "BATS",
+              "why": "Single-country India exposure for the demographic-tailwind thesis with deep US-listed liquidity."
+            }
           ]
         },
         {
@@ -216,6 +356,26 @@
             "Self-graded ESG screens with weak or vague criteria (greenwashing risk).",
             "Holdings that contradict the fund's stated ESG mission.",
             "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ],
+          "etfs": [
+            {
+              "symbol": "ESGV",
+              "name": "Vanguard ESG US Stock ETF",
+              "exchange": "BATS",
+              "why": "Low-fee (0.09%) FTSE-screened ESG US large/mid/small exposure with broad diversification."
+            },
+            {
+              "symbol": "ESGU",
+              "name": "iShares ESG Aware MSCI USA ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated US large/mid-cap exposure with documented third-party screen — defensible methodology."
+            },
+            {
+              "symbol": "ICLN",
+              "name": "iShares Global Clean Energy ETF",
+              "exchange": "NASDAQ",
+              "why": "Pure-thematic global renewable-energy exposure for impact-focused investors wanting visible mission alignment."
+            }
           ]
         },
         {
@@ -242,6 +402,26 @@
             "Marketing or fund material that downplays daily-reset risk.",
             "Headline expense ratio above leveraged-peer norms.",
             "Wide bid-ask combined with thin volume."
+          ],
+          "etfs": [
+            {
+              "symbol": "TQQQ",
+              "name": "ProShares UltraPro QQQ",
+              "exchange": "NASDAQ",
+              "why": "3x daily-leveraged Nasdaq 100 — canonical retail tactical-bet vehicle with the deepest leveraged-ETF options market."
+            },
+            {
+              "symbol": "SOXL",
+              "name": "Direxion Daily Semiconductor Bull 3X Shares",
+              "exchange": "NYSEARCA",
+              "why": "3x leveraged semiconductor exposure for sector-momentum trades — high-volatility expression of the AI/chips thesis."
+            },
+            {
+              "symbol": "SQQQ",
+              "name": "ProShares UltraPro Short QQQ",
+              "exchange": "NASDAQ",
+              "why": "3x daily-inverse Nasdaq 100 for retail short-side bets without locating shares to borrow."
+            }
           ]
         }
       ]
@@ -275,6 +455,26 @@
             "Material recent capital-gain distributions in a passive-style fund.",
             "Active or thematic strategy with high turnover dragging after-tax return.",
             "Distribution character largely ROC or short-term gain without disclosure."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Heritage capital-gain distributions near zero — ideal for HNW taxable accounts at top federal+state+NIIT bracket."
+            },
+            {
+              "symbol": "ITOT",
+              "name": "iShares Core S&P Total US Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "iShares total-US wrapper with strong tax-efficiency record at 0.03% — clean alternative-issuer to VTI."
+            },
+            {
+              "symbol": "IXUS",
+              "name": "iShares Core MSCI Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "International exposure at 0.07% with foreign-tax-credit pass-through — material pickup at top brackets in taxable accounts."
+            }
           ]
         },
         {
@@ -301,6 +501,26 @@
             "High-yield muni exposure inside a generically named muni fund without disclosure.",
             "Private-activity-bond concentration triggering AMT for high-bracket investors.",
             "Single-state muni with documented pension or revenue-base distress."
+          ],
+          "etfs": [
+            {
+              "symbol": "CMF",
+              "name": "iShares California Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "California-resident muni exposure stacking state-tax exemption on top of the federal exemption for top-bracket CA residents."
+            },
+            {
+              "symbol": "NYF",
+              "name": "iShares New York Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "New York-resident muni exposure stacking NY state-tax exemption — same stacked-TEY logic for NY top-bracket residents."
+            },
+            {
+              "symbol": "MUB",
+              "name": "iShares National Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "National IG muni at 0.05% — fallback for residents without an in-state muni ETF or seeking broader diversification."
+            }
           ]
         },
         {
@@ -327,6 +547,26 @@
             "Fund labeled 'inflation hedge' but historically tracking equity beta.",
             "Unhedged single-currency or single-commodity concentration sized larger than satellite.",
             "K-1 reporting without offsetting tax or hedging benefit."
+          ],
+          "etfs": [
+            {
+              "symbol": "GLD",
+              "name": "SPDR Gold Shares",
+              "exchange": "NYSEARCA",
+              "why": "Spot-backed gold with deep liquidity — canonical inflation/disinflation real-asset diversifier in a 1099 wrapper."
+            },
+            {
+              "symbol": "PDBC",
+              "name": "Invesco Optimum Yield Diversified Commodity Strategy No K-1 ETF",
+              "exchange": "NASDAQ",
+              "why": "Diversified commodities (energy/metals/ag) in a 1099 wrapper avoiding K-1 friction at HNW reporting scale."
+            },
+            {
+              "symbol": "VNQ",
+              "name": "Vanguard Real Estate ETF",
+              "exchange": "NYSEARCA",
+              "why": "Diversified US REIT exposure at 0.13% — public real-estate sleeve complementing direct private holdings."
+            }
           ]
         },
         {
@@ -353,6 +593,26 @@
             "Defined-outcome fund where the cap and floor have already been breached mid-cycle.",
             "Counterparty / credit exposure that adds risk beyond the concentrated position.",
             "Methodology that doesn't explain how downside protection is funded."
+          ],
+          "etfs": [
+            {
+              "symbol": "BUFR",
+              "name": "FT Vest Laddered Buffer ETF",
+              "exchange": "BATS",
+              "why": "Laddered S&P 500 buffered-equity sleeve with rolling downside protection — used to step out of a concentrated single-stock without immediate gain realization."
+            },
+            {
+              "symbol": "PJAN",
+              "name": "Innovator U.S. Equity Power Buffer ETF – January",
+              "exchange": "BATS",
+              "why": "Single-outcome-period defined buffer (~9% downside protection, capped upside) — one rung of a customized buffered-equity ladder."
+            },
+            {
+              "symbol": "USMV",
+              "name": "iShares MSCI USA Min Vol Factor ETF",
+              "exchange": "BATS",
+              "why": "Low-volatility US equity diversifier providing broad equity exposure with materially reduced volatility vs a concentrated single holding."
+            }
           ]
         },
         {
@@ -379,6 +639,26 @@
             "Distribution funded mostly by ROC without explicit disclosure.",
             "Capture ratio that gives up most upside without delivering matching income.",
             "Strategy that significantly underperforms the underlying index in flat markets."
+          ],
+          "etfs": [
+            {
+              "symbol": "JEPI",
+              "name": "JPMorgan Equity Premium Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "S&P 500 covered-call overlay with ~7-8% distribution — flagship equity-overlay product for monthly income supplement."
+            },
+            {
+              "symbol": "JEPQ",
+              "name": "JPMorgan Nasdaq Equity Premium Income ETF",
+              "exchange": "NASDAQ",
+              "why": "Same overlay applied to Nasdaq 100 — higher option premium and richer monthly income for tech-heavy equity sleeves."
+            },
+            {
+              "symbol": "QYLD",
+              "name": "Global X NASDAQ 100 Covered Call ETF",
+              "exchange": "NASDAQ",
+              "why": "At-the-money Nasdaq 100 covered-call writing — pure income-maximizer trading off most of the upside."
+            }
           ]
         },
         {
@@ -405,6 +685,26 @@
             "Fund too small to absorb HNW position sizes without market impact.",
             "Wrong benchmark family forcing tracking-error commentary.",
             "Distribution mechanics that complicate capital-call funding."
+          ],
+          "etfs": [
+            {
+              "symbol": "VOO",
+              "name": "Vanguard S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "Largest S&P 500 wrapper at 0.03% — workhorse public-equity beta with ample bid-ask depth for capital-call funding."
+            },
+            {
+              "symbol": "IEFA",
+              "name": "iShares Core MSCI EAFE ETF",
+              "exchange": "NYSEARCA",
+              "why": "Broad developed-international beta at 0.07% with institutional-scale liquidity for the ex-US sleeve."
+            },
+            {
+              "symbol": "AGG",
+              "name": "iShares Core US Aggregate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "IG core fixed income at 0.03% — bond-side liquid-beta complement to the equity-private allocation."
+            }
           ]
         },
         {
@@ -431,6 +731,26 @@
             "Self-graded ESG screens with weak or vague criteria.",
             "Holdings that contradict the fund's stated mission alignment.",
             "Material fee premium vs the unscreened equivalent without methodology advantage."
+          ],
+          "etfs": [
+            {
+              "symbol": "ESGV",
+              "name": "Vanguard ESG US Stock ETF",
+              "exchange": "BATS",
+              "why": "Vanguard’s screened US equity at 0.09% — broad diversification with FTSE ESG screen suitable for family-IPS use."
+            },
+            {
+              "symbol": "ESGU",
+              "name": "iShares ESG Aware MSCI USA ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated US large/mid-cap with documented third-party screen — defensible for family-office due-diligence files."
+            },
+            {
+              "symbol": "ESGD",
+              "name": "iShares ESG Aware MSCI EAFE ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated developed-international exposure to apply the same screen across the international sleeve."
+            }
           ]
         },
         {
@@ -457,6 +777,26 @@
             "Recent benchmark or strategy changes that break the multi-decade record.",
             "Issuer operational concerns over long horizons.",
             "High-turnover strategy that breaks tax-deferral within the trust."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Total-US exposure with mandate stability and Vanguard’s multi-decade operational track record — fits 30-50 year trust horizons."
+            },
+            {
+              "symbol": "ITOT",
+              "name": "iShares Core S&P Total US Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "iShares total-US alternative — diversifies fund-issuer concentration alongside VTI; both have stable benchmark mandates."
+            },
+            {
+              "symbol": "VXUS",
+              "name": "Vanguard Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "Broad ex-US equity exposure at 0.05% to round out the multi-generational global equity sleeve."
+            }
           ]
         }
       ]
@@ -490,6 +830,26 @@
             "Fund too small for institutional-scale allocation without dominant-holder risk.",
             "Methodology drift that breaks IPS benchmark consistency.",
             "Concentration / closure risk from a single large investor's outflow."
+          ],
+          "etfs": [
+            {
+              "symbol": "TLT",
+              "name": "iShares 20+ Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Long-duration Treasury exposure at scale — workhorse for pension long-end duration matching with deep institutional liquidity."
+            },
+            {
+              "symbol": "EDV",
+              "name": "Vanguard Extended Duration Treasury ETF",
+              "exchange": "NYSEARCA",
+              "why": "STRIPS-based ~25-year duration for the longest portion of the LDI curve where TLT alone is insufficient."
+            },
+            {
+              "symbol": "LTPZ",
+              "name": "PIMCO 15+ Year US TIPS Index ETF",
+              "exchange": "NYSEARCA",
+              "why": "Long-duration TIPS for inflation-linked liability matching — direct real-rate exposure for cost-of-living-adjusted obligations."
+            }
           ]
         },
         {
@@ -516,6 +876,26 @@
             "ESG-labeled funds with weak self-graded screens (greenwashing risk).",
             "Methodology drift breaking IPS benchmark consistency.",
             "Insufficient liquidity to fund the annual distribution at scale."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Liquid US equity beta at 0.03% — efficient core for endowment public sleeve alongside the illiquid private book."
+            },
+            {
+              "symbol": "IEFA",
+              "name": "iShares Core MSCI EAFE ETF",
+              "exchange": "NYSEARCA",
+              "why": "Developed-international beta at 0.07% for the international piece of the endowment liquid sleeve."
+            },
+            {
+              "symbol": "BND",
+              "name": "Vanguard Total Bond Market ETF",
+              "exchange": "NASDAQ",
+              "why": "IG core bond exposure at 0.03% as the diversifying fixed-income sleeve supporting the spending policy."
+            }
           ]
         },
         {
@@ -542,6 +922,26 @@
             "Wrong benchmark family forcing attribution adjustments.",
             "Limited capacity making the institution a dominant holder.",
             "Issuer or fund-family operational concerns at institutional scale."
+          ],
+          "etfs": [
+            {
+              "symbol": "IVV",
+              "name": "iShares Core S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "iShares S&P 500 wrapper at 0.03% — institutional staple with deep capacity and securities-lending revenue offset."
+            },
+            {
+              "symbol": "IEFA",
+              "name": "iShares Core MSCI EAFE ETF",
+              "exchange": "NYSEARCA",
+              "why": "MSCI EAFE-tracking developed-international beta with institutional-scale capacity for $50M+ allocations."
+            },
+            {
+              "symbol": "IEMG",
+              "name": "iShares Core MSCI Emerging Markets ETF",
+              "exchange": "NYSEARCA",
+              "why": "MSCI EM-tracking institutional EM beta with $90B+ AUM — capacity to absorb pension/endowment block sizes."
+            }
           ]
         },
         {
@@ -568,6 +968,26 @@
             "Self-graded ESG screens unsuitable for fiduciary use.",
             "Exclusion-list gaps that the IPS specifically prohibits.",
             "Capacity insufficient for the institutional allocation size."
+          ],
+          "etfs": [
+            {
+              "symbol": "ESGU",
+              "name": "iShares ESG Aware MSCI USA ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated US large/mid-cap with auditable third-party screen — fiduciary-grade documentation for IPS files."
+            },
+            {
+              "symbol": "ESGD",
+              "name": "iShares ESG Aware MSCI EAFE ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated developed-international screen for the institutional ex-US sleeve, matching the US screen methodology."
+            },
+            {
+              "symbol": "SUSA",
+              "name": "iShares MSCI USA ESG Select ETF",
+              "exchange": "NYSEARCA",
+              "why": "Higher-conviction MSCI ESG US screen for IPSes requiring deeper exclusions than the broader ESGU mandate."
+            }
           ]
         },
         {
@@ -594,6 +1014,26 @@
             "Strategy that quietly tracks equities in bull markets but fails in bear markets.",
             "Fee at or above peer median with no demonstrated low correlation.",
             "Mandate drift — recent strategy or benchmark change."
+          ],
+          "etfs": [
+            {
+              "symbol": "DBMF",
+              "name": "iMGP DBi Managed Futures Strategy ETF",
+              "exchange": "NYSEARCA",
+              "why": "Replicates a managed-futures hedge-fund composite — designed to deliver positive return in equity drawdowns."
+            },
+            {
+              "symbol": "QAI",
+              "name": "NYLI Hedge Multi-Strategy Tracker ETF",
+              "exchange": "NYSEARCA",
+              "why": "Multi-strategy hedge-fund replicator providing low-correlation institutional alts exposure in a liquid wrapper."
+            },
+            {
+              "symbol": "MNA",
+              "name": "NYLI Merger Arbitrage ETF",
+              "exchange": "NYSEARCA",
+              "why": "Merger-arbitrage strategy delivering structurally low equity-correlation returns suitable for the diversifier sleeve."
+            }
           ]
         },
         {
@@ -620,6 +1060,26 @@
             "Material overlap with directly held private real assets.",
             "Commodity exposure delivered via equity proxies that track stocks more than spot.",
             "Capacity insufficient for the institutional allocation size."
+          ],
+          "etfs": [
+            {
+              "symbol": "TIP",
+              "name": "iShares TIPS Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Broad TIPS exposure providing direct CPI linkage at institutional scale — cleanest measured-inflation hedge."
+            },
+            {
+              "symbol": "DBC",
+              "name": "Invesco DB Commodity Index Tracking Fund",
+              "exchange": "NYSEARCA",
+              "why": "Diversified commodity-futures basket for unanticipated-inflation hedging where institutions can absorb K-1 reporting."
+            },
+            {
+              "symbol": "VNQ",
+              "name": "Vanguard Real Estate ETF",
+              "exchange": "NYSEARCA",
+              "why": "Public US REIT exposure at 0.13% — equity-real-asset complement to the TIPS and commodity legs."
+            }
           ]
         },
         {
@@ -646,6 +1106,26 @@
             "Wrong benchmark family forcing attribution mismatch.",
             "Limited capacity at institutional scale.",
             "Currency-hedging methodology that materially deviates from the underlying spot."
+          ],
+          "etfs": [
+            {
+              "symbol": "IEFA",
+              "name": "iShares Core MSCI EAFE ETF",
+              "exchange": "NYSEARCA",
+              "why": "MSCI EAFE-tracking developed-international beta with $100B+ AUM — institutional capacity for $50M-$5B blocks."
+            },
+            {
+              "symbol": "IEMG",
+              "name": "iShares Core MSCI Emerging Markets ETF",
+              "exchange": "NYSEARCA",
+              "why": "MSCI EM-tracking institutional EM exposure at $90B+ AUM with broad country-tier inclusion."
+            },
+            {
+              "symbol": "VXUS",
+              "name": "Vanguard Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "FTSE-based total ex-US (developed + EM) at 0.05% — for IPSes that prefer the FTSE benchmark family."
+            }
           ]
         },
         {
@@ -672,6 +1152,26 @@
             "Insufficient dollar volume for institutional-block trades.",
             "Material premium-discount drift during normal conditions.",
             "Capacity that would make the institution a dominant holder."
+          ],
+          "etfs": [
+            {
+              "symbol": "VOO",
+              "name": "Vanguard S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "$400B+ AUM with the deepest bid-ask in the equity wrapper market — absorbs $50-500M block trades for capital-call funding."
+            },
+            {
+              "symbol": "IVV",
+              "name": "iShares Core S&P 500 ETF",
+              "exchange": "NYSEARCA",
+              "why": "iShares S&P 500 alternative at similar scale — diversifies fund-issuer concentration in the rebalancing reservoir."
+            },
+            {
+              "symbol": "AGG",
+              "name": "iShares Core US Aggregate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "IG core bond exposure at $110B+ AUM — bond-side rebalancing buffer when private-credit calls land."
+            }
           ]
         }
       ]
@@ -705,6 +1205,26 @@
             "Duration creep — fund labeled 'ultra-short' holding 18+ month paper.",
             "Material credit-quality drift below IG.",
             "NAV instability beyond expected ultra-short range."
+          ],
+          "etfs": [
+            {
+              "symbol": "BIL",
+              "name": "SPDR Bloomberg 1-3 Month T-Bill ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pure 1-3 month T-bill exposure for treasury cash parking with same-day liquidity and minimal NAV variance."
+            },
+            {
+              "symbol": "ICSH",
+              "name": "iShares Ultra Short-Term Bond ETF",
+              "exchange": "BATS",
+              "why": "Active ultra-short IG bond fund with target ~0.5y duration — modest yield pickup over money-market funds."
+            },
+            {
+              "symbol": "JPST",
+              "name": "JPMorgan Ultra-Short Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "JP Morgan’s flagship ultra-short IG fund offering yield pickup over T-bills with daily corporate-scale liquidity."
+            }
           ]
         },
         {
@@ -731,6 +1251,26 @@
             "Any sub-investment-grade exposure inside the wrapper.",
             "Long duration exposure incompatible with the policy.",
             "Unclear regulatory look-through treatment."
+          ],
+          "etfs": [
+            {
+              "symbol": "AGG",
+              "name": "iShares Core US Aggregate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "IG core bond benchmark exposure at $110B+ AUM — institutional liquidity for insurance/treasury allocations."
+            },
+            {
+              "symbol": "BND",
+              "name": "Vanguard Total Bond Market ETF",
+              "exchange": "NASDAQ",
+              "why": "Vanguard’s IG core bond at 0.03% with similar broad mandate — alternative wrapper to AGG for issuer diversification."
+            },
+            {
+              "symbol": "IUSB",
+              "name": "iShares Core Total USD Bond Market ETF",
+              "exchange": "NASDAQ",
+              "why": "Broader USD IG bond exposure including some non-Agg sectors — slight diversification within the IG sleeve."
+            }
           ]
         },
         {
@@ -757,6 +1297,26 @@
             "Wrapper structure that loses HQLA Level-1 treatment under regulator look-through.",
             "Securities-lending program that pulls shares out of HQLA buffer.",
             "Composition drift away from pure treasury into agency or IG corporate."
+          ],
+          "etfs": [
+            {
+              "symbol": "SHY",
+              "name": "iShares 1-3 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "1-3 year treasury exposure for the HQLA Level-1 buffer — deep liquidity and pure-treasury composition."
+            },
+            {
+              "symbol": "BIL",
+              "name": "SPDR Bloomberg 1-3 Month T-Bill ETF",
+              "exchange": "NYSEARCA",
+              "why": "Pure short T-bill exposure — most liquid HQLA Level-1 holding and tightest NAV-stability profile."
+            },
+            {
+              "symbol": "GBIL",
+              "name": "Goldman Sachs Access Treasury 0-1 Year ETF",
+              "exchange": "NYSEARCA",
+              "why": "Goldman’s 0-1 year treasury wrapper providing sub-1y HQLA Level-1 exposure with low expense ratio."
+            }
           ]
         },
         {
@@ -783,6 +1343,26 @@
             "High-yield muni exposure inside a generically named muni fund.",
             "Single-state concentration with documented credit distress.",
             "Unclear NAIC treatment of the muni wrapper."
+          ],
+          "etfs": [
+            {
+              "symbol": "MUB",
+              "name": "iShares National Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "National IG muni at 0.05% — workhorse for P&C insurance after-tax muni allocation with broad credit diversification."
+            },
+            {
+              "symbol": "VTEB",
+              "name": "Vanguard Tax-Exempt Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Vanguard’s national IG muni at 0.05% — alternative wrapper for issuer diversification within the muni sleeve."
+            },
+            {
+              "symbol": "SUB",
+              "name": "iShares Short-Term National Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Short-duration national muni for insurers preferring lower duration risk in the after-tax muni sleeve."
+            }
           ]
         },
         {
@@ -809,6 +1389,26 @@
             "Duration mismatch with the targeted liability profile.",
             "Material drift below IG composition.",
             "Insufficient capacity for insurance-scale allocations."
+          ],
+          "etfs": [
+            {
+              "symbol": "IEI",
+              "name": "iShares 3-7 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Intermediate-duration treasury (~5y) matching common life-insurance and long-tail P&C liability profiles."
+            },
+            {
+              "symbol": "IEF",
+              "name": "iShares 7-10 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "7-10 year treasury exposure for the longer end of the intermediate-duration liability profile."
+            },
+            {
+              "symbol": "VCIT",
+              "name": "Vanguard Intermediate-Term Corporate Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Intermediate IG corporate exposure providing yield pickup over comparable-duration treasury within IG-only mandates."
+            }
           ]
         },
         {
@@ -835,6 +1435,26 @@
             "Wrapper that obscures the inflation-accrual tax treatment.",
             "Duration that mismatches the inflation-linked liability.",
             "Insufficient capacity for insurance-scale allocations."
+          ],
+          "etfs": [
+            {
+              "symbol": "TIP",
+              "name": "iShares TIPS Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Broad intermediate-duration TIPS exposure — direct CPI linkage at institutional scale with deep liquidity."
+            },
+            {
+              "symbol": "SCHP",
+              "name": "Schwab US TIPS ETF",
+              "exchange": "NYSEARCA",
+              "why": "Schwab’s TIPS wrapper at 0.03% — lowest-cost IG-only inflation linkage for cost-conscious treasury teams."
+            },
+            {
+              "symbol": "VTIP",
+              "name": "Vanguard Short-Term Inflation-Protected Securities ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-duration TIPS for insurers preferring lower duration risk while preserving direct CPI linkage."
+            }
           ]
         },
         {
@@ -861,6 +1481,26 @@
             "Material BBB tilt that increases downgrade-to-HY risk.",
             "Spread behavior worse than peers in past credit stress.",
             "Unclear NAIC / Basel look-through treatment."
+          ],
+          "etfs": [
+            {
+              "symbol": "VCSH",
+              "name": "Vanguard Short-Term Corporate Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-duration IG corporate exposure capturing typical 30-100 bp pickup over comparable-duration treasury."
+            },
+            {
+              "symbol": "IGSB",
+              "name": "iShares 1-5 Year Investment Grade Corporate Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "1-5 year IG corporate alternative with the same yield-pickup mandate — issuer-diversifies the credit sleeve."
+            },
+            {
+              "symbol": "SLQD",
+              "name": "iShares 0-5 Year Investment Grade Corporate Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Even shorter 0-5y IG corporate for treasuries wanting minimal duration alongside the credit-spread pickup."
+            }
           ]
         }
       ]
@@ -894,6 +1534,26 @@
             "Niche issuer with no analyst coverage or wholesaler relationship.",
             "Active or thematic strategy that complicates the model-portfolio thesis.",
             "Closure risk that would force a cross-account taxable transition for many clients."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Cheapest broad US workhorse at 0.03% with maximum TAMP/custody-platform availability for model portfolios."
+            },
+            {
+              "symbol": "IXUS",
+              "name": "iShares Core MSCI Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "Total ex-US (developed + EM) at 0.07% — single-fund international building block simplifying the model."
+            },
+            {
+              "symbol": "AGG",
+              "name": "iShares Core US Aggregate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "IG core bond benchmark exposure at 0.03% — bond-side workhorse with TAMP-friendly fact sheet."
+            }
           ]
         },
         {
@@ -920,6 +1580,26 @@
             "Fund tracking the same index as the existing holding (wash-sale violation risk).",
             "Material tracking-error difference that materially shifts portfolio risk during the swap.",
             "One side of the pair has thin AUM or wide bid-ask, defeating the harvest math."
+          ],
+          "etfs": [
+            {
+              "symbol": "VTI",
+              "name": "Vanguard Total Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Tracks the CRSP US Total Market index — pairs with ITOT (different index) for wash-sale-safe US-equity TLH."
+            },
+            {
+              "symbol": "ITOT",
+              "name": "iShares Core S&P Total US Stock Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Tracks the S&P US Total Market index — TLH partner to VTI delivering nearly identical exposure on a different benchmark."
+            },
+            {
+              "symbol": "SCHB",
+              "name": "Schwab US Broad Market ETF",
+              "exchange": "NYSEARCA",
+              "why": "Tracks the Dow Jones US Broad Stock Market index — third differentiated US-total benchmark for rolling TLH cycles."
+            }
           ]
         },
         {
@@ -946,6 +1626,26 @@
             "Distribution funded substantially by ROC without clear advisor-facing disclosure.",
             "Long-duration bond exposure incompatible with retiree drawdown tolerance.",
             "Active fund failing to beat its passive peer net of fees over 5+ years."
+          ],
+          "etfs": [
+            {
+              "symbol": "SCHD",
+              "name": "Schwab US Dividend Equity ETF",
+              "exchange": "NYSEARCA",
+              "why": "Quality-screened dividend-equity sleeve with sustainable distribution character — popular advisor pick for retiree models."
+            },
+            {
+              "symbol": "VYM",
+              "name": "Vanguard High Dividend Yield ETF",
+              "exchange": "NYSEARCA",
+              "why": "Broad large-cap dividend exposure at 0.06% — defensible building block with intuitive client-communication story."
+            },
+            {
+              "symbol": "JEPI",
+              "name": "JPMorgan Equity Premium Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "Equity-overlay covered-call wrapper for the income-supplement piece — explains the upside-cap tradeoff to retiree clients."
+            }
           ]
         },
         {
@@ -972,6 +1672,26 @@
             "Duration creep beyond the conservative-tier target.",
             "Credit-quality drift below IG.",
             "Wide bid-ask amplified across many client accounts."
+          ],
+          "etfs": [
+            {
+              "symbol": "BSV",
+              "name": "Vanguard Short-Term Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-duration IG bond at 0.04% — workhorse short-bond sleeve for conservative-tier models across many client accounts."
+            },
+            {
+              "symbol": "VCSH",
+              "name": "Vanguard Short-Term Corporate Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short IG corporate exposure capturing modest credit pickup over treasury inside the conservative sleeve."
+            },
+            {
+              "symbol": "SHY",
+              "name": "iShares 1-3 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "1-3 year treasury alternative for the most defensive end of the bond sleeve in retiree-tier models."
+            }
           ]
         },
         {
@@ -998,6 +1718,26 @@
             "Wrong benchmark family creating attribution mismatch.",
             "Material premium-discount drift in EM during stress windows.",
             "Wrapper structure that loses foreign-tax-credit creditability."
+          ],
+          "etfs": [
+            {
+              "symbol": "IEFA",
+              "name": "iShares Core MSCI EAFE ETF",
+              "exchange": "NYSEARCA",
+              "why": "Developed-international workhorse at 0.07% — TAMP-friendly large-AUM building block for growth-tier models."
+            },
+            {
+              "symbol": "IEMG",
+              "name": "iShares Core MSCI Emerging Markets ETF",
+              "exchange": "NYSEARCA",
+              "why": "EM equity exposure at 0.09% with $90B+ AUM and broad TAMP availability for cross-account allocation."
+            },
+            {
+              "symbol": "VXUS",
+              "name": "Vanguard Total International Stock ETF",
+              "exchange": "NASDAQ",
+              "why": "Single-fund total ex-US (developed + EM) at 0.05% — for advisors preferring one-ticker international simplicity."
+            }
           ]
         },
         {
@@ -1024,6 +1764,26 @@
             "Theme drift — fund name and top holdings don't align.",
             "Headline fee well above peers in the same theme without methodology advantage.",
             "Closure risk that would force a cross-account taxable transition."
+          ],
+          "etfs": [
+            {
+              "symbol": "VNQ",
+              "name": "Vanguard Real Estate ETF",
+              "exchange": "NYSEARCA",
+              "why": "Diversified US REIT exposure at 0.13% — most common real-estate satellite tilt in advisor model portfolios."
+            },
+            {
+              "symbol": "XLK",
+              "name": "Technology Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Cheap (0.09%) cap-weighted US tech tilt — defensible methodology for client-facing model documentation."
+            },
+            {
+              "symbol": "IGF",
+              "name": "iShares Global Infrastructure ETF",
+              "exchange": "NASDAQ",
+              "why": "Global infrastructure exposure for the diversification-and-inflation tilt rationale at 5-15% sleeve sizes."
+            }
           ]
         },
         {
@@ -1050,6 +1810,26 @@
             "Self-graded ESG screens with weak or vague criteria.",
             "Holdings that contradict the fund's stated mission.",
             "Material fee premium without methodology advantage."
+          ],
+          "etfs": [
+            {
+              "symbol": "ESGU",
+              "name": "iShares ESG Aware MSCI USA ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated US large/mid-cap with auditable third-party screen — defensible advisor anchor for the ESG variant."
+            },
+            {
+              "symbol": "ESGD",
+              "name": "iShares ESG Aware MSCI EAFE ETF",
+              "exchange": "NASDAQ",
+              "why": "MSCI ESG-rated developed-international screen substituting for IEFA in the ESG client-model variant."
+            },
+            {
+              "symbol": "ESGV",
+              "name": "Vanguard ESG US Stock ETF",
+              "exchange": "BATS",
+              "why": "Vanguard’s screened US equity at 0.09% — alternative-issuer ESG building block for fee-conscious advisors."
+            }
           ]
         },
         {
@@ -1076,6 +1856,26 @@
             "High-yield muni exposure inside a generically named muni fund.",
             "Single-state muni with documented credit distress.",
             "Wide bid-ask amplified across many client accounts."
+          ],
+          "etfs": [
+            {
+              "symbol": "MUB",
+              "name": "iShares National Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "National IG muni at 0.05% — workhorse for high-bracket client muni sleeves with broad TAMP availability."
+            },
+            {
+              "symbol": "VTEB",
+              "name": "Vanguard Tax-Exempt Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Vanguard’s national IG muni at 0.05% — alternative wrapper for fund-issuer diversification across client accounts."
+            },
+            {
+              "symbol": "SUB",
+              "name": "iShares Short-Term National Muni Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Short-duration national muni for the conservative-tier-with-muni client sub-models that need lower duration risk."
+            }
           ]
         },
         {
@@ -1102,6 +1902,26 @@
             "K-1 reporting for client accounts where the advisor avoids K-1s.",
             "Fund labeled inflation-hedge but historically tracking equity beta.",
             "Material commodity-spot vs equity-proxy mismatch."
+          ],
+          "etfs": [
+            {
+              "symbol": "SCHP",
+              "name": "Schwab US TIPS ETF",
+              "exchange": "NYSEARCA",
+              "why": "Low-cost (0.03%) TIPS exposure for the measured-CPI portion of the real-asset diversification sleeve."
+            },
+            {
+              "symbol": "VNQ",
+              "name": "Vanguard Real Estate ETF",
+              "exchange": "NYSEARCA",
+              "why": "Diversified US REIT exposure at 0.13% — equity-correlated real-asset complement at 5-10% sleeve sizes."
+            },
+            {
+              "symbol": "PDBC",
+              "name": "Invesco Optimum Yield Diversified Commodity Strategy No K-1 ETF",
+              "exchange": "NASDAQ",
+              "why": "1099-reporting commodity exposure avoiding K-1 friction — preferred by advisors keeping client tax simple."
+            }
           ]
         },
         {
@@ -1128,6 +1948,26 @@
             "Defined-outcome fund where the cap and floor have already been breached mid-cycle.",
             "Capture ratio that gives up most upside without delivering matching income.",
             "Distribution funded mostly by ROC without explicit disclosure."
+          ],
+          "etfs": [
+            {
+              "symbol": "BUFR",
+              "name": "FT Vest Laddered Buffer ETF",
+              "exchange": "BATS",
+              "why": "Laddered S&P 500 buffered-equity sleeve providing rolling downside protection for retiree-tier models."
+            },
+            {
+              "symbol": "PJAN",
+              "name": "Innovator U.S. Equity Power Buffer ETF – January",
+              "exchange": "BATS",
+              "why": "Single-outcome-period S&P 500 buffer with defined floor/cap — one rung of a custom advisor-built buffered ladder."
+            },
+            {
+              "symbol": "JEPI",
+              "name": "JPMorgan Equity Premium Income ETF",
+              "exchange": "NYSEARCA",
+              "why": "Covered-call equity overlay for the derivative-income piece of retiree models — flagship income-supplement vehicle."
+            }
           ]
         }
       ]
@@ -1161,6 +2001,26 @@
             "Options market thin or non-existent.",
             "High borrow cost or limited shortable supply.",
             "Wide premium / discount drift during normal conditions."
+          ],
+          "etfs": [
+            {
+              "symbol": "SPY",
+              "name": "SPDR S&P 500 ETF Trust",
+              "exchange": "NYSEARCA",
+              "why": "Largest, most-liquid S&P 500 wrapper with the deepest options market — desk-standard equity-beta vehicle."
+            },
+            {
+              "symbol": "QQQ",
+              "name": "Invesco QQQ Trust",
+              "exchange": "NASDAQ",
+              "why": "Nasdaq 100 wrapper with deep options market — standard tech/growth-beta expression for desk transition trades."
+            },
+            {
+              "symbol": "IWM",
+              "name": "iShares Russell 2000 ETF",
+              "exchange": "NYSEARCA",
+              "why": "Russell 2000 small-cap wrapper with deep options market — small-cap-beta workhorse for desk-block trades."
+            }
           ]
         },
         {
@@ -1187,6 +2047,26 @@
             "Borrow cost on the short leg that erodes the trade economics.",
             "Methodology mismatch between the two sector funds invalidating the thesis.",
             "Material option-market thinness on either leg."
+          ],
+          "etfs": [
+            {
+              "symbol": "XLK",
+              "name": "Technology Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Standard tech-sector wrapper with tight bid-ask and deep options market — common long leg of pair trades."
+            },
+            {
+              "symbol": "XLE",
+              "name": "Energy Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Standard energy-sector wrapper — deep options and reliable borrow inventory for the short side of pairs."
+            },
+            {
+              "symbol": "XLF",
+              "name": "Financial Select Sector SPDR Fund",
+              "exchange": "NYSEARCA",
+              "why": "Standard financial-sector wrapper completing the desk’s core sector-rotation toolkit alongside XLK/XLE."
+            }
           ]
         },
         {
@@ -1213,6 +2093,26 @@
             "Material premium / discount drift in HY ETF during normal conditions.",
             "Options market thin on the HY ETF leg.",
             "High borrow cost on the short leg."
+          ],
+          "etfs": [
+            {
+              "symbol": "HYG",
+              "name": "iShares iBoxx $ High Yield Corporate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Largest HY wrapper with the deepest options market — standard HY leg for credit-spread directional trades."
+            },
+            {
+              "symbol": "LQD",
+              "name": "iShares iBoxx $ Investment Grade Corporate Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Largest IG corporate wrapper — standard IG leg for credit-spread relative-value pair trades vs HY."
+            },
+            {
+              "symbol": "JNK",
+              "name": "SPDR Bloomberg High Yield Bond ETF",
+              "exchange": "NYSEARCA",
+              "why": "Alternative HY wrapper — secondary leg for HYG-only desks or for HY pair-trade construction."
+            }
           ]
         },
         {
@@ -1239,6 +2139,26 @@
             "Bid-ask widening in stress vs the underlying treasury market.",
             "Options market thin on chosen treasury ETF.",
             "Material premium / discount drift in stress windows."
+          ],
+          "etfs": [
+            {
+              "symbol": "TLT",
+              "name": "iShares 20+ Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Long-end Treasury wrapper with deep options market — workhorse for long-duration directional bets."
+            },
+            {
+              "symbol": "IEF",
+              "name": "iShares 7-10 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Intermediate Treasury wrapper for belly-of-curve expression and curve-shape trades."
+            },
+            {
+              "symbol": "SHY",
+              "name": "iShares 1-3 Year Treasury Bond ETF",
+              "exchange": "NASDAQ",
+              "why": "Short-end Treasury wrapper for front-end-of-curve expression and butterfly trade construction."
+            }
           ]
         },
         {
@@ -1265,6 +2185,26 @@
             "Material contango friction eroding the trade thesis.",
             "K-1 reporting where the desk's tax structure can't accept it.",
             "Limited options market on the chosen commodity ETF."
+          ],
+          "etfs": [
+            {
+              "symbol": "GLD",
+              "name": "SPDR Gold Shares",
+              "exchange": "NYSEARCA",
+              "why": "Spot-backed gold with the deepest options market — standard gold-directional vehicle in a 1099 wrapper."
+            },
+            {
+              "symbol": "USO",
+              "name": "United States Oil Fund LP",
+              "exchange": "NYSEARCA",
+              "why": "Front-month WTI futures wrapper — standard crude-oil expression for desks without commodity prime brokerage."
+            },
+            {
+              "symbol": "DBC",
+              "name": "Invesco DB Commodity Index Tracking Fund",
+              "exchange": "NYSEARCA",
+              "why": "Diversified commodity-futures basket for broad commodity directional bets across energy/metals/ag."
+            }
           ]
         },
         {
@@ -1291,6 +2231,26 @@
             "Documented tracking failures on the daily-leverage objective.",
             "Wide bid-ask combined with thin volume.",
             "Marketing that downplays daily-reset risk."
+          ],
+          "etfs": [
+            {
+              "symbol": "TQQQ",
+              "name": "ProShares UltraPro QQQ",
+              "exchange": "NASDAQ",
+              "why": "3x daily-leveraged Nasdaq 100 — most-liquid leveraged ETF with deep options for capital-efficient bets."
+            },
+            {
+              "symbol": "SOXL",
+              "name": "Direxion Daily Semiconductor Bull 3X Shares",
+              "exchange": "NYSEARCA",
+              "why": "3x leveraged semiconductor exposure — focused-sector leverage with deep options for tactical chip-cycle trades."
+            },
+            {
+              "symbol": "FAS",
+              "name": "Direxion Daily Financial Bull 3X Shares",
+              "exchange": "NYSEARCA",
+              "why": "3x leveraged financials — sector-leverage tool for financial-tilt expressions inside short-horizon hedges."
+            }
           ]
         },
         {
@@ -1317,6 +2277,26 @@
             "Documented tracking failures on the daily-inverse objective.",
             "Wide bid-ask defeating the hedge economics.",
             "Material daily-reset decay over the intended hedge horizon."
+          ],
+          "etfs": [
+            {
+              "symbol": "SH",
+              "name": "ProShares Short S&P 500",
+              "exchange": "NYSEARCA",
+              "why": "1x daily-inverse S&P 500 — cleanest inverse-hedge vehicle with minimal daily-reset decay over short windows."
+            },
+            {
+              "symbol": "SDS",
+              "name": "ProShares UltraShort S&P 500",
+              "exchange": "NYSEARCA",
+              "why": "2x daily-inverse S&P 500 — capital-efficient inverse hedge accepting modest decay for higher beta-to-underlying."
+            },
+            {
+              "symbol": "SQQQ",
+              "name": "ProShares UltraPro Short QQQ",
+              "exchange": "NASDAQ",
+              "why": "3x daily-inverse Nasdaq 100 — capital-efficient hedge for tech-tilt portfolios needing concentrated short exposure."
+            }
           ]
         },
         {
@@ -1343,6 +2323,26 @@
             "Material basis vs spot crypto in normal conditions.",
             "Custodian concentration risk inside the ETF wrapper.",
             "Limited options market for the chosen spot-crypto ETF."
+          ],
+          "etfs": [
+            {
+              "symbol": "IBIT",
+              "name": "iShares Bitcoin Trust ETF",
+              "exchange": "NASDAQ",
+              "why": "BlackRock’s spot-bitcoin ETF — fastest-growing AUM with rapidly developing options market for tactical positions."
+            },
+            {
+              "symbol": "FBTC",
+              "name": "Fidelity Wise Origin Bitcoin Fund",
+              "exchange": "BATS",
+              "why": "Fidelity’s spot-bitcoin alternative — second-largest spot-BTC ETF for issuer/custodian diversification."
+            },
+            {
+              "symbol": "ETHA",
+              "name": "iShares Ethereum Trust ETF",
+              "exchange": "NASDAQ",
+              "why": "BlackRock’s spot-ether ETF — primary spot-ETH wrapper for tactical Ethereum directional positions."
+            }
           ]
         }
       ]

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -120,8 +120,6 @@ export interface EtfCategoryAnalysisResponse {
  * (and optionally specific Morningstar categories) defined in etf-analysis-categories.json.
  */
 
-export type EtfInvestorExperienceLevel = 'Beginner' | 'Intermediate' | 'Experienced';
-
 export type EtfInvestorHorizon = 'Short (<1y)' | 'Medium (1-5y)' | 'Long (5-15y)' | 'Very Long (15y+)';
 
 export type EtfInvestorRiskTolerance = 'Low' | 'Low-Moderate' | 'Moderate' | 'Moderate-High' | 'High' | 'Very High';
@@ -139,16 +137,12 @@ export type EtfInvestorIncomeNeed = 'None' | 'Modest' | 'High';
 
 export type EtfInvestorTaxSensitivity = 'Low' | 'Moderate' | 'High';
 
-export type EtfInvestorAccountPreference = 'Taxable' | 'Tax-Advantaged' | 'Either';
-
 export interface EtfInvestorProfile {
-  experienceLevel: EtfInvestorExperienceLevel;
   investmentHorizon: EtfInvestorHorizon;
   riskTolerance: EtfInvestorRiskTolerance;
   primaryGoal: EtfInvestorPrimaryGoal;
   incomeNeed: EtfInvestorIncomeNeed;
   taxSensitivity: EtfInvestorTaxSensitivity;
-  accountTypePreference: EtfInvestorAccountPreference;
   typicalInvestor: string;
 }
 
@@ -171,7 +165,6 @@ export interface EtfTargetInvestorGroup {
   name: string;
   shortDescription: string;
   profile: EtfInvestorProfile;
-  goalLabels: string[];
   analysisAngle: string;
   keyConsiderations: string[];
   redFlags: string[];

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -146,7 +146,12 @@ export interface EtfInvestorProfile {
   typicalInvestor: string;
 }
 
-export interface EtfTargetInvestorGroup {
+/**
+ * A single goal-persona — concrete enough to write ETF analysis against.
+ * Used both as a top-level entry (for goals that don't need an audience wrapper,
+ * e.g., first-time-investor) and as a nested entry inside an audience's goals[].
+ */
+export interface EtfInvestorGoal {
   key: string;
   name: string;
   shortDescription: string;
@@ -154,6 +159,29 @@ export interface EtfTargetInvestorGroup {
   analysisAngle: string;
   keyConsiderations: string[];
   redFlags: string[];
+}
+
+/**
+ * A broad audience that contains multiple distinct goals worth analyzing
+ * separately (e.g., HNW, pension/endowment/foundation, RIA). The audience
+ * itself has only descriptive metadata; the analytical detail lives in goals[].
+ */
+export interface EtfInvestorAudience {
+  key: string;
+  name: string;
+  shortDescription: string;
+  goals: EtfInvestorGoal[];
+}
+
+/**
+ * Heterogeneous: an entry is either a flat goal-persona (EtfInvestorGoal shape)
+ * or an audience wrapper with nested goals (EtfInvestorAudience shape). Discriminate
+ * by the presence of a `goals` array.
+ */
+export type EtfTargetInvestorGroup = EtfInvestorGoal | EtfInvestorAudience;
+
+export function isEtfInvestorAudience(group: EtfTargetInvestorGroup): group is EtfInvestorAudience {
+  return Array.isArray((group as EtfInvestorAudience).goals);
 }
 
 export interface EtfTargetInvestorGroupsConfig {

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -151,6 +151,14 @@ export interface EtfInvestorProfile {
   typicalInvestor: string;
 }
 
+/** A specific ETF recommended for a given goal. */
+export interface EtfInvestorGoalEtf {
+  symbol: string;
+  name: string;
+  exchange: string;
+  why: string;
+}
+
 /** A specific goal an investor pursues when buying ETFs. */
 export interface EtfInvestorGoal {
   key: string;
@@ -160,6 +168,7 @@ export interface EtfInvestorGoal {
   analysisAngle: string;
   keyConsiderations: string[];
   redFlags: string[];
+  etfs: EtfInvestorGoalEtf[];
 }
 
 /** A type of investor (retail, HNW, pension, etc.) with the goals they pursue. */

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -146,12 +146,6 @@ export interface EtfInvestorProfile {
   typicalInvestor: string;
 }
 
-export interface EtfInvestorGroupCategoryHighlight {
-  category: string;
-  group: string;
-  rationale: string;
-}
-
 export interface EtfTargetInvestorGroup {
   key: string;
   name: string;
@@ -160,7 +154,6 @@ export interface EtfTargetInvestorGroup {
   analysisAngle: string;
   keyConsiderations: string[];
   redFlags: string[];
-  highlightedCategories: EtfInvestorGroupCategoryHighlight[];
 }
 
 export interface EtfTargetInvestorGroupsConfig {

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -146,14 +146,6 @@ export interface EtfInvestorProfile {
   typicalInvestor: string;
 }
 
-export type EtfGroupFitLevel = 'primary' | 'secondary' | 'occasional' | 'avoid';
-
-export interface EtfInvestorGroupGroupFit {
-  groupKey: string;
-  fit: EtfGroupFitLevel;
-  rationale: string;
-}
-
 export interface EtfInvestorGroupCategoryHighlight {
   category: string;
   group: string;
@@ -168,7 +160,6 @@ export interface EtfTargetInvestorGroup {
   analysisAngle: string;
   keyConsiderations: string[];
   redFlags: string[];
-  etfGroupFit: EtfInvestorGroupGroupFit[];
   highlightedCategories: EtfInvestorGroupCategoryHighlight[];
 }
 

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -113,3 +113,73 @@ export interface EtfCategoryAnalysisResponse {
   overallAnalysisDetails: string;
   factors: EtfFactorAnalysisResult[];
 }
+
+/**
+ * Target investor groups taxonomy. Each group is an investor archetype that an ETF
+ * analysis can be written from the perspective of. Groups map onto the ETF groups
+ * (and optionally specific Morningstar categories) defined in etf-analysis-categories.json.
+ */
+
+export type EtfInvestorExperienceLevel = 'Beginner' | 'Intermediate' | 'Experienced';
+
+export type EtfInvestorHorizon = 'Short (<1y)' | 'Medium (1-5y)' | 'Long (5-15y)' | 'Very Long (15y+)';
+
+export type EtfInvestorRiskTolerance = 'Low' | 'Low-Moderate' | 'Moderate' | 'Moderate-High' | 'High' | 'Very High';
+
+export type EtfInvestorPrimaryGoal =
+  | 'Wealth Accumulation'
+  | 'Income Generation'
+  | 'Capital Preservation'
+  | 'Tax Optimization'
+  | 'Speculation / Trading'
+  | 'Diversification / Hedging'
+  | 'Thematic Exposure';
+
+export type EtfInvestorIncomeNeed = 'None' | 'Modest' | 'High';
+
+export type EtfInvestorTaxSensitivity = 'Low' | 'Moderate' | 'High';
+
+export type EtfInvestorAccountPreference = 'Taxable' | 'Tax-Advantaged' | 'Either';
+
+export interface EtfInvestorProfile {
+  experienceLevel: EtfInvestorExperienceLevel;
+  investmentHorizon: EtfInvestorHorizon;
+  riskTolerance: EtfInvestorRiskTolerance;
+  primaryGoal: EtfInvestorPrimaryGoal;
+  incomeNeed: EtfInvestorIncomeNeed;
+  taxSensitivity: EtfInvestorTaxSensitivity;
+  accountTypePreference: EtfInvestorAccountPreference;
+  typicalInvestor: string;
+}
+
+export type EtfGroupFitLevel = 'primary' | 'secondary' | 'occasional' | 'avoid';
+
+export interface EtfInvestorGroupGroupFit {
+  groupKey: string;
+  fit: EtfGroupFitLevel;
+  rationale: string;
+}
+
+export interface EtfInvestorGroupCategoryHighlight {
+  category: string;
+  group: string;
+  rationale: string;
+}
+
+export interface EtfTargetInvestorGroup {
+  key: string;
+  name: string;
+  shortDescription: string;
+  profile: EtfInvestorProfile;
+  goalLabels: string[];
+  analysisAngle: string;
+  keyConsiderations: string[];
+  redFlags: string[];
+  etfGroupFit: EtfInvestorGroupGroupFit[];
+  highlightedCategories: EtfInvestorGroupCategoryHighlight[];
+}
+
+export interface EtfTargetInvestorGroupsConfig {
+  description: string;
+  investorGroups: EtfTargetInvestorGroup[];
+}

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -115,9 +115,14 @@ export interface EtfCategoryAnalysisResponse {
 }
 
 /**
- * Target investor groups taxonomy. Each group is an investor archetype that an ETF
- * analysis can be written from the perspective of. Groups map onto the ETF groups
- * (and optionally specific Morningstar categories) defined in etf-analysis-categories.json.
+ * ETF investor taxonomy. Two-level structure:
+ *   - Level 1: EtfInvestor — a type of investor (retail, HNW, pension, etc.).
+ *     Types are intentionally non-overlapping (each defined by a distinct funding
+ *     source / governance / regulatory context).
+ *   - Level 2: EtfInvestorGoal — a specific goal an investor of that type pursues
+ *     when buying ETFs (e.g., "tax-efficient public-equity beta sleeve",
+ *     "liability-driven investing"). Goals can recur across types but are framed
+ *     for that type's specific perspective.
  */
 
 export type EtfInvestorHorizon = 'Short (<1y)' | 'Medium (1-5y)' | 'Long (5-15y)' | 'Very Long (15y+)';
@@ -146,11 +151,7 @@ export interface EtfInvestorProfile {
   typicalInvestor: string;
 }
 
-/**
- * A single goal-persona — concrete enough to write ETF analysis against.
- * Used both as a top-level entry (for goals that don't need an audience wrapper,
- * e.g., first-time-investor) and as a nested entry inside an audience's goals[].
- */
+/** A specific goal an investor pursues when buying ETFs. */
 export interface EtfInvestorGoal {
   key: string;
   name: string;
@@ -161,30 +162,15 @@ export interface EtfInvestorGoal {
   redFlags: string[];
 }
 
-/**
- * A broad audience that contains multiple distinct goals worth analyzing
- * separately (e.g., HNW, pension/endowment/foundation, RIA). The audience
- * itself has only descriptive metadata; the analytical detail lives in goals[].
- */
-export interface EtfInvestorAudience {
+/** A type of investor (retail, HNW, pension, etc.) with the goals they pursue. */
+export interface EtfInvestor {
   key: string;
   name: string;
   shortDescription: string;
-  goals: EtfInvestorGoal[];
+  etfInvestorGoals: EtfInvestorGoal[];
 }
 
-/**
- * Heterogeneous: an entry is either a flat goal-persona (EtfInvestorGoal shape)
- * or an audience wrapper with nested goals (EtfInvestorAudience shape). Discriminate
- * by the presence of a `goals` array.
- */
-export type EtfTargetInvestorGroup = EtfInvestorGoal | EtfInvestorAudience;
-
-export function isEtfInvestorAudience(group: EtfTargetInvestorGroup): group is EtfInvestorAudience {
-  return Array.isArray((group as EtfInvestorAudience).goals);
-}
-
-export interface EtfTargetInvestorGroupsConfig {
+export interface EtfInvestorTaxonomyConfig {
   description: string;
-  investorGroups: EtfTargetInvestorGroup[];
+  investors: EtfInvestor[];
 }


### PR DESCRIPTION
## Summary

Adds a new ETF *target investor groups* taxonomy used to frame ETF analyses from the perspective of who the potential investors are. KoalaGains generates analysis across many ETF types; this taxonomy lets each report be written for a specific investor archetype rather than one neutral voice.

Aligns with Phase 2 ('Target audience / Goals') in `tasks/koala-gains/etfs.md`.

## Changes

- **New data file:** `insights-ui/src/etf-analysis-data/etf-target-investor-groups.json` — 10 investor groups, each with profile, analysis angle, key considerations, red flags, mapping to all 8 ETF groups (with `primary` / `secondary` / `occasional` / `avoid` fit + rationale), and highlighted Morningstar categories.
- **New TypeScript types:** `insights-ui/src/types/etf/etf-analysis-types.ts` — `EtfInvestorProfile`, `EtfTargetInvestorGroup`, `EtfTargetInvestorGroupsConfig` and supporting union types.

## Investor groups

1. `first-time-investor` — Beginner / First-Time Investor
2. `long-term-wealth-builder` — Long-Term Wealth Builder (Buy & Hold)
3. `growth-accumulator` — Growth-Focused Accumulator
4. `retirement-income-seeker` — Retirement Income Seeker
5. `tax-sensitive-high-earner` — Tax-Sensitive High-Income Investor
6. `income-yield-seeker` — Income / High-Yield Seeker
7. `sector-thematic-conviction` — Sector / Thematic Conviction Investor
8. `active-trader-speculator` — Active Trader / Tactical Speculator
9. `all-weather-diversifier` — All-Weather Diversifier / Risk-Off Hedger
10. `inflation-real-asset-hedger` — Inflation & Real-Asset Hedger

Groups are intentionally **non-mutually-exclusive** — a single ETF (e.g. a TIPS fund) may legitimately appear under several investor groups.

## Data model rationale

Each investor group captures three layers:

| Layer | Fields | Purpose |
|---|---|---|
| Profile | experienceLevel, investmentHorizon, riskTolerance, primaryGoal, incomeNeed, taxSensitivity, accountTypePreference, typicalInvestor | Anchor the prompt: who is this person? |
| Analysis guidance | analysisAngle, keyConsiderations, redFlags, goalLabels | Tell the writer what to lead with, what to flag, what disqualifies an ETF for this investor |
| ETF mapping | etfGroupFit (per-group fit + rationale, all 8 groups), highlightedCategories (specific Morningstar categories with rationale) | Connect the archetype to the existing ETF group / category structure |

`goalLabels` mirrors the Phase-2 taxonomy examples (\"Fixed income with low risk\", \"High yield with moderate or high risk\", \"Single-country thematic exposure\") so the per-ETF goal-tagging step in Phase 2 can reuse the same labels.

## Validation

- Every `groupKey` in `etfGroupFit` resolves to a real group key in `etf-analysis-categories.json`.
- Every `category` in `highlightedCategories` matches a real category name, and the embedded `group` matches the category's actual group.
- `yarn prettier-check`, `yarn lint`, `yarn compile` all pass.

## Test plan

- [ ] Review the 10 investor groups for completeness vs the kinds of analyses you want generated.
- [ ] Confirm the goal-label vocabulary matches the Phase-2 plan you have in mind.
- [ ] Decide whether highlighted categories should be exhaustive (every relevant category) or curated (only the strongest fits) — this PR uses curated.