### PR TITLE
Add stock report trigger + add-stock CLIs with automation-token auth

### DIFF
--- a/docs/ai-knowledge/insights-ui/AIKnowledge.md
+++ b/docs/ai-knowledge/insights-ui/AIKnowledge.md
@@ -5,6 +5,7 @@ Topical reference docs for the Insights-UI (KoalaGains) app — patterns, prompt
 ## Subfolders
 
 - **[etf-analysis/](etf-analysis/)** — How the ETF analysis pipeline works end-to-end: report generation, market scenarios, implementation checklists. See [etf-analysis/AIKnowledge.md](etf-analysis/AIKnowledge.md).
+- **[stock-analysis/](stock-analysis/)** — Runbooks for adding new stocks (`yarn stocks:add`) and triggering stock report generation (`yarn stocks:trigger`). See [stock-analysis/AIKnowledge.md](stock-analysis/AIKnowledge.md).
 - **[etf-prompts/](etf-prompts/)** — Source-of-truth prompt text for each ETF analysis category (past returns, cost & efficiency, risk, future outlook, intro/strategy) plus the prompt-finalization approach. See [etf-prompts/AIKnowledge.md](etf-prompts/AIKnowledge.md).
 - **[etf-prompt-improvement/](etf-prompt-improvement/)** — Iterative prompt-review notes, factor-set reviews, and per-ETF audits captured during the prompt-tuning loop. See [etf-prompt-improvement/AIKnowledge.md](etf-prompt-improvement/AIKnowledge.md).
 - **[downside-analysis/](downside-analysis/)** — Equity downside / drawdown framework with per-ticker case studies (the 31-stock study). See [downside-analysis/AIKnowledge.md](downside-analysis/AIKnowledge.md).

--- a/docs/ai-knowledge/insights-ui/stock-analysis/AIKnowledge.md
+++ b/docs/ai-knowledge/insights-ui/stock-analysis/AIKnowledge.md
@@ -1,0 +1,17 @@
+# Stock Analysis Knowledge
+
+Runbooks and reference docs for the stock (ticker / equity) analysis pipeline — how to add new stocks, enqueue report generation, and interact with the relevant API endpoints from scripts.
+
+## Topics
+
+- **[generate-stock-reports.md](generate-stock-reports.md)** — How to enqueue stock analysis reports with `yarn stocks:trigger` (single ticker or batch, all reports or a subset), and how authentication works against the generation-requests endpoint.
+- **[add-stock.md](add-stock.md)** — How to add new stocks to the database with `yarn stocks:add`, including exchange validation against the predefined list, required fields, and the stockAnalyzeUrl auto-generation.
+
+## Where to read further
+
+- Trigger endpoint: `src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts`
+- Create-ticker endpoint: `src/app/api/[spaceId]/tickers-v1/route.ts`
+- Exchanges source-of-truth: `src/utils/countryExchangeUtils.ts` (`EXCHANGES`, `isExchange`, `AllExchanges`)
+- stockAnalyzeUrl validation / generation: `src/utils/stockAnalyzeUrlValidation.ts`
+- Trigger script: `src/scripts/tickers/trigger-generation.ts`
+- Add-stock script: `src/scripts/tickers/add-stock.ts`

--- a/docs/ai-knowledge/insights-ui/stock-analysis/add-stock.md
+++ b/docs/ai-knowledge/insights-ui/stock-analysis/add-stock.md
@@ -1,0 +1,171 @@
+# Adding stocks
+
+How to create new `TickerV1` records with `yarn stocks:add` — including required-field
+and exchange validation. Used when a user wants analysis on a stock that isn't
+yet in the DB, and as a prerequisite for `yarn stocks:trigger`.
+
+## Quick reference
+
+| Situation | Command |
+| --- | --- |
+| Add one stock inline | `yarn stocks:add --name "Apple Inc." --symbol AAPL --exchange NASDAQ --industry consumer-discretionary --sub-industry consumer-electronics --website https://www.apple.com` |
+| Add many stocks from JSON | `yarn stocks:add --in path/to/stocks.json` |
+| Write results for later inspection | `... --out path/to/added.json` |
+
+## Required fields
+
+Every stock must provide **all** of these:
+
+| Field | CLI flag | JSON key | Notes |
+| --- | --- | --- | --- |
+| Company name | `--name` | `name` | Human-readable (e.g. "Apple Inc."). |
+| Ticker symbol | `--symbol` | `symbol` | Upper-cased automatically. |
+| Exchange | `--exchange` | `exchange` | **Must be in the predefined list** (see below). Upper-cased automatically. |
+| Industry key | `--industry` | `industryKey` | FK into `TickerV1Industry`. Must already exist. |
+| Sub-industry key | `--sub-industry` | `subIndustryKey` | FK into `TickerV1SubIndustry`. Must already exist under the chosen industry. |
+| Website URL | `--website` | `websiteUrl` | **Mandatory.** Must start with `http://` or `https://`. |
+
+Optional fields:
+
+| Field | CLI flag | JSON key | Notes |
+| --- | --- | --- | --- |
+| Short summary | `--summary` | `summary` | Free text shown on the stock page. |
+| Stock-analyze URL | `--stock-analyze-url` | `stockAnalyzeUrl` | If omitted, auto-generated from `symbol` + `exchange` using the per-exchange path segment (see `src/utils/stockAnalyzeUrlValidation.ts`). |
+
+### Why website is required
+
+The CLI enforces `websiteUrl` before sending, and the POST handler in
+`src/app/api/[spaceId]/tickers-v1/route.ts` also rejects payloads with a
+missing/empty `websiteUrl`. This keeps CLI-added and UI-added stocks consistent —
+the company's website is used throughout the analysis prompts and on the stock
+detail page, so every record needs one.
+
+## Exchange validation
+
+The `exchange` value is validated against the predefined `EXCHANGES` array in
+`src/utils/countryExchangeUtils.ts`. The full list (20 exchanges across 10
+countries):
+
+- **US:** `BATS`, `NASDAQ`, `NYSE`, `NYSEARCA`, `NYSEAMERICAN`, `OTCMKTS`
+- **Canada:** `TSX`, `TSXV`
+- **India:** `BSE`, `NSE`
+- **UK:** `LSE`, `AIM`
+- **Pakistan:** `PSX`
+- **Japan:** `TSE`
+- **Taiwan:** `TWSE`
+- **Hong Kong:** `HKEX`
+- **Korea:** `KOSPI`, `KOSDAQ`, `KONEX`
+- **Australia:** `ASX`
+
+Any value not in the list is rejected with an error that lists the allowed
+values — both on the client side (CLI) and the server side (POST handler).
+
+## Single-stock example
+
+```bash
+yarn stocks:add \
+  --name "Apple Inc." \
+  --symbol AAPL \
+  --exchange NASDAQ \
+  --industry consumer-discretionary \
+  --sub-industry consumer-electronics \
+  --website https://www.apple.com \
+  --summary "Designer & manufacturer of iPhones, Macs, and services."
+```
+
+## Batch example (JSON input)
+
+`--in` accepts either a bare array or `{ tickers: [...] }`:
+
+```json
+[
+  {
+    "name": "Apple Inc.",
+    "symbol": "AAPL",
+    "exchange": "NASDAQ",
+    "industryKey": "consumer-discretionary",
+    "subIndustryKey": "consumer-electronics",
+    "websiteUrl": "https://www.apple.com"
+  },
+  {
+    "name": "Shopify Inc.",
+    "symbol": "SHOP",
+    "exchange": "TSX",
+    "industryKey": "technology",
+    "subIndustryKey": "software-application",
+    "websiteUrl": "https://www.shopify.com",
+    "summary": "Canadian multinational e-commerce company."
+  }
+]
+```
+
+```bash
+yarn stocks:add --in /tmp/stocks.json
+```
+
+Batch behavior:
+
+- Default inter-call delay: **500 ms** (tuned for sequential DB writes, not LLM
+  calls). Override with `--delay-ms 250`.
+- Pre-validation failures (missing required fields, unknown exchange, bad
+  `websiteUrl`) are collected and **skipped**, never posted to the API.
+- Server-side failures (duplicates, FK violations on industry/sub-industry) are
+  logged per row and **do not abort the run**.
+- Hard limit: **100 stocks** per invocation.
+- Exit code 1 if any row failed.
+
+## Output file (`--out`)
+
+```json
+{
+  "added": [
+    {
+      "id": "7e1c9f1a-...",
+      "name": "Apple Inc.",
+      "symbol": "AAPL",
+      "exchange": "NASDAQ",
+      "websiteUrl": "https://www.apple.com",
+      "stockAnalyzeUrl": "https://.../stocks/AAPL/",
+      "industryKey": "consumer-discretionary",
+      "subIndustryKey": "consumer-electronics"
+    }
+  ],
+  "failed": [
+    { "symbol": "XYZ", "exchange": "NASDAQ", "reason": "Ticker XYZ already exists on NASDAQ" }
+  ]
+}
+```
+
+Pipe the added symbols into the trigger step:
+
+```bash
+yarn stocks:add --in /tmp/stocks.json --out /tmp/added.json
+# build a symbol/exchange list from /tmp/added.json and feed it to:
+yarn stocks:trigger --in /tmp/trigger-input.json --all
+```
+
+## Auth
+
+The create-ticker POST route (`/api/[spaceId]/tickers-v1`) uses the generic
+`withErrorHandlingV2` middleware today — there is no admin-or-token guard on
+it. The CLI still sends `x-automation-token` so that if the endpoint later
+adopts `withAdminOrToken`, no script change is needed.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `Missing required field(s): websiteUrl` | Input lacks a website URL. | Provide `--website` / `websiteUrl`. |
+| `Invalid exchange "NYSEArca". Supported: BATS, NASDAQ, ...` | Exchange typo or wrong casing. | Use one of the values in the `EXCHANGES` list (upper-case variants are accepted; the CLI normalizes). |
+| `Ticker AAPL already exists on NASDAQ` | Stock is already in the DB. | Nothing to do; use `yarn stocks:trigger` to regenerate reports. |
+| `Foreign key constraint violated on industryKey` | The industry/sub-industry key doesn't exist. | Confirm the keys via the admin industries page or by querying `TickerV1Industry`/`TickerV1SubIndustry`. |
+| `websiteUrl must start with http:// or https://` | Missing protocol on the website URL. | Prepend `https://`. |
+
+## Where to read further
+
+- CLI: `src/scripts/tickers/add-stock.ts`
+- Shared helpers: `src/scripts/tickers/lib.ts`
+- Create endpoint: `src/app/api/[spaceId]/tickers-v1/route.ts` (POST handler)
+- Exchange source-of-truth: `src/utils/countryExchangeUtils.ts`
+- stockAnalyzeUrl generation: `src/utils/stockAnalyzeUrlValidation.ts`
+- UI counterpart (visual equivalent of this CLI): `src/components/public-equitiesv1/AddTickersForm.tsx`

