### PR TITLE
add Generate Competition option to ETF actions menus

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/BulkActionsBar.tsx
@@ -43,6 +43,7 @@ export default function BulkActionsBar({ selectedEtfs, onClearSelection, onRefre
     riskAnalysis?: boolean;
     futurePerformanceOutlook?: boolean;
     indexStrategy?: boolean;
+    competition?: boolean;
   }) {
     const allTypes = !options;
     const payloads: EtfGenerationRequestPayload[] = selectedEtfs.map((etf) => ({
@@ -52,6 +53,7 @@ export default function BulkActionsBar({ selectedEtfs, onClearSelection, onRefre
       regenerateRiskAnalysis: allTypes || (options?.riskAnalysis ?? false),
       regenerateFuturePerformanceOutlook: allTypes || (options?.futurePerformanceOutlook ?? false),
       regenerateIndexStrategy: allTypes || (options?.indexStrategy ?? false),
+      regenerateCompetition: allTypes || (options?.competition ?? false),
       regenerateFinalSummary: allTypes,
     }));
     await createGenerationRequests(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/generation-requests`, payloads);
@@ -114,6 +116,9 @@ export default function BulkActionsBar({ selectedEtfs, onClearSelection, onRefre
       </button>
       <button className={buttonClass} disabled={isBusy} onClick={() => handleGenerateAnalysis({ futurePerformanceOutlook: true })}>
         Future Outlook
+      </button>
+      <button className={buttonClass} disabled={isBusy} onClick={() => handleGenerateAnalysis({ competition: true })}>
+        Competition
       </button>
 
       <div className="h-4 w-px bg-indigo-700/60" />

--- a/insights-ui/src/app/admin-v1/etf-reports/EtfRowActionsDropdown.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/EtfRowActionsDropdown.tsx
@@ -50,6 +50,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
     { key: 'generateRiskAnalysis', label: 'Generate Risk Analysis', disabled: isBusyAll },
     { key: 'generateFutureOutlook', label: 'Generate Future Outlook', disabled: isBusyAll },
     { key: 'generateIndexStrategy', label: 'Generate Index & Strategy', disabled: isBusyAll },
+    { key: 'generateCompetition', label: 'Generate Competition', disabled: isBusyAll },
     { key: 'generateFinalSummary', label: 'Generate Final Summary', disabled: isBusyAll },
     { key: 'financial', label: 'Financial Info', disabled: isBusyAll },
     { key: 'morAnalyzer', label: 'Mor Analyzer', disabled: isBusyAll },
@@ -72,6 +73,7 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regenerateRiskAnalysis: true,
               regenerateFuturePerformanceOutlook: true,
               regenerateIndexStrategy: true,
+              regenerateCompetition: true,
               regenerateFinalSummary: true,
             },
           ]);
@@ -137,6 +139,20 @@ export default function EtfRowActionsDropdown({ etf, onDone }: EtfRowActionsDrop
               regenerateRiskAnalysis: false,
               regenerateFuturePerformanceOutlook: false,
               regenerateIndexStrategy: true,
+              regenerateFinalSummary: false,
+            },
+          ]);
+          onDone();
+        } else if (key === 'generateCompetition') {
+          await createGenerationRequest(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/etfs-v1/generation-requests`, [
+            {
+              etf: { symbol: etf.symbol, exchange: etf.exchange },
+              regeneratePerformanceAndReturns: false,
+              regenerateCostEfficiencyAndTeam: false,
+              regenerateRiskAnalysis: false,
+              regenerateFuturePerformanceOutlook: false,
+              regenerateIndexStrategy: false,
+              regenerateCompetition: true,
               regenerateFinalSummary: false,
             },
           ]);

--- a/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
+++ b/insights-ui/src/app/admin-v1/etf-reports/SelectMissingBar.tsx
@@ -17,6 +17,7 @@ const reportTypeCategories: MissingCategory[] = [
   { key: 'missingSummary', label: 'Missing Summary', filter: (e) => isReportMissing(e.reportStatuses.summary) },
   { key: 'missingIndexStrategy', label: 'Missing Index & Strategy', filter: (e) => isReportMissing(e.reportStatuses.indexStrategy) },
   { key: 'missingFutureOutlook', label: 'Missing Future Outlook', filter: (e) => isReportMissing(e.reportStatuses.futureOutlook) },
+  { key: 'missingCompetition', label: 'Missing Competition', filter: (e) => isReportMissing(e.reportStatuses.competition) },
   {
     key: 'missingAllAnalysis',
     label: 'Missing All Analysis',
@@ -26,7 +27,8 @@ const reportTypeCategories: MissingCategory[] = [
       isReportMissing(e.reportStatuses.risk) &&
       isReportMissing(e.reportStatuses.summary) &&
       isReportMissing(e.reportStatuses.indexStrategy) &&
-      isReportMissing(e.reportStatuses.futureOutlook),
+      isReportMissing(e.reportStatuses.futureOutlook) &&
+      isReportMissing(e.reportStatuses.competition),
   },
 ];
 

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/EtfActions.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/EtfActions.tsx
@@ -24,6 +24,7 @@ type GenerateKey =
   | 'risk-analysis'
   | 'future-performance-outlook'
   | 'index-strategy'
+  | 'competition'
   | 'final-summary';
 
 const REPORT_OPTIONS: Array<{ key: GenerateKey; label: string }> = [
@@ -33,6 +34,7 @@ const REPORT_OPTIONS: Array<{ key: GenerateKey; label: string }> = [
   { key: 'risk-analysis', label: 'Generate Risk Analysis' },
   { key: 'future-performance-outlook', label: 'Generate Future Outlook' },
   { key: 'index-strategy', label: 'Generate Index & Strategy' },
+  { key: 'competition', label: 'Generate Competition' },
   { key: 'final-summary', label: 'Generate Final Summary' },
 ];
 
@@ -45,6 +47,7 @@ function buildPayload(etf: EtfIdentifier, key: GenerateKey): EtfGenerationReques
     regenerateRiskAnalysis: all || key === 'risk-analysis',
     regenerateFuturePerformanceOutlook: all || key === 'future-performance-outlook',
     regenerateIndexStrategy: all || key === 'index-strategy',
+    regenerateCompetition: all || key === 'competition',
     regenerateFinalSummary: all || key === 'final-summary',
   };
 }

--- a/insights-ui/src/scripts/etfs/trigger-generation.ts
+++ b/insights-ui/src/scripts/etfs/trigger-generation.ts
@@ -10,6 +10,7 @@ interface EtfGenerationRequestPayload {
   regenerateRiskAnalysis: boolean;
   regenerateFuturePerformanceOutlook?: boolean;
   regenerateIndexStrategy?: boolean;
+  regenerateCompetition?: boolean;
   regenerateFinalSummary?: boolean;
 }
 
@@ -26,7 +27,12 @@ const EVALUATION_CATEGORIES: readonly EtfReportType[] = [
   EtfReportType.FUTURE_PERFORMANCE_OUTLOOK,
 ];
 
-const ALL_REPORT_TYPES: readonly EtfReportType[] = [...EVALUATION_CATEGORIES, EtfReportType.INDEX_STRATEGY, EtfReportType.FINAL_SUMMARY];
+const ALL_REPORT_TYPES: readonly EtfReportType[] = [
+  ...EVALUATION_CATEGORIES,
+  EtfReportType.INDEX_STRATEGY,
+  EtfReportType.COMPETITION,
+  EtfReportType.FINAL_SUMMARY,
+];
 
 const MAX_ETFS_PER_INVOCATION = 50;
 const DEFAULT_DELAY_MS = 10_000;
@@ -40,6 +46,7 @@ function buildPayload(etf: { symbol: string; exchange: string }, categories: Etf
     regenerateRiskAnalysis: set.has(EtfReportType.RISK_ANALYSIS),
     regenerateFuturePerformanceOutlook: set.has(EtfReportType.FUTURE_PERFORMANCE_OUTLOOK),
     regenerateIndexStrategy: set.has(EtfReportType.INDEX_STRATEGY),
+    regenerateCompetition: set.has(EtfReportType.COMPETITION),
     regenerateFinalSummary: set.has(EtfReportType.FINAL_SUMMARY),
   };
 }


### PR DESCRIPTION
## Summary
- Adds a **Generate Competition** entry to the Generate Report modal on the ETF detail page (`EtfActions.tsx`), wiring it through `buildPayload` to set `regenerateCompetition`
- Adds a matching **Generate Competition** item to the admin `EtfRowActionsDropdown`, with its own handler that sends a competition-only regeneration request
- Includes `regenerateCompetition: true` in the existing "Generate All Analysis" admin shortcut so the bulk option stays in sync

## Why
The backend already accepts `regenerateCompetition` in the generation request payload, but neither UI surfaced a button for it, so the Competition report couldn't be kicked off from the ETF page or the admin row menu.

## Test plan
- [x] `yarn lint`
- [x] `yarn prettier-check`
- [x] `yarn compile`
- [ ] Manual: on an ETF detail page (e.g. `/etfs/NYSEARCA/EDV`), open Generate Report and confirm "Generate Competition" is present and creates a request
- [ ] Manual: in the admin ETF reports table, confirm the row dropdown shows "Generate Competition" and the handler posts `regenerateCompetition: true`