### PR TITLE
Add dedicated Financial Statement Analysis page for tickers

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -30,4 +30,7 @@
   <sitemap>
     <loc>https://koalagains.com/stocks/business-and-moat-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/stocks/financial-statement-analysis-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/financial-statement-analysis-data/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/financial-statement-analysis-data/route.ts
@@ -1,0 +1,11 @@
+import { FinancialStatementAnalysisResponse, TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import { fetchPerformanceCategoryByTicker } from '@/utils/performance-api-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string; ticker: string }> }): Promise<FinancialStatementAnalysisResponse> {
+  const { spaceId, ticker } = await context.params;
+  return fetchPerformanceCategoryByTicker(spaceId, ticker, TickerAnalysisCategory.FinancialStatementAnalysis);
+}
+
+export const GET = withErrorHandlingV2<FinancialStatementAnalysisResponse>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/financial-statement-analysis-data/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/financial-statement-analysis-data/route.ts
@@ -1,0 +1,14 @@
+import { FinancialStatementAnalysisResponse, TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import { fetchPerformanceCategoryByExchange } from '@/utils/performance-api-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+async function getHandler(
+  req: NextRequest,
+  context: { params: Promise<{ spaceId: string; ticker: string; exchange: string }> }
+): Promise<FinancialStatementAnalysisResponse> {
+  const { spaceId, ticker, exchange } = await context.params;
+  return fetchPerformanceCategoryByExchange(spaceId, ticker, exchange, TickerAnalysisCategory.FinancialStatementAnalysis);
+}
+
+export const GET = withErrorHandlingV2<FinancialStatementAnalysisResponse>(getHandler);

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -1,0 +1,134 @@
+import FinancialStatementAnalysis from '@/components/ticker-reportsv1/FinancialStatementAnalysis';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { generateFinancialStatementAnalysisArticleSchema, generateFinancialStatementAnalysisBreadcrumbSchema } from '@/utils/metadata-generators';
+import {
+  buildPerformanceBreadcrumbs,
+  extractPerformanceTimestamps,
+  fetchPerformanceByExchange,
+  getPerformanceOrRedirect,
+  truncateForMeta,
+} from '@/utils/performance-page-utils';
+import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+const DATA_SLUG = 'financial-statement-analysis-data';
+const PAGE_SLUG = 'financial-statement-analysis';
+
+/**
+ * Static-by-default with on-demand invalidation.
+ */
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+/** Route params (strict) */
+export type RouteParams = Promise<Readonly<{ exchange: string; ticker: string }>>;
+
+/** Metadata */
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const routeParams = await params;
+  const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
+
+  let companyName: string = ticker;
+  let industryName: string = '';
+  let createdTime: string;
+  let updatedTime: string;
+
+  try {
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    companyName = data.ticker?.name ?? companyName;
+    industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
+    const timestamps = extractPerformanceTimestamps(data);
+    createdTime = timestamps.createdTime;
+    updatedTime = timestamps.updatedTime;
+  } catch {
+    const now = new Date().toISOString();
+    createdTime = now;
+    updatedTime = now;
+  }
+
+  const year = new Date().getFullYear();
+
+  const shortDesc = truncateForMeta(
+    `Detailed financial statement analysis of ${companyName} (${ticker})${
+      industryName ? ` in the ${industryName} industry` : ''
+    }. Review income statement, balance sheet, cash flow, and key financial ratios to gauge overall financial health.`
+  );
+
+  const canonicalUrl = `https://koalagains.com/stocks/${exchange}/${ticker}/${PAGE_SLUG}`;
+
+  const keywords: string[] = [
+    `${companyName} financial statements`,
+    `${companyName} balance sheet`,
+    `${ticker} income statement`,
+    `${companyName} cash flow`,
+    `${ticker} financial ratios`,
+    `${companyName} financial health`,
+    `${ticker} financial analysis`,
+    'financial statement analysis',
+    'balance sheet analysis',
+    'cash flow analysis',
+    'investment insights',
+    'KoalaGains',
+  ];
+
+  return {
+    title: `${companyName} (${ticker}) Financial Statement Analysis (${year})`,
+    description: shortDesc,
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: `${companyName} (${ticker}) Financial Statement Analysis | KoalaGains`,
+      description: shortDesc,
+      url: canonicalUrl,
+      siteName: 'KoalaGains',
+      type: 'article',
+      publishedTime: createdTime,
+      modifiedTime: updatedTime,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${companyName} (${ticker}) Financial Statement Analysis | KoalaGains`,
+      description: shortDesc,
+      site: '@koalagains',
+      creator: '@koalagains',
+    },
+    keywords,
+  };
+}
+
+/** PAGE */
+export default async function FinancialStatementAnalysisPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const routeParams = await params;
+  const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
+
+  const financialStatementData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const tickerData = financialStatementData.ticker;
+  if (!tickerData) {
+    notFound();
+  }
+
+  const country = getCountryByExchange(tickerData.exchange as USExchanges | CanadaExchanges | IndiaExchanges | UKExchanges);
+
+  const articleSchema = generateFinancialStatementAnalysisArticleSchema(tickerData, financialStatementData.categoryResult);
+  const breadcrumbSchema = generateFinancialStatementAnalysisBreadcrumbSchema(tickerData, country);
+
+  const breadcrumbs = buildPerformanceBreadcrumbs(exchange, ticker, tickerData, 'Financial Statement Analysis', PAGE_SLUG);
+
+  return (
+    <PageWrapper>
+      {/* Structured Data for SEO */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([articleSchema, breadcrumbSchema]),
+        }}
+      />
+
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+
+      <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -524,6 +524,7 @@ function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): 
                 <div
                   className={`flex items-center gap-2 mb-2 ${
                     categoryKey === TickerAnalysisCategory.BusinessAndMoat ||
+                    categoryKey === TickerAnalysisCategory.FinancialStatementAnalysis ||
                     categoryKey === TickerAnalysisCategory.PastPerformance ||
                     categoryKey === TickerAnalysisCategory.FutureGrowth
                       ? 'justify-between'
@@ -545,6 +546,16 @@ function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): 
                   {categoryKey === TickerAnalysisCategory.BusinessAndMoat && (
                     <Link
                       href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/business-and-moat`}
+                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
+                    >
+                      View Detailed Analysis →
+                    </Link>
+                  )}
+
+                  {categoryKey === TickerAnalysisCategory.FinancialStatementAnalysis && (
+                    <Link
+                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/financial-statement-analysis`}
                       className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
                       style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
                     >
@@ -597,9 +608,13 @@ function TickerDetailsInfo({ data }: { data: Promise<TickerV1FastResponse> }): J
     [TickerAnalysisCategory.FairValue]: `Is ${d.name} Fairly Valued?`,
   };
 
-  // Filter out PastPerformance and FutureGrowth — they now have their own dedicated pages
+  // Filter out categories that have their own dedicated detail pages
   const categoriesToShow = Object.values(TickerAnalysisCategory).filter(
-    (key) => key !== TickerAnalysisCategory.BusinessAndMoat && key !== TickerAnalysisCategory.PastPerformance && key !== TickerAnalysisCategory.FutureGrowth
+    (key) =>
+      key !== TickerAnalysisCategory.BusinessAndMoat &&
+      key !== TickerAnalysisCategory.FinancialStatementAnalysis &&
+      key !== TickerAnalysisCategory.PastPerformance &&
+      key !== TickerAnalysisCategory.FutureGrowth
   );
 
   return (

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -1,0 +1,73 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import { NextRequest, NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+async function generateFinancialStatementAnalysisUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  const financialStatementRecords = await prisma.tickerV1CategoryAnalysisResult.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      categoryKey: TickerAnalysisCategory.FinancialStatementAnalysis,
+    },
+    select: {
+      updatedAt: true,
+      ticker: {
+        select: {
+          symbol: true,
+          exchange: true,
+        },
+      },
+    },
+  });
+
+  for (const record of financialStatementRecords) {
+    const financialStatementUrl = `/stocks/${record.ticker.exchange}/${record.ticker.symbol}/financial-statement-analysis`;
+
+    urls.push({
+      url: financialStatementUrl,
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod: record.updatedAt ? new Date(record.updatedAt).toISOString().split('T')[0] : undefined,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
+  const host = req.headers.get('host') as string;
+
+  try {
+    const urls = await generateFinancialStatementAnalysisUrls();
+    const smStream = new SitemapStream({ hostname: 'https://' + host });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating financial statement analysis sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
@@ -1,0 +1,30 @@
+import type { FinancialStatementAnalysisResponse } from '@/types/ticker-typesv1';
+import React from 'react';
+import TickerCategoryReport from './TickerCategoryReport';
+
+export interface FinancialStatementAnalysisProps {
+  tickerData: FinancialStatementAnalysisResponse['ticker'];
+  data: FinancialStatementAnalysisResponse;
+}
+
+export default function FinancialStatementAnalysis({ tickerData, data }: FinancialStatementAnalysisProps): JSX.Element | null {
+  const { categoryResult } = data;
+
+  if (!tickerData || !categoryResult) {
+    return null;
+  }
+
+  const ticker = tickerData.symbol;
+
+  const analysisTitle = `${tickerData.name} (${ticker}) Financial Statement Analysis`;
+
+  return (
+    <TickerCategoryReport
+      tickerData={tickerData}
+      categoryResult={categoryResult}
+      analysisTitle={analysisTitle}
+      categoryBadgeText="Financial Statements"
+      categoryBadgeClassName="bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300"
+    />
+  );
+}

--- a/insights-ui/src/types/ticker-typesv1.ts
+++ b/insights-ui/src/types/ticker-typesv1.ts
@@ -85,6 +85,7 @@ export type PerformanceResponse = {
 export type PastPerformanceResponse = PerformanceResponse;
 export type FuturePerformanceResponse = PerformanceResponse;
 export type BusinessAndMoatResponse = PerformanceResponse;
+export type FinancialStatementAnalysisResponse = PerformanceResponse;
 
 export interface IndustryWithSubIndustries extends TickerV1Industry {
   subIndustries: TickerV1SubIndustry[];

--- a/insights-ui/src/utils/metadata-generators.ts
+++ b/insights-ui/src/utils/metadata-generators.ts
@@ -1023,6 +1023,130 @@ export const generateFuturePerformanceBreadcrumbSchema = (ticker: TickerWithOpti
 };
 
 // ────────────────────────────────────────────────────────────────────────────────
+// Stock financial statement analysis structured data generators
+// ────────────────────────────────────────────────────────────────────────────────
+
+export const generateFinancialStatementAnalysisArticleSchema = (
+  ticker: TickerWithOptionalIndustry,
+  categoryResult?: { createdAt?: string | Date; updatedAt?: string | Date } | null
+) => {
+  const stockUrl = `https://koalagains.com/stocks/${ticker.exchange}/${ticker.symbol}`;
+  const canonicalUrl = `${stockUrl}/financial-statement-analysis`;
+
+  const datePublished = categoryResult?.createdAt ? new Date(categoryResult.createdAt).toISOString() : new Date(ticker.createdAt).toISOString();
+  const dateModified = categoryResult?.updatedAt ? new Date(categoryResult.updatedAt).toISOString() : new Date(ticker.updatedAt).toISOString();
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${ticker.name} (${ticker.symbol}) Financial Statement Analysis`,
+    description: `Detailed financial statement analysis of ${ticker.name} (${ticker.symbol}). Evaluate income statement, balance sheet, cash flow, key financial ratios, and overall financial health.`,
+    image: ['https://koalagains.com/koalagain_logo.png'],
+    datePublished,
+    dateModified,
+    author: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://koalagains.com/koalagain_logo.png',
+      },
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://koalagains.com/koalagain_logo.png',
+        width: 600,
+        height: 60,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    articleSection: 'Financial Statement Analysis',
+    keywords: [
+      ticker.name,
+      `${ticker.symbol} financial statements`,
+      `${ticker.name} balance sheet`,
+      `${ticker.symbol} income statement`,
+      `${ticker.name} cash flow`,
+      `${ticker.symbol} financial ratios`,
+      `${ticker.name} financial health`,
+      'financial statement analysis',
+      'balance sheet analysis',
+      'cash flow analysis',
+      'investment analysis',
+      `${ticker.exchange} stocks`,
+      ticker.industryKey,
+      ticker.industry?.name,
+      'KoalaGains',
+    ]
+      .filter(Boolean)
+      .join(', '),
+    about: {
+      '@type': 'Corporation',
+      name: ticker.name,
+      tickerSymbol: ticker.symbol,
+      exchange: ticker.exchange,
+    },
+    inLanguage: 'en-US',
+  };
+};
+
+export const generateFinancialStatementAnalysisBreadcrumbSchema = (ticker: TickerWithOptionalIndustry, country: string) => {
+  const stockUrl = `https://koalagains.com/stocks/${ticker.exchange}/${ticker.symbol}`;
+  const canonicalUrl = `${stockUrl}/financial-statement-analysis`;
+  const industryName = ticker.industry?.name || ticker.industryKey;
+
+  const breadcrumbItems: { '@type': string; position: number; name: string; item: string }[] = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://koalagains.com',
+    },
+  ];
+
+  if (country === 'US') {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: 'US Stocks', item: 'https://koalagains.com/stocks' },
+      { '@type': 'ListItem', position: 3, name: industryName, item: `https://koalagains.com/stocks/industries/${ticker.industryKey}` },
+      { '@type': 'ListItem', position: 4, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 5, name: 'Financial Statement Analysis', item: canonicalUrl }
+    );
+  } else if (country) {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: `${country} Stocks`, item: `https://koalagains.com/stocks/countries/${country}` },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: industryName,
+        item: `https://koalagains.com/stocks/countries/${country}/industries/${ticker.industryKey}`,
+      },
+      { '@type': 'ListItem', position: 4, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 5, name: 'Financial Statement Analysis', item: canonicalUrl }
+    );
+  } else {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: 'Stocks', item: 'https://koalagains.com/stocks' },
+      { '@type': 'ListItem', position: 3, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 4, name: 'Financial Statement Analysis', item: canonicalUrl }
+    );
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbItems,
+  };
+};
+
+// ────────────────────────────────────────────────────────────────────────────────
 // Common viewport configuration
 // ────────────────────────────────────────────────────────────────────────────────
 export const commonViewport = {


### PR DESCRIPTION
## Summary

Introduces a standalone Financial Statement Analysis detail page for each ticker, following the same pattern used for Business & Moat, Past Performance, and Future Performance.

## What's Added

- **Route:** \`/stocks/[exchange]/[ticker]/financial-statement-analysis\` with SEO metadata (title, description, canonical URL, OpenGraph, Twitter) and JSON-LD (Article + BreadcrumbList).
- **API endpoints:**
  - \`GET /api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/financial-statement-analysis-data\`
  - \`GET /api/[spaceId]/tickers-v1/[ticker]/financial-statement-analysis-data\` (any-exchange fallback, powering the canonical-redirect flow)
- **Component:** \`FinancialStatementAnalysis\` reuses \`TickerCategoryReport\` for header, executive summary, comprehensive analysis, factor list, and footer.
- **Type:** \`FinancialStatementAnalysisResponse\` alias of \`PerformanceResponse\`.
- **Metadata generators:** \`generateFinancialStatementAnalysisArticleSchema\` and \`generateFinancialStatementAnalysisBreadcrumbSchema\`.
- **Sitemap:** \`stocks/financial-statement-analysis-sitemap.xml\` + entry in \`public/sitemap_index.xml\`.

## Stock Page Changes

- Added **View Detailed Analysis →** link for the FinancialStatementAnalysis category in the summary section.
- Removed the inline detailed Financial Statement Analysis block from the \`TickerDetailsInfo\` section since it now has its own dedicated page (same treatment as Business & Moat / Past / Future).

## Test plan

- [ ] Visit \`/stocks/<exchange>/<ticker>/financial-statement-analysis\` for a ticker that has FinancialStatementAnalysis data and confirm the page renders the header, summary, overall analysis, and each factor.
- [ ] Verify breadcrumbs render correctly for US, other supported countries, and the fallback branch.
- [ ] Confirm wrong-exchange URL performs a canonical redirect to the correct exchange.
- [ ] Confirm the main stock page now links to the new page and no longer duplicates the Financial Statement Analysis section inline.
- [ ] Hit \`/stocks/financial-statement-analysis-sitemap.xml\` and verify URLs are produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)