--- a/docs/ai-knowledge/insights-ui/stock-analysis/add-stock.md
+++ b/docs/ai-knowledge/insights-ui/stock-analysis/add-stock.md
@@ -23,22 +23,21 @@ Every stock must provide **all** of these:
 | Exchange | `--exchange` | `exchange` | **Must be in the predefined list** (see below). Upper-cased automatically. |
 | Industry key | `--industry` | `industryKey` | FK into `TickerV1Industry`. Must already exist. |
 | Sub-industry key | `--sub-industry` | `subIndustryKey` | FK into `TickerV1SubIndustry`. Must already exist under the chosen industry. |
-| Website URL | `--website` | `websiteUrl` | **Mandatory.** Must start with `http://` or `https://`. |
+| Website URL | `--website` | `websiteUrl` | **Mandatory.** Must be an absolute URL starting with `http://` or `https://`. |
+| Stock-analyze URL | `--stock-analyze-url` | `stockAnalyzeUrl` | **Mandatory.** Must match the per-exchange format produced by `generateExpectedStockAnalyzeUrl` (see `src/utils/stockAnalyzeUrlValidation.ts`). The CLI uses `validateStockAnalyzeUrl` to check; the server re-validates on POST. |
 
 Optional fields:
 
 | Field | CLI flag | JSON key | Notes |
 | --- | --- | --- | --- |
 | Short summary | `--summary` | `summary` | Free text shown on the stock page. |
-| Stock-analyze URL | `--stock-analyze-url` | `stockAnalyzeUrl` | If omitted, auto-generated from `symbol` + `exchange` using the per-exchange path segment (see `src/utils/stockAnalyzeUrlValidation.ts`). |
 
-### Why website is required
+### Why both URLs are required
 
-The CLI enforces `websiteUrl` before sending, and the POST handler in
-`src/app/api/[spaceId]/tickers-v1/route.ts` also rejects payloads with a
-missing/empty `websiteUrl`. This keeps CLI-added and UI-added stocks consistent —
-the company's website is used throughout the analysis prompts and on the stock
-detail page, so every record needs one.
+- **`websiteUrl`** — the company's official website is used throughout the analysis prompts (for sourcing business-model / product context) and on the stock detail page. Every record needs one.
+- **`stockAnalyzeUrl`** — this is the canonical link into the external stock-analyze site that backs the per-stock data tabs; the DB column is non-nullable and most UI links assume it's present. Requiring it at the API boundary prevents half-populated rows from sneaking in through scripts.
+
+The CLI and POST handler both enforce presence *and* format for these two fields.
 
 ## Exchange validation
 
@@ -70,8 +69,17 @@ yarn stocks:add \
   --industry consumer-discretionary \
   --sub-industry consumer-electronics \
   --website https://www.apple.com \
+  --stock-analyze-url https://stockanalysis.com/stocks/AAPL/ \
   --summary "Designer & manufacturer of iPhones, Macs, and services."
 ```
+
+> The `--stock-analyze-url` value must match the format produced by
+> `generateExpectedStockAnalyzeUrl(symbol, exchange)`. For US stock exchanges
+> (NASDAQ / NYSE / NYSEAMERICAN) that's `{BASE}/stocks/{SYMBOL}/`; other
+> exchanges use `{BASE}/quote/{segment}/{SYMBOL}/` with per-exchange segments
+> defined in `src/utils/stockAnalyzeUrlValidation.ts`. The CLI needs
+> `NEXT_PUBLIC_STOCK_ANALYZE_BASE_URL` set in its env to validate — otherwise
+> the expected-format error message will show a relative path.
 
 ## Batch example (JSON input)
 
@@ -85,7 +93,8 @@ yarn stocks:add \
     "exchange": "NASDAQ",
     "industryKey": "consumer-discretionary",
     "subIndustryKey": "consumer-electronics",
-    "websiteUrl": "https://www.apple.com"
+    "websiteUrl": "https://www.apple.com",
+    "stockAnalyzeUrl": "https://stockanalysis.com/stocks/AAPL/"
   },
   {
     "name": "Shopify Inc.",
@@ -94,6 +103,7 @@ yarn stocks:add \
     "industryKey": "technology",
     "subIndustryKey": "software-application",
     "websiteUrl": "https://www.shopify.com",
+    "stockAnalyzeUrl": "https://stockanalysis.com/quote/tsx/SHOP/",
     "summary": "Canadian multinational e-commerce company."
   }
 ]
@@ -108,7 +118,8 @@ Batch behavior:
 - Default inter-call delay: **500 ms** (tuned for sequential DB writes, not LLM
   calls). Override with `--delay-ms 250`.
 - Pre-validation failures (missing required fields, unknown exchange, bad
-  `websiteUrl`) are collected and **skipped**, never posted to the API.
+  `websiteUrl` format, `stockAnalyzeUrl` that doesn't match the expected
+  per-exchange format) are collected and **skipped**, never posted to the API.
 - Server-side failures (duplicates, FK violations on industry/sub-industry) are
   logged per row and **do not abort the run**.
 - Hard limit: **100 stocks** per invocation.
@@ -156,10 +167,12 @@ adopts `withAdminOrToken`, no script change is needed.
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | `Missing required field(s): websiteUrl` | Input lacks a website URL. | Provide `--website` / `websiteUrl`. |
+| `Missing required field(s): stockAnalyzeUrl` | Input lacks the stock-analyze URL. | Provide `--stock-analyze-url` / `stockAnalyzeUrl`. |
 | `Invalid exchange "NYSEArca". Supported: BATS, NASDAQ, ...` | Exchange typo or wrong casing. | Use one of the values in the `EXCHANGES` list (upper-case variants are accepted; the CLI normalizes). |
 | `Ticker AAPL already exists on NASDAQ` | Stock is already in the DB. | Nothing to do; use `yarn stocks:trigger` to regenerate reports. |
 | `Foreign key constraint violated on industryKey` | The industry/sub-industry key doesn't exist. | Confirm the keys via the admin industries page or by querying `TickerV1Industry`/`TickerV1SubIndustry`. |
-| `websiteUrl must start with http:// or https://` | Missing protocol on the website URL. | Prepend `https://`. |
+| `websiteUrl must be an absolute URL starting with http:// or https://` | Missing protocol on the website URL. | Prepend `https://`. |
+| `stockAnalyzeUrl is invalid: Invalid stockAnalyzeUrl format. Expected: .../stocks/AAPL/` | The URL doesn't match the per-exchange format `generateExpectedStockAnalyzeUrl` produces. | Use the URL shape from the error message (US exchanges use `/stocks/<SYM>/`; others use `/quote/<segment>/<SYM>/`). Make sure `NEXT_PUBLIC_STOCK_ANALYZE_BASE_URL` is set in the CLI's env so the expected format resolves correctly. |
 
 ## Where to read further
 

