### PR TITLE
fix(etf): clear stale factor results on save-report-callback

### DIFF
--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -23,63 +23,69 @@ export async function saveEtfFactorAnalysisResponse(
   const spaceId = KoalaGainsSpaceId;
   const etfRecord = await fetchEtfBySymbolAndExchange(symbol, exchange);
 
-  await prisma.etfCategoryAnalysisResult.upsert({
-    where: {
-      spaceId_etfId_categoryKey: {
-        spaceId,
-        etfId: etfRecord.id,
-        categoryKey,
-      },
-    },
-    update: {
-      summary: response.overallSummary,
-      overallAnalysisDetails: response.overallAnalysisDetails,
-      updatedAt: new Date(),
-    },
-    create: {
-      spaceId,
-      etfId: etfRecord.id,
-      categoryKey,
-      summary: response.overallSummary,
-      overallAnalysisDetails: response.overallAnalysisDetails,
-    },
-  });
-
-  for (const factor of response.factors) {
+  // Keep only factors whose keys are recognized for this category. Unknown keys
+  // are logged and dropped so they can't become stale rows on a replace.
+  const validFactors = response.factors.filter((factor) => {
     const factorDef = findFactorDefinition(categoryKey, factor.factorAnalysisKey);
     if (!factorDef) {
       console.warn(`Unknown factor key: ${factor.factorAnalysisKey} for ETF ${symbol}`);
-      continue;
+      return false;
     }
+    return true;
+  });
 
-    await prisma.etfAnalysisCategoryFactorResult.upsert({
+  // Replace the category's factor results atomically: the current prompt
+  // invocation is the source of truth, so any factor rows from a previous run
+  // (e.g. when the group config included more factors) must be cleared before
+  // we insert the new set. Without this, the listing page shows stale factors
+  // that were not part of the latest LLM response.
+  await prisma.$transaction(async (tx) => {
+    await tx.etfCategoryAnalysisResult.upsert({
       where: {
-        spaceId_etfId_factorKey: {
+        spaceId_etfId_categoryKey: {
           spaceId,
           etfId: etfRecord.id,
-          factorKey: factor.factorAnalysisKey,
+          categoryKey,
         },
       },
       update: {
-        categoryKey,
-        oneLineExplanation: factor.oneLineExplanation,
-        detailedExplanation: factor.detailedExplanation,
-        result: factor.result,
+        summary: response.overallSummary,
+        overallAnalysisDetails: response.overallAnalysisDetails,
         updatedAt: new Date(),
       },
       create: {
         spaceId,
         etfId: etfRecord.id,
         categoryKey,
-        factorKey: factor.factorAnalysisKey,
-        oneLineExplanation: factor.oneLineExplanation,
-        detailedExplanation: factor.detailedExplanation,
-        result: factor.result,
+        summary: response.overallSummary,
+        overallAnalysisDetails: response.overallAnalysisDetails,
       },
     });
-  }
 
-  const score = response.factors.filter((f) => f.result && f.result.toLowerCase().includes('pass')).length;
+    await tx.etfAnalysisCategoryFactorResult.deleteMany({
+      where: {
+        spaceId,
+        etfId: etfRecord.id,
+        categoryKey,
+      },
+    });
+
+    if (validFactors.length > 0) {
+      await tx.etfAnalysisCategoryFactorResult.createMany({
+        data: validFactors.map((factor) => ({
+          spaceId,
+          etfId: etfRecord.id,
+          categoryKey,
+          factorKey: factor.factorAnalysisKey,
+          oneLineExplanation: factor.oneLineExplanation,
+          detailedExplanation: factor.detailedExplanation,
+          result: factor.result,
+        })),
+      });
+    }
+  });
+
+  const score = validFactors.filter((f) => f.result && f.result.toLowerCase().includes('pass')).length;
   await updateEtfCachedScore(etfRecord.id, categoryKey, score);
 
   // Per-ETF detail tag plus listing tag — score change affects the listing-page ranking.


### PR DESCRIPTION
## Summary

The ETF performance-returns page (e.g. https://koalagains.com/etfs/NASDAQ/TLT/performance-returns) was showing 9 analysis factors while the latest prompt invocation only produced 5. The extra 4 were stale rows left over from a previous run.

`saveEtfFactorAnalysisResponse` was using a per-factor `upsert` keyed on `(spaceId, etfId, factorKey)`. When a later run returned a smaller factor set (e.g. because the group config for the fund's category was reduced), the new keys got updated but the old keys remained in `etf_analysis_category_factor_results` — the listing page surfaces all rows for the ETF/category, so the stale ones kept appearing.

## Fix

In `saveEtfFactorAnalysisResponse`:

- Filter out factors whose keys aren't recognized for the current category up front (same `console.warn` as before).
- Wrap the category row upsert, a `deleteMany` on `(spaceId, etfId, categoryKey)`, and a `createMany` of the new factors inside a single `prisma.$transaction` so the replace is atomic.
- Use the filtered set for the pass-count score as well, so unknown keys can't inflate `updateEtfCachedScore`.

The `(spaceId, etfId, categoryKey)` index already exists on the factor table, so the delete is cheap.

## Test plan

- [ ] Re-run a performance-returns analysis for an ETF that previously had more factors than the current group config, and confirm only the current-run factors remain on `/etfs/<exchange>/<symbol>/performance-returns`.
- [ ] Verify analyses for other categories (cost-efficiency, risk, future-performance) still save correctly and the `updateEtfCachedScore` numbers update as expected.