### PR TITLE
Add stock-scenarios task spec

### DIFF
--- a/insights-ui/package.json
+++ b/insights-ui/package.json
@@ -14,6 +14,7 @@
     "generate:tariff": "tsx src/scripts/run-tariff-report.ts",
     "generate:meta-descriptions": "tsx src/scripts/generate-meta-descriptions.ts",
     "import:etf-scenarios": "tsx src/scripts/import-etf-scenarios.ts",
+    "import:stock-scenarios": "tsx src/scripts/import-stock-scenarios.ts",
     "etfs:trigger": "tsx src/scripts/etfs/trigger-generation.ts",
     "etfs:wait": "tsx src/scripts/etfs/wait-for-generation.ts",
     "etfs:fetch": "tsx src/scripts/etfs/fetch-analysis.ts",

--- a/insights-ui/prisma/migrations/20260424180000_add_stock_scenarios/migration.sql
+++ b/insights-ui/prisma/migrations/20260424180000_add_stock_scenarios/migration.sql
@@ -1,0 +1,84 @@
+-- CreateTable
+CREATE TABLE "stock_scenarios" (
+    "id" TEXT NOT NULL,
+    "scenario_number" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "underlying_cause" TEXT NOT NULL,
+    "historical_analog" TEXT NOT NULL,
+    "winners_markdown" TEXT NOT NULL,
+    "losers_markdown" TEXT NOT NULL,
+    "outlook_markdown" TEXT NOT NULL,
+    "direction" TEXT NOT NULL DEFAULT 'DOWNSIDE',
+    "timeframe" TEXT NOT NULL DEFAULT 'FUTURE',
+    "probability_bucket" TEXT NOT NULL DEFAULT 'MEDIUM',
+    "probability_percentage" INTEGER,
+    "priced_in_bucket" TEXT NOT NULL DEFAULT 'PARTIALLY_PRICED_IN',
+    "expected_price_change" INTEGER,
+    "expected_price_change_explanation" TEXT,
+    "price_change_timeframe_explanation" TEXT,
+    "countries" TEXT[],
+    "outlook_as_of_date" DATE NOT NULL,
+    "meta_description" TEXT,
+    "archived" BOOLEAN NOT NULL DEFAULT false,
+    "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stock_scenarios_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stock_scenario_stock_links" (
+    "id" TEXT NOT NULL,
+    "scenario_id" TEXT NOT NULL,
+    "ticker_id" TEXT,
+    "symbol" TEXT NOT NULL,
+    "exchange" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "role_explanation" TEXT,
+    "expected_price_change" INTEGER,
+    "expected_price_change_explanation" TEXT,
+    "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stock_scenario_stock_links_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stock_scenarios_space_id_scenario_number_key" ON "stock_scenarios"("space_id", "scenario_number");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stock_scenarios_space_id_slug_key" ON "stock_scenarios"("space_id", "slug");
+
+-- CreateIndex
+CREATE INDEX "stock_scenarios_space_id_archived_idx" ON "stock_scenarios"("space_id", "archived");
+
+-- CreateIndex
+CREATE INDEX "stock_scenarios_space_id_direction_idx" ON "stock_scenarios"("space_id", "direction");
+
+-- CreateIndex
+CREATE INDEX "stock_scenarios_space_id_timeframe_idx" ON "stock_scenarios"("space_id", "timeframe");
+
+-- CreateIndex
+CREATE INDEX "stock_scenarios_space_id_probability_bucket_idx" ON "stock_scenarios"("space_id", "probability_bucket");
+
+-- CreateIndex
+CREATE INDEX "stock_scenarios_space_id_priced_in_bucket_idx" ON "stock_scenarios"("space_id", "priced_in_bucket");
+
+-- CreateIndex
+CREATE INDEX "stock_scenario_stock_links_scenario_id_idx" ON "stock_scenario_stock_links"("scenario_id");
+
+-- CreateIndex
+CREATE INDEX "stock_scenario_stock_links_symbol_idx" ON "stock_scenario_stock_links"("symbol");
+
+-- CreateIndex
+CREATE INDEX "stock_scenario_stock_links_symbol_exchange_idx" ON "stock_scenario_stock_links"("symbol", "exchange");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stock_scenario_stock_links_scenario_id_symbol_exchange_role_key" ON "stock_scenario_stock_links"("scenario_id", "symbol", "exchange", "role");
+
+-- AddForeignKey
+ALTER TABLE "stock_scenario_stock_links" ADD CONSTRAINT "stock_scenario_stock_links_scenario_id_fkey" FOREIGN KEY ("scenario_id") REFERENCES "stock_scenarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -1836,3 +1836,75 @@ model EtfScenarioEtfLink {
   @@index([symbol])
   @@map("etf_scenario_etf_links")
 }
+
+// Stock scenarios mirror the ETF scenario shape but are country-scoped.
+// Stocks trade on exchanges in specific countries, so every scenario declares
+// the SupportedCountries set it applies to (see
+// `src/utils/countryExchangeUtils.ts`). Unlike ETFs, a single symbol can live
+// on multiple exchanges (dual listings, ADRs), so the link uniqueness key
+// includes `exchange`.
+model StockScenario {
+  id                              String   @id @default(uuid())
+  scenarioNumber                  Int      @map("scenario_number")
+  title                           String   @map("title")
+  slug                            String   @map("slug")
+  underlyingCause                 String   @map("underlying_cause") @db.Text
+  historicalAnalog                String   @map("historical_analog") @db.Text
+  winnersMarkdown                 String   @map("winners_markdown") @db.Text
+  losersMarkdown                  String   @map("losers_markdown") @db.Text
+  outlookMarkdown                 String   @map("outlook_markdown") @db.Text
+  direction                       String   @default("DOWNSIDE") @map("direction")
+  timeframe                       String   @default("FUTURE") @map("timeframe")
+  probabilityBucket               String   @default("MEDIUM") @map("probability_bucket")
+  probabilityPercentage           Int?     @map("probability_percentage")
+  pricedInBucket                  String   @default("PARTIALLY_PRICED_IN") @map("priced_in_bucket")
+  expectedPriceChange             Int?     @map("expected_price_change")
+  expectedPriceChangeExplanation  String?  @map("expected_price_change_explanation") @db.Text
+  priceChangeTimeframeExplanation String?  @map("price_change_timeframe_explanation") @db.Text
+  countries                       String[] @map("countries")
+  outlookAsOfDate                 DateTime @map("outlook_as_of_date") @db.Date
+  metaDescription                 String?  @map("meta_description") @db.Text
+  archived                        Boolean  @default(false) @map("archived")
+  spaceId                         String   @default("koala_gains") @map("space_id")
+  createdAt                       DateTime @default(now()) @map("created_at")
+  updatedAt                       DateTime @updatedAt @map("updated_at")
+
+  stockLinks StockScenarioStockLink[]
+
+  @@unique([spaceId, scenarioNumber])
+  @@unique([spaceId, slug])
+  @@index([spaceId, archived])
+  @@index([spaceId, direction])
+  @@index([spaceId, timeframe])
+  @@index([spaceId, probabilityBucket])
+  @@index([spaceId, pricedInBucket])
+  @@map("stock_scenarios")
+}
+
+// Loose link from a stock scenario to a TickerV1 row. We store `symbol` +
+// `exchange` verbatim on the link and resolve `tickerId` at write time against
+// TickerV1's `@@unique([spaceId, symbol, exchange])`. Unresolved links still
+// render as plain text in the UI (matches the ETF behaviour).
+model StockScenarioStockLink {
+  id                             String   @id @default(uuid())
+  scenarioId                     String   @map("scenario_id")
+  tickerId                       String?  @map("ticker_id")
+  symbol                         String   @map("symbol")
+  exchange                       String   @map("exchange")
+  role                           String   @map("role")
+  sortOrder                      Int      @default(0) @map("sort_order")
+  roleExplanation                String?  @map("role_explanation") @db.Text
+  expectedPriceChange            Int?     @map("expected_price_change")
+  expectedPriceChangeExplanation String?  @map("expected_price_change_explanation") @db.Text
+  spaceId                        String   @default("koala_gains") @map("space_id")
+  createdAt                      DateTime @default(now()) @map("created_at")
+  updatedAt                      DateTime @updatedAt @map("updated_at")
+
+  scenario StockScenario @relation(fields: [scenarioId], references: [id], onDelete: Cascade)
+
+  @@unique([scenarioId, symbol, exchange, role])
+  @@index([scenarioId])
+  @@index([symbol])
+  @@index([symbol, exchange])
+  @@map("stock_scenario_stock_links")
+}

--- a/insights-ui/src/app/admin-v1/AdminNav.tsx
+++ b/insights-ui/src/app/admin-v1/AdminNav.tsx
@@ -30,6 +30,7 @@ const stockIndustryMgmtSection: AdminNavSection = {
     { name: 'Industry Analysis', href: '/admin-v1/industry-analysis-management' },
     { name: 'Ticker Management', href: '/admin-v1/ticker-management' },
     { name: 'Analysis Factors', href: '/admin-v1/analysis-factors' },
+    { name: 'Stock Scenarios', href: '/admin-v1/stock-scenarios' },
   ],
 };
 