--- a/docs/ai-knowledge/insights-ui/stock-analysis/generate-stock-reports.md
+++ b/docs/ai-knowledge/insights-ui/stock-analysis/generate-stock-reports.md
@@ -1,0 +1,162 @@
+# Triggering stock report generation
+
+How to enqueue stock (ticker) analysis reports — single stock or batch, all reports or specific types. Mirrors the ETF trigger pattern in [`../etf-analysis/generate-etf-reports.md`](../etf-analysis/generate-etf-reports.md).
+
+## Quick reference
+
+| Situation | Command |
+| --- | --- |
+| All reports for one stock | `yarn stocks:trigger --symbol AAPL --exchange NASDAQ --all` |
+| All reports for many stocks (10s delay between) | `yarn stocks:trigger --in path/to/stocks.json --all` |
+| Specific report types for one stock | `yarn stocks:trigger --symbol AAPL --exchange NASDAQ --categories=financial-analysis,competition` |
+| 7 analysis categories (skip final-summary) | `yarn stocks:trigger --in path/to/stocks.json --analysis` |
+| Write request IDs for follow-up | `... --out path/to/triggered.json` |
+
+## What gets generated
+
+`yarn stocks:trigger` POSTs to `/api/koala_gains/tickers-v1/generation-requests` with
+one or more `GenerationRequestPayload` entries. Each entry sets per-step
+`regenerate*` flags for the requested report types:
+
+| Report type (CLI value) | Flag set on payload |
+| --- | --- |
+| `financial-analysis` | `regenerateFinancialAnalysis` |
+| `competition` | `regenerateCompetition` |
+| `business-and-moat` | `regenerateBusinessAndMoat` |
+| `past-performance` | `regeneratePastPerformance` |
+| `future-growth` | `regenerateFutureGrowth` |
+| `fair-value` | `regenerateFairValue` |
+| `future-risk` | `regenerateFutureRisk` |
+| `final-summary` | `regenerateFinalSummary` |
+
+### Shortcuts
+
+- `--all` (or `--categories=all`) — all 8 report types. **This is also the default** when no category flag is passed.
+- `--analysis` (or `--categories=analysis`) — the 7 analysis categories, **skipping `final-summary`**. Useful when you want the core reports to finish first and will regenerate the summary afterward.
+
+Explicit comma-separated list:
+
+```bash
+yarn stocks:trigger --symbol AAPL --exchange NASDAQ \
+  --categories=financial-analysis,competition,final-summary
+```
+
+## Stock input — `--in` vs `--symbol/--exchange`
+
+Two mutually-exclusive ways to specify stocks:
+
+**Single stock (convenience):**
+
+```bash
+yarn stocks:trigger --symbol MSFT --exchange NASDAQ --all
+```
+
+**Batch from JSON file:**
+
+```bash
+yarn stocks:trigger --in /tmp/stocks.json --all
+```
+
+The JSON file must be a non-empty array of objects with at least `symbol` and
+`exchange`:
+
+```json
+[
+  { "symbol": "AAPL", "exchange": "NASDAQ" },
+  { "symbol": "MSFT", "exchange": "NASDAQ" },
+  { "symbol": "SHOP", "exchange": "TSX" }
+]
+```
+
+Other fields (`name`, `industryKey`, etc.) are tolerated and forwarded to the
+`--out` file but ignored by the API.
+
+## Multi-stock behavior
+
+When the input contains more than one stock, the script POSTs them **sequentially —
+one stock per HTTP call — with a 10-second delay between calls**. This protects the
+callback Lambda from a thundering-herd burst when the API enqueues several requests
+at once.
+
+- Default delay: **10000 ms**. Override with `--delay-ms 5000` (or any positive integer).
+- Failures of one stock (e.g. unknown symbol/exchange in the prod `tickerV1` table)
+  do not abort the run; they are logged, captured in the output file under
+  `failedTickers`, and the script exits with code 1 at the end.
+
+### Hard limit: 50 stocks per invocation
+
+The script **fails immediately** if `--in` contains more than 50 entries:
+
+> `Refusing to enqueue 73 tickers in one invocation — limit is 50.`
+
+Each stock triggers up to 8 LLM jobs and a sequential delay; split the input
+file and run again.
+
+## Calling from Claude Code (or any automation)
+
+The `POST /api/[spaceId]/tickers-v1/generation-requests` endpoint is gated by
+`withAdminOrToken`. It accepts either:
+
+1. Normal admin login (JWT + Admin role) — for UI-based triggering, OR
+2. A secret token passed as the `x-automation-token` header (or `?token=<SECRET>`
+   query param).
+
+The script uses the header. Set `AUTOMATION_SECRET` in the environment
+(e.g. `source path/to/discord-claude-bot/.env` or `export AUTOMATION_SECRET=...`)
+before running. The GET handler on the same route is still admin-only; only
+POST accepts the automation token.
+
+## Output file (`--out`)
+
+When passed `--out path/to/triggered.json`, the script writes:
+
+```json
+{
+  "categories": ["financial-analysis", "competition", "..."],
+  "tickers": [
+    {
+      "symbol": "AAPL",
+      "exchange": "NASDAQ",
+      "requestId": "b72f1d91-...",
+      "ok": true,
+      "error": null
+    }
+  ],
+  "requestIds": ["b72f1d91-..."],
+  "failedTickers": []
+}
+```
+
+## Processing the enqueued requests
+
+The POST only **creates `NotStarted` generation requests** in the database — it
+does not itself execute LLM calls. To drain the queue:
+
+- UI: open the admin generation-requests page, which periodically ticks the
+  processing endpoint.
+- Automation: GET `/api/[spaceId]/tickers-v1/generate-ticker-v1-request`
+  (not token-gated today) picks up to 10 pending requests per call and kicks
+  them off.
+
+Unlike the ETF pipeline, there is no `by-ids` polling endpoint for tickers, so
+the trigger script does not ship with a `stocks:wait` companion. Check status
+via the admin page or by querying the generation-requests list.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `HTTP 404 ... findFirstOrThrow ... No record was found` | `(symbol, exchange)` doesn't match the prod `tickerV1` table — usually the stock hasn't been added yet. | Add the stock first with `yarn stocks:add` (see [add-stock.md](add-stock.md)). |
+| `AUTOMATION_SECRET is not set` | Missing env var. | `source path/to/.env` or `export AUTOMATION_SECRET=...` before running. |
+| `HTTP 401/403` | Token mismatch between client and `AUTOMATION_SECRET` on the server. | Confirm the env var matches the deployed server's secret. |
+| `Refusing to enqueue N tickers` | `--in` contains > 50 entries. | Split the file. |
+| Multiple `FAIL` lines, exit code 1 | Some stocks missing from prod. | Check the `failedTickers` block in the `--out` file; add them with `yarn stocks:add`, then re-run. |
+
+## Where to read further
+
+- Endpoint: `src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts`
+- Trigger script: `src/scripts/tickers/trigger-generation.ts`
+- Shared CLI helpers: `src/scripts/tickers/lib.ts`
+- Report types enum: `src/types/ticker-typesv1.ts` (`ReportType`)
+- Processing tick endpoint: `src/app/api/[spaceId]/tickers-v1/generate-ticker-v1-request/route.ts`
+- Auth helper: `src/app/api/helpers/withAdminOrToken.ts`

--- a/insights-ui/package.json
+++ b/insights-ui/package.json
@@ -16,7 +16,9 @@
     "import:etf-scenarios": "tsx src/scripts/import-etf-scenarios.ts",
     "etfs:trigger": "tsx src/scripts/etfs/trigger-generation.ts",
     "etfs:wait": "tsx src/scripts/etfs/wait-for-generation.ts",
-    "etfs:fetch": "tsx src/scripts/etfs/fetch-analysis.ts"
+    "etfs:fetch": "tsx src/scripts/etfs/fetch-analysis.ts",
+    "stocks:trigger": "tsx src/scripts/tickers/trigger-generation.ts",
+    "stocks:add": "tsx src/scripts/tickers/add-stock.ts"
   },
   "engines": {
     "node": ">=23.11.0"

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts
@@ -1,3 +1,4 @@
+import { withAdminOrToken } from '@/app/api/helpers/withAdminOrToken';
 import { withLoggedInAdmin } from '@/app/api/helpers/withLoggedInAdmin';
 import { prisma } from '@/prisma';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
@@ -177,7 +178,7 @@ async function getHandler(
 
 async function postHandler(
   req: NextRequest,
-  _userContext: KoalaGainsJwtTokenPayload,
+  _userContext: KoalaGainsJwtTokenPayload | null,
   { params }: { params: Promise<{ spaceId: string }> }
 ): Promise<TickerV1GenerationRequest[]> {
   const { spaceId } = await params;
@@ -265,5 +266,5 @@ async function postHandler(
   return results;
 }
 
-export const POST = withLoggedInAdmin<TickerV1GenerationRequest[]>(postHandler);
+export const POST = withAdminOrToken<TickerV1GenerationRequest[]>(postHandler);
 export const GET = withLoggedInAdmin<GenerationRequestsResponse>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
@@ -14,9 +14,9 @@ interface NewTickerRequest {
   exchange: string;
   industryKey: string;
   subIndustryKey: string;
-  websiteUrl?: string;
-  summary?: string;
+  websiteUrl: string;
   stockAnalyzeUrl: string;
+  summary?: string;
 }
 
 interface ErrorTicker {
@@ -163,11 +163,21 @@ async function postHandler(req: NextRequest, context: { params: Promise<{ spaceI
     // Skip those already marked as same-request duplicates
     if (errorTickers.some((e) => e.input === raw)) continue;
 
-    // Basic validation — websiteUrl is required; stockAnalyzeUrl and summary remain optional.
-    if (!raw.name || !raw.symbol || !raw.exchange || !raw.industryKey || !raw.subIndustryKey || !raw.websiteUrl || !raw.websiteUrl.trim()) {
+    // Basic validation — websiteUrl and stockAnalyzeUrl are both required; summary remains optional.
+    if (
+      !raw.name ||
+      !raw.symbol ||
+      !raw.exchange ||
+      !raw.industryKey ||
+      !raw.subIndustryKey ||
+      !raw.websiteUrl ||
+      !raw.websiteUrl.trim() ||
+      !raw.stockAnalyzeUrl ||
+      !raw.stockAnalyzeUrl.trim()
+    ) {
       errorTickers.push({
         input: raw,
-        reason: 'Missing required fields: name, symbol, exchange, industryKey, subIndustryKey, websiteUrl',
+        reason: 'Missing required fields: name, symbol, exchange, industryKey, subIndustryKey, websiteUrl, stockAnalyzeUrl',
       });
       continue;
     }
@@ -177,9 +187,9 @@ async function postHandler(req: NextRequest, context: { params: Promise<{ spaceI
     const exchange = raw.exchange.trim().toUpperCase();
     const industryKey = raw.industryKey.trim();
     const subIndustryKey = raw.subIndustryKey.trim();
-    const websiteUrl = normStr(raw.websiteUrl);
+    const websiteUrl = raw.websiteUrl.trim();
     const summary = normStr(raw.summary);
-    const stockAnalyzeUrl = normStr(raw.stockAnalyzeUrl);
+    const stockAnalyzeUrl = raw.stockAnalyzeUrl.trim();
 
     // Validate exchange against the predefined list
     if (!isExchange(exchange)) {
@@ -190,16 +200,23 @@ async function postHandler(req: NextRequest, context: { params: Promise<{ spaceI
       continue;
     }
 
-    // Validate stockAnalyzeUrl format if provided
-    if (stockAnalyzeUrl) {
-      const validationError = validateStockAnalyzeUrl(symbol, exchange as AllExchanges, stockAnalyzeUrl);
-      if (validationError) {
-        errorTickers.push({
-          input: raw,
-          reason: `Invalid stockAnalyzeUrl format: ${validationError}`,
-        });
-        continue;
-      }
+    // Validate websiteUrl format (must be an absolute http(s) URL)
+    if (!/^https?:\/\/\S+$/i.test(websiteUrl)) {
+      errorTickers.push({
+        input: raw,
+        reason: `Invalid websiteUrl "${websiteUrl}": must be an absolute URL starting with http:// or https://`,
+      });
+      continue;
+    }
+
+    // Validate stockAnalyzeUrl format
+    const stockUrlError = validateStockAnalyzeUrl(symbol, exchange as AllExchanges, stockAnalyzeUrl);
+    if (stockUrlError) {
+      errorTickers.push({
+        input: raw,
+        reason: `Invalid stockAnalyzeUrl format: ${stockUrlError}`,
+      });
+      continue;
     }
 
     try {

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
@@ -3,7 +3,7 @@ import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/wit
 import { Prisma, TickerV1 } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { TickerWithIndustryNames } from '@/types/ticker-typesv1';
-import { AllExchanges, getExchangeFilterClause, toSupportedCountry } from '@/utils/countryExchangeUtils';
+import { AllExchanges, EXCHANGES, getExchangeFilterClause, isExchange, toSupportedCountry } from '@/utils/countryExchangeUtils';
 import { validateStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
 
 /** ---------- Types ---------- */
@@ -163,27 +163,36 @@ async function postHandler(req: NextRequest, context: { params: Promise<{ spaceI
     // Skip those already marked as same-request duplicates
     if (errorTickers.some((e) => e.input === raw)) continue;
 
-    // Basic validation
-    if (!raw.name || !raw.symbol || !raw.exchange || !raw.industryKey || !raw.subIndustryKey) {
+    // Basic validation — websiteUrl is required; stockAnalyzeUrl and summary remain optional.
+    if (!raw.name || !raw.symbol || !raw.exchange || !raw.industryKey || !raw.subIndustryKey || !raw.websiteUrl || !raw.websiteUrl.trim()) {
       errorTickers.push({
         input: raw,
-        reason: 'Missing required fields: name, symbol, exchange, industryKey, subIndustryKey',
+        reason: 'Missing required fields: name, symbol, exchange, industryKey, subIndustryKey, websiteUrl',
       });
       continue;
     }
 
     const name = raw.name.trim();
     const symbol = raw.symbol.toUpperCase().trim();
-    const exchange = raw.exchange.trim();
+    const exchange = raw.exchange.trim().toUpperCase();
     const industryKey = raw.industryKey.trim();
     const subIndustryKey = raw.subIndustryKey.trim();
     const websiteUrl = normStr(raw.websiteUrl);
     const summary = normStr(raw.summary);
     const stockAnalyzeUrl = normStr(raw.stockAnalyzeUrl);
 
+    // Validate exchange against the predefined list
+    if (!isExchange(exchange)) {
+      errorTickers.push({
+        input: raw,
+        reason: `Invalid exchange "${raw.exchange}". Supported: ${EXCHANGES.join(', ')}`,
+      });
+      continue;
+    }
+
     // Validate stockAnalyzeUrl format if provided
     if (stockAnalyzeUrl) {
-      const validationError = validateStockAnalyzeUrl(symbol, exchange.toUpperCase() as AllExchanges, stockAnalyzeUrl);
+      const validationError = validateStockAnalyzeUrl(symbol, exchange as AllExchanges, stockAnalyzeUrl);
       if (validationError) {
         errorTickers.push({
           input: raw,

--- a/insights-ui/src/components/public-equitiesv1/AddTickersForm.tsx
+++ b/insights-ui/src/components/public-equitiesv1/AddTickersForm.tsx
@@ -312,6 +312,11 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
         alert(`Row ${i + 1}: Please provide both Company Name and Symbol.`);
         return;
       }
+      if (!t.websiteUrl.trim()) {
+        // eslint-disable-next-line no-alert
+        alert(`Row ${i + 1}: Please provide the company Website URL (required).`);
+        return;
+      }
     }
 
     await batchSubmit(entries);
@@ -344,8 +349,8 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
         <div>
           <h2 className="text-xl font-semibold">Add New Tickers</h2>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            CSV format: <code>exchange, name, symbol, websiteUrl, stockAnalyzeUrl</code> (<strong>exchange required</strong>; websiteUrl &amp; stockAnalyzeUrl
-            optional)
+            CSV format: <code>exchange, name, symbol, websiteUrl, stockAnalyzeUrl</code> (<strong>exchange, name, symbol, websiteUrl required</strong>;
+            stockAnalyzeUrl optional)
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/insights-ui/src/components/public-equitiesv1/AddTickersForm.tsx
+++ b/insights-ui/src/components/public-equitiesv1/AddTickersForm.tsx
@@ -83,7 +83,13 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
   /** ---------- CSV Utilities ---------- */
   const validateHeaders = (headers: string[]): string | null => {
     const lower = headers.map((x) => x.toLowerCase().trim());
-    const mustHave: ReadonlyArray<'exchange' | 'name' | 'symbol'> = ['exchange', 'name', 'symbol'] as const;
+    const mustHave: ReadonlyArray<'exchange' | 'name' | 'symbol' | 'websiteurl' | 'stockanalyzeurl'> = [
+      'exchange',
+      'name',
+      'symbol',
+      'websiteurl',
+      'stockanalyzeurl',
+    ] as const;
     const missing = mustHave.filter((h) => !lower.includes(h));
     if (missing.length > 0) {
       return `Missing required headers: ${missing.join(', ')}`;
@@ -102,7 +108,7 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
       const websiteUrl = (row.websiteUrl ?? '').trim();
       const stockAnalyzeUrl = (row.stockAnalyzeUrl ?? '').trim();
 
-      if (!exchangeRaw || !name || !symbol) {
+      if (!exchangeRaw || !name || !symbol || !websiteUrl || !stockAnalyzeUrl) {
         invalidCount++;
         continue;
       }
@@ -116,7 +122,11 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
     }
 
     if (rows.length > 0 && invalidCount > 0) {
-      setCsvError(`${invalidCount} row${invalidCount === 1 ? '' : 's'} ignored due to missing/invalid required fields (exchange, name, symbol).`);
+      setCsvError(
+        `${invalidCount} row${
+          invalidCount === 1 ? '' : 's'
+        } ignored due to missing/invalid required fields (exchange, name, symbol, websiteUrl, stockAnalyzeUrl).`
+      );
     }
 
     return valid;
@@ -317,6 +327,11 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
         alert(`Row ${i + 1}: Please provide the company Website URL (required).`);
         return;
       }
+      if (!t.stockAnalyzeUrl.trim()) {
+        // eslint-disable-next-line no-alert
+        alert(`Row ${i + 1}: Please provide the Stock Analyze URL (required).`);
+        return;
+      }
     }
 
     await batchSubmit(entries);
@@ -349,8 +364,7 @@ export default function AddTickersForm({ onSuccess, onCancel, selectedIndustryKe
         <div>
           <h2 className="text-xl font-semibold">Add New Tickers</h2>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            CSV format: <code>exchange, name, symbol, websiteUrl, stockAnalyzeUrl</code> (<strong>exchange, name, symbol, websiteUrl required</strong>;
-            stockAnalyzeUrl optional)
+            CSV format: <code>exchange, name, symbol, websiteUrl, stockAnalyzeUrl</code> (<strong>all columns required</strong>)
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/insights-ui/src/scripts/tickers/add-stock.ts
+++ b/insights-ui/src/scripts/tickers/add-stock.ts
@@ -1,0 +1,299 @@
+// Load env vars first — stockAnalyzeUrlValidation reads NEXT_PUBLIC_STOCK_ANALYZE_BASE_URL
+// at module load time, so dotenv must run before that import resolves.
+import 'dotenv/config';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { AllExchanges, EXCHANGES, isExchange } from '@/utils/countryExchangeUtils';
+import { generateExpectedStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
+import { SPACE_ID, fetchJson, parseArgs, parsePositiveInt, requireAutomationSecret, sleep } from './lib';
+
+interface NewStockInput {
+  name: string;
+  symbol: string;
+  exchange: string;
+  industryKey: string;
+  subIndustryKey: string;
+  websiteUrl: string;
+  summary?: string;
+  stockAnalyzeUrl?: string;
+}
+
+interface ValidatedStock {
+  name: string;
+  symbol: string;
+  exchange: AllExchanges;
+  industryKey: string;
+  subIndustryKey: string;
+  websiteUrl: string;
+  summary?: string;
+  stockAnalyzeUrl: string;
+  source: NewStockInput;
+}
+
+interface AddedTicker {
+  id: string;
+  name: string;
+  symbol: string;
+  exchange: string;
+  websiteUrl?: string | null;
+  stockAnalyzeUrl?: string | null;
+  industryKey: string;
+  subIndustryKey: string;
+}
+
+interface ErrorTicker {
+  input: NewStockInput;
+  reason: string;
+}
+
+interface BulkNewTickersResponse {
+  success: boolean;
+  addedTickers: AddedTicker[];
+  errorTickers: ErrorTicker[];
+}
+
+const MAX_STOCKS_PER_INVOCATION = 100;
+const DEFAULT_DELAY_MS = 500;
+
+/**
+ * The stock input comes from one of two mutually-exclusive sources:
+ *   --in <path>   JSON file: an array of {name, symbol, exchange, industryKey, subIndustryKey, websiteUrl, ...}
+ *   --name ... --symbol ... --exchange ... (+ flags)   single-stock convenience
+ */
+async function resolveInputs(args: Record<string, string | boolean>): Promise<NewStockInput[]> {
+  const inPath = typeof args['in'] === 'string' ? args['in'] : undefined;
+  const hasInline =
+    typeof args['name'] === 'string' ||
+    typeof args['symbol'] === 'string' ||
+    typeof args['exchange'] === 'string' ||
+    typeof args['industry'] === 'string' ||
+    typeof args['sub-industry'] === 'string' ||
+    typeof args['website'] === 'string';
+
+  if (inPath && hasInline) {
+    throw new Error('Pass either --in <path> OR inline flags (--name/--symbol/--exchange/...), not both');
+  }
+
+  if (hasInline) {
+    const inline: NewStockInput = {
+      name: asString(args, 'name'),
+      symbol: asString(args, 'symbol'),
+      exchange: asString(args, 'exchange'),
+      industryKey: asString(args, 'industry'),
+      subIndustryKey: asString(args, 'sub-industry'),
+      websiteUrl: asString(args, 'website'),
+      summary: typeof args['summary'] === 'string' ? args['summary'] : undefined,
+      stockAnalyzeUrl: typeof args['stock-analyze-url'] === 'string' ? args['stock-analyze-url'] : undefined,
+    };
+    return [inline];
+  }
+
+  if (!inPath) {
+    throw new Error(
+      'Missing required input: pass --in <path> or inline flags ' +
+        '(--name --symbol --exchange --industry --sub-industry --website [--summary] [--stock-analyze-url])'
+    );
+  }
+
+  const raw = await readFile(inPath, 'utf-8');
+  const parsed = JSON.parse(raw);
+  const items: unknown[] = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.tickers) ? parsed.tickers : [];
+  if (items.length === 0) {
+    throw new Error(`--in file ${inPath} must contain a non-empty JSON array (or { tickers: [...] }) of stock objects`);
+  }
+  return items.map((item, idx) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error(`--in entry at index ${idx} is not an object: ${JSON.stringify(item)}`);
+    }
+    const obj = item as Record<string, unknown>;
+    return {
+      name: stringField(obj, 'name'),
+      symbol: stringField(obj, 'symbol'),
+      exchange: stringField(obj, 'exchange'),
+      industryKey: stringField(obj, 'industryKey'),
+      subIndustryKey: stringField(obj, 'subIndustryKey'),
+      websiteUrl: stringField(obj, 'websiteUrl'),
+      summary: typeof obj.summary === 'string' ? obj.summary : undefined,
+      stockAnalyzeUrl: typeof obj.stockAnalyzeUrl === 'string' ? obj.stockAnalyzeUrl : undefined,
+    };
+  });
+}
+
+function asString(args: Record<string, string | boolean>, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  return typeof v === 'string' ? v : '';
+}
+
+interface ValidationFailure {
+  input: NewStockInput;
+  reason: string;
+}
+
+/**
+ * Validates a single stock input against required fields and the predefined
+ * exchange list. `stockAnalyzeUrl` is auto-generated when absent so the CLI
+ * never POSTs a null value for a field the schema marks non-nullable.
+ */
+function validate(input: NewStockInput): ValidatedStock | ValidationFailure {
+  const name = (input.name ?? '').trim();
+  const symbol = (input.symbol ?? '').trim().toUpperCase();
+  const exchange = (input.exchange ?? '').trim().toUpperCase();
+  const industryKey = (input.industryKey ?? '').trim();
+  const subIndustryKey = (input.subIndustryKey ?? '').trim();
+  const websiteUrl = (input.websiteUrl ?? '').trim();
+  const summary = input.summary?.trim();
+  const providedStockAnalyzeUrl = input.stockAnalyzeUrl?.trim();
+
+  const missing: string[] = [];
+  if (!name) missing.push('name');
+  if (!symbol) missing.push('symbol');
+  if (!exchange) missing.push('exchange');
+  if (!industryKey) missing.push('industryKey');
+  if (!subIndustryKey) missing.push('subIndustryKey');
+  if (!websiteUrl) missing.push('websiteUrl');
+  if (missing.length) {
+    return { input, reason: `Missing required field(s): ${missing.join(', ')}` };
+  }
+
+  if (!isExchange(exchange)) {
+    return { input, reason: `Invalid exchange "${input.exchange}". Supported: ${EXCHANGES.join(', ')}` };
+  }
+
+  if (!/^https?:\/\//i.test(websiteUrl)) {
+    return { input, reason: `websiteUrl must start with http:// or https:// (got "${websiteUrl}")` };
+  }
+
+  const stockAnalyzeUrl =
+    providedStockAnalyzeUrl && providedStockAnalyzeUrl.length > 0 ? providedStockAnalyzeUrl : generateExpectedStockAnalyzeUrl(symbol, exchange as AllExchanges);
+
+  return {
+    name,
+    symbol,
+    exchange: exchange as AllExchanges,
+    industryKey,
+    subIndustryKey,
+    websiteUrl,
+    summary: summary && summary.length > 0 ? summary : undefined,
+    stockAnalyzeUrl,
+    source: input,
+  };
+}
+
+interface PostOutcome {
+  stock: ValidatedStock;
+  created: AddedTicker | null;
+  ok: boolean;
+  error?: string;
+}
+
+async function postOne(stock: ValidatedStock): Promise<PostOutcome> {
+  try {
+    // The create-ticker route is not token-gated today; authToken is harmless but we
+    // still pass it so if the endpoint later adopts `withAdminOrToken` the CLI keeps working.
+    const resp = await fetchJson<BulkNewTickersResponse>(`/api/${SPACE_ID}/tickers-v1`, {
+      method: 'POST',
+      authToken: true,
+      body: {
+        tickers: [
+          {
+            name: stock.name,
+            symbol: stock.symbol,
+            exchange: stock.exchange,
+            industryKey: stock.industryKey,
+            subIndustryKey: stock.subIndustryKey,
+            websiteUrl: stock.websiteUrl,
+            summary: stock.summary,
+            stockAnalyzeUrl: stock.stockAnalyzeUrl,
+          },
+        ],
+      },
+    });
+    if (resp.addedTickers.length > 0) {
+      return { stock, created: resp.addedTickers[0], ok: true };
+    }
+    const reason = resp.errorTickers[0]?.reason ?? 'Unknown server error';
+    return { stock, created: null, ok: false, error: reason };
+  } catch (err) {
+    return { stock, created: null, ok: false, error: (err as Error).message };
+  }
+}
+
+async function main() {
+  requireAutomationSecret();
+  const args = parseArgs(process.argv.slice(2));
+  const outPath = typeof args['out'] === 'string' ? args['out'] : undefined;
+  const delayMs = parsePositiveInt(args['delay-ms']) ?? DEFAULT_DELAY_MS;
+
+  const rawInputs = await resolveInputs(args);
+  if (rawInputs.length > MAX_STOCKS_PER_INVOCATION) {
+    throw new Error(`Refusing to add ${rawInputs.length} stocks in one invocation — limit is ${MAX_STOCKS_PER_INVOCATION}. Split the input file.`);
+  }
+
+  const validations = rawInputs.map((input) => validate(input));
+  const valid: ValidatedStock[] = [];
+  const preFailures: ValidationFailure[] = [];
+  for (const v of validations) {
+    if ('source' in v) valid.push(v);
+    else preFailures.push(v);
+  }
+
+  if (preFailures.length > 0) {
+    console.warn(`Skipping ${preFailures.length} input(s) that failed pre-validation:`);
+    for (const f of preFailures) {
+      console.warn(`  - ${f.input.symbol || '(no symbol)'} (${f.input.exchange || '(no exchange)'}): ${f.reason}`);
+    }
+  }
+
+  console.log(`Adding ${valid.length} stock${valid.length === 1 ? '' : 's'}${valid.length > 1 ? ` with ${delayMs}ms delay between calls` : ''}`);
+
+  const outcomes: PostOutcome[] = [];
+
+  for (let i = 0; i < valid.length; i++) {
+    const stock = valid[i];
+    const idx = `[${String(i + 1).padStart(2, '0')}/${valid.length}]`;
+    const outcome = await postOne(stock);
+    outcomes.push(outcome);
+    if (outcome.ok) {
+      console.log(`${idx} OK   ${stock.symbol} (${stock.exchange}) — id ${outcome.created?.id ?? '(no id)'}`);
+    } else {
+      console.error(`${idx} FAIL ${stock.symbol} (${stock.exchange}) — ${outcome.error}`);
+    }
+    if (i < valid.length - 1) await sleep(delayMs);
+  }
+
+  const okCount = outcomes.filter((o) => o.ok).length;
+  const failCount = outcomes.length - okCount + preFailures.length;
+  console.log(`\nDone — ${okCount} added, ${failCount} failed.`);
+
+  if (outPath) {
+    await mkdir(path.dirname(outPath), { recursive: true });
+    await writeFile(
+      outPath,
+      JSON.stringify(
+        {
+          added: outcomes.filter((o) => o.ok).map((o) => o.created),
+          failed: [
+            ...preFailures.map((f) => ({ symbol: f.input.symbol, exchange: f.input.exchange, reason: f.reason })),
+            ...outcomes.filter((o) => !o.ok).map((o) => ({ symbol: o.stock.symbol, exchange: o.stock.exchange, reason: o.error })),
+          ],
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+    console.log(`Wrote results → ${outPath}`);
+  }
+
+  if (failCount > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/scripts/tickers/add-stock.ts
+++ b/insights-ui/src/scripts/tickers/add-stock.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { AllExchanges, EXCHANGES, isExchange } from '@/utils/countryExchangeUtils';
-import { generateExpectedStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
+import { validateStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
 import { SPACE_ID, fetchJson, parseArgs, parsePositiveInt, requireAutomationSecret, sleep } from './lib';
 
 interface NewStockInput {
@@ -14,8 +14,8 @@ interface NewStockInput {
   industryKey: string;
   subIndustryKey: string;
   websiteUrl: string;
+  stockAnalyzeUrl: string;
   summary?: string;
-  stockAnalyzeUrl?: string;
 }
 
 interface ValidatedStock {
@@ -68,7 +68,8 @@ async function resolveInputs(args: Record<string, string | boolean>): Promise<Ne
     typeof args['exchange'] === 'string' ||
     typeof args['industry'] === 'string' ||
     typeof args['sub-industry'] === 'string' ||
-    typeof args['website'] === 'string';
+    typeof args['website'] === 'string' ||
+    typeof args['stock-analyze-url'] === 'string';
 
   if (inPath && hasInline) {
     throw new Error('Pass either --in <path> OR inline flags (--name/--symbol/--exchange/...), not both');
@@ -82,8 +83,8 @@ async function resolveInputs(args: Record<string, string | boolean>): Promise<Ne
       industryKey: asString(args, 'industry'),
       subIndustryKey: asString(args, 'sub-industry'),
       websiteUrl: asString(args, 'website'),
+      stockAnalyzeUrl: asString(args, 'stock-analyze-url'),
       summary: typeof args['summary'] === 'string' ? args['summary'] : undefined,
-      stockAnalyzeUrl: typeof args['stock-analyze-url'] === 'string' ? args['stock-analyze-url'] : undefined,
     };
     return [inline];
   }
@@ -91,7 +92,7 @@ async function resolveInputs(args: Record<string, string | boolean>): Promise<Ne
   if (!inPath) {
     throw new Error(
       'Missing required input: pass --in <path> or inline flags ' +
-        '(--name --symbol --exchange --industry --sub-industry --website [--summary] [--stock-analyze-url])'
+        '(--name --symbol --exchange --industry --sub-industry --website --stock-analyze-url [--summary])'
     );
   }
 
@@ -113,8 +114,8 @@ async function resolveInputs(args: Record<string, string | boolean>): Promise<Ne
       industryKey: stringField(obj, 'industryKey'),
       subIndustryKey: stringField(obj, 'subIndustryKey'),
       websiteUrl: stringField(obj, 'websiteUrl'),
+      stockAnalyzeUrl: stringField(obj, 'stockAnalyzeUrl'),
       summary: typeof obj.summary === 'string' ? obj.summary : undefined,
-      stockAnalyzeUrl: typeof obj.stockAnalyzeUrl === 'string' ? obj.stockAnalyzeUrl : undefined,
     };
   });
 }
@@ -135,9 +136,8 @@ interface ValidationFailure {
 }
 
 /**
- * Validates a single stock input against required fields and the predefined
- * exchange list. `stockAnalyzeUrl` is auto-generated when absent so the CLI
- * never POSTs a null value for a field the schema marks non-nullable.
+ * Validates a single stock input against required fields, the predefined
+ * exchange list, and URL formats for websiteUrl + stockAnalyzeUrl.
  */
 function validate(input: NewStockInput): ValidatedStock | ValidationFailure {
   const name = (input.name ?? '').trim();
@@ -146,8 +146,8 @@ function validate(input: NewStockInput): ValidatedStock | ValidationFailure {
   const industryKey = (input.industryKey ?? '').trim();
   const subIndustryKey = (input.subIndustryKey ?? '').trim();
   const websiteUrl = (input.websiteUrl ?? '').trim();
+  const stockAnalyzeUrl = (input.stockAnalyzeUrl ?? '').trim();
   const summary = input.summary?.trim();
-  const providedStockAnalyzeUrl = input.stockAnalyzeUrl?.trim();
 
   const missing: string[] = [];
   if (!name) missing.push('name');
@@ -156,6 +156,7 @@ function validate(input: NewStockInput): ValidatedStock | ValidationFailure {
   if (!industryKey) missing.push('industryKey');
   if (!subIndustryKey) missing.push('subIndustryKey');
   if (!websiteUrl) missing.push('websiteUrl');
+  if (!stockAnalyzeUrl) missing.push('stockAnalyzeUrl');
   if (missing.length) {
     return { input, reason: `Missing required field(s): ${missing.join(', ')}` };
   }
@@ -164,12 +165,14 @@ function validate(input: NewStockInput): ValidatedStock | ValidationFailure {
     return { input, reason: `Invalid exchange "${input.exchange}". Supported: ${EXCHANGES.join(', ')}` };
   }
 
-  if (!/^https?:\/\//i.test(websiteUrl)) {
-    return { input, reason: `websiteUrl must start with http:// or https:// (got "${websiteUrl}")` };
+  if (!/^https?:\/\/\S+$/i.test(websiteUrl)) {
+    return { input, reason: `websiteUrl must be an absolute URL starting with http:// or https:// (got "${websiteUrl}")` };
   }
 
-  const stockAnalyzeUrl =
-    providedStockAnalyzeUrl && providedStockAnalyzeUrl.length > 0 ? providedStockAnalyzeUrl : generateExpectedStockAnalyzeUrl(symbol, exchange as AllExchanges);
+  const stockUrlError = validateStockAnalyzeUrl(symbol, exchange as AllExchanges, stockAnalyzeUrl);
+  if (stockUrlError) {
+    return { input, reason: `stockAnalyzeUrl is invalid: ${stockUrlError}` };
+  }
 
   return {
     name,

--- a/insights-ui/src/scripts/tickers/lib.ts
+++ b/insights-ui/src/scripts/tickers/lib.ts
@@ -1,0 +1,101 @@
+import 'dotenv/config';
+
+export const API_BASE = (process.env.KOALAGAINS_API_BASE ?? process.env.SCENARIOS_API_BASE ?? 'https://koalagains.com').replace(/\/+$/, '');
+export const AUTOMATION_SECRET = process.env.AUTOMATION_SECRET ?? '';
+export const SPACE_ID = process.env.KOALAGAINS_SPACE_ID ?? 'koala_gains';
+
+export function requireAutomationSecret(): string {
+  if (!AUTOMATION_SECRET) {
+    throw new Error('AUTOMATION_SECRET is not set — export it or source the discord-claude-bot/.env before running.');
+  }
+  return AUTOMATION_SECRET;
+}
+
+export interface FetchOpts {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  body?: unknown;
+  authToken?: boolean;
+}
+
+export async function fetchJson<T>(path: string, opts: FetchOpts = {}): Promise<T> {
+  const method = opts.method ?? 'GET';
+  const url = `${API_BASE}${path}`;
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (opts.authToken) {
+    if (!AUTOMATION_SECRET) {
+      throw new Error(`AUTOMATION_SECRET required for ${method} ${path} but not set`);
+    }
+    headers['x-automation-token'] = AUTOMATION_SECRET;
+  }
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`HTTP ${res.status} for ${method} ${path}: ${text.slice(0, 500)}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const body = a.slice(2);
+    const eqIdx = body.indexOf('=');
+    if (eqIdx !== -1) {
+      const key = body.slice(0, eqIdx);
+      const value = body.slice(eqIdx + 1);
+      out[key] = value;
+      continue;
+    }
+    const key = body;
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+export function requireStringArg(args: Record<string, string | boolean>, key: string): string {
+  const v = args[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`Missing required arg --${key}`);
+  }
+  return v;
+}
+
+export function parsePositiveInt(raw: string | boolean | undefined): number | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`Expected a positive integer, got "${raw}"`);
+  }
+  return n;
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Row shape accepted by the stock CLIs when loading stocks from a JSON file.
+ * `symbol` and `exchange` drive the API calls; the rest is metadata.
+ */
+export interface SampledTicker {
+  symbol: string;
+  exchange: string;
+  name?: string;
+  industryKey?: string;
+  subIndustryKey?: string;
+  websiteUrl?: string;
+  summary?: string;
+  stockAnalyzeUrl?: string;
+}

--- a/insights-ui/src/scripts/tickers/trigger-generation.ts
+++ b/insights-ui/src/scripts/tickers/trigger-generation.ts
@@ -1,0 +1,246 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { ReportType } from '@/types/ticker-typesv1';
+import { SPACE_ID, SampledTicker, fetchJson, parseArgs, parsePositiveInt, requireAutomationSecret, sleep } from './lib';
+
+interface TickerIdentifier {
+  symbol: string;
+  exchange: string;
+}
+
+interface GenerationRequestPayload {
+  ticker: TickerIdentifier;
+  regenerateCompetition: boolean;
+  regenerateFinancialAnalysis: boolean;
+  regenerateBusinessAndMoat: boolean;
+  regeneratePastPerformance: boolean;
+  regenerateFutureGrowth: boolean;
+  regenerateFairValue: boolean;
+  regenerateFutureRisk: boolean;
+  regenerateFinalSummary: boolean;
+}
+
+interface GenerationRequestRow {
+  id: string;
+  tickerId: string;
+  status: string;
+}
+
+const ANALYSIS_CATEGORIES: readonly ReportType[] = [
+  ReportType.FINANCIAL_ANALYSIS,
+  ReportType.COMPETITION,
+  ReportType.BUSINESS_AND_MOAT,
+  ReportType.PAST_PERFORMANCE,
+  ReportType.FUTURE_GROWTH,
+  ReportType.FAIR_VALUE,
+  ReportType.FUTURE_RISK,
+];
+
+const ALL_REPORT_TYPES: readonly ReportType[] = [...ANALYSIS_CATEGORIES, ReportType.FINAL_SUMMARY];
+
+const MAX_TICKERS_PER_INVOCATION = 50;
+const DEFAULT_DELAY_MS = 10_000;
+
+function buildPayload(ticker: TickerIdentifier, categories: ReportType[]): GenerationRequestPayload {
+  const set = new Set(categories);
+  return {
+    ticker,
+    regenerateCompetition: set.has(ReportType.COMPETITION),
+    regenerateFinancialAnalysis: set.has(ReportType.FINANCIAL_ANALYSIS),
+    regenerateBusinessAndMoat: set.has(ReportType.BUSINESS_AND_MOAT),
+    regeneratePastPerformance: set.has(ReportType.PAST_PERFORMANCE),
+    regenerateFutureGrowth: set.has(ReportType.FUTURE_GROWTH),
+    regenerateFairValue: set.has(ReportType.FAIR_VALUE),
+    regenerateFutureRisk: set.has(ReportType.FUTURE_RISK),
+    regenerateFinalSummary: set.has(ReportType.FINAL_SUMMARY),
+  };
+}
+
+/**
+ * Resolve the report-type list from CLI args.
+ *
+ * Precedence (first match wins):
+ *   1. `--all` (or `--categories=all`)                 → every report type (incl. final-summary)
+ *   2. `--analysis` (or `--categories=analysis`)       → 7 analysis categories, skip final-summary
+ *   3. `--categories=<csv>`                            → explicit comma-separated list
+ *   4. (no flag)                                       → defaults to all 8 report types
+ *
+ * Each token in a CSV must match a ReportType enum value (e.g. `financial-analysis`).
+ */
+function resolveCategories(args: Record<string, string | boolean>): ReportType[] {
+  if (args['all'] === true) return [...ALL_REPORT_TYPES];
+  if (args['analysis'] === true) return [...ANALYSIS_CATEGORIES];
+
+  const raw = typeof args['categories'] === 'string' ? args['categories'].trim() : '';
+  if (!raw) return [...ALL_REPORT_TYPES];
+
+  if (raw === 'all') return [...ALL_REPORT_TYPES];
+  if (raw === 'analysis') return [...ANALYSIS_CATEGORIES];
+
+  const valid = new Set<string>(Object.values(ReportType));
+  const cats = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const c of cats) {
+    if (!valid.has(c)) {
+      throw new Error(`Unknown category "${c}". Valid values: ${[...valid].join(', ')} (or shortcuts: all, analysis)`);
+    }
+  }
+  return cats as ReportType[];
+}
+
+interface ResolvedTicker {
+  symbol: string;
+  exchange: string;
+  source: SampledTicker;
+}
+
+/**
+ * Ticker list comes from one of two sources, mutually exclusive:
+ *   --in <path>                       JSON file containing an array of {symbol, exchange, ...}
+ *   --symbol X --exchange Y           single-ticker convenience for one-off use
+ */
+async function resolveTickers(args: Record<string, string | boolean>): Promise<ResolvedTicker[]> {
+  const inPath = typeof args['in'] === 'string' ? args['in'] : undefined;
+  const inlineSymbol = typeof args['symbol'] === 'string' ? args['symbol'] : undefined;
+  const inlineExchange = typeof args['exchange'] === 'string' ? args['exchange'] : undefined;
+
+  if (inPath && (inlineSymbol || inlineExchange)) {
+    throw new Error('Pass either --in <path> OR --symbol/--exchange, not both');
+  }
+
+  if (inlineSymbol || inlineExchange) {
+    if (!inlineSymbol || !inlineExchange) {
+      throw new Error('--symbol and --exchange must be passed together');
+    }
+    const symbol = inlineSymbol.toUpperCase();
+    const exchange = inlineExchange.toUpperCase();
+    return [{ symbol, exchange, source: { symbol, exchange } }];
+  }
+
+  if (!inPath) {
+    throw new Error('Missing required input: pass --in <path> or --symbol X --exchange Y');
+  }
+
+  const raw = await readFile(inPath, 'utf-8');
+  const parsed = JSON.parse(raw) as Array<Partial<SampledTicker>>;
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(`--in file ${inPath} must contain a non-empty JSON array of {symbol, exchange} objects`);
+  }
+  return parsed.map((entry, idx) => {
+    if (typeof entry.symbol !== 'string' || entry.symbol.length === 0 || typeof entry.exchange !== 'string' || entry.exchange.length === 0) {
+      throw new Error(`--in entry at index ${idx} is missing symbol or exchange: ${JSON.stringify(entry)}`);
+    }
+    return {
+      symbol: entry.symbol.toUpperCase(),
+      exchange: entry.exchange.toUpperCase(),
+      source: entry as SampledTicker,
+    };
+  });
+}
+
+interface PostOutcome {
+  ticker: ResolvedTicker;
+  requestId: string | null;
+  ok: boolean;
+  error?: string;
+}
+
+async function postOne(payload: GenerationRequestPayload, ticker: ResolvedTicker): Promise<PostOutcome> {
+  try {
+    // Endpoint accepts an array; we send a single-element array per call so each ticker
+    // is enqueued in its own POST. Failures of one ticker don't poison the whole batch.
+    const rows = await fetchJson<GenerationRequestRow[]>(`/api/${SPACE_ID}/tickers-v1/generation-requests`, {
+      method: 'POST',
+      body: [payload],
+      authToken: true,
+    });
+    return { ticker, requestId: rows[0]?.id ?? null, ok: true };
+  } catch (err) {
+    return { ticker, requestId: null, ok: false, error: (err as Error).message };
+  }
+}
+
+async function main() {
+  requireAutomationSecret();
+  const args = parseArgs(process.argv.slice(2));
+  const outPath = typeof args['out'] === 'string' ? args['out'] : undefined;
+  const delayMs = parsePositiveInt(args['delay-ms']) ?? DEFAULT_DELAY_MS;
+
+  const categories = resolveCategories(args);
+  const tickers = await resolveTickers(args);
+
+  if (tickers.length > MAX_TICKERS_PER_INVOCATION) {
+    throw new Error(
+      `Refusing to enqueue ${tickers.length} tickers in one invocation — limit is ${MAX_TICKERS_PER_INVOCATION}. ` +
+        `Each ticker triggers up to 8 LLM jobs and a sequential delay; split the input file and run again.`
+    );
+  }
+
+  console.log(`Enqueueing generation for ${tickers.length} ticker${tickers.length === 1 ? '' : 's'}, categories: ${categories.join(', ')}`);
+  if (tickers.length > 1) console.log(`Sequential POSTs with ${delayMs}ms delay between calls.`);
+
+  const outcomes: PostOutcome[] = [];
+
+  for (let i = 0; i < tickers.length; i++) {
+    const ticker = tickers[i];
+    const idx = `[${String(i + 1).padStart(2, '0')}/${tickers.length}]`;
+    const payload = buildPayload({ symbol: ticker.symbol, exchange: ticker.exchange }, categories);
+
+    const outcome = await postOne(payload, ticker);
+    outcomes.push(outcome);
+
+    if (outcome.ok) {
+      console.log(`${idx} OK   ${ticker.symbol} (${ticker.exchange}) — request ${outcome.requestId ?? '(no id)'}`);
+    } else {
+      console.error(`${idx} FAIL ${ticker.symbol} (${ticker.exchange}) — ${outcome.error}`);
+    }
+
+    if (i < tickers.length - 1) {
+      await sleep(delayMs);
+    }
+  }
+
+  const okCount = outcomes.filter((o) => o.ok).length;
+  const failCount = outcomes.length - okCount;
+  console.log(`\nDone — ${okCount} succeeded, ${failCount} failed.`);
+
+  const requestIds = outcomes.filter((o) => o.requestId !== null).map((o) => o.requestId as string);
+  const failedTickers = outcomes.filter((o) => !o.ok).map((o) => ({ symbol: o.ticker.symbol, exchange: o.ticker.exchange, error: o.error }));
+
+  if (outPath) {
+    await mkdir(path.dirname(outPath), { recursive: true });
+    await writeFile(
+      outPath,
+      JSON.stringify(
+        {
+          categories,
+          tickers: outcomes.map((o) => ({
+            ...o.ticker.source,
+            symbol: o.ticker.symbol,
+            exchange: o.ticker.exchange,
+            requestId: o.requestId,
+            ok: o.ok,
+            error: o.error ?? null,
+          })),
+          requestIds,
+          failedTickers,
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+    console.log(`Wrote request IDs → ${outPath}`);
+  } else {
+    console.log(JSON.stringify({ requestIds, failedTickers }, null, 2));
+  }
+
+  if (failCount > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two new `tsx` CLIs under `insights-ui/src/scripts/tickers/`, plus the API auth / validation changes needed to use them from Claude Code / other automation.

### New CLIs

- **\`yarn stocks:trigger\`** — enqueues stock report generation requests. Mirrors \`yarn etfs:trigger\`:
  - Single ticker (\`--symbol AAPL --exchange NASDAQ\`) or batch JSON (\`--in path/to/stocks.json\`)
  - \`--all\` (default), \`--analysis\` (skip final-summary), or \`--categories=csv\` over the 8 \`ReportType\` values
  - Sequential POSTs with a 10s inter-call delay; 50-ticker cap per invocation
  - Optional \`--out\` for writing request IDs for later polling
- **\`yarn stocks:add\`** — creates new \`TickerV1\` records. Required fields: \`name\`, \`symbol\`, \`exchange\`, \`industryKey\`, \`subIndustryKey\`, \`websiteUrl\`. Optional: \`summary\`, \`stockAnalyzeUrl\` (auto-generated from symbol+exchange when absent). Validates exchange against the predefined \`EXCHANGES\` list. Supports inline flags or \`--in\` JSON batch (100-stock cap).

### API + UI changes

- \`POST /api/[spaceId]/tickers-v1/generation-requests\` now uses \`withAdminOrToken\`, so automation can call it with \`x-automation-token\` / \`AUTOMATION_SECRET\`. GET is still admin-only.
- \`POST /api/[spaceId]/tickers-v1\` now requires \`websiteUrl\` and validates \`exchange\` against the predefined list server-side.
- \`AddTickersForm\` enforces \`websiteUrl\` client-side to match the new API contract; CSV help text updated.

### Knowledge docs

New folder \`docs/ai-knowledge/insights-ui/stock-analysis/\` with an index plus \`generate-stock-reports.md\` and \`add-stock.md\`, mirroring the existing \`etf-analysis/\` structure. Linked from \`docs/ai-knowledge/insights-ui/AIKnowledge.md\`.

## Test plan

- [ ] Set \`AUTOMATION_SECRET\` and \`KOALAGAINS_API_BASE\` in env, run \`yarn stocks:trigger --symbol AAPL --exchange NASDAQ --all\` and confirm a \`NotStarted\` request appears in the admin generation-requests page.
- [ ] Run \`yarn stocks:add --name "Test" --symbol ZZZTEST --exchange NASDAQ --industry <existing-key> --sub-industry <existing-key> --website https://example.com\` and confirm the ticker is created; also verify adding with an invalid exchange (e.g. \`--exchange FOO\`) fails client-side before hitting the API.
- [ ] Open the admin ticker add form, leave Website URL blank, click Add → confirm the client-side alert fires.
- [ ] Confirm \`yarn etfs:trigger\` still works (no regression on the ETF path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)