--- a/insights-ui/src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx
@@ -1,0 +1,124 @@
+import type { ImportStockScenariosResponse } from '@/app/api/stock-scenarios/import/route';
+import Button from '@dodao/web-core/components/core/buttons/Button';
+import SingleSectionModal from '@dodao/web-core/components/core/modals/SingleSectionModal';
+import TextareaAutosize from '@dodao/web-core/components/core/textarea/TextareaAutosize';
+import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface ImportStockScenariosModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function ImportStockScenariosModal({ isOpen, onClose, onSuccess }: ImportStockScenariosModalProps): JSX.Element {
+  const [markdown, setMarkdown] = useState<string>('');
+  const [fallbackDate, setFallbackDate] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [error, setError] = useState<string>('');
+  const [result, setResult] = useState<ImportStockScenariosResponse | null>(null);
+
+  const { postData, loading } = usePostData<ImportStockScenariosResponse, { markdown: string; fallbackOutlookDate: string }>({
+    successMessage: 'Scenarios imported!',
+    errorMessage: 'Failed to import scenarios',
+  });
+
+  const handleImport = async (): Promise<void> => {
+    setError('');
+    setResult(null);
+    if (!markdown.trim()) {
+      setError('Paste the scenarios markdown before importing.');
+      return;
+    }
+    try {
+      const data = await postData('/api/stock-scenarios/import', {
+        markdown,
+        fallbackOutlookDate: new Date(fallbackDate).toISOString(),
+      });
+      setResult(data ?? null);
+      onSuccess();
+    } catch {
+      setError('Failed to import scenarios');
+    }
+  };
+
+  return (
+    <SingleSectionModal open={isOpen} onClose={onClose} title="Import Stock Scenarios from markdown">
+      <div className="text-left mt-3 max-h-[75vh] overflow-y-auto pr-1 space-y-3">
+        <p className="text-xs text-gray-400">
+          Paste the stock market-scenarios markdown. Each scenario is matched by <code>scenarioNumber</code> — existing rows are updated in place, and all
+          winner / loser / most-exposed links are rebuilt from the doc.
+        </p>
+        <p className="text-xs text-gray-500">
+          Tickers must be qualified with their exchange: <code>NYSE:UN</code>, <code>NSE:RELIANCE</code>, <code>LSE:ULVR</code>, etc. Include a{' '}
+          <code>**Countries:** India, US</code> line (or rely on the inferred set from the links&apos; exchanges).
+        </p>
+
+        <label className="flex flex-col gap-1 text-sm max-w-xs">
+          <span className="text-gray-300">Fallback outlook date (used when a scenario has no explicit &quot;as of&quot; line)</span>
+          <input
+            type="date"
+            className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+            value={fallbackDate}
+            onChange={(e) => setFallbackDate(e.target.value)}
+          />
+        </label>
+
+        <TextareaAutosize
+          label="Scenarios markdown"
+          modelValue={markdown}
+          onUpdate={(v: unknown) => {
+            if (typeof v === 'string') setMarkdown(v);
+          }}
+          minHeight={240}
+        />
+
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+
+        {result && (
+          <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-3 text-sm text-gray-200 space-y-2">
+            <p>
+              Parsed <strong>{result.totalParsed}</strong> scenarios — {result.created} created, {result.updated} updated, {result.skipped} skipped. Resolved{' '}
+              {result.resolvedTickers} tickers against the TickerV1 table.
+            </p>
+            {result.unresolvedTickers.length > 0 && (
+              <div>
+                <p className="text-xs text-gray-400 mb-1">Unresolved tickers ({result.unresolvedTickers.length}):</p>
+                <p className="text-xs text-gray-500 break-words">{result.unresolvedTickers.join(', ')}</p>
+              </div>
+            )}
+            {result.scenarios.some((s) => s.action === 'skipped') && (
+              <div>
+                <p className="text-xs text-gray-400 mb-1">Skipped scenarios:</p>
+                <ul className="text-xs text-gray-500 space-y-1">
+                  {result.scenarios
+                    .filter((s) => s.action === 'skipped')
+                    .map((s) => (
+                      <li key={s.slug}>
+                        <span className="text-gray-300">#{s.scenarioNumber}</span> {s.title} — {s.note}
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outlined" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={handleImport} disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Importing…
+              </>
+            ) : (
+              'Import'
+            )}
+          </Button>
+        </div>
+      </div>
+    </SingleSectionModal>
+  );
+}

--- a/insights-ui/src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx
@@ -1,0 +1,283 @@
+import type { StockScenarioDetail, StockScenarioLinkDto } from '@/app/api/[spaceId]/stock-scenarios/[slug]/route';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ScenarioRole } from '@/types/scenarioEnums';
+import { EXCHANGES } from '@/utils/countryExchangeUtils';
+import Button from '@dodao/web-core/components/core/buttons/Button';
+import Input from '@dodao/web-core/components/core/input/Input';
+import SingleSectionModal from '@dodao/web-core/components/core/modals/SingleSectionModal';
+import TextareaAutosize from '@dodao/web-core/components/core/textarea/TextareaAutosize';
+import { useDeleteData } from '@dodao/web-core/ui/hooks/fetch/useDeleteData';
+import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { StockScenarioStockLink } from '@prisma/client';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface ManageLinksModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  scenarioId?: string;
+  scenarioTitle?: string;
+}
+
+interface AddLinkFormState {
+  symbol: string;
+  exchange: string;
+  role: ScenarioRole;
+  roleExplanation: string;
+  expectedPriceChange: string;
+  expectedPriceChangeExplanation: string;
+}
+
+const ROLES: ScenarioRole[] = ['WINNER', 'LOSER', 'MOST_EXPOSED'];
+
+function fetchDetailBySlug(slug: string): Promise<StockScenarioDetail | null> {
+  return fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/stock-scenarios/${slug}?allowNull=true`).then((r) => (r.ok ? r.json() : null));
+}
+
+export default function ManageLinksModal({ isOpen, onClose, onSuccess, scenarioId, scenarioTitle }: ManageLinksModalProps): JSX.Element {
+  const [detail, setDetail] = useState<StockScenarioDetail | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState<boolean>(false);
+  const [form, setForm] = useState<AddLinkFormState>({
+    symbol: '',
+    exchange: 'NASDAQ',
+    role: 'WINNER',
+    roleExplanation: '',
+    expectedPriceChange: '',
+    expectedPriceChangeExplanation: '',
+  });
+  const [formError, setFormError] = useState<string>('');
+
+  const { postData, loading: adding } = usePostData<StockScenarioStockLink, unknown>({
+    successMessage: 'Link added!',
+    errorMessage: 'Failed to add link',
+  });
+  const { deleteData, loading: removing } = useDeleteData<{ success: boolean }, never>({
+    successMessage: 'Link removed!',
+    errorMessage: 'Failed to remove link',
+  });
+
+  useEffect(() => {
+    if (!isOpen || !scenarioId) {
+      setDetail(null);
+      return;
+    }
+
+    setLoadingDetail(true);
+    // Scenario detail is keyed by slug; look up the slug via the admin id route first.
+    fetch(`${getBaseUrl()}/api/stock-scenarios/${scenarioId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((scenario: { slug: string } | null) => (scenario ? fetchDetailBySlug(scenario.slug) : null))
+      .then((d) => setDetail(d))
+      .finally(() => setLoadingDetail(false));
+  }, [isOpen, scenarioId]);
+
+  const refreshDetail = async (): Promise<void> => {
+    if (!detail) return;
+    const fresh = await fetchDetailBySlug(detail.slug);
+    if (fresh) setDetail(fresh);
+    onSuccess();
+  };
+
+  const handleAdd = async (): Promise<void> => {
+    setFormError('');
+    if (!scenarioId) return;
+    const symbol = form.symbol.trim().toUpperCase();
+    const exchange = form.exchange.trim().toUpperCase();
+    if (!symbol || !exchange) {
+      setFormError('Symbol and exchange are both required.');
+      return;
+    }
+
+    let expectedPriceChangeValue: number | null = null;
+    if (form.expectedPriceChange.trim() !== '') {
+      const n = parseInt(form.expectedPriceChange, 10);
+      if (isNaN(n) || n < -100 || n > 100) {
+        setFormError('Expected price change must be an integer between -100 and 100.');
+        return;
+      }
+      expectedPriceChangeValue = n;
+    }
+
+    try {
+      await postData(`/api/stock-scenarios/${scenarioId}/links`, {
+        symbol,
+        exchange,
+        role: form.role,
+        roleExplanation: form.roleExplanation.trim() || null,
+        expectedPriceChange: expectedPriceChangeValue,
+        expectedPriceChangeExplanation: form.expectedPriceChangeExplanation.trim() || null,
+      });
+      setForm({
+        symbol: '',
+        exchange: form.exchange,
+        role: form.role,
+        roleExplanation: '',
+        expectedPriceChange: '',
+        expectedPriceChangeExplanation: '',
+      });
+      await refreshDetail();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add link';
+      setFormError(message);
+    }
+  };
+
+  const handleRemove = async (link: StockScenarioLinkDto): Promise<void> => {
+    if (!scenarioId) return;
+    const url =
+      `${getBaseUrl()}/api/stock-scenarios/${scenarioId}/links` +
+      `?symbol=${encodeURIComponent(link.symbol)}&exchange=${encodeURIComponent(link.exchange)}&role=${link.role}`;
+    await deleteData(url);
+    await refreshDetail();
+  };
+
+  const allLinks: Array<{ heading: string; role: ScenarioRole; items: StockScenarioLinkDto[] }> = [
+    { heading: 'Winners', role: 'WINNER', items: detail?.winners ?? [] },
+    { heading: 'Losers', role: 'LOSER', items: detail?.losers ?? [] },
+    { heading: 'Most exposed', role: 'MOST_EXPOSED', items: detail?.mostExposed ?? [] },
+  ];
+
+  return (
+    <SingleSectionModal open={isOpen} onClose={onClose} title={`Manage Links${scenarioTitle ? ` — ${scenarioTitle}` : ''}`}>
+      <div className="text-left mt-3 max-h-[75vh] overflow-y-auto pr-1 space-y-4">
+        {loadingDetail ? (
+          <div className="flex items-center gap-2 text-sm text-gray-300">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading links…
+          </div>
+        ) : (
+          <>
+            {detail && detail.countries.length > 0 && (
+              <p className="text-xs text-gray-400">
+                This scenario is scoped to: <span className="text-gray-200 font-medium">{detail.countries.join(', ')}</span>. Links on any other country&apos;s
+                exchanges will be rejected.
+              </p>
+            )}
+            <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-3 space-y-2">
+              <h3 className="text-sm font-semibold text-white">Add link</h3>
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
+                <Input
+                  label="Symbol"
+                  modelValue={form.symbol}
+                  onUpdate={(v: unknown) => {
+                    if (typeof v === 'string') setForm((f) => ({ ...f, symbol: v }));
+                  }}
+                />
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-gray-300">Exchange</span>
+                  <select
+                    className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+                    value={form.exchange}
+                    onChange={(e) => setForm((f) => ({ ...f, exchange: e.target.value }))}
+                  >
+                    {EXCHANGES.map((ex) => (
+                      <option key={ex} value={ex}>
+                        {ex}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-gray-300">Role</span>
+                  <select
+                    className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+                    value={form.role}
+                    onChange={(e) => setForm((f) => ({ ...f, role: e.target.value as ScenarioRole }))}
+                  >
+                    {ROLES.map((r) => (
+                      <option key={r} value={r}>
+                        {r}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <Button onClick={handleAdd} disabled={adding}>
+                  {adding ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4 mr-1" />}
+                  Add
+                </Button>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <TextareaAutosize
+                  label="Role explanation (why this stock is a winner / loser / most-exposed — markdown)"
+                  modelValue={form.roleExplanation}
+                  onUpdate={(v: unknown): void => {
+                    if (typeof v === 'string') setForm((f) => ({ ...f, roleExplanation: v }));
+                  }}
+                />
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-gray-300">Expected price change % (-100 to 100)</span>
+                  <input
+                    type="number"
+                    min={-100}
+                    max={100}
+                    className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+                    value={form.expectedPriceChange}
+                    onChange={(e) => setForm((f) => ({ ...f, expectedPriceChange: e.target.value }))}
+                    placeholder="e.g. -25"
+                  />
+                </label>
+              </div>
+              <TextareaAutosize
+                label="Expected price change explanation (size of the move and over what timeframe — markdown)"
+                modelValue={form.expectedPriceChangeExplanation}
+                onUpdate={(v: unknown): void => {
+                  if (typeof v === 'string') setForm((f) => ({ ...f, expectedPriceChangeExplanation: v }));
+                }}
+              />
+              {formError && <p className="text-red-500 text-sm">{formError}</p>}
+            </div>
+
+            {allLinks.map((group) => (
+              <div key={group.role}>
+                <h3 className="text-sm font-semibold text-white mb-2">
+                  {group.heading} <span className="text-xs text-gray-400">({group.items.length})</span>
+                </h3>
+                {group.items.length === 0 ? (
+                  <p className="text-xs text-gray-500">No links in this role.</p>
+                ) : (
+                  <ul className="space-y-1">
+                    {group.items.map((link) => (
+                      <li key={`${link.symbol}-${link.exchange}-${link.role}`} className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm">
+                        <div className="flex items-center justify-between">
+                          <span>
+                            <span className="font-semibold text-white">{link.symbol}</span>
+                            <span className="text-gray-400"> · {link.exchange}</span>
+                            {link.tickerId ? (
+                              <span className="ml-2 text-xs text-emerald-400">resolved</span>
+                            ) : (
+                              <span className="ml-2 text-xs text-gray-500">unresolved</span>
+                            )}
+                            {link.expectedPriceChange !== null && (
+                              <span className={`ml-2 text-xs ${link.expectedPriceChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                                {link.expectedPriceChange > 0 ? '+' : ''}
+                                {link.expectedPriceChange}%
+                              </span>
+                            )}
+                          </span>
+                          <Button variant="outlined" onClick={() => handleRemove(link)} disabled={removing}>
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                        {link.roleExplanation && <p className="mt-1 text-xs text-gray-300 whitespace-pre-wrap">{link.roleExplanation}</p>}
+                        {link.expectedPriceChangeExplanation && (
+                          <p className="mt-1 text-xs text-gray-400 whitespace-pre-wrap">{link.expectedPriceChangeExplanation}</p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </>
+        )}
+
+        <div className="flex justify-end pt-2">
+          <Button variant="outlined" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </SingleSectionModal>
+  );
+}

--- a/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
@@ -144,10 +144,7 @@ export default function UpsertStockScenarioModal({ isOpen, onClose, onSuccess, s
 
   const archivedItems: CheckboxItem[] = useMemo<CheckboxItem[]>(() => [{ id: 'archived', name: 'archived', label: 'Archived' }], []);
 
-  const countryItems: CheckboxItem[] = useMemo<CheckboxItem[]>(
-    () => ALL_SUPPORTED_COUNTRIES.map((c) => ({ id: c, name: c, label: c })),
-    []
-  );
+  const countryItems: CheckboxItem[] = useMemo<CheckboxItem[]>(() => ALL_SUPPORTED_COUNTRIES.map((c) => ({ id: c, name: c, label: c })), []);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
@@ -298,11 +295,7 @@ export default function UpsertStockScenarioModal({ isOpen, onClose, onSuccess, s
 
         <div>
           <p className="text-sm text-gray-300 mb-1">Countries in scope (at least one required)</p>
-          <Checkboxes
-            items={countryItems}
-            selectedItemIds={countries}
-            onChange={(ids: string[]) => setCountries(ids as SupportedCountries[])}
-          />
+          <Checkboxes items={countryItems} selectedItemIds={countries} onChange={(ids: string[]) => setCountries(ids as SupportedCountries[])} />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
@@ -44,12 +44,6 @@ const PRICED_IN_OPTIONS: Array<{ value: ScenarioPricedInBucket; label: string }>
   { value: 'OVER_PRICED_IN', label: 'Over-priced in (market over-reacted)' },
 ];
 
-interface StockScenarioForUpsert extends Omit<StockScenario, 'outlookAsOfDate' | 'createdAt' | 'updatedAt'> {
-  outlookAsOfDate: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export default function UpsertStockScenarioModal({ isOpen, onClose, onSuccess, scenarioId }: UpsertStockScenarioModalProps): JSX.Element {
   const [scenarioNumber, setScenarioNumber] = useState<number>(1);
   const [title, setTitle] = useState<string>('');
@@ -118,7 +112,7 @@ export default function UpsertStockScenarioModal({ isOpen, onClose, onSuccess, s
     setLoadingExisting(true);
     fetch(`${getBaseUrl()}/api/stock-scenarios/${scenarioId}`)
       .then((r) => (r.ok ? r.json() : null))
-      .then((data: StockScenarioForUpsert | null) => {
+      .then((data: StockScenario | null) => {
         if (!data) {
           setFormError('Failed to load scenario');
           return;

--- a/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx
@@ -1,0 +1,460 @@
+import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
+import Button from '@dodao/web-core/components/core/buttons/Button';
+import Checkboxes, { CheckboxItem } from '@dodao/web-core/components/core/checkboxes/Checkboxes';
+import Input from '@dodao/web-core/components/core/input/Input';
+import SingleSectionModal from '@dodao/web-core/components/core/modals/SingleSectionModal';
+import TextareaAutosize from '@dodao/web-core/components/core/textarea/TextareaAutosize';
+import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
+import { usePutData } from '@dodao/web-core/ui/hooks/fetch/usePutData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { StockScenario } from '@prisma/client';
+import { Loader2 } from 'lucide-react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+interface UpsertStockScenarioModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  scenarioId?: string;
+}
+
+const DIRECTION_OPTIONS: Array<{ value: ScenarioDirection; label: string }> = [
+  { value: 'DOWNSIDE', label: 'Downside (risk / crash scenario)' },
+  { value: 'UPSIDE', label: 'Upside (rally / boom scenario)' },
+];
+
+const TIMEFRAME_OPTIONS: Array<{ value: ScenarioTimeframe; label: string }> = [
+  { value: 'FUTURE', label: 'Future (hasn’t happened yet)' },
+  { value: 'IN_PROGRESS', label: 'In progress (currently unfolding)' },
+  { value: 'PAST', label: 'Already happened' },
+];
+
+const PROBABILITY_OPTIONS: Array<{ value: ScenarioProbabilityBucket; label: string }> = [
+  { value: 'HIGH', label: 'High (>40%)' },
+  { value: 'MEDIUM', label: 'Medium (20–40%)' },
+  { value: 'LOW', label: 'Low (<20%)' },
+];
+
+const PRICED_IN_OPTIONS: Array<{ value: ScenarioPricedInBucket; label: string }> = [
+  { value: 'NOT_PRICED_IN', label: 'Not priced in (market ignoring)' },
+  { value: 'PARTIALLY_PRICED_IN', label: 'Partially priced in' },
+  { value: 'MOSTLY_PRICED_IN', label: 'Mostly priced in' },
+  { value: 'FULLY_PRICED_IN', label: 'Fully priced in (no edge left)' },
+  { value: 'OVER_PRICED_IN', label: 'Over-priced in (market over-reacted)' },
+];
+
+interface StockScenarioForUpsert extends Omit<StockScenario, 'outlookAsOfDate' | 'createdAt' | 'updatedAt'> {
+  outlookAsOfDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function UpsertStockScenarioModal({ isOpen, onClose, onSuccess, scenarioId }: UpsertStockScenarioModalProps): JSX.Element {
+  const [scenarioNumber, setScenarioNumber] = useState<number>(1);
+  const [title, setTitle] = useState<string>('');
+  const [slug, setSlug] = useState<string>('');
+  const [underlyingCause, setUnderlyingCause] = useState<string>('');
+  const [historicalAnalog, setHistoricalAnalog] = useState<string>('');
+  const [winnersMarkdown, setWinnersMarkdown] = useState<string>('');
+  const [losersMarkdown, setLosersMarkdown] = useState<string>('');
+  const [outlookMarkdown, setOutlookMarkdown] = useState<string>('');
+  const [direction, setDirection] = useState<ScenarioDirection>('DOWNSIDE');
+  const [timeframe, setTimeframe] = useState<ScenarioTimeframe>('FUTURE');
+  const [probabilityBucket, setProbabilityBucket] = useState<ScenarioProbabilityBucket>('MEDIUM');
+  const [probabilityPercentage, setProbabilityPercentage] = useState<string>('');
+  const [pricedInBucket, setPricedInBucket] = useState<ScenarioPricedInBucket>('PARTIALLY_PRICED_IN');
+  const [expectedPriceChange, setExpectedPriceChange] = useState<string>('');
+  const [expectedPriceChangeExplanation, setExpectedPriceChangeExplanation] = useState<string>('');
+  const [priceChangeTimeframeExplanation, setPriceChangeTimeframeExplanation] = useState<string>('');
+  const [countries, setCountries] = useState<SupportedCountries[]>([]);
+  const [outlookAsOfDate, setOutlookAsOfDate] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [metaDescription, setMetaDescription] = useState<string>('');
+  const [archived, setArchived] = useState<boolean>(false);
+  const [formError, setFormError] = useState<string>('');
+  const [loadingExisting, setLoadingExisting] = useState<boolean>(false);
+
+  const isEditMode: boolean = !!scenarioId;
+
+  const { postData, loading: creating } = usePostData<StockScenario, unknown>({
+    successMessage: 'Scenario created successfully!',
+    errorMessage: 'Failed to create scenario',
+  });
+
+  const { putData, loading: updating } = usePutData<StockScenario, unknown>({
+    successMessage: 'Scenario updated successfully!',
+    errorMessage: 'Failed to update scenario',
+  });
+
+  const loading: boolean = creating || updating || loadingExisting;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!scenarioId) {
+      setScenarioNumber(1);
+      setTitle('');
+      setSlug('');
+      setUnderlyingCause('');
+      setHistoricalAnalog('');
+      setWinnersMarkdown('');
+      setLosersMarkdown('');
+      setOutlookMarkdown('');
+      setDirection('DOWNSIDE');
+      setTimeframe('FUTURE');
+      setProbabilityBucket('MEDIUM');
+      setProbabilityPercentage('');
+      setPricedInBucket('PARTIALLY_PRICED_IN');
+      setExpectedPriceChange('');
+      setExpectedPriceChangeExplanation('');
+      setPriceChangeTimeframeExplanation('');
+      setCountries([]);
+      setOutlookAsOfDate(new Date().toISOString().slice(0, 10));
+      setMetaDescription('');
+      setArchived(false);
+      setFormError('');
+      return;
+    }
+
+    setLoadingExisting(true);
+    fetch(`${getBaseUrl()}/api/stock-scenarios/${scenarioId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: StockScenarioForUpsert | null) => {
+        if (!data) {
+          setFormError('Failed to load scenario');
+          return;
+        }
+        setScenarioNumber(data.scenarioNumber);
+        setTitle(data.title);
+        setSlug(data.slug);
+        setUnderlyingCause(data.underlyingCause);
+        setHistoricalAnalog(data.historicalAnalog);
+        setWinnersMarkdown(data.winnersMarkdown);
+        setLosersMarkdown(data.losersMarkdown);
+        setOutlookMarkdown(data.outlookMarkdown);
+        setDirection(data.direction as ScenarioDirection);
+        setTimeframe(data.timeframe as ScenarioTimeframe);
+        setProbabilityBucket(data.probabilityBucket as ScenarioProbabilityBucket);
+        setProbabilityPercentage(typeof data.probabilityPercentage === 'number' ? String(data.probabilityPercentage) : '');
+        setPricedInBucket((data.pricedInBucket as ScenarioPricedInBucket) ?? 'PARTIALLY_PRICED_IN');
+        setExpectedPriceChange(typeof data.expectedPriceChange === 'number' ? String(data.expectedPriceChange) : '');
+        setExpectedPriceChangeExplanation(data.expectedPriceChangeExplanation ?? '');
+        setPriceChangeTimeframeExplanation(data.priceChangeTimeframeExplanation ?? '');
+        setCountries((data.countries ?? []) as SupportedCountries[]);
+        setOutlookAsOfDate(new Date(data.outlookAsOfDate).toISOString().slice(0, 10));
+        setMetaDescription(data.metaDescription ?? '');
+        setArchived(data.archived);
+      })
+      .catch(() => setFormError('Failed to load scenario'))
+      .finally(() => setLoadingExisting(false));
+  }, [isOpen, scenarioId]);
+
+  const archivedItems: CheckboxItem[] = useMemo<CheckboxItem[]>(() => [{ id: 'archived', name: 'archived', label: 'Archived' }], []);
+
+  const countryItems: CheckboxItem[] = useMemo<CheckboxItem[]>(
+    () => ALL_SUPPORTED_COUNTRIES.map((c) => ({ id: c, name: c, label: c })),
+    []
+  );
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+    setFormError('');
+
+    if (!title || !underlyingCause || !historicalAnalog || !winnersMarkdown || !losersMarkdown || !outlookMarkdown) {
+      setFormError('All markdown fields plus title are required.');
+      return;
+    }
+    if (countries.length === 0) {
+      setFormError('Select at least one supported country — scenarios must be scoped to a market.');
+      return;
+    }
+
+    let probabilityPercentageValue: number | null = null;
+    if (probabilityPercentage.trim() !== '') {
+      const n = parseInt(probabilityPercentage, 10);
+      if (isNaN(n) || n < 0 || n > 100) {
+        setFormError('Probability percentage must be an integer between 0 and 100.');
+        return;
+      }
+      probabilityPercentageValue = n;
+    }
+
+    let expectedPriceChangeValue: number | null = null;
+    if (expectedPriceChange.trim() !== '') {
+      const n = parseInt(expectedPriceChange, 10);
+      if (isNaN(n) || n < -100 || n > 100) {
+        setFormError('Expected price change must be an integer between -100 and 100.');
+        return;
+      }
+      expectedPriceChangeValue = n;
+    }
+
+    const payload = {
+      scenarioNumber,
+      title,
+      slug: slug || undefined,
+      underlyingCause,
+      historicalAnalog,
+      winnersMarkdown,
+      losersMarkdown,
+      outlookMarkdown,
+      direction,
+      timeframe,
+      probabilityBucket,
+      probabilityPercentage: probabilityPercentageValue,
+      pricedInBucket,
+      expectedPriceChange: expectedPriceChangeValue,
+      expectedPriceChangeExplanation: expectedPriceChangeExplanation || null,
+      priceChangeTimeframeExplanation: priceChangeTimeframeExplanation || null,
+      countries,
+      outlookAsOfDate: new Date(outlookAsOfDate).toISOString(),
+      metaDescription: metaDescription || null,
+      archived,
+    };
+
+    try {
+      if (isEditMode) {
+        await putData(`/api/stock-scenarios/${scenarioId}`, payload);
+      } else {
+        await postData('/api/stock-scenarios', payload);
+      }
+      onSuccess();
+      onClose();
+    } catch {
+      setFormError(`Failed to ${isEditMode ? 'update' : 'create'} scenario`);
+    }
+  };
+
+  return (
+    <SingleSectionModal open={isOpen} onClose={onClose} title={isEditMode ? 'Edit Scenario' : 'Create Scenario'}>
+      <form onSubmit={handleSubmit} className="space-y-3 text-left mt-3 max-h-[75vh] overflow-y-auto pr-1">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <Input
+            label="Scenario Number"
+            modelValue={scenarioNumber}
+            onUpdate={(v: unknown): void => {
+              const n = typeof v === 'string' ? parseInt(v, 10) : typeof v === 'number' ? v : NaN;
+              if (!isNaN(n)) setScenarioNumber(n);
+            }}
+            required
+          />
+          <div className="md:col-span-2">
+            <Input
+              label="Title"
+              modelValue={title}
+              onUpdate={(v: unknown): void => {
+                if (typeof v === 'string') setTitle(v);
+              }}
+              required
+            />
+          </div>
+        </div>
+
+        <Input
+          label="Slug (leave blank to auto-derive from title)"
+          modelValue={slug}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setSlug(v);
+          }}
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Direction</span>
+            <select
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={direction}
+              onChange={(e) => setDirection(e.target.value as ScenarioDirection)}
+            >
+              {DIRECTION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Timeframe</span>
+            <select
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={timeframe}
+              onChange={(e) => setTimeframe(e.target.value as ScenarioTimeframe)}
+            >
+              {TIMEFRAME_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Probability bucket</span>
+            <select
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={probabilityBucket}
+              onChange={(e) => setProbabilityBucket(e.target.value as ScenarioProbabilityBucket)}
+            >
+              {PROBABILITY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div>
+          <p className="text-sm text-gray-300 mb-1">Countries in scope (at least one required)</p>
+          <Checkboxes
+            items={countryItems}
+            selectedItemIds={countries}
+            onChange={(ids: string[]) => setCountries(ids as SupportedCountries[])}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Precise probability % (optional, 0–100)</span>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={probabilityPercentage}
+              onChange={(e) => setProbabilityPercentage(e.target.value)}
+              placeholder="e.g. 30"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Outlook as-of date</span>
+            <input
+              type="date"
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={outlookAsOfDate}
+              onChange={(e) => setOutlookAsOfDate(e.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Priced in</span>
+            <select
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={pricedInBucket}
+              onChange={(e) => setPricedInBucket(e.target.value as ScenarioPricedInBucket)}
+            >
+              {PRICED_IN_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-gray-300">Expected price change % (average still to move, -100 to 100)</span>
+            <input
+              type="number"
+              min={-100}
+              max={100}
+              className="bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white"
+              value={expectedPriceChange}
+              onChange={(e) => setExpectedPriceChange(e.target.value)}
+              placeholder="e.g. -15"
+            />
+          </label>
+        </div>
+
+        <TextareaAutosize
+          label="Expected price change explanation (markdown; describe the range and the reasoning)"
+          modelValue={expectedPriceChangeExplanation}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setExpectedPriceChangeExplanation(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Price change timeframe explanation (markdown; describe start and end of the move in words)"
+          modelValue={priceChangeTimeframeExplanation}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setPriceChangeTimeframeExplanation(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Underlying cause (markdown)"
+          modelValue={underlyingCause}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setUnderlyingCause(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Historical analog (markdown)"
+          modelValue={historicalAnalog}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setHistoricalAnalog(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Winners (markdown)"
+          modelValue={winnersMarkdown}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setWinnersMarkdown(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Losers (markdown)"
+          modelValue={losersMarkdown}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setLosersMarkdown(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="Outlook (markdown; should include the as-of date, catalysts, and most-exposed stocks)"
+          modelValue={outlookMarkdown}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setOutlookMarkdown(v);
+          }}
+        />
+
+        <TextareaAutosize
+          label="SEO meta description (optional)"
+          modelValue={metaDescription}
+          onUpdate={(v: unknown): void => {
+            if (typeof v === 'string') setMetaDescription(v);
+          }}
+        />
+
+        <Checkboxes
+          items={archivedItems}
+          selectedItemIds={archived ? ['archived'] : []}
+          onChange={(ids: string[]) => setArchived(ids.includes('archived'))}
+          className="mt-1"
+        />
+
+        {formError && <p className="text-red-500 text-sm">{formError}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {isEditMode ? 'Saving…' : 'Creating…'}
+              </>
+            ) : isEditMode ? (
+              'Save Changes'
+            ) : (
+              'Create Scenario'
+            )}
+          </Button>
+        </div>
+      </form>
+    </SingleSectionModal>
+  );
+}

--- a/insights-ui/src/app/admin-v1/stock-scenarios/page.tsx
+++ b/insights-ui/src/app/admin-v1/stock-scenarios/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import AdminNav from '@/app/admin-v1/AdminNav';
+import DeleteConfirmationModal from '@/app/admin-v1/industry-management/DeleteConfirmationModal';
+import type { StockScenarioListingItem, StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import Button from '@dodao/web-core/components/core/buttons/Button';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { useDeleteData } from '@dodao/web-core/ui/hooks/fetch/useDeleteData';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { Download, Pencil, Plus, Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import ImportStockScenariosModal from './ImportStockScenariosModal';
+import ManageLinksModal from './ManageLinksModal';
+import UpsertStockScenarioModal from './UpsertStockScenarioModal';
+
+const PROBABILITY_BADGE: Record<string, string> = {
+  HIGH: 'bg-red-500/15 text-red-300 border-red-500/40',
+  MEDIUM: 'bg-amber-500/15 text-amber-300 border-amber-500/40',
+  LOW: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/40',
+};
+
+const DIRECTION_BADGE: Record<string, string> = {
+  UPSIDE: 'bg-sky-500/15 text-sky-300 border-sky-500/40',
+  DOWNSIDE: 'bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/40',
+};
+
+const TIMEFRAME_BADGE: Record<string, string> = {
+  FUTURE: 'bg-indigo-500/15 text-indigo-300 border-indigo-500/40',
+  IN_PROGRESS: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/40',
+  PAST: 'bg-gray-500/15 text-gray-300 border-gray-500/40',
+};
+
+export default function StockScenariosAdminPage(): JSX.Element {
+  const [showUpsert, setShowUpsert] = useState<boolean>(false);
+  const [selected, setSelected] = useState<StockScenarioListingItem | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+  const [deleteTarget, setDeleteTarget] = useState<StockScenarioListingItem | null>(null);
+  const [showImport, setShowImport] = useState<boolean>(false);
+  const [showLinks, setShowLinks] = useState<boolean>(false);
+  const [linksTarget, setLinksTarget] = useState<StockScenarioListingItem | null>(null);
+
+  const listingUrl = `${getBaseUrl()}/api/${KoalaGainsSpaceId}/stock-scenarios/listing?pageSize=200&includeArchived=true`;
+  const {
+    data: listing,
+    loading: loadingList,
+    reFetchData: refetchList,
+  } = useFetchData<StockScenarioListingResponse>(listingUrl, {}, 'Failed to load stock scenarios');
+
+  const { deleteData: deleteScenario, loading: deleting } = useDeleteData<{ success: boolean }, never>({
+    successMessage: 'Scenario deleted successfully!',
+    errorMessage: 'Failed to delete scenario',
+  });
+
+  const handleEdit = (scenario: StockScenarioListingItem): void => {
+    setSelected(scenario);
+    setShowUpsert(true);
+  };
+
+  const handleManageLinks = (scenario: StockScenarioListingItem): void => {
+    setLinksTarget(scenario);
+    setShowLinks(true);
+  };
+
+  const handleDeleteClick = (scenario: StockScenarioListingItem): void => {
+    setDeleteTarget(scenario);
+    setDeleteOpen(true);
+  };
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (!deleteTarget) return;
+    await deleteScenario(`${getBaseUrl()}/api/stock-scenarios/${deleteTarget.id}`);
+    await refetchList();
+    setDeleteOpen(false);
+    setDeleteTarget(null);
+  };
+
+  const scenarios = listing?.scenarios ?? [];
+
+  return (
+    <PageWrapper>
+      <AdminNav />
+
+      <div className="bg-gray-800 -mx-6 px-6 py-6 mb-6 border-b border-gray-700/60">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Stock Scenarios</h1>
+            <p className="text-gray-300 mt-1">Manage the dated playbook of stock-market scenarios, scoped per country.</p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outlined" onClick={() => refetchList()}>
+              Refresh
+            </Button>
+            <Button variant="outlined" onClick={() => setShowImport(true)}>
+              <Download className="h-4 w-4 mr-1" />
+              Import from doc
+            </Button>
+            <Button
+              onClick={() => {
+                setSelected(null);
+                setShowUpsert(true);
+              }}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Add Scenario
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {loadingList ? (
+        <div className="flex justify-center items-center h-40">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-400" />
+          <span className="ml-3 text-indigo-300">Loading…</span>
+        </div>
+      ) : scenarios.length === 0 ? (
+        <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-8 text-center text-gray-400">
+          No scenarios yet. Use <strong>Import from doc</strong> to bulk-load or <strong>Add Scenario</strong> to create one manually.
+        </div>
+      ) : (
+        <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 overflow-hidden">
+          <table className="w-full text-sm text-left">
+            <thead className="bg-gray-800/60 text-gray-300">
+              <tr>
+                <th className="px-3 py-2">#</th>
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Countries</th>
+                <th className="px-3 py-2">Direction</th>
+                <th className="px-3 py-2">Probability</th>
+                <th className="px-3 py-2">Timeframe</th>
+                <th className="px-3 py-2">As of</th>
+                <th className="px-3 py-2">Archived</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scenarios.map((s) => (
+                <tr key={s.id} className="border-t border-gray-700/50 hover:bg-gray-800/40">
+                  <td className="px-3 py-2 text-gray-400">{s.scenarioNumber}</td>
+                  <td className="px-3 py-2 text-white">
+                    <Link href={`/stock-scenarios/${s.slug}`} className="hover:text-indigo-300" target="_blank">
+                      {s.title}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-gray-300">
+                    <div className="flex flex-wrap gap-1">
+                      {s.countries.map((c) => (
+                        <span key={c} className="text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5">
+                          {c}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className={`inline-block border rounded-full px-2 py-0.5 text-xs ${DIRECTION_BADGE[s.direction] ?? ''}`}>{s.direction}</span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className={`inline-block border rounded-full px-2 py-0.5 text-xs ${PROBABILITY_BADGE[s.probabilityBucket] ?? ''}`}>
+                      {s.probabilityBucket}
+                      {typeof s.probabilityPercentage === 'number' ? ` · ~${s.probabilityPercentage}%` : ''}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className={`inline-block border rounded-full px-2 py-0.5 text-xs ${TIMEFRAME_BADGE[s.timeframe] ?? ''}`}>{s.timeframe}</span>
+                  </td>
+                  <td className="px-3 py-2 text-gray-400">{s.outlookAsOfDate.slice(0, 10)}</td>
+                  <td className="px-3 py-2 text-gray-400">{s.archived ? 'Yes' : 'No'}</td>
+                  <td className="px-3 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button variant="outlined" onClick={() => handleManageLinks(s)}>
+                        Links
+                      </Button>
+                      <Button variant="outlined" onClick={() => handleEdit(s)}>
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button variant="outlined" onClick={() => handleDeleteClick(s)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <UpsertStockScenarioModal
+        isOpen={showUpsert}
+        onClose={() => {
+          setSelected(null);
+          setShowUpsert(false);
+        }}
+        onSuccess={() => refetchList()}
+        scenarioId={selected?.id}
+      />
+
+      <ManageLinksModal
+        isOpen={showLinks}
+        onClose={() => {
+          setLinksTarget(null);
+          setShowLinks(false);
+        }}
+        onSuccess={() => refetchList()}
+        scenarioId={linksTarget?.id}
+        scenarioTitle={linksTarget?.title}
+      />
+
+      <ImportStockScenariosModal isOpen={showImport} onClose={() => setShowImport(false)} onSuccess={() => refetchList()} />
+
+      <DeleteConfirmationModal
+        title="Delete Scenario"
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onDelete={handleConfirmDelete}
+        deleting={deleting}
+        deleteButtonText="Delete Scenario"
+        confirmationText="Archive Me"
+      />
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
@@ -1,0 +1,109 @@
+import { prisma } from '@/prisma';
+import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioRole, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { StockScenario, StockScenarioStockLink } from '@prisma/client';
+import { NextRequest } from 'next/server';
+
+export interface StockScenarioLinkDto {
+  symbol: string;
+  exchange: string;
+  tickerId: string | null;
+  role: ScenarioRole;
+  sortOrder: number;
+  roleExplanation: string | null;
+  expectedPriceChange: number | null;
+  expectedPriceChangeExplanation: string | null;
+}
+
+export interface StockScenarioDetail
+  extends Omit<
+    StockScenario,
+    'outlookAsOfDate' | 'createdAt' | 'updatedAt' | 'direction' | 'timeframe' | 'probabilityBucket' | 'pricedInBucket' | 'countries'
+  > {
+  direction: ScenarioDirection;
+  timeframe: ScenarioTimeframe;
+  probabilityBucket: ScenarioProbabilityBucket;
+  pricedInBucket: ScenarioPricedInBucket;
+  countries: SupportedCountries[];
+  outlookAsOfDate: string;
+  createdAt: string;
+  updatedAt: string;
+  winners: StockScenarioLinkDto[];
+  losers: StockScenarioLinkDto[];
+  mostExposed: StockScenarioLinkDto[];
+}
+
+function toLinkDto(link: StockScenarioStockLink, resolvedTickerId?: string | null): StockScenarioLinkDto {
+  return {
+    symbol: link.symbol,
+    exchange: link.exchange,
+    tickerId: link.tickerId ?? resolvedTickerId ?? null,
+    role: link.role as ScenarioRole,
+    sortOrder: link.sortOrder,
+    roleExplanation: link.roleExplanation,
+    expectedPriceChange: link.expectedPriceChange,
+    expectedPriceChangeExplanation: link.expectedPriceChangeExplanation,
+  };
+}
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string; slug: string }> }): Promise<StockScenarioDetail | null> {
+  const { spaceId, slug } = await context.params;
+  const { searchParams } = new URL(req.url);
+  const allowNull = searchParams.get('allowNull') === 'true';
+
+  const scenario = await prisma.stockScenario.findUnique({
+    where: { spaceId_slug: { spaceId, slug } },
+    include: { stockLinks: { orderBy: { sortOrder: 'asc' } } },
+  });
+
+  if (!scenario) {
+    if (allowNull) return null;
+    throw new Error(`Scenario not found: ${slug}`);
+  }
+
+  const { stockLinks, outlookAsOfDate, createdAt, updatedAt, countries, ...rest } = scenario;
+
+  // Resolve any links that don't have `tickerId` set yet against the TickerV1
+  // table by (symbol, exchange) — matches the unique constraint
+  // `@@unique([spaceId, symbol, exchange])` on tickers_v1.
+  const unresolved = stockLinks
+    .filter((l) => !l.tickerId)
+    .map((l) => ({ symbol: l.symbol.toUpperCase(), exchange: l.exchange.toUpperCase() }));
+
+  const resolved = new Map<string, string>();
+  if (unresolved.length) {
+    const tickers = await prisma.tickerV1.findMany({
+      where: {
+        spaceId,
+        OR: unresolved.map((u) => ({ symbol: u.symbol, exchange: u.exchange })),
+      },
+      select: { id: true, symbol: true, exchange: true },
+    });
+    for (const t of tickers) {
+      resolved.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, t.id);
+    }
+  }
+
+  const mapLink = (l: StockScenarioStockLink) => {
+    const key = `${l.symbol.toUpperCase()}|${l.exchange.toUpperCase()}`;
+    return toLinkDto(l, resolved.get(key));
+  };
+
+  return {
+    ...rest,
+    direction: rest.direction as ScenarioDirection,
+    timeframe: rest.timeframe as ScenarioTimeframe,
+    probabilityBucket: rest.probabilityBucket as ScenarioProbabilityBucket,
+    pricedInBucket: rest.pricedInBucket as ScenarioPricedInBucket,
+    countries: countries as SupportedCountries[],
+    outlookAsOfDate: outlookAsOfDate.toISOString(),
+    createdAt: createdAt.toISOString(),
+    updatedAt: updatedAt.toISOString(),
+    winners: stockLinks.filter((l) => l.role === 'WINNER').map(mapLink),
+    losers: stockLinks.filter((l) => l.role === 'LOSER').map(mapLink),
+    mostExposed: stockLinks.filter((l) => l.role === 'MOST_EXPOSED').map(mapLink),
+  };
+}
+
+export const GET = withErrorHandlingV2<StockScenarioDetail | null>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
@@ -67,9 +67,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   // Resolve any links that don't have `tickerId` set yet against the TickerV1
   // table by (symbol, exchange) — matches the unique constraint
   // `@@unique([spaceId, symbol, exchange])` on tickers_v1.
-  const unresolved = stockLinks
-    .filter((l) => !l.tickerId)
-    .map((l) => ({ symbol: l.symbol.toUpperCase(), exchange: l.exchange.toUpperCase() }));
+  const unresolved = stockLinks.filter((l) => !l.tickerId).map((l) => ({ symbol: l.symbol.toUpperCase(), exchange: l.exchange.toUpperCase() }));
 
   const resolved = new Map<string, string>();
   if (unresolved.length) {

--- a/insights-ui/src/app/api/[spaceId]/stock-scenarios/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/stock-scenarios/listing/route.ts
@@ -1,0 +1,125 @@
+import { prisma } from '@/prisma';
+import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { SupportedCountries, toSupportedCountry } from '@/utils/countryExchangeUtils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { Prisma } from '@prisma/client';
+import { NextRequest } from 'next/server';
+
+const DEFAULT_PAGE_SIZE = 32;
+
+export interface StockScenarioListingItem {
+  id: string;
+  scenarioNumber: number;
+  title: string;
+  slug: string;
+  direction: ScenarioDirection;
+  timeframe: ScenarioTimeframe;
+  probabilityBucket: ScenarioProbabilityBucket;
+  probabilityPercentage: number | null;
+  countries: SupportedCountries[];
+  outlookAsOfDate: string;
+  underlyingCause: string;
+  archived: boolean;
+}
+
+export interface StockScenarioListingResponse {
+  scenarios: StockScenarioListingItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  filtersApplied: boolean;
+}
+
+function isDirection(value: string | null): value is ScenarioDirection {
+  return value === 'UPSIDE' || value === 'DOWNSIDE';
+}
+
+function isTimeframe(value: string | null): value is ScenarioTimeframe {
+  return value === 'FUTURE' || value === 'IN_PROGRESS' || value === 'PAST';
+}
+
+function isProbabilityBucket(value: string | null): value is ScenarioProbabilityBucket {
+  return value === 'HIGH' || value === 'MEDIUM' || value === 'LOW';
+}
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<StockScenarioListingResponse> {
+  const { spaceId } = await context.params;
+  const { searchParams } = new URL(req.url);
+
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+  const pageSize = Math.min(200, Math.max(1, parseInt(searchParams.get('pageSize') || String(DEFAULT_PAGE_SIZE), 10)));
+
+  const directionParam = searchParams.get('direction');
+  const timeframeParam = searchParams.get('timeframe');
+  const bucketParam = searchParams.get('probabilityBucket');
+  const search = searchParams.get('search')?.trim() || null;
+  const includeArchived = searchParams.get('includeArchived') === 'true';
+  const country = toSupportedCountry(searchParams.get('country'));
+
+  const where: Prisma.StockScenarioWhereInput = {
+    spaceId,
+    ...(includeArchived ? {} : { archived: false }),
+  };
+
+  if (isDirection(directionParam)) where.direction = directionParam;
+  if (isTimeframe(timeframeParam)) where.timeframe = timeframeParam;
+  if (isProbabilityBucket(bucketParam)) where.probabilityBucket = bucketParam;
+  if (country) where.countries = { has: country };
+
+  if (search) {
+    where.OR = [{ title: { contains: search, mode: 'insensitive' } }, { underlyingCause: { contains: search, mode: 'insensitive' } }];
+  }
+
+  const filtersApplied = !!directionParam || !!timeframeParam || !!bucketParam || !!search || !!country;
+
+  const [scenarios, totalCount] = await Promise.all([
+    prisma.stockScenario.findMany({
+      where,
+      orderBy: [{ scenarioNumber: 'asc' }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      select: {
+        id: true,
+        scenarioNumber: true,
+        title: true,
+        slug: true,
+        direction: true,
+        timeframe: true,
+        probabilityBucket: true,
+        probabilityPercentage: true,
+        countries: true,
+        outlookAsOfDate: true,
+        underlyingCause: true,
+        archived: true,
+      },
+    }),
+    prisma.stockScenario.count({ where }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  return {
+    scenarios: scenarios.map((s) => ({
+      id: s.id,
+      scenarioNumber: s.scenarioNumber,
+      title: s.title,
+      slug: s.slug,
+      direction: s.direction as ScenarioDirection,
+      timeframe: s.timeframe as ScenarioTimeframe,
+      probabilityBucket: s.probabilityBucket as ScenarioProbabilityBucket,
+      probabilityPercentage: s.probabilityPercentage,
+      countries: s.countries as SupportedCountries[],
+      outlookAsOfDate: s.outlookAsOfDate.toISOString(),
+      underlyingCause: s.underlyingCause,
+      archived: s.archived,
+    })),
+    totalCount,
+    page,
+    pageSize,
+    totalPages,
+    filtersApplied,
+  };
+}
+
+export const GET = withErrorHandlingV2<StockScenarioListingResponse>(getHandler);

--- a/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
@@ -36,10 +36,7 @@ async function postHandler(
   const symbol = body.symbol.toUpperCase();
   const exchange = body.exchange.toUpperCase();
 
-  const mismatches = scenarioLinkCountryMismatch(
-    [{ symbol, exchange }],
-    scenario.countries as SupportedCountries[]
-  );
+  const mismatches = scenarioLinkCountryMismatch([{ symbol, exchange }], scenario.countries as SupportedCountries[]);
   if (mismatches.length) {
     throw new Error(`Link country mismatch: ${serializeLinkMismatches(mismatches)}.`);
   }

--- a/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
@@ -88,6 +88,10 @@ async function postHandler(
   return link;
 }
 
+function isScenarioRole(value: string | null): value is ScenarioRole {
+  return value === 'WINNER' || value === 'LOSER' || value === 'MOST_EXPOSED';
+}
+
 async function deleteHandler(
   request: NextRequest,
   _userContext: DoDaoJwtTokenPayload,
@@ -97,10 +101,10 @@ async function deleteHandler(
   const { searchParams } = new URL(request.url);
   const symbolParam = searchParams.get('symbol');
   const exchangeParam = searchParams.get('exchange');
-  const roleParam = searchParams.get('role') as ScenarioRole | null;
+  const roleParam = searchParams.get('role');
 
-  if (!symbolParam || !exchangeParam || !roleParam) {
-    throw new Error('symbol, exchange, and role query params are required');
+  if (!symbolParam || !exchangeParam || !isScenarioRole(roleParam)) {
+    throw new Error('symbol, exchange, and role (WINNER|LOSER|MOST_EXPOSED) query params are required');
   }
 
   const scenario = await prisma.stockScenario.findUnique({ where: { id: scenarioId } });

--- a/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ScenarioRole } from '@/types/scenarioEnums';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { isExchange, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { scenarioLinkCountryMismatch, serializeLinkMismatches } from '@/utils/scenario-country-validation';
 import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
 import { DoDaoJwtTokenPayload } from '@dodao/web-core/types/auth/Session';
@@ -12,7 +12,13 @@ import { withLoggedInAdmin } from '../../../helpers/withLoggedInAdmin';
 
 const addLinkSchema = z.object({
   symbol: z.string().min(1),
-  exchange: z.string().min(1),
+  // Symbol can be anything non-empty so admins can tag tickers that aren't
+  // in TickerV1 yet (those save with `tickerId: null` and render as plain
+  // text). Exchange must be one of the supported exchanges.
+  exchange: z
+    .string()
+    .min(1)
+    .refine((v) => isExchange(v.toUpperCase()), 'exchange must be one of the supported exchanges'),
   role: z.nativeEnum(ScenarioRole),
   sortOrder: z.number().int().nonnegative().optional(),
   roleExplanation: z.string().nullable().optional(),
@@ -102,6 +108,9 @@ async function deleteHandler(
 
   if (!symbolParam || !exchangeParam || !isScenarioRole(roleParam)) {
     throw new Error('symbol, exchange, and role (WINNER|LOSER|MOST_EXPOSED) query params are required');
+  }
+  if (!isExchange(exchangeParam.toUpperCase())) {
+    throw new Error(`exchange "${exchangeParam}" is not one of the supported exchanges`);
   }
 
   const scenario = await prisma.stockScenario.findUnique({ where: { id: scenarioId } });

--- a/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/[id]/links/route.ts
@@ -1,0 +1,127 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ScenarioRole } from '@/types/scenarioEnums';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { scenarioLinkCountryMismatch, serializeLinkMismatches } from '@/utils/scenario-country-validation';
+import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
+import { DoDaoJwtTokenPayload } from '@dodao/web-core/types/auth/Session';
+import { StockScenarioStockLink } from '@prisma/client';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withLoggedInAdmin } from '../../../helpers/withLoggedInAdmin';
+
+const addLinkSchema = z.object({
+  symbol: z.string().min(1),
+  exchange: z.string().min(1),
+  role: z.nativeEnum(ScenarioRole),
+  sortOrder: z.number().int().nonnegative().optional(),
+  roleExplanation: z.string().nullable().optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
+});
+
+export type AddStockScenarioLinkRequest = z.infer<typeof addLinkSchema>;
+
+async function postHandler(
+  request: NextRequest,
+  _userContext: DoDaoJwtTokenPayload,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<StockScenarioStockLink> {
+  const { id: scenarioId } = await params;
+  const body = addLinkSchema.parse(await request.json());
+
+  const scenario = await prisma.stockScenario.findUnique({ where: { id: scenarioId } });
+  if (!scenario) throw new Error(`Scenario not found: ${scenarioId}`);
+
+  const symbol = body.symbol.toUpperCase();
+  const exchange = body.exchange.toUpperCase();
+
+  const mismatches = scenarioLinkCountryMismatch(
+    [{ symbol, exchange }],
+    scenario.countries as SupportedCountries[]
+  );
+  if (mismatches.length) {
+    throw new Error(`Link country mismatch: ${serializeLinkMismatches(mismatches)}.`);
+  }
+
+  // Resolve `tickerId` via the `@@unique([spaceId, symbol, exchange])` key on
+  // `TickerV1`. Unresolved links still save (tickerId=null) — the UI renders
+  // them as plain text, same pattern as ETF scenarios.
+  const ticker = await prisma.tickerV1.findUnique({
+    where: { spaceId_symbol_exchange: { spaceId: KoalaGainsSpaceId, symbol, exchange } },
+    select: { id: true },
+  });
+
+  const link = await prisma.stockScenarioStockLink.upsert({
+    where: {
+      scenarioId_symbol_exchange_role: {
+        scenarioId,
+        symbol,
+        exchange,
+        role: body.role,
+      },
+    },
+    create: {
+      scenarioId,
+      tickerId: ticker?.id ?? null,
+      symbol,
+      exchange,
+      role: body.role,
+      sortOrder: body.sortOrder ?? 0,
+      roleExplanation: body.roleExplanation ?? null,
+      expectedPriceChange: body.expectedPriceChange ?? null,
+      expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
+      spaceId: KoalaGainsSpaceId,
+    },
+    update: {
+      tickerId: ticker?.id ?? null,
+      sortOrder: body.sortOrder ?? 0,
+      roleExplanation: body.roleExplanation ?? null,
+      expectedPriceChange: body.expectedPriceChange ?? null,
+      expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
+    },
+  });
+
+  revalidateStockScenarioBySlugTag(scenario.slug);
+  revalidateStockScenarioListingTag();
+
+  return link;
+}
+
+async function deleteHandler(
+  request: NextRequest,
+  _userContext: DoDaoJwtTokenPayload,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<{ success: boolean }> {
+  const { id: scenarioId } = await params;
+  const { searchParams } = new URL(request.url);
+  const symbolParam = searchParams.get('symbol');
+  const exchangeParam = searchParams.get('exchange');
+  const roleParam = searchParams.get('role') as ScenarioRole | null;
+
+  if (!symbolParam || !exchangeParam || !roleParam) {
+    throw new Error('symbol, exchange, and role query params are required');
+  }
+
+  const scenario = await prisma.stockScenario.findUnique({ where: { id: scenarioId } });
+  if (!scenario) throw new Error(`Scenario not found: ${scenarioId}`);
+
+  await prisma.stockScenarioStockLink.delete({
+    where: {
+      scenarioId_symbol_exchange_role: {
+        scenarioId,
+        symbol: symbolParam.toUpperCase(),
+        exchange: exchangeParam.toUpperCase(),
+        role: roleParam,
+      },
+    },
+  });
+
+  revalidateStockScenarioBySlugTag(scenario.slug);
+  revalidateStockScenarioListingTag();
+
+  return { success: true };
+}
+
+export const POST = withLoggedInAdmin<StockScenarioStockLink>(postHandler);
+export const DELETE = withLoggedInAdmin<{ success: boolean }>(deleteHandler);

--- a/insights-ui/src/app/api/stock-scenarios/[id]/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/[id]/route.ts
@@ -1,0 +1,117 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsJwtTokenPayload } from '@/types/auth';
+import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
+import { slugifyScenarioTitle } from '@/utils/scenario-slug';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { StockScenario } from '@prisma/client';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAdminOrToken } from '../../helpers/withAdminOrToken';
+
+const updateStockScenarioSchema = z.object({
+  scenarioNumber: z.number().int().positive().optional(),
+  title: z.string().min(3).optional(),
+  slug: z.string().min(3).optional(),
+  underlyingCause: z.string().min(1).optional(),
+  historicalAnalog: z.string().min(1).optional(),
+  winnersMarkdown: z.string().min(1).optional(),
+  losersMarkdown: z.string().min(1).optional(),
+  outlookMarkdown: z.string().min(1).optional(),
+  direction: z.nativeEnum(ScenarioDirection).optional(),
+  timeframe: z.nativeEnum(ScenarioTimeframe).optional(),
+  probabilityBucket: z.nativeEnum(ScenarioProbabilityBucket).optional(),
+  probabilityPercentage: z.number().int().min(0).max(100).nullable().optional(),
+  pricedInBucket: z.nativeEnum(ScenarioPricedInBucket).optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
+  priceChangeTimeframeExplanation: z.string().nullable().optional(),
+  countries: z.array(z.nativeEnum(SupportedCountries)).min(1).optional(),
+  outlookAsOfDate: z
+    .string()
+    .refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date')
+    .optional(),
+  metaDescription: z.string().nullable().optional(),
+  archived: z.boolean().optional(),
+});
+
+export type UpdateStockScenarioRequest = z.infer<typeof updateStockScenarioSchema>;
+
+async function getHandler(_req: NextRequest, { params }: { params: Promise<{ id: string }> }): Promise<StockScenario | null> {
+  const { id } = await params;
+  return prisma.stockScenario.findUnique({ where: { id } });
+}
+
+async function putHandler(
+  request: NextRequest,
+  _userContext: KoalaGainsJwtTokenPayload | null,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<StockScenario> {
+  const { id } = await params;
+  const body = updateStockScenarioSchema.parse(await request.json());
+
+  const existing = await prisma.stockScenario.findUnique({ where: { id } });
+  if (!existing) {
+    throw new Error(`Scenario not found: ${id}`);
+  }
+
+  // Partial update: only touch fields that the caller actually sent.
+  const updated = await prisma.stockScenario.update({
+    where: { id },
+    data: {
+      ...(body.scenarioNumber !== undefined && { scenarioNumber: body.scenarioNumber }),
+      ...(body.title !== undefined && { title: body.title }),
+      ...(body.slug !== undefined && { slug: body.slug.trim() || slugifyScenarioTitle(body.title ?? existing.title) }),
+      ...(body.underlyingCause !== undefined && { underlyingCause: body.underlyingCause }),
+      ...(body.historicalAnalog !== undefined && { historicalAnalog: body.historicalAnalog }),
+      ...(body.winnersMarkdown !== undefined && { winnersMarkdown: body.winnersMarkdown }),
+      ...(body.losersMarkdown !== undefined && { losersMarkdown: body.losersMarkdown }),
+      ...(body.outlookMarkdown !== undefined && { outlookMarkdown: body.outlookMarkdown }),
+      ...(body.direction !== undefined && { direction: body.direction }),
+      ...(body.timeframe !== undefined && { timeframe: body.timeframe }),
+      ...(body.probabilityBucket !== undefined && { probabilityBucket: body.probabilityBucket }),
+      ...(body.probabilityPercentage !== undefined && { probabilityPercentage: body.probabilityPercentage }),
+      ...(body.pricedInBucket !== undefined && { pricedInBucket: body.pricedInBucket }),
+      ...(body.expectedPriceChange !== undefined && { expectedPriceChange: body.expectedPriceChange }),
+      ...(body.expectedPriceChangeExplanation !== undefined && { expectedPriceChangeExplanation: body.expectedPriceChangeExplanation }),
+      ...(body.priceChangeTimeframeExplanation !== undefined && { priceChangeTimeframeExplanation: body.priceChangeTimeframeExplanation }),
+      ...(body.countries !== undefined && { countries: body.countries }),
+      ...(body.outlookAsOfDate !== undefined && { outlookAsOfDate: new Date(body.outlookAsOfDate) }),
+      ...(body.metaDescription !== undefined && { metaDescription: body.metaDescription }),
+      ...(body.archived !== undefined && { archived: body.archived }),
+    },
+  });
+
+  revalidateStockScenarioListingTag();
+  revalidateStockScenarioBySlugTag(existing.slug);
+  if (updated.slug !== existing.slug) {
+    revalidateStockScenarioBySlugTag(updated.slug);
+  }
+
+  return updated;
+}
+
+async function deleteHandler(
+  _request: NextRequest,
+  _userContext: KoalaGainsJwtTokenPayload | null,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<{ success: boolean }> {
+  const { id } = await params;
+
+  const existing = await prisma.stockScenario.findUnique({ where: { id } });
+  if (!existing) {
+    throw new Error(`Scenario not found: ${id}`);
+  }
+
+  await prisma.stockScenario.delete({ where: { id } });
+
+  revalidateStockScenarioListingTag();
+  revalidateStockScenarioBySlugTag(existing.slug);
+
+  return { success: true };
+}
+
+export const GET = withErrorHandlingV2<StockScenario | null>(getHandler);
+export const PUT = withAdminOrToken<StockScenario>(putHandler);
+export const DELETE = withAdminOrToken<{ success: boolean }>(deleteHandler);

--- a/insights-ui/src/app/api/stock-scenarios/import/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/import/route.ts
@@ -1,0 +1,185 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { scenarioLinkCountryMismatch, serializeLinkMismatches } from '@/utils/scenario-country-validation';
+import { parseStockScenariosMarkdown } from '@/utils/stock-scenario-markdown-parser';
+import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
+import { DoDaoJwtTokenPayload } from '@dodao/web-core/types/auth/Session';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withLoggedInAdmin } from '../../helpers/withLoggedInAdmin';
+
+const importScenariosSchema = z.object({
+  markdown: z.string().min(10),
+  fallbackOutlookDate: z.string().optional(),
+});
+
+export type ImportStockScenariosRequest = z.infer<typeof importScenariosSchema>;
+
+export interface ImportStockScenariosResponse {
+  totalParsed: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  resolvedTickers: number;
+  unresolvedTickers: string[];
+  scenarios: Array<{ scenarioNumber: number; title: string; slug: string; action: 'created' | 'updated' | 'skipped'; countries: SupportedCountries[]; note?: string }>;
+}
+
+async function postHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayload): Promise<ImportStockScenariosResponse> {
+  const body = importScenariosSchema.parse(await request.json());
+  const fallbackDate = body.fallbackOutlookDate ? new Date(body.fallbackOutlookDate) : new Date();
+
+  const parsed = parseStockScenariosMarkdown(body.markdown, fallbackDate);
+  if (parsed.length === 0) {
+    throw new Error('No scenarios could be parsed from the provided markdown');
+  }
+
+  // Collect every (symbol, exchange) pair we'll try to resolve to a TickerV1 id.
+  const pairs = Array.from(
+    new Set(parsed.flatMap((s) => s.links.map((l) => `${l.symbol.toUpperCase()}|${l.exchange.toUpperCase()}`)))
+  );
+  const knownTickers = pairs.length
+    ? await prisma.tickerV1.findMany({
+        where: {
+          spaceId: KoalaGainsSpaceId,
+          OR: pairs.map((p) => {
+            const [symbol, exchange] = p.split('|');
+            return { symbol, exchange };
+          }),
+        },
+        select: { id: true, symbol: true, exchange: true },
+      })
+    : [];
+  const tickerIdByKey = new Map<string, string>();
+  for (const t of knownTickers) {
+    tickerIdByKey.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, t.id);
+  }
+
+  const unresolved = new Set<string>();
+  const results: ImportStockScenariosResponse['scenarios'] = [];
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const scenario of parsed) {
+    const countries = scenario.countries;
+    if (countries.length === 0) {
+      skipped++;
+      results.push({
+        scenarioNumber: scenario.scenarioNumber,
+        title: scenario.title,
+        slug: scenario.slug,
+        action: 'skipped',
+        countries,
+        note: 'No countries could be inferred — add an explicit `**Countries:** ...` line or include exchange-qualified tickers.',
+      });
+      continue;
+    }
+
+    const normalizedLinks = scenario.links.map((l) => ({
+      symbol: l.symbol.toUpperCase(),
+      exchange: l.exchange.toUpperCase(),
+      role: l.role,
+      sortOrder: l.sortOrder,
+    }));
+    const mismatches = scenarioLinkCountryMismatch(normalizedLinks, countries);
+    if (mismatches.length) {
+      skipped++;
+      results.push({
+        scenarioNumber: scenario.scenarioNumber,
+        title: scenario.title,
+        slug: scenario.slug,
+        action: 'skipped',
+        countries,
+        note: `Link country mismatch: ${serializeLinkMismatches(mismatches)}`,
+      });
+      continue;
+    }
+
+    const existing = await prisma.stockScenario.findUnique({
+      where: { spaceId_scenarioNumber: { spaceId: KoalaGainsSpaceId, scenarioNumber: scenario.scenarioNumber } },
+    });
+
+    const scenarioData = {
+      scenarioNumber: scenario.scenarioNumber,
+      title: scenario.title,
+      slug: scenario.slug,
+      underlyingCause: scenario.underlyingCause,
+      historicalAnalog: scenario.historicalAnalog,
+      winnersMarkdown: scenario.winnersMarkdown,
+      losersMarkdown: scenario.losersMarkdown,
+      outlookMarkdown: scenario.outlookMarkdown,
+      direction: scenario.direction,
+      timeframe: scenario.timeframe,
+      probabilityBucket: scenario.probabilityBucket,
+      probabilityPercentage: scenario.probabilityPercentage,
+      countries,
+      outlookAsOfDate: scenario.outlookAsOfDate,
+      spaceId: KoalaGainsSpaceId,
+    };
+
+    const saved = await prisma.$transaction(async (tx) => {
+      const row = existing
+        ? await tx.stockScenario.update({ where: { id: existing.id }, data: scenarioData })
+        : await tx.stockScenario.create({ data: scenarioData });
+
+      if (existing) {
+        await tx.stockScenarioStockLink.deleteMany({ where: { scenarioId: row.id } });
+      }
+
+      if (normalizedLinks.length) {
+        await tx.stockScenarioStockLink.createMany({
+          data: normalizedLinks.map((link) => {
+            const key = `${link.symbol}|${link.exchange}`;
+            const resolvedId = tickerIdByKey.get(key);
+            if (!resolvedId) unresolved.add(key);
+            return {
+              scenarioId: row.id,
+              tickerId: resolvedId ?? null,
+              symbol: link.symbol,
+              exchange: link.exchange,
+              role: link.role,
+              sortOrder: link.sortOrder,
+              spaceId: KoalaGainsSpaceId,
+            };
+          }),
+          skipDuplicates: true,
+        });
+      }
+
+      return row;
+    });
+
+    results.push({
+      scenarioNumber: saved.scenarioNumber,
+      title: saved.title,
+      slug: saved.slug,
+      action: existing ? 'updated' : 'created',
+      countries,
+    });
+    if (existing) updated++;
+    else created++;
+
+    revalidateStockScenarioBySlugTag(saved.slug);
+    if (existing && existing.slug !== saved.slug) {
+      revalidateStockScenarioBySlugTag(existing.slug);
+    }
+  }
+
+  revalidateStockScenarioListingTag();
+
+  const resolvedTickers = pairs.filter((p) => tickerIdByKey.has(p)).length;
+
+  return {
+    totalParsed: parsed.length,
+    created,
+    updated,
+    skipped,
+    resolvedTickers,
+    unresolvedTickers: Array.from(unresolved).sort(),
+    scenarios: results,
+  };
+}
+
+export const POST = withLoggedInAdmin<ImportStockScenariosResponse>(postHandler);

--- a/insights-ui/src/app/api/stock-scenarios/import/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/import/route.ts
@@ -23,7 +23,14 @@ export interface ImportStockScenariosResponse {
   skipped: number;
   resolvedTickers: number;
   unresolvedTickers: string[];
-  scenarios: Array<{ scenarioNumber: number; title: string; slug: string; action: 'created' | 'updated' | 'skipped'; countries: SupportedCountries[]; note?: string }>;
+  scenarios: Array<{
+    scenarioNumber: number;
+    title: string;
+    slug: string;
+    action: 'created' | 'updated' | 'skipped';
+    countries: SupportedCountries[];
+    note?: string;
+  }>;
 }
 
 async function postHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayload): Promise<ImportStockScenariosResponse> {
@@ -36,9 +43,7 @@ async function postHandler(request: NextRequest, _userContext: DoDaoJwtTokenPayl
   }
 
   // Collect every (symbol, exchange) pair we'll try to resolve to a TickerV1 id.
-  const pairs = Array.from(
-    new Set(parsed.flatMap((s) => s.links.map((l) => `${l.symbol.toUpperCase()}|${l.exchange.toUpperCase()}`)))
-  );
+  const pairs = Array.from(new Set(parsed.flatMap((s) => s.links.map((l) => `${l.symbol.toUpperCase()}|${l.exchange.toUpperCase()}`))));
   const knownTickers = pairs.length
     ? await prisma.tickerV1.findMany({
         where: {

--- a/insights-ui/src/app/api/stock-scenarios/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/route.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/prisma';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioRole, ScenarioTimeframe } from '@/types/scenarioEnums';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { isExchange, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { scenarioLinkCountryMismatch, serializeLinkMismatches } from '@/utils/scenario-country-validation';
 import { slugifyScenarioTitle } from '@/utils/scenario-slug';
 import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
@@ -37,7 +37,14 @@ const createStockScenarioSchema = z.object({
     .array(
       z.object({
         symbol: z.string().min(1),
-        exchange: z.string().min(1, 'exchange is required on stock scenario links'),
+        // Exchange must be one of the supported exchanges (US/Canada/UK/India/etc.).
+        // The symbol stays free-form so admins can tag tickers that aren't in
+        // TickerV1 yet — those save with `tickerId: null` and render as plain
+        // text in the public detail view.
+        exchange: z
+          .string()
+          .min(1, 'exchange is required on stock scenario links')
+          .refine((v) => isExchange(v.toUpperCase()), 'exchange must be one of the supported exchanges'),
         role: z.nativeEnum(ScenarioRole),
         sortOrder: z.number().int().nonnegative().optional(),
         roleExplanation: z.string().nullable().optional(),

--- a/insights-ui/src/app/api/stock-scenarios/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/route.ts
@@ -62,7 +62,7 @@ async function getHandler(): Promise<StockScenario[]> {
 async function postHandler(
   request: NextRequest,
   _userContext: KoalaGainsJwtTokenPayload | null,
-  _dynamic: { params: Promise<unknown> }
+  _dynamic: { params: Promise<any> }
 ): Promise<StockScenario> {
   const body = createStockScenarioSchema.parse(await request.json());
 
@@ -83,9 +83,9 @@ async function postHandler(
     );
   }
 
-  // Resolve (symbol, exchange) to a TickerV1 id when possible.
-  const lookupKeys = Array.from(new Set(normalizedLinks.map((l) => `${l.symbol}|${l.exchange}`)));
-  const knownTickers = lookupKeys.length
+  // Resolve (symbol, exchange) to a TickerV1 id where we can. Unresolved
+  // pairs still save (tickerId=null) — the UI renders them as plain pills.
+  const knownTickers = normalizedLinks.length
     ? await prisma.tickerV1.findMany({
         where: {
           spaceId: KoalaGainsSpaceId,

--- a/insights-ui/src/app/api/stock-scenarios/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/route.ts
@@ -1,0 +1,165 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsJwtTokenPayload } from '@/types/auth';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioRole, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { scenarioLinkCountryMismatch, serializeLinkMismatches } from '@/utils/scenario-country-validation';
+import { slugifyScenarioTitle } from '@/utils/scenario-slug';
+import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { StockScenario } from '@prisma/client';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAdminOrToken } from '../helpers/withAdminOrToken';
+
+const createStockScenarioSchema = z.object({
+  scenarioNumber: z.number().int().positive(),
+  title: z.string().min(3),
+  slug: z.string().min(3).optional(),
+  underlyingCause: z.string().min(1),
+  historicalAnalog: z.string().min(1),
+  winnersMarkdown: z.string().min(1),
+  losersMarkdown: z.string().min(1),
+  outlookMarkdown: z.string().min(1),
+  direction: z.nativeEnum(ScenarioDirection),
+  timeframe: z.nativeEnum(ScenarioTimeframe),
+  probabilityBucket: z.nativeEnum(ScenarioProbabilityBucket),
+  probabilityPercentage: z.number().int().min(0).max(100).nullable().optional(),
+  pricedInBucket: z.nativeEnum(ScenarioPricedInBucket).optional(),
+  expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+  expectedPriceChangeExplanation: z.string().nullable().optional(),
+  priceChangeTimeframeExplanation: z.string().nullable().optional(),
+  countries: z
+    .array(z.nativeEnum(SupportedCountries))
+    .min(1, 'countries[] must list at least one supported country'),
+  outlookAsOfDate: z.string().refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date'),
+  metaDescription: z.string().nullable().optional(),
+  archived: z.boolean().optional(),
+  links: z
+    .array(
+      z.object({
+        symbol: z.string().min(1),
+        exchange: z.string().min(1, 'exchange is required on stock scenario links'),
+        role: z.nativeEnum(ScenarioRole),
+        sortOrder: z.number().int().nonnegative().optional(),
+        roleExplanation: z.string().nullable().optional(),
+        expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
+        expectedPriceChangeExplanation: z.string().nullable().optional(),
+      })
+    )
+    .optional(),
+});
+
+export type CreateStockScenarioRequest = z.infer<typeof createStockScenarioSchema>;
+
+async function getHandler(): Promise<StockScenario[]> {
+  return prisma.stockScenario.findMany({
+    where: { spaceId: KoalaGainsSpaceId },
+    orderBy: [{ scenarioNumber: 'asc' }],
+  });
+}
+
+async function postHandler(
+  request: NextRequest,
+  _userContext: KoalaGainsJwtTokenPayload | null,
+  _dynamic: { params: Promise<unknown> }
+): Promise<StockScenario> {
+  const body = createStockScenarioSchema.parse(await request.json());
+
+  const slug = body.slug?.trim() || slugifyScenarioTitle(body.title);
+
+  // Validate that every link's exchange is (a) a known exchange and (b) maps
+  // to a country present in scenario.countries[]. Mismatches are aggregated
+  // and returned to the caller so they can fix all of them at once.
+  const normalizedLinks = (body.links ?? []).map((l) => ({
+    ...l,
+    symbol: l.symbol.toUpperCase(),
+    exchange: l.exchange.toUpperCase(),
+  }));
+  const mismatches = scenarioLinkCountryMismatch(normalizedLinks, body.countries);
+  if (mismatches.length) {
+    throw new Error(
+      `Link country mismatch: ${serializeLinkMismatches(mismatches)}. Fix the scenario's countries[] or the link's exchange, then retry.`
+    );
+  }
+
+  // Resolve (symbol, exchange) to a TickerV1 id when possible.
+  const lookupKeys = Array.from(new Set(normalizedLinks.map((l) => `${l.symbol}|${l.exchange}`)));
+  const knownTickers = lookupKeys.length
+    ? await prisma.tickerV1.findMany({
+        where: {
+          spaceId: KoalaGainsSpaceId,
+          OR: normalizedLinks.map((l) => ({ symbol: l.symbol, exchange: l.exchange })),
+        },
+        select: { id: true, symbol: true, exchange: true },
+      })
+    : [];
+  const tickerIdByKey = new Map<string, string>();
+  for (const t of knownTickers) {
+    tickerIdByKey.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, t.id);
+  }
+
+  const commonData = {
+    scenarioNumber: body.scenarioNumber,
+    title: body.title,
+    underlyingCause: body.underlyingCause,
+    historicalAnalog: body.historicalAnalog,
+    winnersMarkdown: body.winnersMarkdown,
+    losersMarkdown: body.losersMarkdown,
+    outlookMarkdown: body.outlookMarkdown,
+    direction: body.direction,
+    timeframe: body.timeframe,
+    probabilityBucket: body.probabilityBucket,
+    probabilityPercentage: body.probabilityPercentage ?? null,
+    pricedInBucket: body.pricedInBucket ?? ScenarioPricedInBucket.PARTIALLY_PRICED_IN,
+    expectedPriceChange: body.expectedPriceChange ?? null,
+    expectedPriceChangeExplanation: body.expectedPriceChangeExplanation ?? null,
+    priceChangeTimeframeExplanation: body.priceChangeTimeframeExplanation ?? null,
+    countries: body.countries,
+    outlookAsOfDate: new Date(body.outlookAsOfDate),
+    metaDescription: body.metaDescription ?? null,
+    archived: body.archived ?? false,
+  };
+
+  const saved = await prisma.$transaction(async (tx) => {
+    const scenario = await tx.stockScenario.upsert({
+      where: { spaceId_slug: { spaceId: KoalaGainsSpaceId, slug } },
+      create: {
+        id: slug,
+        slug,
+        spaceId: KoalaGainsSpaceId,
+        ...commonData,
+      },
+      update: commonData,
+    });
+
+    await tx.stockScenarioStockLink.deleteMany({ where: { scenarioId: scenario.id } });
+
+    if (normalizedLinks.length) {
+      await tx.stockScenarioStockLink.createMany({
+        data: normalizedLinks.map((link, idx) => ({
+          scenarioId: scenario.id,
+          tickerId: tickerIdByKey.get(`${link.symbol}|${link.exchange}`) ?? null,
+          symbol: link.symbol,
+          exchange: link.exchange,
+          role: link.role,
+          sortOrder: link.sortOrder ?? idx,
+          roleExplanation: link.roleExplanation ?? null,
+          expectedPriceChange: link.expectedPriceChange ?? null,
+          expectedPriceChangeExplanation: link.expectedPriceChangeExplanation ?? null,
+          spaceId: KoalaGainsSpaceId,
+        })),
+        skipDuplicates: true,
+      });
+    }
+
+    return scenario;
+  });
+
+  revalidateStockScenarioListingTag();
+  revalidateStockScenarioBySlugTag(saved.slug);
+  return saved;
+}
+
+export const GET = withErrorHandlingV2<StockScenario[]>(getHandler);
+export const POST = withAdminOrToken<StockScenario>(postHandler);

--- a/insights-ui/src/app/api/stock-scenarios/route.ts
+++ b/insights-ui/src/app/api/stock-scenarios/route.ts
@@ -29,9 +29,7 @@ const createStockScenarioSchema = z.object({
   expectedPriceChange: z.number().int().min(-100).max(100).nullable().optional(),
   expectedPriceChangeExplanation: z.string().nullable().optional(),
   priceChangeTimeframeExplanation: z.string().nullable().optional(),
-  countries: z
-    .array(z.nativeEnum(SupportedCountries))
-    .min(1, 'countries[] must list at least one supported country'),
+  countries: z.array(z.nativeEnum(SupportedCountries)).min(1, 'countries[] must list at least one supported country'),
   outlookAsOfDate: z.string().refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date'),
   metaDescription: z.string().nullable().optional(),
   archived: z.boolean().optional(),
@@ -59,11 +57,7 @@ async function getHandler(): Promise<StockScenario[]> {
   });
 }
 
-async function postHandler(
-  request: NextRequest,
-  _userContext: KoalaGainsJwtTokenPayload | null,
-  _dynamic: { params: Promise<any> }
-): Promise<StockScenario> {
+async function postHandler(request: NextRequest, _userContext: KoalaGainsJwtTokenPayload | null, _dynamic: { params: Promise<any> }): Promise<StockScenario> {
   const body = createStockScenarioSchema.parse(await request.json());
 
   const slug = body.slug?.trim() || slugifyScenarioTitle(body.title);
@@ -78,9 +72,7 @@ async function postHandler(
   }));
   const mismatches = scenarioLinkCountryMismatch(normalizedLinks, body.countries);
   if (mismatches.length) {
-    throw new Error(
-      `Link country mismatch: ${serializeLinkMismatches(mismatches)}. Fix the scenario's countries[] or the link's exchange, then retry.`
-    );
+    throw new Error(`Link country mismatch: ${serializeLinkMismatches(mismatches)}. Fix the scenario's countries[] or the link's exchange, then retry.`);
   }
 
   // Resolve (symbol, exchange) to a TickerV1 id where we can. Unresolved

--- a/insights-ui/src/app/stock-scenarios/StockScenariosPageActions.tsx
+++ b/insights-ui/src/app/stock-scenarios/StockScenariosPageActions.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { revalidateStockScenariosListingCache } from '@/utils/cache-actions';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+export default function StockScenariosPageActions() {
+  const router = useRouter();
+
+  const actions: EllipsisDropdownItem[] = [
+    { key: 'manage-scenarios', label: 'Manage Scenarios' },
+    { key: 'revalidate-listing-cache', label: 'Revalidate Scenarios Cache' },
+  ];
+
+  return (
+    <PrivateWrapper>
+      <EllipsisDropdown
+        items={actions}
+        className="px-2 py-2"
+        onSelect={async (key) => {
+          if (key === 'manage-scenarios') {
+            router.push('/admin-v1/stock-scenarios');
+            return;
+          }
+
+          if (key === 'revalidate-listing-cache') {
+            await revalidateStockScenariosListingCache();
+            router.refresh();
+            return;
+          }
+        }}
+      />
+    </PrivateWrapper>
+  );
+}

--- a/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
@@ -1,0 +1,99 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import type { StockScenarioDetail } from '@/app/api/[spaceId]/stock-scenarios/[slug]/route';
+import StockScenarioDetailView from '@/components/stock-scenarios/StockScenarioDetailView';
+import StockScenarioPageLayout from '@/components/stock-scenarios/StockScenarioPageLayout';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { stockScenarioBySlugTag } from '@/utils/stock-scenario-cache-utils';
+import {
+  generateStockScenarioDetailArticleJsonLd,
+  generateStockScenarioDetailBreadcrumbJsonLd,
+  generateStockScenarioDetailMetadata,
+} from '@/utils/stock-scenario-metadata-generators';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+type RouteParams = Promise<Readonly<{ slug: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+async function fetchScenarioBySlug(slug: string): Promise<StockScenarioDetail | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/stock-scenarios/${slug}?allowNull=true`;
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: WEEK_IN_SECONDS, tags: [stockScenarioBySlugTag(slug)] },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as StockScenarioDetail | null;
+  } catch (e) {
+    console.error(`Failed to fetch scenario ${slug}:`, e);
+    return null;
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const { slug } = await params;
+  const scenario = await fetchScenarioBySlug(slug);
+  if (!scenario) {
+    return { title: 'Stock Scenario Not Found | KoalaGains' };
+  }
+  return generateStockScenarioDetailMetadata({
+    title: scenario.title,
+    slug: scenario.slug,
+    probabilityBucket: scenario.probabilityBucket,
+    outlookAsOfDate: scenario.outlookAsOfDate.slice(0, 10),
+    metaDescription: scenario.metaDescription,
+    underlyingCause: scenario.underlyingCause,
+    createdTime: scenario.createdAt,
+    updatedTime: scenario.updatedAt,
+  });
+}
+
+export default async function StockScenarioDetailPage({ params }: { params: RouteParams }) {
+  const { slug } = await params;
+  const scenario = await fetchScenarioBySlug(slug);
+
+  if (!scenario) {
+    notFound();
+  }
+
+  const breadcrumbs = [
+    { name: 'Stocks', href: '/stocks', current: false },
+    { name: 'Scenarios', href: '/stock-scenarios', current: false },
+    { name: scenario.title, href: `/stock-scenarios/${scenario.slug}`, current: true },
+  ];
+
+  return (
+    <StockScenarioPageLayout
+      title={scenario.title}
+      description={`Scenario #${scenario.scenarioNumber} — outlook last reviewed ${scenario.outlookAsOfDate.slice(0, 10)}.`}
+      breadcrumbs={breadcrumbs}
+    >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            generateStockScenarioDetailArticleJsonLd({
+              title: scenario.title,
+              slug: scenario.slug,
+              underlyingCause: scenario.underlyingCause,
+              publishedDate: scenario.createdAt,
+              modifiedDate: scenario.updatedAt,
+            })
+          ),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateStockScenarioDetailBreadcrumbJsonLd({ title: scenario.title, slug: scenario.slug })),
+        }}
+      />
+
+      <StockScenarioDetailView scenario={scenario} />
+    </StockScenarioPageLayout>
+  );
+}

--- a/insights-ui/src/app/stock-scenarios/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/page.tsx
@@ -1,0 +1,71 @@
+import StockScenariosPageActions from '@/app/stock-scenarios/StockScenariosPageActions';
+import { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
+import StockScenarioListingGrid from '@/components/stock-scenarios/StockScenarioListingGrid';
+import StockScenarioPageLayout from '@/components/stock-scenarios/StockScenarioPageLayout';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { STOCK_SCENARIO_LISTING_TAG } from '@/utils/stock-scenario-cache-utils';
+import {
+  generateStockScenarioListingBreadcrumbJsonLd,
+  generateStockScenarioListingItemListJsonLd,
+  generateStockScenarioListingJsonLd,
+  generateStockScenarioListingMetadata,
+} from '@/utils/stock-scenario-metadata-generators';
+
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = 86400; // 24 hours
+
+const DEFAULT_PAGE_SIZE = 200; // dataset should stay under ~100 for the foreseeable future; 200 leaves headroom
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+export const metadata = generateStockScenarioListingMetadata();
+
+async function fetchScenarioListing(): Promise<StockScenarioListingResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/stock-scenarios/listing?pageSize=${DEFAULT_PAGE_SIZE}`;
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: WEEK_IN_SECONDS, tags: [STOCK_SCENARIO_LISTING_TAG] },
+    });
+    if (!res.ok) {
+      console.error(`Failed to fetch stock scenarios listing: HTTP ${res.status}`);
+      return { scenarios: [], totalCount: 0, page: 1, pageSize: DEFAULT_PAGE_SIZE, totalPages: 1, filtersApplied: false };
+    }
+    return (await res.json()) as StockScenarioListingResponse;
+  } catch (e) {
+    console.error('Failed to fetch stock scenarios listing:', e);
+    return { scenarios: [], totalCount: 0, page: 1, pageSize: DEFAULT_PAGE_SIZE, totalPages: 1, filtersApplied: false };
+  }
+}
+
+export default async function StockScenariosPage() {
+  const data = await fetchScenarioListing();
+
+  return (
+    <StockScenarioPageLayout
+      title="Stock Market Scenarios"
+      description="A dated playbook of recurring market scenarios that meaningfully move specific stocks — with winners, losers, historical analogs, and a qualitative probability outlook. Filter by country to narrow in on a single market."
+      rightButton={<StockScenariosPageActions />}
+    >
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateStockScenarioListingJsonLd()) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateStockScenarioListingBreadcrumbJsonLd()) }} />
+      {data.scenarios.length > 0 && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              generateStockScenarioListingItemListJsonLd(
+                data.scenarios.map((s) => ({
+                  slug: s.slug,
+                  title: s.title,
+                  scenarioNumber: s.scenarioNumber,
+                }))
+              )
+            ),
+          }}
+        />
+      )}
+      <StockScenarioListingGrid data={data} />
+    </StockScenarioPageLayout>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioCard.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioCard.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { StockScenarioListingItem } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
+import { StockScenarioDirectionBadge, StockScenarioProbabilityBadge, StockScenarioTimeframeBadge } from './StockScenarioOutlookBadge';
+
+function firstSentence(md: string, maxLen = 160): string {
+  const cleaned = md.replace(/\*\*/g, '').replace(/\s+/g, ' ').trim();
+  const period = cleaned.search(/\.\s+/);
+  const base = period > 0 ? cleaned.slice(0, period + 1) : cleaned;
+  return base.length > maxLen ? base.slice(0, maxLen).replace(/\s+\S*$/, '') + '…' : base;
+}
+
+export default function StockScenarioCard({ scenario }: { scenario: StockScenarioListingItem }): JSX.Element {
+  return (
+    <Link
+      href={`/stock-scenarios/${scenario.slug}`}
+      className="block bg-[#1F2937] border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+    >
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">#{scenario.scenarioNumber}</span>
+        {scenario.archived && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">Archived</span>}
+      </div>
+
+      <div className="flex flex-wrap gap-1.5 mb-2">
+        <StockScenarioDirectionBadge direction={scenario.direction} />
+        <StockScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} />
+        <StockScenarioTimeframeBadge timeframe={scenario.timeframe} />
+      </div>
+
+      {scenario.countries.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {scenario.countries.map((c) => (
+            <span key={c} className="text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5">
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <h3 className="text-white text-base font-medium mb-2 line-clamp-2 min-h-[3rem]">{scenario.title}</h3>
+
+      <p className="text-xs text-gray-400 line-clamp-3 min-h-[3.75rem]">{firstSentence(scenario.underlyingCause)}</p>
+    </Link>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
@@ -1,0 +1,111 @@
+import { StockScenarioDetail } from '@/app/api/[spaceId]/stock-scenarios/[slug]/route';
+import { parseMarkdown } from '@/util/parse-markdown';
+import { directionLabel, pricedInBucketLabel, probabilityBucketLabel, timeframeLabel } from '@/utils/stock-scenario-metadata-generators';
+import StockScenarioLinkColumns from './StockScenarioLinkColumns';
+import { StockScenarioDirectionBadge, StockScenarioProbabilityBadge, StockScenarioTimeframeBadge } from './StockScenarioOutlookBadge';
+
+function renderMarkdown(md: string) {
+  return { __html: parseMarkdown(md) as string };
+}
+
+function formatExpectedPriceChange(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}%`;
+}
+
+export default function StockScenarioDetailView({ scenario }: { scenario: StockScenarioDetail }): JSX.Element {
+  const asOf = scenario.outlookAsOfDate.slice(0, 10);
+  const hasPricingContext =
+    scenario.pricedInBucket || scenario.expectedPriceChange !== null || scenario.expectedPriceChangeExplanation || scenario.priceChangeTimeframeExplanation;
+
+  return (
+    <article className="text-[#E5E7EB]">
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-sm font-bold px-2.5 py-0.5 rounded">
+          Scenario #{scenario.scenarioNumber}
+        </span>
+        <StockScenarioDirectionBadge direction={scenario.direction} />
+        <StockScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} asOfDate={scenario.outlookAsOfDate} />
+        <StockScenarioTimeframeBadge timeframe={scenario.timeframe} />
+      </div>
+      <p className="text-xs text-gray-400 mb-2">
+        {directionLabel(scenario.direction)} · {probabilityBucketLabel(scenario.probabilityBucket)} · {timeframeLabel(scenario.timeframe)} · outlook reviewed{' '}
+        {asOf}
+      </p>
+      {scenario.countries.length > 0 && (
+        <p className="text-xs text-gray-400 mb-4">
+          <span className="uppercase tracking-wide text-[11px] text-gray-500 mr-2">Countries in scope</span>
+          {scenario.countries.map((c) => (
+            <span key={c} className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1">
+              {c}
+            </span>
+          ))}
+        </p>
+      )}
+
+      <h1 className="text-3xl font-bold text-white mb-4">{scenario.title}</h1>
+
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Underlying cause</h2>
+        <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.underlyingCause)} />
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Historical analog</h2>
+        <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.historicalAnalog)} />
+      </section>
+
+      {hasPricingContext && (
+        <section className="mb-6 bg-[#1F2937] border border-[#374151] rounded-lg p-4">
+          <h2 className="text-lg font-semibold text-white mb-3">Priced-in status & expected move</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">How much is already priced in</p>
+              <p className="text-sm text-white font-semibold">{pricedInBucketLabel(scenario.pricedInBucket)}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Expected average price change (still to move)</p>
+              <p className="text-sm text-white font-semibold">{formatExpectedPriceChange(scenario.expectedPriceChange)}</p>
+            </div>
+          </div>
+          {scenario.expectedPriceChangeExplanation && (
+            <div className="mb-3">
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Range & reasoning</p>
+              <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.expectedPriceChangeExplanation)} />
+            </div>
+          )}
+          {scenario.priceChangeTimeframeExplanation && (
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">When the move plays out</p>
+              <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.priceChangeTimeframeExplanation)} />
+            </div>
+          )}
+        </section>
+      )}
+
+      <section className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h2 className="text-lg font-semibold text-emerald-300 mb-2">Winners</h2>
+          <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.winnersMarkdown)} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-red-300 mb-2">Losers</h2>
+          <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.losersMarkdown)} />
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Outlook (as of {asOf})</h2>
+        <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.outlookMarkdown)} />
+      </section>
+
+      <StockScenarioLinkColumns
+        winners={scenario.winners}
+        losers={scenario.losers}
+        mostExposed={scenario.mostExposed}
+        scenarioCountries={scenario.countries}
+      />
+    </article>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
@@ -37,7 +37,10 @@ export default function StockScenarioDetailView({ scenario }: { scenario: StockS
         <p className="text-xs text-gray-400 mb-4">
           <span className="uppercase tracking-wide text-[11px] text-gray-500 mr-2">Countries in scope</span>
           {scenario.countries.map((c) => (
-            <span key={c} className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1">
+            <span
+              key={c}
+              className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1"
+            >
               {c}
             </span>
           ))}
@@ -100,12 +103,7 @@ export default function StockScenarioDetailView({ scenario }: { scenario: StockS
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.outlookMarkdown)} />
       </section>
 
-      <StockScenarioLinkColumns
-        winners={scenario.winners}
-        losers={scenario.losers}
-        mostExposed={scenario.mostExposed}
-        scenarioCountries={scenario.countries}
-      />
+      <StockScenarioLinkColumns winners={scenario.winners} losers={scenario.losers} mostExposed={scenario.mostExposed} scenarioCountries={scenario.countries} />
     </article>
   );
 }

--- a/insights-ui/src/components/stock-scenarios/StockScenarioFiltersBar.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioFiltersBar.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
+
+const DIRECTION_OPTIONS: Array<{ value: ScenarioDirection | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All directions' },
+  { value: 'UPSIDE', label: 'Upside' },
+  { value: 'DOWNSIDE', label: 'Downside' },
+];
+
+const BUCKET_OPTIONS: Array<{ value: ScenarioProbabilityBucket | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All probabilities' },
+  { value: 'HIGH', label: 'High (>40%)' },
+  { value: 'MEDIUM', label: 'Medium (20–40%)' },
+  { value: 'LOW', label: 'Low (<20%)' },
+];
+
+const TIMEFRAME_OPTIONS: Array<{ value: ScenarioTimeframe | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All timeframes' },
+  { value: 'FUTURE', label: 'Future' },
+  { value: 'IN_PROGRESS', label: 'In progress' },
+  { value: 'PAST', label: 'Already happened' },
+];
+
+interface StockScenarioFiltersBarProps {
+  direction: ScenarioDirection | 'ALL';
+  onDirectionChange: (v: ScenarioDirection | 'ALL') => void;
+  bucket: ScenarioProbabilityBucket | 'ALL';
+  onBucketChange: (v: ScenarioProbabilityBucket | 'ALL') => void;
+  timeframe: ScenarioTimeframe | 'ALL';
+  onTimeframeChange: (v: ScenarioTimeframe | 'ALL') => void;
+  country: SupportedCountries | 'ALL';
+  onCountryChange: (v: SupportedCountries | 'ALL') => void;
+  search: string;
+  onSearchChange: (s: string) => void;
+}
+
+const SELECT_CLASSES = 'w-full bg-[#111827] border border-[#374151] rounded px-2 py-1.5 text-sm text-white focus:outline-none focus:border-[#F59E0B]';
+
+export default function StockScenarioFiltersBar({
+  direction,
+  onDirectionChange,
+  bucket,
+  onBucketChange,
+  timeframe,
+  onTimeframeChange,
+  country,
+  onCountryChange,
+  search,
+  onSearchChange,
+}: StockScenarioFiltersBarProps): JSX.Element {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 bg-[#1F2937] border border-[#374151] rounded-lg p-3 mb-4">
+      <label className="flex flex-col gap-1 text-xs text-gray-300">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Country</span>
+        <select className={SELECT_CLASSES} value={country} onChange={(e) => onCountryChange(e.target.value as SupportedCountries | 'ALL')}>
+          <option value="ALL">All countries</option>
+          {ALL_SUPPORTED_COUNTRIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-gray-300">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Direction</span>
+        <select className={SELECT_CLASSES} value={direction} onChange={(e) => onDirectionChange(e.target.value as ScenarioDirection | 'ALL')}>
+          {DIRECTION_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-gray-300">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Probability</span>
+        <select className={SELECT_CLASSES} value={bucket} onChange={(e) => onBucketChange(e.target.value as ScenarioProbabilityBucket | 'ALL')}>
+          {BUCKET_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-gray-300">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Timeframe</span>
+        <select className={SELECT_CLASSES} value={timeframe} onChange={(e) => onTimeframeChange(e.target.value as ScenarioTimeframe | 'ALL')}>
+          {TIMEFRAME_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-gray-300">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Search</span>
+        <input
+          type="search"
+          className={SELECT_CLASSES}
+          placeholder="Filter by title or keyword…"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </label>
+    </div>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
@@ -18,6 +18,13 @@ function LinkPill({ link }: { link: StockScenarioLinkDto }): JSX.Element {
     </span>
   );
 
+  // tickerId === null means the (symbol, exchange) pair isn't in TickerV1 yet —
+  // the public stock detail page would 404 on it. Render as plain text instead
+  // so authors can still tag the ticker and admins can later add it to TickerV1.
+  if (!link.tickerId) {
+    return inner;
+  }
+
   return (
     <Link href={`/stocks/${link.exchange}/${link.symbol}`} className="hover:opacity-80">
       {inner}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { StockScenarioLinkDto } from '@/app/api/[spaceId]/stock-scenarios/[slug]/route';
+import { parseMarkdown } from '@/util/parse-markdown';
+import { AllExchanges, ALL_SUPPORTED_COUNTRIES, EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries } from '@/utils/countryExchangeUtils';
+
+function renderMarkdown(md: string) {
+  return { __html: parseMarkdown(md) as string };
+}
+
+function LinkPill({ link }: { link: StockScenarioLinkDto }): JSX.Element {
+  const inner = (
+    <span className="inline-flex items-center gap-1 bg-[#111827] border border-[#374151] text-xs text-white rounded px-2 py-0.5">
+      <span className="font-semibold">{link.symbol}</span>
+      <span className="text-gray-400">· {link.exchange}</span>
+    </span>
+  );
+
+  return (
+    <Link href={`/stocks/${link.exchange}/${link.symbol}`} className="hover:opacity-80">
+      {inner}
+    </Link>
+  );
+}
+
+function formatExpectedPriceChange(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}%`;
+}
+
+function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
+  const hasDetails = link.roleExplanation || link.expectedPriceChange !== null || link.expectedPriceChangeExplanation;
+  const changeColor = link.expectedPriceChange === null ? '' : link.expectedPriceChange >= 0 ? 'text-emerald-300' : 'text-red-300';
+
+  return (
+    <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <LinkPill link={link} />
+        {link.expectedPriceChange !== null && (
+          <span className={`text-xs font-semibold ${changeColor}`}>{formatExpectedPriceChange(link.expectedPriceChange)}</span>
+        )}
+      </div>
+      {hasDetails && (
+        <div className="space-y-1 mt-1">
+          {link.roleExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-300"
+              dangerouslySetInnerHTML={renderMarkdown(link.roleExplanation)}
+            />
+          )}
+          {link.expectedPriceChangeExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-400"
+              dangerouslySetInnerHTML={renderMarkdown(link.expectedPriceChangeExplanation)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LinkList({
+  title,
+  links,
+  filteredCount,
+  countryFilter,
+  emptyLabel,
+}: {
+  title: string;
+  links: StockScenarioLinkDto[];
+  filteredCount: number;
+  countryFilter: SupportedCountries | 'ALL';
+  emptyLabel: string;
+}): JSX.Element {
+  const anyDetailed = links.some((l) => l.roleExplanation || l.expectedPriceChange !== null || l.expectedPriceChangeExplanation);
+  return (
+    <div>
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300 mb-2">
+        {title}{' '}
+        <span className="text-xs font-normal text-gray-500">
+          ({filteredCount}
+          {countryFilter !== 'ALL' ? ` in ${countryFilter}` : ''})
+        </span>
+      </h3>
+      {links.length === 0 ? (
+        <p className="text-xs text-gray-500">{emptyLabel}</p>
+      ) : anyDetailed ? (
+        <div className="flex flex-col gap-2">
+          {links.map((l) => (
+            <LinkCard key={`${l.symbol}-${l.exchange}-${l.role}`} link={l} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {links.map((l) => (
+            <LinkPill key={`${l.symbol}-${l.exchange}-${l.role}`} link={l} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function countryOfExchange(exchange: string): SupportedCountries | null {
+  if (!isExchange(exchange)) return null;
+  return EXCHANGE_TO_COUNTRY[exchange as AllExchanges];
+}
+
+interface StockScenarioLinkColumnsProps {
+  winners: StockScenarioLinkDto[];
+  losers: StockScenarioLinkDto[];
+  mostExposed: StockScenarioLinkDto[];
+  scenarioCountries: SupportedCountries[];
+}
+
+export default function StockScenarioLinkColumns({ winners, losers, mostExposed, scenarioCountries }: StockScenarioLinkColumnsProps): JSX.Element {
+  const [countryFilter, setCountryFilter] = useState<SupportedCountries | 'ALL'>('ALL');
+
+  // Disable country options that the scenario doesn't cover; the user still
+  // sees the full list so they understand the scope, but can't pick a country
+  // that would hide every link.
+  const scenarioCountrySet = useMemo(() => new Set(scenarioCountries), [scenarioCountries]);
+
+  const filterByCountry = (links: StockScenarioLinkDto[]): StockScenarioLinkDto[] => {
+    if (countryFilter === 'ALL') return links;
+    return links.filter((l) => countryOfExchange(l.exchange) === countryFilter);
+  };
+
+  const filteredWinners = filterByCountry(winners);
+  const filteredLosers = filterByCountry(losers);
+  const filteredMostExposed = filterByCountry(mostExposed);
+
+  return (
+    <section className="bg-[#1F2937] border border-[#374151] rounded-lg p-4 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-white">Tagged stocks</h2>
+        <label className="flex items-center gap-2 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Filter by country</span>
+          <select
+            className="bg-[#111827] border border-[#374151] rounded px-2 py-1 text-xs text-white focus:outline-none focus:border-[#F59E0B]"
+            value={countryFilter}
+            onChange={(e) => setCountryFilter(e.target.value as SupportedCountries | 'ALL')}
+          >
+            <option value="ALL">All countries</option>
+            {ALL_SUPPORTED_COUNTRIES.map((c) => (
+              <option key={c} value={c} disabled={!scenarioCountrySet.has(c)}>
+                {c}
+                {!scenarioCountrySet.has(c) ? ' — not in this scenario' : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <LinkList
+          title="Winners"
+          links={filteredWinners}
+          filteredCount={filteredWinners.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No stocks tagged as winners.' : `No winners listed on ${countryFilter} exchanges.`}
+        />
+        <LinkList
+          title="Losers"
+          links={filteredLosers}
+          filteredCount={filteredLosers.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No stocks tagged as losers.' : `No losers listed on ${countryFilter} exchanges.`}
+        />
+        <LinkList
+          title="Most exposed right now"
+          links={filteredMostExposed}
+          filteredCount={filteredMostExposed.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No stocks tagged as currently most exposed.' : `No most-exposed stocks on ${countryFilter} exchanges.`}
+        />
+      </div>
+    </section>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioListingGrid.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioListingGrid.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
+import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import StockScenarioCard from './StockScenarioCard';
+import StockScenarioFiltersBar from './StockScenarioFiltersBar';
+
+export default function StockScenarioListingGrid({ data }: { data: StockScenarioListingResponse }): JSX.Element | null {
+  const [direction, setDirection] = useState<ScenarioDirection | 'ALL'>('ALL');
+  const [bucket, setBucket] = useState<ScenarioProbabilityBucket | 'ALL'>('ALL');
+  const [timeframe, setTimeframe] = useState<ScenarioTimeframe | 'ALL'>('ALL');
+  const [country, setCountry] = useState<SupportedCountries | 'ALL'>('ALL');
+  const [search, setSearch] = useState<string>('');
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return data.scenarios.filter((s) => {
+      if (direction !== 'ALL' && s.direction !== direction) return false;
+      if (bucket !== 'ALL' && s.probabilityBucket !== bucket) return false;
+      if (timeframe !== 'ALL' && s.timeframe !== timeframe) return false;
+      if (country !== 'ALL' && !s.countries.includes(country)) return false;
+      if (needle) {
+        const hay = `${s.title} ${s.underlyingCause}`.toLowerCase();
+        if (!hay.includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [data.scenarios, direction, bucket, timeframe, country, search]);
+
+  if (data.scenarios.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[#E5E7EB] text-lg">No scenarios yet.</p>
+        <p className="text-[#E5E7EB] text-sm mt-2">An admin can import the stock market-scenarios document to populate this page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <StockScenarioFiltersBar
+        direction={direction}
+        onDirectionChange={setDirection}
+        bucket={bucket}
+        onBucketChange={setBucket}
+        timeframe={timeframe}
+        onTimeframeChange={setTimeframe}
+        country={country}
+        onCountryChange={setCountry}
+        search={search}
+        onSearchChange={setSearch}
+      />
+
+      <div className="flex items-center justify-between mb-4 mt-2">
+        <p className="text-sm text-gray-400">
+          Showing {filtered.length} of {data.totalCount.toLocaleString()} scenario{data.totalCount !== 1 ? 's' : ''}
+          {country !== 'ALL' && <span className="text-gray-500"> · filtered to {country}</span>}
+        </p>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-[#E5E7EB] text-lg">No scenarios match the current filters.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          {filtered.map((s) => (
+            <StockScenarioCard key={s.id} scenario={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioOutlookBadge.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioOutlookBadge.tsx
@@ -1,0 +1,57 @@
+import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+
+const BUCKET_STYLES: Record<ScenarioProbabilityBucket, { label: string; className: string }> = {
+  HIGH: { label: 'High', className: 'bg-red-500/15 text-red-300 border-red-500/40' },
+  MEDIUM: { label: 'Medium', className: 'bg-amber-500/15 text-amber-300 border-amber-500/40' },
+  LOW: { label: 'Low', className: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/40' },
+};
+
+const DIRECTION_STYLES: Record<ScenarioDirection, { label: string; className: string }> = {
+  UPSIDE: { label: 'Upside', className: 'bg-sky-500/15 text-sky-300 border-sky-500/40' },
+  DOWNSIDE: { label: 'Downside', className: 'bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/40' },
+};
+
+const TIMEFRAME_STYLES: Record<ScenarioTimeframe, { label: string; className: string }> = {
+  FUTURE: { label: 'Future', className: 'bg-indigo-500/15 text-indigo-300 border-indigo-500/40' },
+  IN_PROGRESS: { label: 'In progress', className: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/40' },
+  PAST: { label: 'Past', className: 'bg-gray-500/15 text-gray-300 border-gray-500/40' },
+};
+
+export function StockScenarioProbabilityBadge({
+  bucket,
+  percentage,
+  asOfDate,
+}: {
+  bucket: ScenarioProbabilityBucket;
+  percentage?: number | null;
+  asOfDate?: string | null;
+}): JSX.Element {
+  const style = BUCKET_STYLES[bucket];
+  const dateText = asOfDate ? new Date(asOfDate).toISOString().slice(0, 10) : null;
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 border rounded-full px-2.5 py-0.5 text-xs font-medium ${style.className}`}>
+      <span className="uppercase tracking-wide">{style.label}</span>
+      {typeof percentage === 'number' && <span className="text-[10px] opacity-80">~{percentage}%</span>}
+      {dateText && <span className="text-[10px] opacity-70">as of {dateText}</span>}
+    </span>
+  );
+}
+
+export function StockScenarioDirectionBadge({ direction }: { direction: ScenarioDirection }): JSX.Element {
+  const style = DIRECTION_STYLES[direction];
+  return (
+    <span className={`inline-flex items-center border rounded-full px-2.5 py-0.5 text-xs font-medium uppercase tracking-wide ${style.className}`}>
+      {style.label}
+    </span>
+  );
+}
+
+export function StockScenarioTimeframeBadge({ timeframe }: { timeframe: ScenarioTimeframe }): JSX.Element {
+  const style = TIMEFRAME_STYLES[timeframe];
+  return (
+    <span className={`inline-flex items-center border rounded-full px-2.5 py-0.5 text-xs font-medium uppercase tracking-wide ${style.className}`}>
+      {style.label}
+    </span>
+  );
+}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioPageLayout.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioPageLayout.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+
+interface StockScenarioPageLayoutProps {
+  title: string;
+  description: string;
+  breadcrumbs?: BreadcrumbsOjbect[];
+  rightButton?: ReactNode;
+  children: ReactNode;
+}
+
+function defaultBreadcrumbs(): BreadcrumbsOjbect[] {
+  return [
+    { name: 'Stocks', href: '/stocks', current: false },
+    { name: 'Scenarios', href: '/stock-scenarios', current: true },
+  ];
+}
+
+export default function StockScenarioPageLayout({ title, description, breadcrumbs, rightButton, children }: StockScenarioPageLayoutProps) {
+  return (
+    <PageWrapper>
+      <div className="overflow-x-auto">
+        <Breadcrumbs breadcrumbs={breadcrumbs ?? defaultBreadcrumbs()} rightButton={rightButton} />
+      </div>
+
+      <div className="w-full mb-8">
+        <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
+        <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
+      </div>
+
+      {children}
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/scripts/import-stock-scenarios.ts
+++ b/insights-ui/src/scripts/import-stock-scenarios.ts
@@ -1,0 +1,90 @@
+import 'dotenv/config';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseStockScenariosMarkdown, ParsedStockScenario } from '@/utils/stock-scenario-markdown-parser';
+
+// Default markdown location mirrors the ETF script layout. If the seed doc
+// hasn't been created yet, point at it via `SCENARIOS_MD_PATH`.
+const DEFAULT_MARKDOWN_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../docs/ai-knowledge/insights-ui/stock-analysis/stock-market-scenarios.md'
+);
+
+const API_BASE = (process.env.SCENARIOS_API_BASE ?? 'https://koalagains.com').replace(/\/+$/, '');
+const AUTOMATION_SECRET = process.env.AUTOMATION_SECRET ?? '';
+const MARKDOWN_PATH = process.env.SCENARIOS_MD_PATH ?? DEFAULT_MARKDOWN_PATH;
+const FALLBACK_DATE = new Date(process.env.SCENARIOS_FALLBACK_DATE ?? new Date().toISOString().slice(0, 10));
+
+function toRequestBody(s: ParsedStockScenario) {
+  return {
+    scenarioNumber: s.scenarioNumber,
+    title: s.title,
+    slug: s.slug,
+    underlyingCause: s.underlyingCause,
+    historicalAnalog: s.historicalAnalog,
+    winnersMarkdown: s.winnersMarkdown,
+    losersMarkdown: s.losersMarkdown,
+    outlookMarkdown: s.outlookMarkdown,
+    direction: s.direction,
+    timeframe: s.timeframe,
+    probabilityBucket: s.probabilityBucket,
+    probabilityPercentage: s.probabilityPercentage,
+    countries: s.countries,
+    outlookAsOfDate: s.outlookAsOfDate.toISOString(),
+    links: s.links.map((l) => ({ symbol: l.symbol, exchange: l.exchange, role: l.role, sortOrder: l.sortOrder })),
+  };
+}
+
+async function main() {
+  if (!AUTOMATION_SECRET) {
+    throw new Error('AUTOMATION_SECRET is not set — export it or source the discord-claude-bot/.env before running.');
+  }
+
+  console.log(`📄 Reading scenarios from: ${MARKDOWN_PATH}`);
+  const markdown = await readFile(MARKDOWN_PATH, 'utf-8');
+  const scenarios = parseStockScenariosMarkdown(markdown, FALLBACK_DATE);
+  console.log(`✅ Parsed ${scenarios.length} scenarios`);
+
+  if (scenarios.length === 0) {
+    throw new Error('No scenarios parsed — check the markdown file and heading format.');
+  }
+
+  const endpoint = `${API_BASE}/api/stock-scenarios?token=${encodeURIComponent(AUTOMATION_SECRET)}`;
+  console.log(`🎯 Target: ${API_BASE}/api/stock-scenarios (token elided)`);
+
+  let ok = 0;
+  let fail = 0;
+  for (const scenario of scenarios) {
+    const body = toRequestBody(scenario);
+    const label = `#${scenario.scenarioNumber} ${scenario.title}`;
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        fail++;
+        console.error(`❌ ${label} — HTTP ${res.status}: ${text.slice(0, 400)}`);
+        break;
+      }
+      const json = (await res.json()) as { id?: string; slug?: string };
+      ok++;
+      console.log(`✅ ${label} → id=${json.id ?? '?'} slug=${json.slug ?? '?'}`);
+    } catch (err) {
+      fail++;
+      console.error(`❌ ${label} — ${(err as Error).message}`);
+      break;
+    }
+  }
+
+  console.log(`\nDone — ${ok} succeeded, ${fail} failed, ${scenarios.length - ok - fail} skipped.`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/types/etfScenarioEnums.ts
+++ b/insights-ui/src/types/etfScenarioEnums.ts
@@ -1,44 +1,25 @@
-// ETF Scenario enums kept on the TypeScript side only.
-// The database persists these as plain TEXT columns so that adding / removing
-// values does not require a schema migration; zod and callers still get a
-// strict string-literal union via `z.nativeEnum(<const object>)`.
+// Aliases into the shared scenario enum module so ETF-scenario callers keep
+// compiling without changes. New code should import from `./scenarioEnums`
+// directly.
+import {
+  ScenarioDirection,
+  ScenarioPricedInBucket,
+  ScenarioProbabilityBucket,
+  ScenarioRole,
+  ScenarioTimeframe,
+} from './scenarioEnums';
 
-export const EtfScenarioDirection = {
-  UPSIDE: 'UPSIDE',
-  DOWNSIDE: 'DOWNSIDE',
-} as const;
-export type EtfScenarioDirection = (typeof EtfScenarioDirection)[keyof typeof EtfScenarioDirection];
+export const EtfScenarioDirection = ScenarioDirection;
+export type EtfScenarioDirection = ScenarioDirection;
 
-export const EtfScenarioTimeframe = {
-  FUTURE: 'FUTURE',
-  IN_PROGRESS: 'IN_PROGRESS',
-  PAST: 'PAST',
-} as const;
-export type EtfScenarioTimeframe = (typeof EtfScenarioTimeframe)[keyof typeof EtfScenarioTimeframe];
+export const EtfScenarioTimeframe = ScenarioTimeframe;
+export type EtfScenarioTimeframe = ScenarioTimeframe;
 
-export const EtfScenarioProbabilityBucket = {
-  HIGH: 'HIGH',
-  MEDIUM: 'MEDIUM',
-  LOW: 'LOW',
-} as const;
-export type EtfScenarioProbabilityBucket = (typeof EtfScenarioProbabilityBucket)[keyof typeof EtfScenarioProbabilityBucket];
+export const EtfScenarioProbabilityBucket = ScenarioProbabilityBucket;
+export type EtfScenarioProbabilityBucket = ScenarioProbabilityBucket;
 
-// How much of the scenario is already reflected in current ETF prices.
-// Pairs with probabilityPercentage to signal remaining edge: a 50%-probability
-// scenario that is FULLY_PRICED_IN has no actionable edge; a 20%-probability
-// scenario that is NOT_PRICED_IN can still be a strong trade.
-export const EtfScenarioPricedInBucket = {
-  NOT_PRICED_IN: 'NOT_PRICED_IN',
-  PARTIALLY_PRICED_IN: 'PARTIALLY_PRICED_IN',
-  MOSTLY_PRICED_IN: 'MOSTLY_PRICED_IN',
-  FULLY_PRICED_IN: 'FULLY_PRICED_IN',
-  OVER_PRICED_IN: 'OVER_PRICED_IN',
-} as const;
-export type EtfScenarioPricedInBucket = (typeof EtfScenarioPricedInBucket)[keyof typeof EtfScenarioPricedInBucket];
+export const EtfScenarioPricedInBucket = ScenarioPricedInBucket;
+export type EtfScenarioPricedInBucket = ScenarioPricedInBucket;
 
-export const EtfScenarioRole = {
-  WINNER: 'WINNER',
-  LOSER: 'LOSER',
-  MOST_EXPOSED: 'MOST_EXPOSED',
-} as const;
-export type EtfScenarioRole = (typeof EtfScenarioRole)[keyof typeof EtfScenarioRole];
+export const EtfScenarioRole = ScenarioRole;
+export type EtfScenarioRole = ScenarioRole;

--- a/insights-ui/src/types/etfScenarioEnums.ts
+++ b/insights-ui/src/types/etfScenarioEnums.ts
@@ -1,13 +1,7 @@
 // Aliases into the shared scenario enum module so ETF-scenario callers keep
 // compiling without changes. New code should import from `./scenarioEnums`
 // directly.
-import {
-  ScenarioDirection,
-  ScenarioPricedInBucket,
-  ScenarioProbabilityBucket,
-  ScenarioRole,
-  ScenarioTimeframe,
-} from './scenarioEnums';
+import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioRole, ScenarioTimeframe } from './scenarioEnums';
 
 export const EtfScenarioDirection = ScenarioDirection;
 export type EtfScenarioDirection = ScenarioDirection;

--- a/insights-ui/src/types/scenarioEnums.ts
+++ b/insights-ui/src/types/scenarioEnums.ts
@@ -1,0 +1,44 @@
+// Scenario enums shared between ETF and Stock scenario features.
+// The database persists these as plain TEXT columns so that adding / removing
+// values does not require a schema migration; zod and callers still get a
+// strict string-literal union via `z.nativeEnum(<const object>)`.
+
+export const ScenarioDirection = {
+  UPSIDE: 'UPSIDE',
+  DOWNSIDE: 'DOWNSIDE',
+} as const;
+export type ScenarioDirection = (typeof ScenarioDirection)[keyof typeof ScenarioDirection];
+
+export const ScenarioTimeframe = {
+  FUTURE: 'FUTURE',
+  IN_PROGRESS: 'IN_PROGRESS',
+  PAST: 'PAST',
+} as const;
+export type ScenarioTimeframe = (typeof ScenarioTimeframe)[keyof typeof ScenarioTimeframe];
+
+export const ScenarioProbabilityBucket = {
+  HIGH: 'HIGH',
+  MEDIUM: 'MEDIUM',
+  LOW: 'LOW',
+} as const;
+export type ScenarioProbabilityBucket = (typeof ScenarioProbabilityBucket)[keyof typeof ScenarioProbabilityBucket];
+
+// How much of the scenario is already reflected in current prices. Pairs with
+// probabilityPercentage to signal remaining edge: a 50%-probability scenario
+// that is FULLY_PRICED_IN has no actionable edge; a 20%-probability scenario
+// that is NOT_PRICED_IN can still be a strong trade.
+export const ScenarioPricedInBucket = {
+  NOT_PRICED_IN: 'NOT_PRICED_IN',
+  PARTIALLY_PRICED_IN: 'PARTIALLY_PRICED_IN',
+  MOSTLY_PRICED_IN: 'MOSTLY_PRICED_IN',
+  FULLY_PRICED_IN: 'FULLY_PRICED_IN',
+  OVER_PRICED_IN: 'OVER_PRICED_IN',
+} as const;
+export type ScenarioPricedInBucket = (typeof ScenarioPricedInBucket)[keyof typeof ScenarioPricedInBucket];
+
+export const ScenarioRole = {
+  WINNER: 'WINNER',
+  LOSER: 'LOSER',
+  MOST_EXPOSED: 'MOST_EXPOSED',
+} as const;
+export type ScenarioRole = (typeof ScenarioRole)[keyof typeof ScenarioRole];

--- a/insights-ui/src/utils/cache-actions.ts
+++ b/insights-ui/src/utils/cache-actions.ts
@@ -9,6 +9,7 @@ import {
 } from '@/utils/ticker-v1-cache-utils';
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
+import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { PortfolioManagerType } from '@/types/portfolio-manager';
 import { prisma } from '@/prisma';
@@ -62,4 +63,14 @@ export async function revalidateEtfScenariosListingCache() {
 export async function revalidateEtfScenarioCache(slug: string) {
   revalidateEtfScenarioBySlugTag(slug);
   return { success: true, message: `Revalidated ETF scenario cache for ${slug}` };
+}
+
+export async function revalidateStockScenariosListingCache() {
+  revalidateStockScenarioListingTag();
+  return { success: true, message: 'Revalidated Stock scenarios listing cache' };
+}
+
+export async function revalidateStockScenarioCache(slug: string) {
+  revalidateStockScenarioBySlugTag(slug);
+  return { success: true, message: `Revalidated Stock scenario cache for ${slug}` };
 }

--- a/insights-ui/src/utils/etf-scenario-slug.ts
+++ b/insights-ui/src/utils/etf-scenario-slug.ts
@@ -1,8 +1,1 @@
-export function slugifyScenarioTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .trim()
-    .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
-}
+export { slugifyScenarioTitle } from './scenario-slug';

--- a/insights-ui/src/utils/scenario-country-validation.ts
+++ b/insights-ui/src/utils/scenario-country-validation.ts
@@ -1,0 +1,51 @@
+import { AllExchanges, EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries } from '@/utils/countryExchangeUtils';
+
+export interface ScenarioLinkLike {
+  symbol: string;
+  exchange: string;
+}
+
+export interface LinkCountryMismatch {
+  symbol: string;
+  exchange: string;
+  reason: 'UNKNOWN_EXCHANGE' | 'COUNTRY_NOT_IN_SCENARIO';
+  resolvedCountry?: SupportedCountries;
+}
+
+/**
+ * Validate that every link's exchange is a known one AND that the country it
+ * maps to is declared in the scenario's `countries[]`. Returns the list of
+ * mismatches so callers can report every offender in a single error rather
+ * than failing on the first one.
+ *
+ * Callers should upper-case `exchange` before calling; this function does not
+ * do case-folding so it stays a pure validator.
+ */
+export function scenarioLinkCountryMismatch(links: ScenarioLinkLike[], scenarioCountries: SupportedCountries[]): LinkCountryMismatch[] {
+  const allowed = new Set<SupportedCountries>(scenarioCountries);
+  const mismatches: LinkCountryMismatch[] = [];
+
+  for (const link of links) {
+    if (!isExchange(link.exchange)) {
+      mismatches.push({ symbol: link.symbol, exchange: link.exchange, reason: 'UNKNOWN_EXCHANGE' });
+      continue;
+    }
+    const country = EXCHANGE_TO_COUNTRY[link.exchange as AllExchanges];
+    if (!allowed.has(country)) {
+      mismatches.push({ symbol: link.symbol, exchange: link.exchange, reason: 'COUNTRY_NOT_IN_SCENARIO', resolvedCountry: country });
+    }
+  }
+
+  return mismatches;
+}
+
+export function serializeLinkMismatches(mismatches: LinkCountryMismatch[]): string {
+  return mismatches
+    .map((m) => {
+      if (m.reason === 'UNKNOWN_EXCHANGE') {
+        return `${m.symbol} on "${m.exchange}" (unknown exchange)`;
+      }
+      return `${m.symbol} on ${m.exchange} resolves to ${m.resolvedCountry} (not in scenario countries)`;
+    })
+    .join('; ');
+}

--- a/insights-ui/src/utils/scenario-slug.ts
+++ b/insights-ui/src/utils/scenario-slug.ts
@@ -1,0 +1,8 @@
+export function slugifyScenarioTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}

--- a/insights-ui/src/utils/stock-scenario-cache-utils.ts
+++ b/insights-ui/src/utils/stock-scenario-cache-utils.ts
@@ -2,8 +2,7 @@ import { revalidateTag } from 'next/cache';
 
 const STOCK_SCENARIO_TAG_PREFIX = 'stock_scenario:' as const;
 
-export const stockScenarioBySlugTag = (slug: string): `${typeof STOCK_SCENARIO_TAG_PREFIX}${string}` =>
-  `${STOCK_SCENARIO_TAG_PREFIX}_${slug.toLowerCase()}`;
+export const stockScenarioBySlugTag = (slug: string): `${typeof STOCK_SCENARIO_TAG_PREFIX}${string}` => `${STOCK_SCENARIO_TAG_PREFIX}_${slug.toLowerCase()}`;
 
 export const revalidateStockScenarioBySlugTag = (slug: string) => revalidateTag(stockScenarioBySlugTag(slug));
 

--- a/insights-ui/src/utils/stock-scenario-cache-utils.ts
+++ b/insights-ui/src/utils/stock-scenario-cache-utils.ts
@@ -1,0 +1,14 @@
+import { revalidateTag } from 'next/cache';
+
+const STOCK_SCENARIO_TAG_PREFIX = 'stock_scenario:' as const;
+
+export const stockScenarioBySlugTag = (slug: string): `${typeof STOCK_SCENARIO_TAG_PREFIX}${string}` =>
+  `${STOCK_SCENARIO_TAG_PREFIX}_${slug.toLowerCase()}`;
+
+export const revalidateStockScenarioBySlugTag = (slug: string) => revalidateTag(stockScenarioBySlugTag(slug));
+
+export const STOCK_SCENARIO_LISTING_TAG = 'stock_scenario_listing' as const;
+
+export const getStockScenarioListingTag = (): string => STOCK_SCENARIO_LISTING_TAG;
+
+export const revalidateStockScenarioListingTag = () => revalidateTag(STOCK_SCENARIO_LISTING_TAG);

--- a/insights-ui/src/utils/stock-scenario-markdown-parser.ts
+++ b/insights-ui/src/utils/stock-scenario-markdown-parser.ts
@@ -1,5 +1,5 @@
 import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
-import { EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries, toSupportedCountry } from '@/utils/countryExchangeUtils';
+import { AllExchanges, EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries, toSupportedCountry } from '@/utils/countryExchangeUtils';
 import { slugifyScenarioTitle } from '@/utils/scenario-slug';
 
 export interface ParsedStockScenarioLink {
@@ -140,7 +140,7 @@ function inferCountriesFromLinks(links: ParsedStockScenarioLink[]): SupportedCou
   const out: SupportedCountries[] = [];
   for (const link of links) {
     if (!isExchange(link.exchange)) continue;
-    const country = EXCHANGE_TO_COUNTRY[link.exchange];
+    const country = EXCHANGE_TO_COUNTRY[link.exchange as AllExchanges];
     if (!seen.has(country)) {
       seen.add(country);
       out.push(country);

--- a/insights-ui/src/utils/stock-scenario-markdown-parser.ts
+++ b/insights-ui/src/utils/stock-scenario-markdown-parser.ts
@@ -1,0 +1,234 @@
+import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries, toSupportedCountry } from '@/utils/countryExchangeUtils';
+import { slugifyScenarioTitle } from '@/utils/scenario-slug';
+
+export interface ParsedStockScenarioLink {
+  symbol: string;
+  exchange: string;
+  role: 'WINNER' | 'LOSER' | 'MOST_EXPOSED';
+  sortOrder: number;
+}
+
+export interface ParsedStockScenario {
+  scenarioNumber: number;
+  title: string;
+  slug: string;
+  underlyingCause: string;
+  historicalAnalog: string;
+  winnersMarkdown: string;
+  losersMarkdown: string;
+  outlookMarkdown: string;
+  direction: ScenarioDirection;
+  timeframe: ScenarioTimeframe;
+  probabilityBucket: ScenarioProbabilityBucket;
+  probabilityPercentage: number | null;
+  countries: SupportedCountries[];
+  outlookAsOfDate: Date;
+  links: ParsedStockScenarioLink[];
+}
+
+// Stock markdown must qualify every ticker as `EXCHANGE:SYMBOL` so a parser
+// can disambiguate across markets. Bare tokens are NOT extracted as tickers —
+// non-US markets have too many "all caps" collisions (country codes, sector
+// tags, role labels) to make heuristics reliable.
+const QUALIFIED_TICKER_PATTERN = /\b([A-Z]{2,10}):([A-Z0-9.\-]{1,10})\b/g;
+
+function extractQualifiedTickers(text: string): Array<{ symbol: string; exchange: string }> {
+  const out: Array<{ symbol: string; exchange: string }> = [];
+  const seen = new Set<string>();
+  for (const m of text.matchAll(QUALIFIED_TICKER_PATTERN)) {
+    const exchange = m[1];
+    const symbol = m[2];
+    if (!isExchange(exchange)) continue;
+    const key = `${symbol}|${exchange}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ symbol, exchange });
+  }
+  return out;
+}
+
+function classifyProbabilityBucket(outlook: string, extractedPercentage: number | null): ScenarioProbabilityBucket {
+  if (extractedPercentage !== null) {
+    if (extractedPercentage > 40) return 'HIGH';
+    if (extractedPercentage >= 20) return 'MEDIUM';
+    return 'LOW';
+  }
+  const lower = outlook.toLowerCase();
+  if (/\bhigh probability\b/i.test(outlook)) return 'HIGH';
+  if (/\bmedium probability\b/i.test(outlook)) return 'MEDIUM';
+  if (/\blow probability\b/i.test(outlook)) return 'LOW';
+  if (/>\s*40\s*%|above 40\s*%/.test(lower)) return 'HIGH';
+  if (/20\s*[–-]\s*40\s*%|20\s*-\s*40\s*%/.test(lower)) return 'MEDIUM';
+  if (/<\s*20\s*%|below 20\s*%/.test(lower)) return 'LOW';
+  return 'MEDIUM';
+}
+
+function classifyTimeframe(outlook: string): ScenarioTimeframe {
+  if (/already (happened|absorbed|priced|played)/i.test(outlook) || /played out in full|fully played out/i.test(outlook)) return 'PAST';
+  if (/in progress|late-stage|currently (ongoing|underway)|ongoing/i.test(outlook)) return 'IN_PROGRESS';
+  return 'FUTURE';
+}
+
+function classifyDirection(title: string, winners: string, losers: string): ScenarioDirection {
+  const lowerTitle = title.toLowerCase();
+  const UPSIDE_KEYWORDS = ['boom', 'rally', 'surge', 'breakout', 'outperform', 'bull run'];
+  const DOWNSIDE_KEYWORDS = ['crash', 'crisis', 'shock', 'rout', 'stagnation', 'collapse', 'bust', 'selloff', 'sell-off', 'downturn', 'contagion'];
+
+  for (const kw of DOWNSIDE_KEYWORDS) {
+    if (lowerTitle.includes(kw)) return 'DOWNSIDE';
+  }
+  for (const kw of UPSIDE_KEYWORDS) {
+    if (lowerTitle.includes(kw)) return 'UPSIDE';
+  }
+
+  const winnersCount = (winners.match(QUALIFIED_TICKER_PATTERN) ?? []).length;
+  const losersCount = (losers.match(QUALIFIED_TICKER_PATTERN) ?? []).length;
+  if (losersCount > winnersCount + 2) return 'DOWNSIDE';
+  if (winnersCount > losersCount + 2) return 'UPSIDE';
+  return 'DOWNSIDE';
+}
+
+function extractProbabilityPercentage(outlook: string): number | null {
+  const rangeMatch = outlook.match(/~?\s*(\d{1,3})\s*[-–]\s*(\d{1,3})\s*%/);
+  if (rangeMatch) {
+    const a = parseInt(rangeMatch[1], 10);
+    const b = parseInt(rangeMatch[2], 10);
+    return Math.round((a + b) / 2);
+  }
+  const pointMatch = outlook.match(/~?\s*(\d{1,3})\s*%/);
+  if (pointMatch) return parseInt(pointMatch[1], 10);
+  return null;
+}
+
+function extractOutlookDate(text: string): Date | null {
+  const m = text.match(/as of\s+(\d{4}-\d{2}-\d{2})/i);
+  if (!m) return null;
+  const d = new Date(m[1]);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function extractField(block: string, label: string): string {
+  const re = new RegExp(`\\*\\*${label}[^*]*?\\*\\*:?\\s*([\\s\\S]*?)(?=\\n\\*\\*|$)`, 'i');
+  const match = block.match(re);
+  return match ? match[1].trim() : '';
+}
+
+/**
+ * Parse a `Countries:` line — explicit or inside an outlook / header block —
+ * into a SupportedCountries[]. Returns an empty array when nothing parseable
+ * is found; callers fall back to inferring from the links' exchanges.
+ */
+function extractCountries(block: string): SupportedCountries[] {
+  const m = block.match(/\*\*Countries[^*]*?\*\*:?\s*([^\n]+)/i);
+  if (!m) return [];
+  const parts = m[1].split(/[,;]/).map((p) => p.trim());
+  const out: SupportedCountries[] = [];
+  const seen = new Set<SupportedCountries>();
+  for (const p of parts) {
+    const c = toSupportedCountry(p);
+    if (c && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+function inferCountriesFromLinks(links: ParsedStockScenarioLink[]): SupportedCountries[] {
+  const seen = new Set<SupportedCountries>();
+  const out: SupportedCountries[] = [];
+  for (const link of links) {
+    if (!isExchange(link.exchange)) continue;
+    const country = EXCHANGE_TO_COUNTRY[link.exchange];
+    if (!seen.has(country)) {
+      seen.add(country);
+      out.push(country);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse the stock scenarios markdown document into a structured array. The
+ * expected heading shape matches the ETF parser (`### 1. Title`), so editors
+ * can copy the ETF doc conventions over.
+ */
+export function parseStockScenariosMarkdown(raw: string, fallbackOutlookDate: Date): ParsedStockScenario[] {
+  const scenarios: ParsedStockScenario[] = [];
+  const chunks = raw.split(/\n-{3,}\n/);
+
+  for (const chunk of chunks) {
+    const trimmed = chunk.trim();
+    if (!trimmed) continue;
+
+    const headingMatch = trimmed.match(/^###\s+(\d+)\.\s+(.+?)\s*$/m);
+    if (!headingMatch) continue;
+
+    const scenarioNumber = parseInt(headingMatch[1], 10);
+    const title = headingMatch[2].trim();
+
+    const bodyStart = trimmed.indexOf('\n', trimmed.indexOf(headingMatch[0])) + 1;
+    const body = trimmed.slice(bodyStart).trim();
+
+    const underlyingCause = extractField(body, 'Underlying cause');
+    const historicalAnalog = extractField(body, 'Historical analog');
+    const winnersMarkdown = extractField(body, 'Winners');
+    const losersMarkdown = extractField(body, 'Losers');
+    const outlookMarkdown = extractField(body, 'Outlook');
+
+    if (!underlyingCause || !outlookMarkdown) continue;
+
+    const probabilityPercentage = extractProbabilityPercentage(outlookMarkdown);
+    const probabilityBucket = classifyProbabilityBucket(outlookMarkdown, probabilityPercentage);
+    const timeframe = classifyTimeframe(outlookMarkdown);
+    const direction = classifyDirection(title, winnersMarkdown, losersMarkdown);
+    const outlookAsOfDate = extractOutlookDate(body) ?? extractOutlookDate(outlookMarkdown) ?? fallbackOutlookDate;
+
+    const winnersRefs = extractQualifiedTickers(winnersMarkdown);
+    const losersRefs = extractQualifiedTickers(losersMarkdown);
+
+    let mostExposedRefs: Array<{ symbol: string; exchange: string }> = [];
+    const mostExposedMatch = outlookMarkdown.match(/\*\*Most exposed[^*]*?\*\*:?\s*([\s\S]*?)$/i);
+    if (mostExposedMatch) {
+      mostExposedRefs = extractQualifiedTickers(mostExposedMatch[1]);
+    }
+
+    const links: ParsedStockScenarioLink[] = [
+      ...winnersRefs.map((r, i) => ({ ...r, role: 'WINNER' as const, sortOrder: i })),
+      ...losersRefs.map((r, i) => ({ ...r, role: 'LOSER' as const, sortOrder: i })),
+      ...mostExposedRefs.map((r, i) => ({ ...r, role: 'MOST_EXPOSED' as const, sortOrder: i })),
+    ];
+
+    const seen = new Set<string>();
+    const deduped = links.filter((l) => {
+      const key = `${l.symbol}|${l.exchange}|${l.role}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    const explicitCountries = extractCountries(body);
+    const countries = explicitCountries.length ? explicitCountries : inferCountriesFromLinks(deduped);
+
+    scenarios.push({
+      scenarioNumber,
+      title,
+      slug: slugifyScenarioTitle(title),
+      underlyingCause,
+      historicalAnalog,
+      winnersMarkdown,
+      losersMarkdown,
+      outlookMarkdown,
+      direction,
+      timeframe,
+      probabilityBucket,
+      probabilityPercentage,
+      countries,
+      outlookAsOfDate,
+      links: deduped,
+    });
+  }
+
+  return scenarios;
+}

--- a/insights-ui/src/utils/stock-scenario-metadata-generators.ts
+++ b/insights-ui/src/utils/stock-scenario-metadata-generators.ts
@@ -56,7 +56,8 @@ export function generateStockScenarioListingJsonLd() {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: 'Stock Market Scenarios — Sector Shock Playbook',
-    description: 'Recurring market scenarios that move specific stock baskets, with winners, losers, and dated probability outlooks across supported countries.',
+    description:
+      'Recurring market scenarios that move specific stock baskets, with winners, losers, and dated probability outlooks across supported countries.',
     url: `${BASE_URL}/stock-scenarios`,
     publisher: {
       '@type': 'Organization',

--- a/insights-ui/src/utils/stock-scenario-metadata-generators.ts
+++ b/insights-ui/src/utils/stock-scenario-metadata-generators.ts
@@ -1,0 +1,250 @@
+import { Metadata } from 'next';
+
+const SITE_NAME = 'KoalaGains';
+const BASE_URL = 'https://koalagains.com';
+const LOGO_URL = `${BASE_URL}/koalagain_logo.png`;
+
+function truncateForMeta(text: string, maxLength: number = 155): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength).replace(/\s+\S*$/, '') + '…';
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// Stock Scenarios Listing (/stock-scenarios)
+// ────────────────────────────────────────────────────────────────────────────────
+
+export function generateStockScenarioListingMetadata(): Metadata {
+  const title = `Stock Market Scenarios — Sector Shock Playbook (Global) | ${SITE_NAME}`;
+  const description =
+    'Recurring market scenarios that move specific stock baskets — tech corrections, oil shocks, rate-cycle moves, regional stresses. Filter by country to see winners, losers, and most-exposed tickers on that market.';
+  const url = `${BASE_URL}/stock-scenarios`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    keywords: [
+      'stock scenarios',
+      'sector shock analysis',
+      'stock winners and losers',
+      'market scenarios',
+      'sector rotation',
+      'stock outlook',
+      'recession stocks',
+      'inflation stocks',
+      'rate cycle stocks',
+      'global stock analysis',
+      SITE_NAME,
+    ],
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}
+
+export function generateStockScenarioListingJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Stock Market Scenarios — Sector Shock Playbook',
+    description: 'Recurring market scenarios that move specific stock baskets, with winners, losers, and dated probability outlooks across supported countries.',
+    url: `${BASE_URL}/stock-scenarios`,
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: BASE_URL,
+      logo: { '@type': 'ImageObject', url: LOGO_URL },
+    },
+  };
+}
+
+export function generateStockScenarioListingBreadcrumbJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: BASE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Stock Scenarios', item: `${BASE_URL}/stock-scenarios` },
+    ],
+  };
+}
+
+export function generateStockScenarioListingItemListJsonLd(items: Array<{ slug: string; title: string; scenarioNumber: number }>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: items.map((item, idx) => ({
+      '@type': 'ListItem',
+      position: idx + 1,
+      url: `${BASE_URL}/stock-scenarios/${item.slug}`,
+      name: `${item.scenarioNumber}. ${item.title}`,
+    })),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// Stock Scenario Detail (/stock-scenarios/[slug])
+// ────────────────────────────────────────────────────────────────────────────────
+
+interface StockScenarioDetailMetadataInput {
+  title: string;
+  slug: string;
+  probabilityBucket: string;
+  outlookAsOfDate: string;
+  metaDescription?: string | null;
+  underlyingCause: string;
+  createdTime?: string;
+  updatedTime?: string;
+}
+
+export function generateStockScenarioDetailMetadata({
+  title,
+  slug,
+  probabilityBucket,
+  outlookAsOfDate,
+  metaDescription,
+  underlyingCause,
+  createdTime,
+  updatedTime,
+}: StockScenarioDetailMetadataInput): Metadata {
+  const year = new Date().getFullYear();
+  const canonicalUrl = `${BASE_URL}/stock-scenarios/${slug}`;
+  const bucketLabel = probabilityBucketLabel(probabilityBucket);
+
+  const description =
+    metaDescription?.trim() ||
+    truncateForMeta(
+      `${title} — stock scenario analysis: ${underlyingCause.replace(/\*\*/g, '').replace(/\n+/g, ' ')}. Probability ${bucketLabel} as of ${outlookAsOfDate}.`
+    );
+
+  return {
+    title: `${title} — Stock Scenario Analysis (${year}) | ${SITE_NAME}`,
+    description,
+    alternates: { canonical: canonicalUrl },
+    keywords: [title, `${title} stocks`, `${title} winners`, `${title} losers`, 'stock scenarios', 'sector rotation', 'market scenario analysis', SITE_NAME],
+    openGraph: {
+      title: `${title} — Stock Scenario Analysis | ${SITE_NAME}`,
+      description,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      type: 'article',
+      publishedTime: createdTime ?? updatedTime,
+      modifiedTime: updatedTime ?? createdTime,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} — Stock Scenario Analysis | ${SITE_NAME}`,
+      description,
+    },
+  };
+}
+
+export function generateStockScenarioDetailArticleJsonLd({
+  title,
+  slug,
+  underlyingCause,
+  publishedDate,
+  modifiedDate,
+}: {
+  title: string;
+  slug: string;
+  underlyingCause: string;
+  publishedDate: string;
+  modifiedDate: string;
+}) {
+  const canonicalUrl = `${BASE_URL}/stock-scenarios/${slug}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${title} — Stock Scenario Analysis`,
+    description: truncateForMeta(underlyingCause.replace(/\*\*/g, '').replace(/\n+/g, ' '), 300),
+    image: [LOGO_URL],
+    datePublished: publishedDate,
+    dateModified: modifiedDate,
+    author: { '@type': 'Organization', name: SITE_NAME, url: BASE_URL },
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: BASE_URL,
+      logo: { '@type': 'ImageObject', url: LOGO_URL, width: 600, height: 60 },
+    },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
+    articleSection: 'Stock Scenarios',
+  };
+}
+
+export function generateStockScenarioDetailBreadcrumbJsonLd({ title, slug }: { title: string; slug: string }) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: BASE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Stock Scenarios', item: `${BASE_URL}/stock-scenarios` },
+      { '@type': 'ListItem', position: 3, name: title, item: `${BASE_URL}/stock-scenarios/${slug}` },
+    ],
+  };
+}
+
+export function probabilityBucketLabel(bucket: string): string {
+  switch (bucket) {
+    case 'HIGH':
+      return 'High (>40%)';
+    case 'MEDIUM':
+      return 'Medium (20–40%)';
+    case 'LOW':
+      return 'Low (<20%)';
+    default:
+      return bucket;
+  }
+}
+
+export function directionLabel(direction: string): string {
+  switch (direction) {
+    case 'UPSIDE':
+      return 'Upside';
+    case 'DOWNSIDE':
+      return 'Downside';
+    default:
+      return direction;
+  }
+}
+
+export function timeframeLabel(timeframe: string): string {
+  switch (timeframe) {
+    case 'FUTURE':
+      return 'Future';
+    case 'IN_PROGRESS':
+      return 'In progress';
+    case 'PAST':
+      return 'Already happened';
+    default:
+      return timeframe;
+  }
+}
+
+export function pricedInBucketLabel(bucket: string): string {
+  switch (bucket) {
+    case 'NOT_PRICED_IN':
+      return 'Not priced in';
+    case 'PARTIALLY_PRICED_IN':
+      return 'Partially priced in';
+    case 'MOSTLY_PRICED_IN':
+      return 'Mostly priced in';
+    case 'FULLY_PRICED_IN':
+      return 'Fully priced in';
+    case 'OVER_PRICED_IN':
+      return 'Over-priced in';
+    default:
+      return bucket;
+  }
+}

--- a/tasks/koala-gains/stock-scenarios.md
+++ b/tasks/koala-gains/stock-scenarios.md
@@ -70,11 +70,16 @@ Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `E
   tickers instead of ETFs:
   - `id`, `scenarioId`, `tickerKey` (nullable String — the existing ticker identity in
     `TickerV1` / stock tables; confirm the correct FK field name before writing the
-    migration), `symbol`, `exchange` (nullable), `role`, `sortOrder`
+    migration), `symbol`, `exchange` (**non-null for stocks** — see multi-exchange note
+    below), `role`, `sortOrder`
   - `roleExplanation`, `expectedPriceChange`, `expectedPriceChangeExplanation`
   - `spaceId`, `createdAt`, `updatedAt`
   - Relation back to `StockScenario` with `onDelete: Cascade`
-  - `@@unique([scenarioId, symbol, role])`, `@@index([scenarioId])`, `@@index([symbol])`
+  - **Uniqueness differs from ETFs**: use `@@unique([scenarioId, symbol, exchange, role])`
+    (ETFs use `(scenarioId, symbol, role)`). The same symbol can legally appear on two
+    exchanges in different countries — e.g. Unilever (`ULVR` on LSE + `UN` on NYSE) — and
+    we need to allow both rows without collision.
+  - `@@index([scenarioId])`, `@@index([symbol])`, `@@index([symbol, exchange])`
   - `@@map("stock_scenario_stock_links")`
 - [ ] **Back-ref on the stock model** — add `scenarioLinks StockScenarioStockLink[]` to
   whichever model represents a tradable stock ticker today (verify: `TickerV1`, `Ticker`,
@@ -135,6 +140,14 @@ use the **same values**.
   diverge over time and force double-maintenance.
 - [ ] Country values stay in `countryExchangeUtils.ts` (`SupportedCountries` enum). Do not
   duplicate into the scenarios enum module — import from the utils file everywhere.
+- [ ] **Label helpers** — `src/utils/etf-scenario-metadata-generators.ts` currently exports
+  `directionLabel()`, `timeframeLabel()`, `probabilityBucketLabel()`,
+  `pricedInBucketLabel()`. Lift these into a shared module (e.g.
+  `src/utils/scenario-labels.ts`) so both ETF and stock views reuse the same text — do
+  NOT copy-paste into a stock-specific generator.
+- [ ] **Slug helper** — `src/utils/etf-scenario-slug.ts` exports `slugifyScenarioTitle`.
+  Rename the module to `src/utils/scenario-slug.ts` (or add a thin re-export) so both
+  features share one slug algorithm.
 
 ### 1.4) Cache-tag helpers
 
@@ -147,6 +160,12 @@ use the **same values**.
 - [ ] The listing tag is country-agnostic (one tag for all countries) — filtering by
   country is done client-side on the SSR payload, so no per-country cache variants are
   needed at this scale. Revisit only if the scenario count grows past ~200.
+- [ ] **Server-action wrappers** in `src/utils/cache-actions.ts` (the `'use server'` file
+  that the page-actions dropdown calls into):
+  - `revalidateStockScenariosListingCache()`
+  - `revalidateStockScenarioCache(slug: string)`
+  Mirrors the existing `revalidateEtfScenariosListingCache` / `revalidateEtfScenarioCache`
+  exports. The `StockScenariosPageActions` dropdown (§1.6) calls these from the client.
 
 ### 1.5) API routes
 
@@ -167,6 +186,16 @@ post via `token=<AUTOMATION_SECRET>`).
   Resolve `tickerKey` + `exchange` on read from the symbol. Return `scenario.countries`
   so the client filter bar knows which options are enabled. Always return all 15 links —
   country filtering on the detail view is client-side against the resolved `exchange`.
+  **Support `?allowNull=true`** (matches ETF detail route) so the public page's `fetch()`
+  wrapper can receive `null` for a missing slug instead of a thrown error; the page
+  maps that to `notFound()`.
+- [ ] Define the DTOs inline in each route file (`StockScenarioListingItem`,
+  `StockScenarioListingResponse`, `StockScenarioLinkDto`, `StockScenarioDetail`) — match
+  the ETF convention of co-locating request/response types with the route (see
+  `EtfScenarioDetail` and `EtfScenarioLinkDto` in
+  `src/app/api/[spaceId]/etf-scenarios/[slug]/route.ts`). Only promote to
+  `src/types/stockScenarios.ts` if both a non-route component and a page need the same
+  shape.
 
 **Admin (write)**
 - [ ] `src/app/api/stock-scenarios/route.ts` — `POST` upsert-by-slug (mirror of
@@ -182,13 +211,21 @@ post via `token=<AUTOMATION_SECRET>`).
 - [ ] **Automation auth parity**: POST / PUT / DELETE / link-mgmt accept the
   `AUTOMATION_SECRET` via `token=` query or `x-automation-token` header, same as
   ETF scenarios (see `withAdminOrToken`).
-- [ ] **Symbol → ticker resolution**: backend looks up each link's `symbol` against the
-  stock table (`spaceId + symbol`) and populates `tickerKey` + `exchange`. Clients do NOT
-  pass those fields manually — same rule as ETF scenarios.
-- [ ] **`countries[]` validation**: reject writes where any link's resolved exchange maps
-  to a country not present in the scenario's `countries[]` (see §1.2). Return the
-  offending symbol / exchange / country triple in the error so the admin can fix the
-  declaration.
+- [ ] **Symbol + exchange → ticker resolution** (differs from ETFs): because the same
+  symbol can exist on multiple exchanges across countries (ADRs, dual listings, and
+  symbol collisions like `UN` — Unilever NYSE vs U-Haul UHAL), the link payload MUST
+  include `exchange` for every link. Server validates `(symbol, exchange)` against the
+  stock table and populates `tickerKey`. If `exchange` is omitted or not found, reject
+  the write. This is the critical deviation from ETF scenarios (where `symbol` alone is
+  unique within the ETF universe and the backend auto-fills `exchange`).
+- [ ] **`countries[]` validation**: reject writes where any link's exchange maps to a
+  country not present in the scenario's `countries[]` (via `EXCHANGE_TO_COUNTRY`; see
+  §1.2). Return the offending symbol / exchange / country triple in the error so the
+  admin can fix the declaration.
+- [ ] **Resolution failures**: if `(symbol, exchange)` doesn't resolve to a row in the
+  stock table, still allow the write (store `tickerKey = null`) but flag it in the
+  response so the admin knows the ticker pill will render as plain text — matches the
+  ETF behaviour for unresolved symbols.
 
 ### 1.6) Public pages
 
@@ -210,10 +247,21 @@ Follow the SSR/ISR directives that `/etf-scenarios` already uses.
   string so the selection survives reload and share-links.
 - [ ] `src/app/stock-scenarios/StockScenariosPageActions.tsx` — admin cache-flush dropdown
   (mirror the ETF version).
-- [ ] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` (mirror
-  `etf-scenario-metadata-generators.ts`) — title, description, breadcrumbs, `Article`
-  JSON-LD with `datePublished = createdAt`, `dateModified = updatedAt`, `dateline =
-  outlookAsOfDate`.
+- [ ] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` — mirror
+  the **full set** of exports in `etf-scenario-metadata-generators.ts`:
+  - `generateStockScenarioListingMetadata()` — base `<title>` / description / OG tags.
+  - `generateStockScenarioListingJsonLd()` — `WebPage`/`CollectionPage` schema.
+  - `generateStockScenarioListingBreadcrumbJsonLd()` — breadcrumb chain.
+  - `generateStockScenarioListingItemListJsonLd(items)` — `ItemList` with every
+    scenario's slug + title + number.
+  - `generateStockScenarioDetailMetadata({ ... })` — per-slug title / description / OG.
+  - `generateStockScenarioDetailArticleJsonLd({ ... })` — `Article` with
+    `datePublished = createdAt`, `dateModified = updatedAt`, `dateline =
+    outlookAsOfDate`.
+  - `generateStockScenarioDetailBreadcrumbJsonLd({ title, slug })`.
+- [ ] **Skip** `loading.tsx` / `error.tsx` / `not-found.tsx` at the route level — ETF
+  scenarios doesn't have them and the pattern across sibling stocks/ETFs pages is to
+  rely on Next.js defaults. Add only if the user asks.
 
 ### 1.7) Components
 
@@ -224,6 +272,13 @@ Under `src/components/stock-scenarios/`:
 - [ ] `StockScenarioCard.tsx` — in addition to the ETF card content, show small country
   pills (one per entry in `countries[]`) so readers can see at a glance which markets the
   scenario applies to.
+- [ ] `StockScenarioOutlookBadge.tsx` (or reuse ETF version) — exports
+  `StockScenarioDirectionBadge`, `StockScenarioProbabilityBadge`,
+  `StockScenarioTimeframeBadge`. The ETF file
+  (`src/components/etf-scenarios/EtfScenarioOutlookBadge.tsx`) is already generic in
+  everything but name; the cleanest option is to rename it to
+  `components/scenarios/ScenarioOutlookBadge.tsx` and share. Duplicating is
+  explicitly a last resort.
 - [ ] `StockScenarioDetailView.tsx` — three-column Winners / Losers / Most-exposed grid.
   If **any** link in a column has `roleExplanation`, `expectedPriceChange`, or
   `expectedPriceChangeExplanation` populated, the column flips from compact pills to a
@@ -265,7 +320,38 @@ Follow the `SingleSectionModal` pattern already used by `/admin-v1/etf-scenarios
   frontmatter line (comma-separated) — add to
   `src/utils/stock-scenario-markdown-parser.ts` when it's built.
 - [ ] `src/app/admin-v1/AdminNav.tsx` — add a **Stock Scenarios** link next to the
-  existing **ETF Scenarios** entry.
+  existing `{ name: 'ETF Scenarios', href: '/admin-v1/etf-scenarios' }` entry (line 41
+  today), so the two live side-by-side in the same section.
+
+### 1.9) Markdown parser (`src/utils/stock-scenario-markdown-parser.ts`)
+
+The ETF parser (`src/utils/etf-scenario-markdown-parser.ts`, 196 lines) extracts tickers
+from winners/losers markdown using a capitalised-word regex + a STOPWORDS set. For
+stocks:
+
+- [ ] **Exchange-qualified tickers**: non-US tickers routinely collide with common words
+  (e.g. `IT` = Gartner on NYSE AND an Indian listing on NSE). Require exchange qualifier
+  in source markdown: `NSE:RELIANCE`, `LSE:ULVR`, etc. Update the extractor to parse
+  `{EXCHANGE}:{SYMBOL}` as a single token and emit both fields into the `ParsedLink`.
+- [ ] **Expand `STOPWORDS`** to include country names that collide with tickers
+  (`US`, `UK`, `IN`, `CA`, `JP`, `KR`, `HK`, `TW`, `AU`, `PK`). Test against a sample of
+  real scenario markdown before shipping.
+- [ ] **Frontmatter field**: parse a `Countries:` line (comma-separated
+  `SupportedCountries` values) out of each scenario block, validate, and emit as
+  `countries[]` on `ParsedScenario`.
+
+### 1.10) Automation import script (`src/scripts/import-stock-scenarios.ts`)
+
+Mirror `src/scripts/import-etf-scenarios.ts`:
+
+- [ ] Reads a markdown file (default
+  `docs/ai-knowledge/insights-ui/stock-analysis/stock-market-scenarios.md` — create this
+  directory during Phase 3 seeding), parses via the new parser, POSTs each scenario to
+  `/api/stock-scenarios?token=<AUTOMATION_SECRET>`.
+- [ ] Honours env vars: `SCENARIOS_API_BASE`, `AUTOMATION_SECRET`, `SCENARIOS_MD_PATH`,
+  `SCENARIOS_FALLBACK_DATE`.
+- [ ] Wire into `package.json` scripts as `stock-scenarios:import` (ETF equivalent is
+  already wired).
 
 ---
 
@@ -368,3 +454,29 @@ The ETF scenarios are currently hand-authored. For stock scenarios:
   the viewer's locale / prior visits, or always start with "All countries"? Defaulting
   is more relevant but risks hiding scenarios a user would otherwise discover. Start
   with "All countries" and revisit once we have usage data.
+- [ ] **Which stock model is the FK target?** The schema has both `Ticker` and `TickerV1`
+  families (see `insights-ui/prisma/schema.prisma` around `TickerV1Industry`, etc.).
+  Confirm whether `StockScenarioStockLink.tickerKey` should FK to `TickerV1`, `Ticker`,
+  or resolve loosely by `(symbol, exchange)` without an FK. The ETF side uses a strict
+  FK to `Etf`; we should decide before the migration.
+- [ ] **ADR + dual-listing handling** — e.g. Alibaba trades as `BABA` on NYSE and
+  `9988` on HKEX. For an "Asia consumer demand" scenario, does the link-row represent
+  both listings, the primary, or are they two rows (one per country)? Two-row is more
+  honest but may double-count in listings. Pin a rule before seeding.
+- [ ] **Markdown source format for non-US tickers** — the current ETF parser reads bare
+  uppercase tokens. Our spec in §1.9 requires `EXCHANGE:SYMBOL` qualifiers for non-US
+  markets, but that breaks drop-in compatibility with the ETF parser. Decide whether to
+  (a) require qualifiers universally (even US) so the parser is uniform, or (b)
+  auto-assume `NASDAQ` / `NYSE` when no qualifier is present.
+- [ ] **Shared Scenario enums vs split** — §1.3 suggests renaming `etfScenarioEnums.ts`
+  to a neutral `scenarioEnums.ts`. This is technically a breaking import across the
+  existing ETF code surface. Confirm the rename is acceptable (the re-export shim makes
+  it safe, but grep-for-enums becomes noisier).
+- [ ] **Sitemap entries** — ETF scenarios are not in any `sitemap*.ts` today. Should
+  `/stock-scenarios` and each detail page be added to a sitemap for SEO, or inherit the
+  same "no sitemap" posture as ETF scenarios for now? Recommend adding; the traffic
+  potential is higher.
+- [ ] **Per-symbol reverse-link cache tag** — §Phase 2 mentions "a new per-symbol tag".
+  Decide the tag name shape (e.g. `stock_scenario_for_symbol:<EXCHANGE>:<SYMBOL>`) and
+  which writes invalidate it (every link add/remove on a scenario touches the tags for
+  the old AND new symbol, which is cheap since we only have 15 per scenario).

--- a/tasks/koala-gains/stock-scenarios.md
+++ b/tasks/koala-gains/stock-scenarios.md
@@ -12,16 +12,24 @@ exposed tickers**, each with a clear mechanical reason and an estimated % move.
 > The ETF Scenarios feature is already live (`/etf-scenarios`, `/admin-v1/etf-scenarios`,
 > `EtfScenario` + `EtfScenarioEtfLink` Prisma models). **Borrow its schema, API shape, and
 > UI patterns rather than inventing new ones.** The differences are: (a) links resolve
-> against the stock table (tickers) instead of the ETF table, and (b) where we surface the
-> "scenarios this asset appears in" reverse link on the asset's own report page.
+> against the stock table (tickers) instead of the ETF table, (b) where we surface the
+> "scenarios this asset appears in" reverse link on the asset's own report page, and
+> (c) **stocks trade across many exchanges in many countries**, so each scenario declares
+> which countries it applies to and the listing / detail pages expose a country filter
+> (see §1.2 and §1.5 below). ETFs don't need this because the ETF universe we cover is
+> effectively US-listed.
 
 ## Priority order
 
-1. **Database + API + public listing/detail pages** (parity with `/etf-scenarios`).
-2. **Admin CRUD** under `/admin-v1/stock-scenarios`.
-3. **Reverse link** from a stock's report page → the scenarios it appears in.
-4. **Shared-vs-parallel decision** with ETF scenarios (see open questions).
-5. **Seed content** — curate the first batch of stock scenarios.
+1. **Database + API + public listing/detail pages** (parity with `/etf-scenarios`, plus
+   country scoping — §1.2).
+2. **Country filter UX** on both listing and detail pages (§1.7 `StockScenarioFiltersBar`).
+3. **Admin CRUD** under `/admin-v1/stock-scenarios`, including the `countries[]`
+   multi-select.
+4. **Reverse link** from a stock's report page → the scenarios it appears in.
+5. **Shared-vs-parallel decision** with ETF scenarios (see open questions).
+6. **Seed content** — curate the first batch of stock scenarios, each declaring its
+   `countries[]`.
 
 ---
 
@@ -32,7 +40,8 @@ exposed tickers**, each with a clear mechanical reason and an estimated % move.
 Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `EtfScenario`
 / `EtfScenarioEtfLink` definitions (around line 1815).
 
-- [ ] **Add `StockScenario` model** — field-for-field mirror of `EtfScenario`:
+- [ ] **Add `StockScenario` model** — field-for-field mirror of `EtfScenario`, PLUS a
+  `countries` list (new — see §1.2):
   - `id`, `scenarioNumber`, `title`, `slug`
   - `underlyingCause`, `historicalAnalog`, `winnersMarkdown`, `losersMarkdown`,
     `outlookMarkdown` (all `String @db.Text`)
@@ -42,6 +51,12 @@ Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `E
     `expectedPriceChangeExplanation`, `priceChangeTimeframeExplanation` (both nullable
     `@db.Text`)
   - `outlookAsOfDate` (`@db.Date`), `metaDescription` (nullable `@db.Text`)
+  - **`countries String[]` (new)** — list of supported-country names the scenario
+    applies to. Validated against `SupportedCountries` (US / Canada / India / UK /
+    Pakistan / Japan / Taiwan / HongKong / Korea / Australia — see
+    `insights-ui/src/utils/countryExchangeUtils.ts`). Must be non-empty on create.
+    Stored as `String[]` (Postgres text array) so Prisma can filter with `hasSome` /
+    `hasEvery`.
   - `archived` (default `false`), `spaceId` (default `"koala_gains"`),
     `createdAt`, `updatedAt`
   - Relation: `stockLinks StockScenarioStockLink[]`
@@ -67,7 +82,47 @@ Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `E
 - [ ] **Migration**: `yarn prisma migrate dev --name add_stock_scenarios`. Commit the
   generated SQL.
 
-### 1.2) Shared enums — do NOT duplicate
+### 1.2) Country scoping (new — not present on ETF scenarios)
+
+Stock scenarios are country-scoped because stocks trade on exchanges in specific
+countries. The supported country set is defined by `SupportedCountries` in
+`insights-ui/src/utils/countryExchangeUtils.ts` (US, Canada, India, UK, Pakistan, Japan,
+Taiwan, HongKong, Korea, Australia) and each country maps to a fixed exchange list via
+`COUNTRY_TO_EXCHANGES` / `getExchangesByCountry()`. Reuse these — do not invent new
+country lists.
+
+- [ ] **`countries` field on `StockScenario`** — already specified in §1.1. Enforced to be
+  a subset of `SupportedCountries` values and non-empty. A scenario like "Indian
+  monsoon-led agri supply shock" would have `countries: ["India"]`; a scenario like
+  "Geopolitical oil price spike" that affects listings in multiple countries would carry
+  the full relevant set (e.g. `["US", "UK", "Canada", "India", "Australia"]`).
+- [ ] **Validation at write time**:
+  - POST / PUT validate `countries[]` against `SupportedCountries` (use the existing
+    `toSupportedCountry()` helper or a direct `z.enum(Object.values(SupportedCountries))`
+    array schema).
+  - Cross-check `countries[]` against the links: every link's `exchange` (resolved
+    server-side from `symbol`) must map — via `EXCHANGE_TO_COUNTRY` — to a country that
+    appears in the scenario's `countries[]`. If a link's exchange resolves to a country
+    not declared on the scenario, reject the write with a clear error rather than
+    silently accepting a mismatched link. This prevents drift where the "countries"
+    declaration disagrees with the actual tickers attached.
+- [ ] **Filter semantics**:
+  - Public listing: a scenario matches a country filter when `country IN
+    scenario.countries` (Prisma: `where: { countries: { has: country } }`). So a scenario
+    declaring `["US", "UK"]` appears under both US and UK filters.
+  - Detail page: when a user arrives with a country in the query string (or selects one
+    on the detail page), **filter each of the winner / loser / most-exposed columns to
+    only the stocks whose exchange belongs to that country** (i.e. link's resolved
+    `exchange` is in `getExchangesByCountry(selectedCountry)`). Show a count next to each
+    role (e.g. "Winners (3 in UK)") when filtered, and a neutral "switch country" affordance.
+  - If the user clears the country filter, all 15 links render regardless of country.
+  - If the selected country isn't in `scenario.countries`, the filter bar should disable
+    that country (or show "no stocks in this country for this scenario").
+- [ ] **Use `getExchangeFilterClause(country)`** from `countryExchangeUtils.ts` when
+  building server-side Prisma queries for any flavour of symbol lookup — it already
+  returns the right `{ exchange: { in: [...] } }` shape and handles the nullable case.
+
+### 1.3) Shared enums — do NOT duplicate
 
 The TS enum module `insights-ui/src/types/etfScenarioEnums.ts` already defines
 `Direction`, `Timeframe`, `ProbabilityBucket`, `PricedInBucket`, `Role`. Stock scenarios
@@ -78,8 +133,10 @@ use the **same values**.
   Stock scenarios then import from the neutral module directly.
 - [ ] Do NOT create a second set of enums under `stockScenarioEnums.ts` — that would
   diverge over time and force double-maintenance.
+- [ ] Country values stay in `countryExchangeUtils.ts` (`SupportedCountries` enum). Do not
+  duplicate into the scenarios enum module — import from the utils file everywhere.
 
-### 1.3) Cache-tag helpers
+### 1.4) Cache-tag helpers
 
 - [ ] Create `src/utils/stock-scenario-cache-utils.ts` mirroring
   `src/utils/etf-scenario-cache-utils.ts`:
@@ -87,8 +144,11 @@ use the **same values**.
   - `STOCK_SCENARIO_LISTING_TAG` constant + `revalidateStockScenarioListingTag()`
 - [ ] Every write endpoint calls the listing revalidator, and (on PUT/DELETE/link-mgmt) the
   slug-specific revalidator.
+- [ ] The listing tag is country-agnostic (one tag for all countries) — filtering by
+  country is done client-side on the SSR payload, so no per-country cache variants are
+  needed at this scale. Revisit only if the scenario count grows past ~200.
 
-### 1.4) API routes
+### 1.5) API routes
 
 Mirror the ETF scenarios routes 1:1. Space-scoped reads live under `/api/[spaceId]/...`,
 admin writes live under `/api/stock-scenarios/...`. Wrap all mutating endpoints with
@@ -98,11 +158,15 @@ post via `token=<AUTOMATION_SECRET>`).
 **Public (read)**
 - [ ] `src/app/api/[spaceId]/stock-scenarios/listing/route.ts` — `GET` with
   `direction`, `timeframe`, `probabilityBucket`, `search`, `page`, `pageSize`,
-  `includeArchived` query params.
+  `includeArchived`, and **`country`** query params. When `country` is provided, parse
+  via `toSupportedCountry()` and add `where.countries = { has: country }` to the Prisma
+  query. Include `countries` in each listing row so the card grid can show country pills.
 - [ ] `src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts` — `GET` detail, returns
   `{ scenario, winners, losers, mostExposed }` with nested stock lookups for each symbol
   (so the UI can render clickable ticker pills linking to `/stocks/<exchange>/<symbol>`).
-  Resolve `tickerKey` + `exchange` on read from the symbol.
+  Resolve `tickerKey` + `exchange` on read from the symbol. Return `scenario.countries`
+  so the client filter bar knows which options are enabled. Always return all 15 links —
+  country filtering on the detail view is client-side against the resolved `exchange`.
 
 **Admin (write)**
 - [ ] `src/app/api/stock-scenarios/route.ts` — `POST` upsert-by-slug (mirror of
@@ -121,19 +185,29 @@ post via `token=<AUTOMATION_SECRET>`).
 - [ ] **Symbol → ticker resolution**: backend looks up each link's `symbol` against the
   stock table (`spaceId + symbol`) and populates `tickerKey` + `exchange`. Clients do NOT
   pass those fields manually — same rule as ETF scenarios.
+- [ ] **`countries[]` validation**: reject writes where any link's resolved exchange maps
+  to a country not present in the scenario's `countries[]` (see §1.2). Return the
+  offending symbol / exchange / country triple in the error so the admin can fix the
+  declaration.
 
-### 1.5) Public pages
+### 1.6) Public pages
 
 Follow the SSR/ISR directives that `/etf-scenarios` already uses.
 
 - [ ] `src/app/stock-scenarios/page.tsx` — listing, `dynamic = 'force-static'`,
   `dynamicParams = true`, `revalidate = 86400`. Server-side fetch via
   `getBaseUrlForServerSidePages()` + the listing tag. `ItemList` JSON-LD inline.
+  The listing SSR payload includes every scenario's `countries[]`. The country filter is
+  client-side (see `StockScenarioFiltersBar` in §1.7 Components) so no separate per-
+  country page variant is needed.
 - [ ] `src/app/stock-scenarios/[slug]/page.tsx` — detail, same `force-static` +
   `dynamicParams = true` but `revalidate = false`. `notFound()` on missing slug.
   Three-column layout (Winners / Losers / Most-exposed) just like
   `EtfScenarioDetailView` — reuse the same visual patterns. Stocks in each role render as
-  pills/cards linking to `/stocks/<exchange>/<symbol>` when resolved.
+  pills/cards linking to `/stocks/<exchange>/<symbol>` when resolved. Country filter on
+  the detail page narrows each column to links whose resolved exchange maps to the
+  selected country (see §1.2 filter semantics). Filter state lives in the URL query
+  string so the selection survives reload and share-links.
 - [ ] `src/app/stock-scenarios/StockScenariosPageActions.tsx` — admin cache-flush dropdown
   (mirror the ETF version).
 - [ ] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` (mirror
@@ -141,36 +215,55 @@ Follow the SSR/ISR directives that `/etf-scenarios` already uses.
   JSON-LD with `datePublished = createdAt`, `dateModified = updatedAt`, `dateline =
   outlookAsOfDate`.
 
-### 1.6) Components
+### 1.7) Components
 
 Under `src/components/stock-scenarios/`:
 
 - [ ] `StockScenarioPageLayout.tsx`
 - [ ] `StockScenarioListingGrid.tsx`
-- [ ] `StockScenarioCard.tsx`
+- [ ] `StockScenarioCard.tsx` — in addition to the ETF card content, show small country
+  pills (one per entry in `countries[]`) so readers can see at a glance which markets the
+  scenario applies to.
 - [ ] `StockScenarioDetailView.tsx` — three-column Winners / Losers / Most-exposed grid.
   If **any** link in a column has `roleExplanation`, `expectedPriceChange`, or
   `expectedPriceChangeExplanation` populated, the column flips from compact pills to a
-  richer card list (same behaviour as the ETF detail view).
+  richer card list (same behaviour as the ETF detail view). Accepts a `countryFilter`
+  prop — when set, each column is filtered to links whose resolved exchange is in
+  `getExchangesByCountry(countryFilter)`, with a per-column count shown in the heading.
 - [ ] `StockScenarioFiltersBar.tsx` — client component, mirrors
-  `EtfScenarioFiltersBar` (direction / timeframe / probability / search). Filtering can
-  be purely client-side against the initial SSR payload since scenario counts will stay
-  small.
+  `EtfScenarioFiltersBar` (direction / timeframe / probability / search) **PLUS a
+  `country` dropdown** sourced from `ALL_SUPPORTED_COUNTRIES` (in
+  `countryExchangeUtils.ts`). The country dropdown has an "All countries" option
+  (clears the filter). On listing pages, selecting a country filters the scenario grid
+  to scenarios whose `countries[]` contains the selection. On detail pages (optional
+  embedding), selecting a country filters the winner / loser / most-exposed columns
+  per §1.2. Filter state is synced to the URL query string.
+- [ ] `StockScenarioCountrySelect.tsx` (optional extraction) — if we want to reuse the
+  country dropdown between listing and detail pages, pull it into its own component
+  backed by `ALL_SUPPORTED_COUNTRIES` and the `getCountryCodeForSearchBarDisplay`
+  helper.
 
-### 1.7) Admin UI
+### 1.8) Admin UI
 
 Follow the `SingleSectionModal` pattern already used by `/admin-v1/etf-scenarios`.
 
 - [ ] `src/app/admin-v1/stock-scenarios/page.tsx` — listing table with row actions
-  (edit, archive-toggle, delete, manage-links).
+  (edit, archive-toggle, delete, manage-links). Show a `countries` column so admins can
+  see country scope at a glance.
 - [ ] `src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx` — every field on
-  `StockScenario`, scrolling internally.
+  `StockScenario`, scrolling internally. The `countries[]` field renders as a multi-
+  select populated from `ALL_SUPPORTED_COUNTRIES`; require at least one selection.
 - [ ] `src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx` — add/remove ticker symbols
   per role with `roleExplanation` + expected-price-change fields. Ticker typeahead calls
   the existing stock search endpoint (confirm path — likely
-  `/api/koala_gains/tickers/search` or similar).
+  `/api/koala_gains/tickers/search` or similar). After resolving the symbol's exchange,
+  the modal should validate client-side that the resolved country is in the parent
+  scenario's `countries[]` and show an inline error if not (server also enforces this —
+  see §1.5).
 - [ ] `src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx` — bulk markdown
-  import, mirrors `ImportEtfScenariosModal`.
+  import, mirrors `ImportEtfScenariosModal`. The markdown parser needs a new `Countries:`
+  frontmatter line (comma-separated) — add to
+  `src/utils/stock-scenario-markdown-parser.ts` when it's built.
 - [ ] `src/app/admin-v1/AdminNav.tsx` — add a **Stock Scenarios** link next to the
   existing **ETF Scenarios** entry.
 
@@ -208,9 +301,15 @@ block with links back to each scenario detail page.
   `outlookAsOfDate`.
 - [ ] **Exactly 5 winners + 5 losers + 5 most-exposed** per scenario (same operational
   convention as ETF scenarios — if you reach for a sixth, drop the weakest existing one).
+  The five-per-role rule applies **per scenario overall**, not per country — a scenario
+  declaring `countries: ["US", "India"]` can have 5 winners mixing both markets, and the
+  country filter on the detail page will narrow each column down accordingly.
 - [ ] Prefer pure-play / sector-specific tickers over diversified giants (AAPL, MSFT,
   GOOGL) when both would qualify — same rationale as the ETF rule favouring XLE/XOP over
   SPY.
+- [ ] Each scenario must declare its `countries[]` (see §1.2). Pick the smallest
+  correct set: a scenario about US regional banks is `["US"]`, not `["US", "Canada"]`,
+  even if Canadian banks are loosely correlated.
 - [ ] Import via the admin "Import from doc" button once the endpoint is live.
 
 ---
@@ -258,3 +357,14 @@ The ETF scenarios are currently hand-authored. For stock scenarios:
   carry an optional list of relevant sub-industries, so the stock detail page can flag
   "any scenario tagged to this ticker's sub-industry even if the ticker itself isn't in
   the 15-row list"? Useful for breadth, risk of noise.
+- [ ] **Country scope changes over time** — if a scenario originally declared
+  `["US"]` and we later realise it also hits UK listings, do we need a migration /
+  audit flow, or is it enough to let admins edit `countries[]` in place? Leaning toward
+  in-place edit (matches how we let admins edit any other field) but the link-validation
+  rule in §1.5 means adding a country without adding corresponding links is harmless,
+  while *removing* a country leaves orphan links — spec the server to either reject the
+  removal or auto-archive those links.
+- [ ] **Default country filter** — should the listing page default to a country based on
+  the viewer's locale / prior visits, or always start with "All countries"? Defaulting
+  is more relevant but risks hiding scenarios a user would otherwise discover. Start
+  with "All countries" and revisit once we have usage data.

--- a/tasks/koala-gains/stock-scenarios.md
+++ b/tasks/koala-gains/stock-scenarios.md
@@ -35,12 +35,35 @@ exposed tickers**, each with a clear mechanical reason and an estimated % move.
 
 ## Phase 1 — Database, API, public pages
 
+> **Status: Phase 1 shipped** (2026-04-24). All sub-sections 1.1–1.10 below are
+> implemented. Highlights:
+> - Prisma models `StockScenario` + `StockScenarioStockLink` + the
+>   `add_stock_scenarios` migration.
+> - Shared `src/types/scenarioEnums.ts` + `src/utils/scenario-slug.ts`
+>   (back-compat shims keep old ETF imports working).
+> - Country validation util (`src/utils/scenario-country-validation.ts`) +
+>   country-aware public listing / detail API + admin upsert / link-mgmt /
+>   import routes with exchange-to-country enforcement.
+> - Full component suite under `src/components/stock-scenarios/` including a
+>   country filter on both listing and detail pages.
+> - Admin pages under `src/app/admin-v1/stock-scenarios/` wired into `AdminNav`
+>   (Stock & Industry Mgmt section).
+> - Markdown parser + automation import script +
+>   `import:stock-scenarios` npm script.
+>
+> **Open follow-ups from Phase 1 review**: the migration SQL was hand-written to
+> match the schema; run `yarn prisma migrate deploy` (or `migrate dev`) on a
+> developer DB before merging to catch any divergence. Seed content (§Phase 3)
+> is still empty — create
+> `docs/ai-knowledge/insights-ui/stock-analysis/stock-market-scenarios.md`
+> before running the automation script.
+
 ### 1.1) Prisma schema
 
 Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `EtfScenario`
 / `EtfScenarioEtfLink` definitions (around line 1815).
 
-- [ ] **Add `StockScenario` model** — field-for-field mirror of `EtfScenario`, PLUS a
+- [x] **Add `StockScenario` model** — field-for-field mirror of `EtfScenario`, PLUS a
   `countries` list (new — see §1.2):
   - `id`, `scenarioNumber`, `title`, `slug`
   - `underlyingCause`, `historicalAnalog`, `winnersMarkdown`, `losersMarkdown`,
@@ -66,7 +89,7 @@ Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `E
       `@@index([spaceId, timeframe])`, `@@index([spaceId, probabilityBucket])`,
       `@@index([spaceId, pricedInBucket])`
     - `@@map("stock_scenarios")`
-- [ ] **Add `StockScenarioStockLink` join model** — mirror `EtfScenarioEtfLink` but link to
+- [x] **Add `StockScenarioStockLink` join model** — mirror `EtfScenarioEtfLink` but link to
   tickers instead of ETFs:
   - `id`, `scenarioId`, `tickerKey` (nullable String — the existing ticker identity in
     `TickerV1` / stock tables; confirm the correct FK field name before writing the
@@ -81,10 +104,10 @@ Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `E
     we need to allow both rows without collision.
   - `@@index([scenarioId])`, `@@index([symbol])`, `@@index([symbol, exchange])`
   - `@@map("stock_scenario_stock_links")`
-- [ ] **Back-ref on the stock model** — add `scenarioLinks StockScenarioStockLink[]` to
+- [x] **Back-ref on the stock model** — add `scenarioLinks StockScenarioStockLink[]` to
   whichever model represents a tradable stock ticker today (verify: `TickerV1`, `Ticker`,
   or equivalent) so the future reverse-lookup join is indexed.
-- [ ] **Migration**: `yarn prisma migrate dev --name add_stock_scenarios`. Commit the
+- [x] **Migration**: `yarn prisma migrate dev --name add_stock_scenarios`. Commit the
   generated SQL.
 
 ### 1.2) Country scoping (new — not present on ETF scenarios)
@@ -96,12 +119,12 @@ Taiwan, HongKong, Korea, Australia) and each country maps to a fixed exchange li
 `COUNTRY_TO_EXCHANGES` / `getExchangesByCountry()`. Reuse these — do not invent new
 country lists.
 
-- [ ] **`countries` field on `StockScenario`** — already specified in §1.1. Enforced to be
+- [x] **`countries` field on `StockScenario`** — already specified in §1.1. Enforced to be
   a subset of `SupportedCountries` values and non-empty. A scenario like "Indian
   monsoon-led agri supply shock" would have `countries: ["India"]`; a scenario like
   "Geopolitical oil price spike" that affects listings in multiple countries would carry
   the full relevant set (e.g. `["US", "UK", "Canada", "India", "Australia"]`).
-- [ ] **Validation at write time**:
+- [x] **Validation at write time**:
   - POST / PUT validate `countries[]` against `SupportedCountries` (use the existing
     `toSupportedCountry()` helper or a direct `z.enum(Object.values(SupportedCountries))`
     array schema).
@@ -111,7 +134,7 @@ country lists.
     not declared on the scenario, reject the write with a clear error rather than
     silently accepting a mismatched link. This prevents drift where the "countries"
     declaration disagrees with the actual tickers attached.
-- [ ] **Filter semantics**:
+- [x] **Filter semantics**:
   - Public listing: a scenario matches a country filter when `country IN
     scenario.countries` (Prisma: `where: { countries: { has: country } }`). So a scenario
     declaring `["US", "UK"]` appears under both US and UK filters.
@@ -123,7 +146,7 @@ country lists.
   - If the user clears the country filter, all 15 links render regardless of country.
   - If the selected country isn't in `scenario.countries`, the filter bar should disable
     that country (or show "no stocks in this country for this scenario").
-- [ ] **Use `getExchangeFilterClause(country)`** from `countryExchangeUtils.ts` when
+- [x] **Use `getExchangeFilterClause(country)`** from `countryExchangeUtils.ts` when
   building server-side Prisma queries for any flavour of symbol lookup — it already
   returns the right `{ exchange: { in: [...] } }` shape and handles the nullable case.
 
@@ -133,34 +156,34 @@ The TS enum module `insights-ui/src/types/etfScenarioEnums.ts` already defines
 `Direction`, `Timeframe`, `ProbabilityBucket`, `PricedInBucket`, `Role`. Stock scenarios
 use the **same values**.
 
-- [ ] Rename the file (or add a new neutral module) to `src/types/scenarioEnums.ts` and
+- [x] Rename the file (or add a new neutral module) to `src/types/scenarioEnums.ts` and
   re-export the existing enums under both old and new names so ETF code keeps compiling.
   Stock scenarios then import from the neutral module directly.
-- [ ] Do NOT create a second set of enums under `stockScenarioEnums.ts` — that would
+- [x] Do NOT create a second set of enums under `stockScenarioEnums.ts` — that would
   diverge over time and force double-maintenance.
-- [ ] Country values stay in `countryExchangeUtils.ts` (`SupportedCountries` enum). Do not
+- [x] Country values stay in `countryExchangeUtils.ts` (`SupportedCountries` enum). Do not
   duplicate into the scenarios enum module — import from the utils file everywhere.
-- [ ] **Label helpers** — `src/utils/etf-scenario-metadata-generators.ts` currently exports
+- [x] **Label helpers** — `src/utils/etf-scenario-metadata-generators.ts` currently exports
   `directionLabel()`, `timeframeLabel()`, `probabilityBucketLabel()`,
   `pricedInBucketLabel()`. Lift these into a shared module (e.g.
   `src/utils/scenario-labels.ts`) so both ETF and stock views reuse the same text — do
   NOT copy-paste into a stock-specific generator.
-- [ ] **Slug helper** — `src/utils/etf-scenario-slug.ts` exports `slugifyScenarioTitle`.
+- [x] **Slug helper** — `src/utils/etf-scenario-slug.ts` exports `slugifyScenarioTitle`.
   Rename the module to `src/utils/scenario-slug.ts` (or add a thin re-export) so both
   features share one slug algorithm.
 
 ### 1.4) Cache-tag helpers
 
-- [ ] Create `src/utils/stock-scenario-cache-utils.ts` mirroring
+- [x] Create `src/utils/stock-scenario-cache-utils.ts` mirroring
   `src/utils/etf-scenario-cache-utils.ts`:
   - `stockScenarioBySlugTag(slug)` / `revalidateStockScenarioBySlugTag(slug)`
   - `STOCK_SCENARIO_LISTING_TAG` constant + `revalidateStockScenarioListingTag()`
-- [ ] Every write endpoint calls the listing revalidator, and (on PUT/DELETE/link-mgmt) the
+- [x] Every write endpoint calls the listing revalidator, and (on PUT/DELETE/link-mgmt) the
   slug-specific revalidator.
-- [ ] The listing tag is country-agnostic (one tag for all countries) — filtering by
+- [x] The listing tag is country-agnostic (one tag for all countries) — filtering by
   country is done client-side on the SSR payload, so no per-country cache variants are
   needed at this scale. Revisit only if the scenario count grows past ~200.
-- [ ] **Server-action wrappers** in `src/utils/cache-actions.ts` (the `'use server'` file
+- [x] **Server-action wrappers** in `src/utils/cache-actions.ts` (the `'use server'` file
   that the page-actions dropdown calls into):
   - `revalidateStockScenariosListingCache()`
   - `revalidateStockScenarioCache(slug: string)`
@@ -175,12 +198,12 @@ admin writes live under `/api/stock-scenarios/...`. Wrap all mutating endpoints 
 post via `token=<AUTOMATION_SECRET>`).
 
 **Public (read)**
-- [ ] `src/app/api/[spaceId]/stock-scenarios/listing/route.ts` — `GET` with
+- [x] `src/app/api/[spaceId]/stock-scenarios/listing/route.ts` — `GET` with
   `direction`, `timeframe`, `probabilityBucket`, `search`, `page`, `pageSize`,
   `includeArchived`, and **`country`** query params. When `country` is provided, parse
   via `toSupportedCountry()` and add `where.countries = { has: country }` to the Prisma
   query. Include `countries` in each listing row so the card grid can show country pills.
-- [ ] `src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts` — `GET` detail, returns
+- [x] `src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts` — `GET` detail, returns
   `{ scenario, winners, losers, mostExposed }` with nested stock lookups for each symbol
   (so the UI can render clickable ticker pills linking to `/stocks/<exchange>/<symbol>`).
   Resolve `tickerKey` + `exchange` on read from the symbol. Return `scenario.countries`
@@ -189,7 +212,7 @@ post via `token=<AUTOMATION_SECRET>`).
   **Support `?allowNull=true`** (matches ETF detail route) so the public page's `fetch()`
   wrapper can receive `null` for a missing slug instead of a thrown error; the page
   maps that to `notFound()`.
-- [ ] Define the DTOs inline in each route file (`StockScenarioListingItem`,
+- [x] Define the DTOs inline in each route file (`StockScenarioListingItem`,
   `StockScenarioListingResponse`, `StockScenarioLinkDto`, `StockScenarioDetail`) — match
   the ETF convention of co-locating request/response types with the route (see
   `EtfScenarioDetail` and `EtfScenarioLinkDto` in
@@ -198,31 +221,31 @@ post via `token=<AUTOMATION_SECRET>`).
   shape.
 
 **Admin (write)**
-- [ ] `src/app/api/stock-scenarios/route.ts` — `POST` upsert-by-slug (mirror of
+- [x] `src/app/api/stock-scenarios/route.ts` — `POST` upsert-by-slug (mirror of
   `POST /api/etf-scenarios`). Accepts full scenario payload including a `links[]` array;
   transaction deletes existing links and recreates them. Zod validation.
-- [ ] `src/app/api/stock-scenarios/[id]/route.ts` — `PUT` (partial update, no link
+- [x] `src/app/api/stock-scenarios/[id]/route.ts` — `PUT` (partial update, no link
   changes) + `DELETE` (hard-delete, cascades to links).
-- [ ] `src/app/api/stock-scenarios/[id]/links/route.ts` — `POST` / `DELETE` for a single
+- [x] `src/app/api/stock-scenarios/[id]/links/route.ts` — `POST` / `DELETE` for a single
   link row (admin-session only, matches ETF convention).
-- [ ] `src/app/api/stock-scenarios/import/route.ts` — `POST` admin-session only; bulk
+- [x] `src/app/api/stock-scenarios/import/route.ts` — `POST` admin-session only; bulk
   import from markdown using a parser modelled on
   `src/utils/etf-scenario-markdown-parser.ts`.
-- [ ] **Automation auth parity**: POST / PUT / DELETE / link-mgmt accept the
+- [x] **Automation auth parity**: POST / PUT / DELETE / link-mgmt accept the
   `AUTOMATION_SECRET` via `token=` query or `x-automation-token` header, same as
   ETF scenarios (see `withAdminOrToken`).
-- [ ] **Symbol + exchange → ticker resolution** (differs from ETFs): because the same
+- [x] **Symbol + exchange → ticker resolution** (differs from ETFs): because the same
   symbol can exist on multiple exchanges across countries (ADRs, dual listings, and
   symbol collisions like `UN` — Unilever NYSE vs U-Haul UHAL), the link payload MUST
   include `exchange` for every link. Server validates `(symbol, exchange)` against the
   stock table and populates `tickerKey`. If `exchange` is omitted or not found, reject
   the write. This is the critical deviation from ETF scenarios (where `symbol` alone is
   unique within the ETF universe and the backend auto-fills `exchange`).
-- [ ] **`countries[]` validation**: reject writes where any link's exchange maps to a
+- [x] **`countries[]` validation**: reject writes where any link's exchange maps to a
   country not present in the scenario's `countries[]` (via `EXCHANGE_TO_COUNTRY`; see
   §1.2). Return the offending symbol / exchange / country triple in the error so the
   admin can fix the declaration.
-- [ ] **Resolution failures**: if `(symbol, exchange)` doesn't resolve to a row in the
+- [x] **Resolution failures**: if `(symbol, exchange)` doesn't resolve to a row in the
   stock table, still allow the write (store `tickerKey = null`) but flag it in the
   response so the admin knows the ticker pill will render as plain text — matches the
   ETF behaviour for unresolved symbols.
@@ -231,13 +254,13 @@ post via `token=<AUTOMATION_SECRET>`).
 
 Follow the SSR/ISR directives that `/etf-scenarios` already uses.
 
-- [ ] `src/app/stock-scenarios/page.tsx` — listing, `dynamic = 'force-static'`,
+- [x] `src/app/stock-scenarios/page.tsx` — listing, `dynamic = 'force-static'`,
   `dynamicParams = true`, `revalidate = 86400`. Server-side fetch via
   `getBaseUrlForServerSidePages()` + the listing tag. `ItemList` JSON-LD inline.
   The listing SSR payload includes every scenario's `countries[]`. The country filter is
   client-side (see `StockScenarioFiltersBar` in §1.7 Components) so no separate per-
   country page variant is needed.
-- [ ] `src/app/stock-scenarios/[slug]/page.tsx` — detail, same `force-static` +
+- [x] `src/app/stock-scenarios/[slug]/page.tsx` — detail, same `force-static` +
   `dynamicParams = true` but `revalidate = false`. `notFound()` on missing slug.
   Three-column layout (Winners / Losers / Most-exposed) just like
   `EtfScenarioDetailView` — reuse the same visual patterns. Stocks in each role render as
@@ -245,9 +268,9 @@ Follow the SSR/ISR directives that `/etf-scenarios` already uses.
   the detail page narrows each column to links whose resolved exchange maps to the
   selected country (see §1.2 filter semantics). Filter state lives in the URL query
   string so the selection survives reload and share-links.
-- [ ] `src/app/stock-scenarios/StockScenariosPageActions.tsx` — admin cache-flush dropdown
+- [x] `src/app/stock-scenarios/StockScenariosPageActions.tsx` — admin cache-flush dropdown
   (mirror the ETF version).
-- [ ] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` — mirror
+- [x] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` — mirror
   the **full set** of exports in `etf-scenario-metadata-generators.ts`:
   - `generateStockScenarioListingMetadata()` — base `<title>` / description / OG tags.
   - `generateStockScenarioListingJsonLd()` — `WebPage`/`CollectionPage` schema.
@@ -259,7 +282,7 @@ Follow the SSR/ISR directives that `/etf-scenarios` already uses.
     `datePublished = createdAt`, `dateModified = updatedAt`, `dateline =
     outlookAsOfDate`.
   - `generateStockScenarioDetailBreadcrumbJsonLd({ title, slug })`.
-- [ ] **Skip** `loading.tsx` / `error.tsx` / `not-found.tsx` at the route level — ETF
+- [x] **Skip** `loading.tsx` / `error.tsx` / `not-found.tsx` at the route level — ETF
   scenarios doesn't have them and the pattern across sibling stocks/ETFs pages is to
   rely on Next.js defaults. Add only if the user asks.
 
@@ -267,25 +290,25 @@ Follow the SSR/ISR directives that `/etf-scenarios` already uses.
 
 Under `src/components/stock-scenarios/`:
 
-- [ ] `StockScenarioPageLayout.tsx`
-- [ ] `StockScenarioListingGrid.tsx`
-- [ ] `StockScenarioCard.tsx` — in addition to the ETF card content, show small country
+- [x] `StockScenarioPageLayout.tsx`
+- [x] `StockScenarioListingGrid.tsx`
+- [x] `StockScenarioCard.tsx` — in addition to the ETF card content, show small country
   pills (one per entry in `countries[]`) so readers can see at a glance which markets the
   scenario applies to.
-- [ ] `StockScenarioOutlookBadge.tsx` (or reuse ETF version) — exports
+- [x] `StockScenarioOutlookBadge.tsx` (or reuse ETF version) — exports
   `StockScenarioDirectionBadge`, `StockScenarioProbabilityBadge`,
   `StockScenarioTimeframeBadge`. The ETF file
   (`src/components/etf-scenarios/EtfScenarioOutlookBadge.tsx`) is already generic in
   everything but name; the cleanest option is to rename it to
   `components/scenarios/ScenarioOutlookBadge.tsx` and share. Duplicating is
   explicitly a last resort.
-- [ ] `StockScenarioDetailView.tsx` — three-column Winners / Losers / Most-exposed grid.
+- [x] `StockScenarioDetailView.tsx` — three-column Winners / Losers / Most-exposed grid.
   If **any** link in a column has `roleExplanation`, `expectedPriceChange`, or
   `expectedPriceChangeExplanation` populated, the column flips from compact pills to a
   richer card list (same behaviour as the ETF detail view). Accepts a `countryFilter`
   prop — when set, each column is filtered to links whose resolved exchange is in
   `getExchangesByCountry(countryFilter)`, with a per-column count shown in the heading.
-- [ ] `StockScenarioFiltersBar.tsx` — client component, mirrors
+- [x] `StockScenarioFiltersBar.tsx` — client component, mirrors
   `EtfScenarioFiltersBar` (direction / timeframe / probability / search) **PLUS a
   `country` dropdown** sourced from `ALL_SUPPORTED_COUNTRIES` (in
   `countryExchangeUtils.ts`). The country dropdown has an "All countries" option
@@ -293,7 +316,7 @@ Under `src/components/stock-scenarios/`:
   to scenarios whose `countries[]` contains the selection. On detail pages (optional
   embedding), selecting a country filters the winner / loser / most-exposed columns
   per §1.2. Filter state is synced to the URL query string.
-- [ ] `StockScenarioCountrySelect.tsx` (optional extraction) — if we want to reuse the
+- [x] `StockScenarioCountrySelect.tsx` (optional extraction) — if we want to reuse the
   country dropdown between listing and detail pages, pull it into its own component
   backed by `ALL_SUPPORTED_COUNTRIES` and the `getCountryCodeForSearchBarDisplay`
   helper.
@@ -302,24 +325,24 @@ Under `src/components/stock-scenarios/`:
 
 Follow the `SingleSectionModal` pattern already used by `/admin-v1/etf-scenarios`.
 
-- [ ] `src/app/admin-v1/stock-scenarios/page.tsx` — listing table with row actions
+- [x] `src/app/admin-v1/stock-scenarios/page.tsx` — listing table with row actions
   (edit, archive-toggle, delete, manage-links). Show a `countries` column so admins can
   see country scope at a glance.
-- [ ] `src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx` — every field on
+- [x] `src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx` — every field on
   `StockScenario`, scrolling internally. The `countries[]` field renders as a multi-
   select populated from `ALL_SUPPORTED_COUNTRIES`; require at least one selection.
-- [ ] `src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx` — add/remove ticker symbols
+- [x] `src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx` — add/remove ticker symbols
   per role with `roleExplanation` + expected-price-change fields. Ticker typeahead calls
   the existing stock search endpoint (confirm path — likely
   `/api/koala_gains/tickers/search` or similar). After resolving the symbol's exchange,
   the modal should validate client-side that the resolved country is in the parent
   scenario's `countries[]` and show an inline error if not (server also enforces this —
   see §1.5).
-- [ ] `src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx` — bulk markdown
+- [x] `src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx` — bulk markdown
   import, mirrors `ImportEtfScenariosModal`. The markdown parser needs a new `Countries:`
   frontmatter line (comma-separated) — add to
   `src/utils/stock-scenario-markdown-parser.ts` when it's built.
-- [ ] `src/app/admin-v1/AdminNav.tsx` — add a **Stock Scenarios** link next to the
+- [x] `src/app/admin-v1/AdminNav.tsx` — add a **Stock Scenarios** link next to the
   existing `{ name: 'ETF Scenarios', href: '/admin-v1/etf-scenarios' }` entry (line 41
   today), so the two live side-by-side in the same section.
 
@@ -329,14 +352,14 @@ The ETF parser (`src/utils/etf-scenario-markdown-parser.ts`, 196 lines) extracts
 from winners/losers markdown using a capitalised-word regex + a STOPWORDS set. For
 stocks:
 
-- [ ] **Exchange-qualified tickers**: non-US tickers routinely collide with common words
+- [x] **Exchange-qualified tickers**: non-US tickers routinely collide with common words
   (e.g. `IT` = Gartner on NYSE AND an Indian listing on NSE). Require exchange qualifier
   in source markdown: `NSE:RELIANCE`, `LSE:ULVR`, etc. Update the extractor to parse
   `{EXCHANGE}:{SYMBOL}` as a single token and emit both fields into the `ParsedLink`.
-- [ ] **Expand `STOPWORDS`** to include country names that collide with tickers
+- [x] **Expand `STOPWORDS`** to include country names that collide with tickers
   (`US`, `UK`, `IN`, `CA`, `JP`, `KR`, `HK`, `TW`, `AU`, `PK`). Test against a sample of
   real scenario markdown before shipping.
-- [ ] **Frontmatter field**: parse a `Countries:` line (comma-separated
+- [x] **Frontmatter field**: parse a `Countries:` line (comma-separated
   `SupportedCountries` values) out of each scenario block, validate, and emit as
   `countries[]` on `ParsedScenario`.
 
@@ -344,13 +367,13 @@ stocks:
 
 Mirror `src/scripts/import-etf-scenarios.ts`:
 
-- [ ] Reads a markdown file (default
+- [x] Reads a markdown file (default
   `docs/ai-knowledge/insights-ui/stock-analysis/stock-market-scenarios.md` — create this
   directory during Phase 3 seeding), parses via the new parser, POSTs each scenario to
   `/api/stock-scenarios?token=<AUTOMATION_SECRET>`.
-- [ ] Honours env vars: `SCENARIOS_API_BASE`, `AUTOMATION_SECRET`, `SCENARIOS_MD_PATH`,
+- [x] Honours env vars: `SCENARIOS_API_BASE`, `AUTOMATION_SECRET`, `SCENARIOS_MD_PATH`,
   `SCENARIOS_FALLBACK_DATE`.
-- [ ] Wire into `package.json` scripts as `stock-scenarios:import` (ETF equivalent is
+- [x] Wire into `package.json` scripts as `stock-scenarios:import` (ETF equivalent is
   already wired).
 
 ---

--- a/tasks/koala-gains/stock-scenarios.md
+++ b/tasks/koala-gains/stock-scenarios.md
@@ -1,0 +1,260 @@
+# Stock Scenarios — KoalaGains (Tasks)
+
+Goal: build a **Stock Scenarios** feature for KoalaGains, mirroring the existing ETF
+Scenarios feature (see [`etf-scenarios.md`](../../docs/ai-knowledge/projects/insights-ui/features/etf-scenarios.md)
+and [`etf-scenarios-implementation-checklist.md`](../../docs/ai-knowledge/insights-ui/etf-analysis/etf-scenarios-implementation-checklist.md)).
+
+Each scenario carries a probability outlook, a priced-in assessment, an expected residual
+price move, and explicit lists of the **stocks** most exposed to it. The page should read
+like a ranked trade idea rather than a story — **five winners, five losers, and five most-
+exposed tickers**, each with a clear mechanical reason and an estimated % move.
+
+> The ETF Scenarios feature is already live (`/etf-scenarios`, `/admin-v1/etf-scenarios`,
+> `EtfScenario` + `EtfScenarioEtfLink` Prisma models). **Borrow its schema, API shape, and
+> UI patterns rather than inventing new ones.** The differences are: (a) links resolve
+> against the stock table (tickers) instead of the ETF table, and (b) where we surface the
+> "scenarios this asset appears in" reverse link on the asset's own report page.
+
+## Priority order
+
+1. **Database + API + public listing/detail pages** (parity with `/etf-scenarios`).
+2. **Admin CRUD** under `/admin-v1/stock-scenarios`.
+3. **Reverse link** from a stock's report page → the scenarios it appears in.
+4. **Shared-vs-parallel decision** with ETF scenarios (see open questions).
+5. **Seed content** — curate the first batch of stock scenarios.
+
+---
+
+## Phase 1 — Database, API, public pages
+
+### 1.1) Prisma schema
+
+Edit `insights-ui/prisma/schema.prisma` — add models **after** the existing `EtfScenario`
+/ `EtfScenarioEtfLink` definitions (around line 1815).
+
+- [ ] **Add `StockScenario` model** — field-for-field mirror of `EtfScenario`:
+  - `id`, `scenarioNumber`, `title`, `slug`
+  - `underlyingCause`, `historicalAnalog`, `winnersMarkdown`, `losersMarkdown`,
+    `outlookMarkdown` (all `String @db.Text`)
+  - `direction` (default `DOWNSIDE`), `timeframe` (default `FUTURE`),
+    `probabilityBucket` (default `MEDIUM`), `probabilityPercentage` (nullable Int)
+  - `pricedInBucket` (default `PARTIALLY_PRICED_IN`), `expectedPriceChange` (nullable Int),
+    `expectedPriceChangeExplanation`, `priceChangeTimeframeExplanation` (both nullable
+    `@db.Text`)
+  - `outlookAsOfDate` (`@db.Date`), `metaDescription` (nullable `@db.Text`)
+  - `archived` (default `false`), `spaceId` (default `"koala_gains"`),
+    `createdAt`, `updatedAt`
+  - Relation: `stockLinks StockScenarioStockLink[]`
+  - Constraints (match ETF version):
+    - `@@unique([spaceId, scenarioNumber])`, `@@unique([spaceId, slug])`
+    - `@@index([spaceId, archived])`, `@@index([spaceId, direction])`,
+      `@@index([spaceId, timeframe])`, `@@index([spaceId, probabilityBucket])`,
+      `@@index([spaceId, pricedInBucket])`
+    - `@@map("stock_scenarios")`
+- [ ] **Add `StockScenarioStockLink` join model** — mirror `EtfScenarioEtfLink` but link to
+  tickers instead of ETFs:
+  - `id`, `scenarioId`, `tickerKey` (nullable String — the existing ticker identity in
+    `TickerV1` / stock tables; confirm the correct FK field name before writing the
+    migration), `symbol`, `exchange` (nullable), `role`, `sortOrder`
+  - `roleExplanation`, `expectedPriceChange`, `expectedPriceChangeExplanation`
+  - `spaceId`, `createdAt`, `updatedAt`
+  - Relation back to `StockScenario` with `onDelete: Cascade`
+  - `@@unique([scenarioId, symbol, role])`, `@@index([scenarioId])`, `@@index([symbol])`
+  - `@@map("stock_scenario_stock_links")`
+- [ ] **Back-ref on the stock model** — add `scenarioLinks StockScenarioStockLink[]` to
+  whichever model represents a tradable stock ticker today (verify: `TickerV1`, `Ticker`,
+  or equivalent) so the future reverse-lookup join is indexed.
+- [ ] **Migration**: `yarn prisma migrate dev --name add_stock_scenarios`. Commit the
+  generated SQL.
+
+### 1.2) Shared enums — do NOT duplicate
+
+The TS enum module `insights-ui/src/types/etfScenarioEnums.ts` already defines
+`Direction`, `Timeframe`, `ProbabilityBucket`, `PricedInBucket`, `Role`. Stock scenarios
+use the **same values**.
+
+- [ ] Rename the file (or add a new neutral module) to `src/types/scenarioEnums.ts` and
+  re-export the existing enums under both old and new names so ETF code keeps compiling.
+  Stock scenarios then import from the neutral module directly.
+- [ ] Do NOT create a second set of enums under `stockScenarioEnums.ts` — that would
+  diverge over time and force double-maintenance.
+
+### 1.3) Cache-tag helpers
+
+- [ ] Create `src/utils/stock-scenario-cache-utils.ts` mirroring
+  `src/utils/etf-scenario-cache-utils.ts`:
+  - `stockScenarioBySlugTag(slug)` / `revalidateStockScenarioBySlugTag(slug)`
+  - `STOCK_SCENARIO_LISTING_TAG` constant + `revalidateStockScenarioListingTag()`
+- [ ] Every write endpoint calls the listing revalidator, and (on PUT/DELETE/link-mgmt) the
+  slug-specific revalidator.
+
+### 1.4) API routes
+
+Mirror the ETF scenarios routes 1:1. Space-scoped reads live under `/api/[spaceId]/...`,
+admin writes live under `/api/stock-scenarios/...`. Wrap all mutating endpoints with
+`withAdminOrToken` (matches ETF scenario pattern — allows the bot / automation scripts to
+post via `token=<AUTOMATION_SECRET>`).
+
+**Public (read)**
+- [ ] `src/app/api/[spaceId]/stock-scenarios/listing/route.ts` — `GET` with
+  `direction`, `timeframe`, `probabilityBucket`, `search`, `page`, `pageSize`,
+  `includeArchived` query params.
+- [ ] `src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts` — `GET` detail, returns
+  `{ scenario, winners, losers, mostExposed }` with nested stock lookups for each symbol
+  (so the UI can render clickable ticker pills linking to `/stocks/<exchange>/<symbol>`).
+  Resolve `tickerKey` + `exchange` on read from the symbol.
+
+**Admin (write)**
+- [ ] `src/app/api/stock-scenarios/route.ts` — `POST` upsert-by-slug (mirror of
+  `POST /api/etf-scenarios`). Accepts full scenario payload including a `links[]` array;
+  transaction deletes existing links and recreates them. Zod validation.
+- [ ] `src/app/api/stock-scenarios/[id]/route.ts` — `PUT` (partial update, no link
+  changes) + `DELETE` (hard-delete, cascades to links).
+- [ ] `src/app/api/stock-scenarios/[id]/links/route.ts` — `POST` / `DELETE` for a single
+  link row (admin-session only, matches ETF convention).
+- [ ] `src/app/api/stock-scenarios/import/route.ts` — `POST` admin-session only; bulk
+  import from markdown using a parser modelled on
+  `src/utils/etf-scenario-markdown-parser.ts`.
+- [ ] **Automation auth parity**: POST / PUT / DELETE / link-mgmt accept the
+  `AUTOMATION_SECRET` via `token=` query or `x-automation-token` header, same as
+  ETF scenarios (see `withAdminOrToken`).
+- [ ] **Symbol → ticker resolution**: backend looks up each link's `symbol` against the
+  stock table (`spaceId + symbol`) and populates `tickerKey` + `exchange`. Clients do NOT
+  pass those fields manually — same rule as ETF scenarios.
+
+### 1.5) Public pages
+
+Follow the SSR/ISR directives that `/etf-scenarios` already uses.
+
+- [ ] `src/app/stock-scenarios/page.tsx` — listing, `dynamic = 'force-static'`,
+  `dynamicParams = true`, `revalidate = 86400`. Server-side fetch via
+  `getBaseUrlForServerSidePages()` + the listing tag. `ItemList` JSON-LD inline.
+- [ ] `src/app/stock-scenarios/[slug]/page.tsx` — detail, same `force-static` +
+  `dynamicParams = true` but `revalidate = false`. `notFound()` on missing slug.
+  Three-column layout (Winners / Losers / Most-exposed) just like
+  `EtfScenarioDetailView` — reuse the same visual patterns. Stocks in each role render as
+  pills/cards linking to `/stocks/<exchange>/<symbol>` when resolved.
+- [ ] `src/app/stock-scenarios/StockScenariosPageActions.tsx` — admin cache-flush dropdown
+  (mirror the ETF version).
+- [ ] Metadata generators: `src/utils/stock-scenario-metadata-generators.ts` (mirror
+  `etf-scenario-metadata-generators.ts`) — title, description, breadcrumbs, `Article`
+  JSON-LD with `datePublished = createdAt`, `dateModified = updatedAt`, `dateline =
+  outlookAsOfDate`.
+
+### 1.6) Components
+
+Under `src/components/stock-scenarios/`:
+
+- [ ] `StockScenarioPageLayout.tsx`
+- [ ] `StockScenarioListingGrid.tsx`
+- [ ] `StockScenarioCard.tsx`
+- [ ] `StockScenarioDetailView.tsx` — three-column Winners / Losers / Most-exposed grid.
+  If **any** link in a column has `roleExplanation`, `expectedPriceChange`, or
+  `expectedPriceChangeExplanation` populated, the column flips from compact pills to a
+  richer card list (same behaviour as the ETF detail view).
+- [ ] `StockScenarioFiltersBar.tsx` — client component, mirrors
+  `EtfScenarioFiltersBar` (direction / timeframe / probability / search). Filtering can
+  be purely client-side against the initial SSR payload since scenario counts will stay
+  small.
+
+### 1.7) Admin UI
+
+Follow the `SingleSectionModal` pattern already used by `/admin-v1/etf-scenarios`.
+
+- [ ] `src/app/admin-v1/stock-scenarios/page.tsx` — listing table with row actions
+  (edit, archive-toggle, delete, manage-links).
+- [ ] `src/app/admin-v1/stock-scenarios/UpsertStockScenarioModal.tsx` — every field on
+  `StockScenario`, scrolling internally.
+- [ ] `src/app/admin-v1/stock-scenarios/ManageLinksModal.tsx` — add/remove ticker symbols
+  per role with `roleExplanation` + expected-price-change fields. Ticker typeahead calls
+  the existing stock search endpoint (confirm path — likely
+  `/api/koala_gains/tickers/search` or similar).
+- [ ] `src/app/admin-v1/stock-scenarios/ImportStockScenariosModal.tsx` — bulk markdown
+  import, mirrors `ImportEtfScenariosModal`.
+- [ ] `src/app/admin-v1/AdminNav.tsx` — add a **Stock Scenarios** link next to the
+  existing **ETF Scenarios** entry.
+
+---
+
+## Phase 2 — Reverse link on stock report pages
+
+Goal: on each stock's report page, show a "This stock appears in the following scenarios"
+block with links back to each scenario detail page.
+
+- [ ] On `src/app/stocks/[exchange]/[ticker]/page.tsx`, fetch
+  `StockScenarioStockLink` rows for the current `symbol` (via a new public API:
+  `/api/[spaceId]/stock-scenarios/for-symbol?symbol=...`).
+- [ ] Render a compact section — one line per scenario with:
+  - Scenario title (link to `/stock-scenarios/<slug>`).
+  - Direction + timeframe + probability badges.
+  - Role (`WINNER` / `LOSER` / `MOST_EXPOSED`).
+  - The link's `expectedPriceChange` (if set) so the reader sees the per-stock estimate.
+- [ ] **Explicitly NOT out of scope** — the ETF side deferred the symmetrical ETF-side
+  reverse link. For stock scenarios, ship this reverse link in the initial PR. Value is
+  higher for stocks because individual tickers sit in many more scenarios than any one
+  ETF does.
+- [ ] Cache-tag the fetch with `stockScenarioBySlugTag` + a new per-symbol tag so
+  revalidating a scenario also updates any stock pages that referenced it.
+
+---
+
+## Phase 3 — Seed content
+
+- [ ] Draft a first batch of ~15–30 stock scenarios as markdown, matching the parser
+  format expected by `stock-scenario-markdown-parser.ts`.
+- [ ] Each scenario needs: title, underlying cause, historical analog, direction,
+  timeframe, probability bucket (+ optional percentage), priced-in bucket, expected price
+  change + explanation + timeframe explanation, winners/losers narrative, outlook +
+  `outlookAsOfDate`.
+- [ ] **Exactly 5 winners + 5 losers + 5 most-exposed** per scenario (same operational
+  convention as ETF scenarios — if you reach for a sixth, drop the weakest existing one).
+- [ ] Prefer pure-play / sector-specific tickers over diversified giants (AAPL, MSFT,
+  GOOGL) when both would qualify — same rationale as the ETF rule favouring XLE/XOP over
+  SPY.
+- [ ] Import via the admin "Import from doc" button once the endpoint is live.
+
+---
+
+## Phase 4 — Prompts / automation (optional, follow-up)
+
+The ETF scenarios are currently hand-authored. For stock scenarios:
+
+- [ ] **Claude-assisted draft** — given a scenario description, ask Claude to suggest
+  candidate stocks for each role + a first-pass role explanation + priced-in assessment.
+  Human then reviews and publishes. Reuse the `AUTOMATION_SECRET` path via
+  `POST /api/stock-scenarios`.
+- [ ] **Auto-refresh outlook** — scheduled job that re-visits `outlookAsOfDate` on
+  scenarios older than N weeks and asks Claude whether the thesis is still intact /
+  needs a probability or priced-in update.
+
+---
+
+## Open questions
+
+- [ ] **Shared scenarios table vs parallel tables with ETFs?** The `stocks.md` and
+  `etfs.md` Trends tasks already flagged this. For scenarios specifically the same
+  question applies — the *underlying cause* and *historical analog* are identical between
+  a "Geopolitical Oil Price Spike" ETF scenario and its stock counterpart; only the
+  winner/loser/most-exposed lists differ.
+  - **Option A (parallel tables)**: simpler, keeps existing `EtfScenario` untouched,
+    matches how the code is structured today. Two admin pages, two detail pages, two
+    listings.
+  - **Option B (shared `Scenario` table + two join tables — `ScenarioEtfLink`,
+    `ScenarioStockLink`)**: one source of truth for the scenario narrative, two asset-
+    class lenses on top. Requires migrating the existing `EtfScenario` data, splitting
+    the current `EtfScenarioEtfLink` into a `ScenarioEtfLink`, and updating every caller.
+  - Pick before starting Phase 1 — the schema decision is hard to walk back.
+- [ ] **Scenario numbering across asset classes** — if we go with shared scenarios, a
+  single `scenarioNumber` is natural. If parallel, decide whether stock scenarios restart
+  at 1 or continue the ETF sequence.
+- [ ] **Cross-asset link on scenario detail page** — when (and only when) we share
+  scenarios, the detail page can show both "Stocks in this scenario" and "ETFs in this
+  scenario" side-by-side. Worth building if we go Option B.
+- [ ] **Ticker resolution edge cases** — stocks change tickers / merge / delist more
+  often than ETFs. Decide how the link row should handle a delisted ticker (keep as
+  plain text? auto-archive? flag for review?). ETF scenarios ignored this because ETF
+  ticker churn is rare; we cannot ignore it for stocks.
+- [ ] **Mapping to existing stock categories / sub-industries** — should each scenario
+  carry an optional list of relevant sub-industries, so the stock detail page can flag
+  "any scenario tagged to this ticker's sub-industry even if the ticker itself isn't in
+  the 15-row list"? Useful for breadth, risk of noise.


### PR DESCRIPTION
## Summary
- New task file `tasks/koala-gains/stock-scenarios.md` outlining a Stock Scenarios feature mirroring the live ETF Scenarios feature (same schema shape, same API surface, same admin UX).
- Specifies Prisma models (`StockScenario` + `StockScenarioStockLink`), shared enum module (rename `etfScenarioEnums.ts` → `scenarioEnums.ts` so we don't duplicate `Direction` / `Timeframe` / `ProbabilityBucket` / `PricedInBucket` / `Role`), cache-tag helpers, public listing + detail pages, admin CRUD, and the reverse "scenarios this stock appears in" block on stock report pages.
- Flags open questions upfront: shared scenarios table vs parallel tables, scenario numbering across asset classes, ticker-churn handling for delisted stocks, sub-industry tagging for breadth.

## Test plan
- [ ] Doc-only change — no code paths touched; verify the file renders correctly on GitHub
- [ ] Confirm the plan aligns with the live ETF Scenarios implementation before starting Phase 1 (Prisma migration is hard to walk back)