### PR TITLE
Add CLI scripts for per-report stock + ETF generation

### DIFF
--- a/docs/ai-knowledge/insights-ui/AIKnowledge.md
+++ b/docs/ai-knowledge/insights-ui/AIKnowledge.md
@@ -15,3 +15,4 @@ Topical reference docs for the Insights-UI (KoalaGains) app — patterns, prompt
 - **[tariffs-functionality.md](tariffs-functionality.md)** — Comprehensive overview of the tariffs analysis subsystem: pipeline, data structures, UI components, S3 storage, admin flow.
 - **[tariff-usecases.md](tariff-usecases.md)** — Catalog of real-world use cases for people who need tariff information; informs feature prioritization.
 - **[new-tariff-features.md](new-tariff-features.md)** — Highest-value tariff features to implement next, with market mapping.
+- **[automated-report-generation.md](automated-report-generation.md)** — Four CLI scripts (`stocks:prompt`, `stocks:save`, `etfs:prompt`, `etfs:save`) that let Claude drive stock + ETF report generation one report type at a time: ask server for prompt → call LLM → hand JSON back to server to save.

--- a/docs/ai-knowledge/insights-ui/automated-report-generation.md
+++ b/docs/ai-knowledge/insights-ui/automated-report-generation.md
@@ -1,0 +1,106 @@
+# Automated Report Generation (Stocks + ETFs)
+
+Four CLI scripts that let Claude (or any automation) drive report generation one report at a time, by asking the server for a prompt and then handing the LLM's JSON answer back to the server to be saved.
+
+## The idea in simple English
+
+Generating a report has two parts:
+
+1. **Build the prompt.** The server already knows which prompt template to use for each report type, and how to fill it in with the latest data for the stock or ETF. The server bakes everything into one final prompt string and hands it back.
+2. **Save the answer.** The LLM returns a JSON response. The server validates it and writes it to the right analysis tables.
+
+Claude runs one stock or ETF through all of its report types by looping: **get prompt → call LLM → save answer → repeat** for the next report type.
+
+For ETFs there is one extra step: before the first report, Claude asks the server to make sure Morningstar (MOR) data is fresh. If any of the four MOR tables (quote, risk, people, portfolio) is empty, the server fires the Morningstar scrape lambda. Because that lambda is fire-and-forget, the script then waits 10 seconds so the rows are in the DB before the prompt is built.
+
+## The four scripts
+
+| Script | What it does |
+| --- | --- |
+| `yarn stocks:prompt` | Returns the final prompt for one stock + one report type. |
+| `yarn stocks:save`   | Takes the LLM's JSON and saves the stock report. |
+| `yarn etfs:prompt`   | Checks MOR data (triggers scrape + waits if missing), then returns the ETF prompt. |
+| `yarn etfs:save`     | Takes the LLM's JSON and saves the ETF report. |
+
+Report type slugs:
+
+- **Stocks:** `financial-analysis`, `competition`, `business-and-moat`, `past-performance`, `future-growth`, `fair-value`, `future-risk`, `final-summary`
+- **ETFs:** `performance-and-returns`, `cost-efficiency-and-team`, `risk-analysis`, `future-performance-outlook`, `index-strategy`, `competition`, `final-summary`
+
+## Usage — stocks
+
+```bash
+# 1. Get the prompt (stdout = prompt, stderr = one-line summary)
+yarn stocks:prompt --symbol AAPL --exchange NASDAQ \
+  --report-type fair-value \
+  --out /tmp/aapl-fair-value.prompt.txt
+
+# 2. Hand the prompt to the LLM of your choice, get back JSON
+#    Save that JSON to /tmp/aapl-fair-value.response.json
+
+# 3. Store the response
+yarn stocks:save --symbol AAPL --exchange NASDAQ \
+  --report-type fair-value \
+  --in /tmp/aapl-fair-value.response.json
+```
+
+Repeat steps 1–3 for each report type you want.
+
+## Usage — ETFs
+
+```bash
+# 1. Get the prompt (this will trigger MOR scrape + wait 10s if needed)
+yarn etfs:prompt --symbol SPY --exchange NYSEARCA \
+  --report-type performance-and-returns \
+  --out /tmp/spy-perf.prompt.txt
+
+# 2. Call the LLM, save its JSON to a file
+
+# 3. Store the response
+yarn etfs:save --symbol SPY --exchange NYSEARCA \
+  --report-type performance-and-returns \
+  --in /tmp/spy-perf.response.json
+```
+
+`yarn etfs:prompt` extra flags:
+
+- `--wait-ms 10000` — override the post-MOR-trigger sleep.
+- `--skip-mor-check` — skip the MOR check entirely (use when you know the data is fresh and want to avoid the extra round-trip).
+
+## How it works under the hood
+
+### Stocks
+
+- `stocks:prompt` → `POST /api/<spaceId>/tickers-v1/exchange/<exchange>/<ticker>/generate-prompt` with `{ reportType }`.
+  - Handler: `generatePromptForReportType()` in `src/utils/analysis-reports/prompt-generator-utils.ts`.
+  - It fetches the ticker, builds the category-specific input JSON (`prepareFairValueInputJson`, etc.), pulls the active `PromptVersion` for the matching key (`US/public-equities-v1/<slug>`), compiles the Handlebars template, and returns the final prompt string.
+- `stocks:save` → `POST /api/<spaceId>/tickers-v1/exchange/<exchange>/<ticker>/save-json-report` with `{ llmResponse, reportType }`.
+  - Validates the JSON against the per-report schema in `schemas/analysis-factors/…`.
+  - Writes to `TickerV1CategoryAnalysisResult` + `TickerV1AnalysisCategoryFactorResult` (factor reports), `TickerV1VsCompetition` (competition), `TickerV1FutureRisk` (future-risk), or the base `TickerV1` row (final-summary).
+
+### ETFs
+
+- `etfs:prompt` first calls `POST /api/<spaceId>/etfs-v1/exchange/<exchange>/<etf>/ensure-mor-info`.
+  - Handler: `ensureMorDataForAnalysis()` in `src/utils/etf-analysis-reports/mor-scrape-utils.ts`.
+  - Counts rows in `EtfMorAnalyzerInfo`, `EtfMorRiskInfo`, `EtfMorPeopleInfo`, `EtfMorPortfolioInfo`. For every table with zero rows, triggers the Morningstar lambda (`ETF_MORN_LAMBDA_URL`) and returns the list of triggered kinds.
+  - If the returned list is non-empty, the script sleeps 10s (configurable with `--wait-ms`) so the async lambda callbacks can finish upserting the rows.
+- Then `etfs:prompt` calls `POST /api/<spaceId>/etfs-v1/exchange/<exchange>/<etf>/generate-prompt` with `{ reportType }`.
+  - Handler: `generateEtfPromptForReportType()` in `src/utils/etf-analysis-reports/etf-prompt-generator-utils.ts` (mirrors the stock side).
+  - Picks the input-JSON preparer (`preparePerformanceAndReturnsInputJson`, etc.), fetches the active prompt at the matching key (`US/etfs/<slug>` — see `ETF_PROMPT_KEYS`), compiles the template, returns the final prompt.
+- `etfs:save` → `POST /api/<spaceId>/etfs-v1/exchange/<exchange>/<etf>/save-report-callback` with `{ llmResponse, additionalData: { reportType } }`.
+  - Re-uses the endpoint the normal pipeline's lambda calls. Because we do **not** send a `generationRequestId`, the endpoint only persists the response — it does not chain-trigger the next step's lambda.
+  - Writes to `EtfCategoryAnalysisResult` (+ factor results), `EtfVsCompetition`, or directly on the `Etf` row for index-strategy and final-summary.
+
+## Authentication
+
+- All four scripts forward `AUTOMATION_SECRET` as `x-automation-token`. Set it with `source path/to/discord-claude-bot/.env` (or `export AUTOMATION_SECRET=...`) before running.
+- The ETF `ensure-mor-info` and `save-report-callback` endpoints are token-gated (`withAdminOrToken`). `generate-prompt` (both stocks and ETFs) and `save-json-report` (stocks) use `withErrorHandlingV2` and are open; the script still passes the header so the request logs attribute the call correctly.
+
+## Files
+
+- Scripts: `src/scripts/tickers/get-report-prompt.ts`, `src/scripts/tickers/save-report.ts`, `src/scripts/etfs/get-report-prompt.ts`, `src/scripts/etfs/save-report.ts`
+- New endpoints: `src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/generate-prompt/route.ts`, `src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/ensure-mor-info/route.ts`
+- New utility: `src/utils/etf-analysis-reports/etf-prompt-generator-utils.ts`
+- Stock prompt utility (already in place): `src/utils/analysis-reports/prompt-generator-utils.ts`
+- Stock save endpoint (already in place): `src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-json-report/route.ts`
+- Shared CLI helpers: `src/scripts/tickers/lib.ts`, `src/scripts/etfs/lib.ts`

--- a/insights-ui/package.json
+++ b/insights-ui/package.json
@@ -17,8 +17,12 @@
     "etfs:trigger": "tsx src/scripts/etfs/trigger-generation.ts",
     "etfs:wait": "tsx src/scripts/etfs/wait-for-generation.ts",
     "etfs:fetch": "tsx src/scripts/etfs/fetch-analysis.ts",
+    "etfs:prompt": "tsx src/scripts/etfs/get-report-prompt.ts",
+    "etfs:save": "tsx src/scripts/etfs/save-report.ts",
     "stocks:trigger": "tsx src/scripts/tickers/trigger-generation.ts",
-    "stocks:add": "tsx src/scripts/tickers/add-stock.ts"
+    "stocks:add": "tsx src/scripts/tickers/add-stock.ts",
+    "stocks:prompt": "tsx src/scripts/tickers/get-report-prompt.ts",
+    "stocks:save": "tsx src/scripts/tickers/save-report.ts"
   },
   "engines": {
     "node": ">=23.11.0"

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/ensure-mor-info/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/ensure-mor-info/route.ts
@@ -1,0 +1,37 @@
+import { withAdminOrToken } from '@/app/api/helpers/withAdminOrToken';
+import { KoalaGainsJwtTokenPayload } from '@/types/auth';
+import { ensureMorDataForAnalysis, MorKind } from '@/utils/etf-analysis-reports/mor-scrape-utils';
+import { fetchEtfBySymbolAndExchange } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
+import { NextRequest } from 'next/server';
+
+export interface EnsureMorInfoResponse {
+  /** Kinds whose tables were empty and for which a scrape lambda was triggered. Empty when all data is already present. */
+  triggeredKinds: MorKind[];
+}
+
+/**
+ * Check the four MOR tables for an ETF; for any that are empty, trigger the Morningstar
+ * scrape lambda to populate them. Scraping is fire-and-forget (callbacks upsert the rows
+ * asynchronously), so a caller that needs the data immediately should sleep a few seconds
+ * before requesting the prompt.
+ */
+async function handler(
+  _req: NextRequest,
+  _userContext: KoalaGainsJwtTokenPayload | null,
+  { params }: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }
+): Promise<EnsureMorInfoResponse> {
+  const { spaceId, exchange, etf } = await params;
+
+  const etfRecord = await fetchEtfBySymbolAndExchange(etf, exchange);
+
+  const triggeredKinds = await ensureMorDataForAnalysis({
+    etfId: etfRecord.id,
+    spaceId,
+    exchange: etfRecord.exchange,
+    symbol: etfRecord.symbol,
+  });
+
+  return { triggeredKinds };
+}
+
+export const POST = withAdminOrToken<EnsureMorInfoResponse>(handler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/generate-prompt/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/generate-prompt/route.ts
@@ -1,0 +1,45 @@
+import { generateEtfPromptForReportType } from '@/utils/etf-analysis-reports/etf-prompt-generator-utils';
+import { EtfReportType } from '@/types/etf/etf-analysis-types';
+import { NextRequest } from 'next/server';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+interface RouteParams {
+  params: Promise<{
+    spaceId: string;
+    exchange: string;
+    etf: string;
+  }>;
+}
+
+export interface EtfGeneratePromptRequest {
+  reportType: EtfReportType;
+}
+
+export interface EtfGeneratePromptResponse {
+  prompt: string;
+  reportType: EtfReportType;
+  promptKey: string;
+}
+
+async function handler(request: NextRequest, { params }: RouteParams): Promise<EtfGeneratePromptResponse> {
+  const { exchange, etf } = await params;
+  const body: EtfGeneratePromptRequest = await request.json();
+  const { reportType } = body;
+
+  if (!reportType) {
+    throw new Error('reportType is required');
+  }
+  if (!Object.values(EtfReportType).includes(reportType)) {
+    throw new Error(`Unsupported ETF reportType "${reportType}". Valid values: ${Object.values(EtfReportType).join(', ')}`);
+  }
+
+  const result = await generateEtfPromptForReportType(etf, exchange, reportType);
+
+  return {
+    prompt: result.prompt,
+    reportType: result.reportType,
+    promptKey: result.promptKey,
+  };
+}
+
+export const POST = withErrorHandlingV2<EtfGeneratePromptResponse>(handler);

--- a/insights-ui/src/scripts/etfs/get-report-prompt.ts
+++ b/insights-ui/src/scripts/etfs/get-report-prompt.ts
@@ -1,0 +1,90 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { EtfReportType } from '@/types/etf/etf-analysis-types';
+import { API_BASE, AUTOMATION_SECRET, SPACE_ID, fetchJson, parseArgs, parsePositiveInt, requireAutomationSecret, requireStringArg, sleep } from './lib';
+
+interface EnsureMorInfoResponse {
+  triggeredKinds: string[];
+}
+
+interface EtfGeneratePromptResponse {
+  prompt: string;
+  reportType: EtfReportType;
+  promptKey: string;
+}
+
+const VALID_REPORT_TYPES: readonly EtfReportType[] = [
+  EtfReportType.PERFORMANCE_AND_RETURNS,
+  EtfReportType.COST_EFFICIENCY_AND_TEAM,
+  EtfReportType.RISK_ANALYSIS,
+  EtfReportType.FUTURE_PERFORMANCE_OUTLOOK,
+  EtfReportType.INDEX_STRATEGY,
+  EtfReportType.COMPETITION,
+  EtfReportType.FINAL_SUMMARY,
+];
+
+const DEFAULT_MOR_WAIT_MS = 10_000;
+
+function toEtfReportType(raw: string): EtfReportType {
+  const matched = VALID_REPORT_TYPES.find((t) => t === raw);
+  if (!matched) {
+    throw new Error(`Invalid --report-type "${raw}". Valid values: ${VALID_REPORT_TYPES.join(', ')}`);
+  }
+  return matched;
+}
+
+async function main(): Promise<void> {
+  // ensure-mor-info is token-gated; fail fast if the caller forgot to set the secret.
+  requireAutomationSecret();
+
+  const args = parseArgs(process.argv.slice(2));
+  const symbol = requireStringArg(args, 'symbol').toUpperCase();
+  const exchange = requireStringArg(args, 'exchange').toUpperCase();
+  const reportType = toEtfReportType(requireStringArg(args, 'report-type'));
+  const outPath = typeof args['out'] === 'string' ? args['out'] : undefined;
+  const waitMs = parsePositiveInt(args['wait-ms']) ?? DEFAULT_MOR_WAIT_MS;
+  const skipMorCheck = args['skip-mor-check'] === true;
+
+  if (!skipMorCheck) {
+    const morResponse = await fetchJson<EnsureMorInfoResponse>(
+      `/api/${SPACE_ID}/etfs-v1/exchange/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}/ensure-mor-info`,
+      {
+        method: 'POST',
+        body: {},
+        authToken: true,
+      }
+    );
+
+    // Morningstar scrapes are fire-and-forget: the lambda callbacks upsert the tables
+    // asynchronously. Sleep so the DB-backed prompt builder sees the freshly-written rows.
+    if (morResponse.triggeredKinds.length > 0) {
+      console.error(`MOR data missing for kinds [${morResponse.triggeredKinds.join(', ')}] — triggered scrape; sleeping ${waitMs}ms before building prompt.`);
+      await sleep(waitMs);
+    } else {
+      console.error(`MOR data already present for ${symbol} ${exchange}.`);
+    }
+  }
+
+  const response = await fetchJson<EtfGeneratePromptResponse>(
+    `/api/${SPACE_ID}/etfs-v1/exchange/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}/generate-prompt`,
+    {
+      method: 'POST',
+      body: { reportType },
+      authToken: true,
+    }
+  );
+
+  if (outPath) {
+    await mkdir(path.dirname(outPath), { recursive: true });
+    await writeFile(outPath, response.prompt, 'utf-8');
+    console.error(`Wrote prompt (${response.prompt.length} chars) → ${outPath} [${API_BASE} | ${symbol} ${exchange} ${reportType} | ${response.promptKey}]`);
+  } else {
+    console.error(`Generated ETF prompt for ${symbol} ${exchange} ${reportType} (${response.prompt.length} chars, key=${response.promptKey}).`);
+    process.stdout.write(response.prompt);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/scripts/etfs/save-report.ts
+++ b/insights-ui/src/scripts/etfs/save-report.ts
@@ -1,0 +1,85 @@
+import { readFile } from 'node:fs/promises';
+import { EtfReportType } from '@/types/etf/etf-analysis-types';
+import { SPACE_ID, fetchJson, parseArgs, requireAutomationSecret, requireStringArg } from './lib';
+
+interface SaveReportResponse {
+  success: boolean;
+}
+
+const VALID_REPORT_TYPES: readonly EtfReportType[] = [
+  EtfReportType.PERFORMANCE_AND_RETURNS,
+  EtfReportType.COST_EFFICIENCY_AND_TEAM,
+  EtfReportType.RISK_ANALYSIS,
+  EtfReportType.FUTURE_PERFORMANCE_OUTLOOK,
+  EtfReportType.INDEX_STRATEGY,
+  EtfReportType.COMPETITION,
+  EtfReportType.FINAL_SUMMARY,
+];
+
+function toEtfReportType(raw: string): EtfReportType {
+  const matched = VALID_REPORT_TYPES.find((t) => t === raw);
+  if (!matched) {
+    throw new Error(`Invalid --report-type "${raw}". Valid values: ${VALID_REPORT_TYPES.join(', ')}`);
+  }
+  return matched;
+}
+
+async function readLlmResponse(args: Record<string, string | boolean>): Promise<unknown> {
+  const inPath = typeof args['in'] === 'string' ? args['in'] : undefined;
+  const inline = typeof args['json'] === 'string' ? args['json'] : undefined;
+
+  if (inPath && inline) {
+    throw new Error('Pass either --in <path> OR --json <string>, not both');
+  }
+
+  if (inline) {
+    try {
+      return JSON.parse(inline);
+    } catch (err) {
+      throw new Error(`Failed to parse --json argument as JSON: ${(err as Error).message}`);
+    }
+  }
+
+  if (!inPath) {
+    throw new Error('Missing required input: pass --in <path-to-llm-response.json> or --json <raw-json-string>');
+  }
+
+  const raw = await readFile(inPath, 'utf-8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse ${inPath} as JSON: ${(err as Error).message}`);
+  }
+}
+
+async function main(): Promise<void> {
+  requireAutomationSecret();
+
+  const args = parseArgs(process.argv.slice(2));
+  const symbol = requireStringArg(args, 'symbol').toUpperCase();
+  const exchange = requireStringArg(args, 'exchange').toUpperCase();
+  const reportType = toEtfReportType(requireStringArg(args, 'report-type'));
+  const llmResponse = await readLlmResponse(args);
+
+  // save-report-callback is the existing endpoint the lambda uses on the normal pipeline.
+  // We call it without a generationRequestId so it only persists the response and skips
+  // the lambda chain-trigger that the callback performs when part of an orchestrated run.
+  const response = await fetchJson<SaveReportResponse>(
+    `/api/${SPACE_ID}/etfs-v1/exchange/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}/save-report-callback`,
+    {
+      method: 'POST',
+      body: {
+        llmResponse,
+        additionalData: { reportType },
+      },
+      authToken: true,
+    }
+  );
+
+  console.log(JSON.stringify({ symbol, exchange, reportType, ...response }, null, 2));
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/scripts/tickers/get-report-prompt.ts
+++ b/insights-ui/src/scripts/tickers/get-report-prompt.ts
@@ -1,0 +1,65 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ReportType } from '@/types/ticker-typesv1';
+import { API_BASE, AUTOMATION_SECRET, SPACE_ID, fetchJson, parseArgs, requireStringArg } from './lib';
+
+interface GeneratePromptResponse {
+  prompt: string;
+  reportType: ReportType;
+}
+
+const VALID_REPORT_TYPES: readonly ReportType[] = [
+  ReportType.FINANCIAL_ANALYSIS,
+  ReportType.COMPETITION,
+  ReportType.BUSINESS_AND_MOAT,
+  ReportType.PAST_PERFORMANCE,
+  ReportType.FUTURE_GROWTH,
+  ReportType.FAIR_VALUE,
+  ReportType.FUTURE_RISK,
+  ReportType.FINAL_SUMMARY,
+];
+
+function toReportType(raw: string): ReportType {
+  const matched = VALID_REPORT_TYPES.find((t) => t === raw);
+  if (!matched) {
+    throw new Error(`Invalid --report-type "${raw}". Valid values: ${VALID_REPORT_TYPES.join(', ')}`);
+  }
+  return matched;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const symbol = requireStringArg(args, 'symbol').toUpperCase();
+  const exchange = requireStringArg(args, 'exchange').toUpperCase();
+  const reportType = toReportType(requireStringArg(args, 'report-type'));
+  const outPath = typeof args['out'] === 'string' ? args['out'] : undefined;
+
+  // generate-prompt is an open endpoint (no auth wrapper), but we still forward the
+  // automation token if present so request logs attribute the call to the scripted caller.
+  const authToken = AUTOMATION_SECRET.length > 0;
+
+  const response = await fetchJson<GeneratePromptResponse>(
+    `/api/${SPACE_ID}/tickers-v1/exchange/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}/generate-prompt`,
+    {
+      method: 'POST',
+      body: { reportType },
+      authToken,
+    }
+  );
+
+  if (outPath) {
+    await mkdir(path.dirname(outPath), { recursive: true });
+    await writeFile(outPath, response.prompt, 'utf-8');
+    console.error(`Wrote prompt (${response.prompt.length} chars) → ${outPath} [${API_BASE} | ${symbol} ${exchange} ${reportType}]`);
+  } else {
+    // Prompt goes to stdout so it can be piped directly into the LLM call. Metadata
+    // goes to stderr to avoid polluting the captured prompt.
+    console.error(`Generated prompt for ${symbol} ${exchange} ${reportType} (${response.prompt.length} chars).`);
+    process.stdout.write(response.prompt);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/scripts/tickers/save-report.ts
+++ b/insights-ui/src/scripts/tickers/save-report.ts
@@ -1,0 +1,83 @@
+import { readFile } from 'node:fs/promises';
+import { ReportType } from '@/types/ticker-typesv1';
+import { AUTOMATION_SECRET, SPACE_ID, fetchJson, parseArgs, requireStringArg } from './lib';
+
+interface SaveReportResponse {
+  success: boolean;
+  message: string;
+}
+
+const VALID_REPORT_TYPES: readonly ReportType[] = [
+  ReportType.FINANCIAL_ANALYSIS,
+  ReportType.COMPETITION,
+  ReportType.BUSINESS_AND_MOAT,
+  ReportType.PAST_PERFORMANCE,
+  ReportType.FUTURE_GROWTH,
+  ReportType.FAIR_VALUE,
+  ReportType.FUTURE_RISK,
+  ReportType.FINAL_SUMMARY,
+];
+
+function toReportType(raw: string): ReportType {
+  const matched = VALID_REPORT_TYPES.find((t) => t === raw);
+  if (!matched) {
+    throw new Error(`Invalid --report-type "${raw}". Valid values: ${VALID_REPORT_TYPES.join(', ')}`);
+  }
+  return matched;
+}
+
+async function readLlmResponse(args: Record<string, string | boolean>): Promise<unknown> {
+  const inPath = typeof args['in'] === 'string' ? args['in'] : undefined;
+  const inline = typeof args['json'] === 'string' ? args['json'] : undefined;
+
+  if (inPath && inline) {
+    throw new Error('Pass either --in <path> OR --json <string>, not both');
+  }
+
+  if (inline) {
+    try {
+      return JSON.parse(inline);
+    } catch (err) {
+      throw new Error(`Failed to parse --json argument as JSON: ${(err as Error).message}`);
+    }
+  }
+
+  if (!inPath) {
+    throw new Error('Missing required input: pass --in <path-to-llm-response.json> or --json <raw-json-string>');
+  }
+
+  const raw = await readFile(inPath, 'utf-8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse ${inPath} as JSON: ${(err as Error).message}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const symbol = requireStringArg(args, 'symbol').toUpperCase();
+  const exchange = requireStringArg(args, 'exchange').toUpperCase();
+  const reportType = toReportType(requireStringArg(args, 'report-type'));
+  const llmResponse = await readLlmResponse(args);
+
+  // save-json-report validates the payload against the schema for the given report type and
+  // then writes it to the appropriate ticker analysis tables.
+  const authToken = AUTOMATION_SECRET.length > 0;
+
+  const response = await fetchJson<SaveReportResponse>(
+    `/api/${SPACE_ID}/tickers-v1/exchange/${encodeURIComponent(exchange)}/${encodeURIComponent(symbol)}/save-json-report`,
+    {
+      method: 'POST',
+      body: { llmResponse, reportType },
+      authToken,
+    }
+  );
+
+  console.log(JSON.stringify({ symbol, exchange, reportType, ...response }, null, 2));
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/utils/etf-analysis-reports/etf-prompt-generator-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-prompt-generator-utils.ts
@@ -1,0 +1,80 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ETF_PROMPT_KEYS, EtfReportType } from '@/types/etf/etf-analysis-types';
+import { fetchEtfWithAllData, EtfWithAllData } from '@/utils/etf-analysis-reports/get-etf-report-data-utils';
+import {
+  prepareCostEfficiencyAndTeamInputJson,
+  prepareEtfCompetitionInputJson,
+  prepareEtfFinalSummaryInputJson,
+  prepareFuturePerformanceOutlookInputJson,
+  prepareIndexStrategyInputJson,
+  preparePerformanceAndReturnsInputJson,
+  prepareRiskAnalysisInputJson,
+} from '@/utils/etf-analysis-reports/etf-report-input-json-utils';
+import { compileTemplate, loadSchema, validateData } from '@/util/get-llm-response';
+import path from 'path';
+
+export interface GeneratedEtfPromptResult {
+  prompt: string;
+  inputJson: Record<string, unknown>;
+  reportType: EtfReportType;
+  promptKey: string;
+}
+
+function prepareEtfInputJsonForReportType(etf: EtfWithAllData, reportType: EtfReportType): Record<string, unknown> {
+  switch (reportType) {
+    case EtfReportType.PERFORMANCE_AND_RETURNS:
+      return preparePerformanceAndReturnsInputJson(etf);
+    case EtfReportType.COST_EFFICIENCY_AND_TEAM:
+      return prepareCostEfficiencyAndTeamInputJson(etf);
+    case EtfReportType.RISK_ANALYSIS:
+      return prepareRiskAnalysisInputJson(etf);
+    case EtfReportType.FUTURE_PERFORMANCE_OUTLOOK:
+      return prepareFuturePerformanceOutlookInputJson(etf);
+    case EtfReportType.INDEX_STRATEGY:
+      return prepareIndexStrategyInputJson(etf);
+    case EtfReportType.COMPETITION:
+      return prepareEtfCompetitionInputJson(etf);
+    case EtfReportType.FINAL_SUMMARY:
+      return prepareEtfFinalSummaryInputJson(etf);
+  }
+}
+
+/**
+ * Build the final LLM-ready prompt string for a given ETF and report type, without
+ * invoking any LLM or lambda. Mirrors `generatePromptForReportType` on the stock side.
+ * The caller is responsible for ensuring MOR data is populated beforehand — this
+ * function only reads whatever is in the DB.
+ */
+export async function generateEtfPromptForReportType(symbol: string, exchange: string, reportType: EtfReportType): Promise<GeneratedEtfPromptResult> {
+  const spaceId = KoalaGainsSpaceId;
+  const etf = await fetchEtfWithAllData(symbol, exchange);
+  const promptKey = ETF_PROMPT_KEYS[reportType];
+  if (!promptKey) {
+    throw new Error(`No prompt key mapped for ETF report type ${reportType}`);
+  }
+
+  const inputJson = prepareEtfInputJsonForReportType(etf, reportType);
+
+  const prompt = await prisma.prompt.findFirstOrThrow({
+    where: { spaceId, key: promptKey },
+    include: { activePromptVersion: true },
+  });
+
+  if (!prompt.activePromptVersion) {
+    throw new Error(`Active prompt version not found for template ${promptKey}`);
+  }
+
+  if (prompt.inputSchema && prompt.inputSchema.trim() !== '') {
+    const inputSchemaPath = path.join(process.cwd(), 'schemas', prompt.inputSchema);
+    const inputSchemaObject = await loadSchema(inputSchemaPath, prompt.inputSchema);
+    const { valid, errors } = validateData(inputSchemaObject, inputJson);
+    if (!valid) {
+      throw new Error(`Input validation failed for ${promptKey}: ${JSON.stringify(errors)}`);
+    }
+  }
+
+  const finalPrompt = compileTemplate(prompt.activePromptVersion.promptTemplate, inputJson);
+
+  return { prompt: finalPrompt, inputJson, reportType, promptKey };
+}


### PR DESCRIPTION
## Summary

Four new CLI scripts (`stocks:prompt`, `stocks:save`, `etfs:prompt`, `etfs:save`) that let Claude (or any other automation driver) generate a stock or ETF report one report type at a time:

1. **Ask the server for the prompt.** Server picks the right template for the requested report type, builds the input JSON the normal pipeline would build, compiles the Handlebars template, and returns the final prompt string.
2. **Run the prompt through the LLM** of your choice.
3. **Hand the JSON response back to the server to persist.**

Repeat for each report type.

### What's new

- Stocks: CLI wrappers around the existing `generate-prompt` + `save-json-report` endpoints — no server changes needed.
- ETFs:
  - New util `generateEtfPromptForReportType()` that mirrors the stock side.
  - New route `POST /api/{spaceId}/etfs-v1/exchange/{exchange}/{etf}/generate-prompt`.
  - New route `POST /api/{spaceId}/etfs-v1/exchange/{exchange}/{etf}/ensure-mor-info` which runs `ensureMorDataForAnalysis()` and returns the list of MOR kinds whose scrape lambda was fired.
  - The ETF prompt script calls `ensure-mor-info` first; if it triggered any scrapes, the script sleeps 10s (configurable via `--wait-ms`) before asking for the prompt, so the async Morningstar lambda callbacks have time to populate the DB.
  - ETF save script calls the existing `save-report-callback` without a `generationRequestId`, which skips the lambda chain-trigger and only persists the response.
- `package.json` adds `stocks:prompt`, `stocks:save`, `etfs:prompt`, `etfs:save` yarn shortcuts.
- New knowledge doc `docs/ai-knowledge/insights-ui/automated-report-generation.md` explains the flow in simple English and is linked from the insights-ui knowledge index.

### Report types

- **Stocks:** `financial-analysis`, `competition`, `business-and-moat`, `past-performance`, `future-growth`, `fair-value`, `future-risk`, `final-summary` (keys under `US/public-equities-v1/...`).
- **ETFs:** `performance-and-returns`, `cost-efficiency-and-team`, `risk-analysis`, `future-performance-outlook`, `index-strategy`, `competition`, `final-summary` (keys under `US/etfs/...`, from `ETF_PROMPT_KEYS`).

## Test plan

- [ ] `yarn stocks:prompt --symbol AAPL --exchange NASDAQ --report-type fair-value --out /tmp/prompt.txt` returns a populated prompt file.
- [ ] Feed that prompt to an LLM → save JSON → `yarn stocks:save --symbol AAPL --exchange NASDAQ --report-type fair-value --in /tmp/resp.json` persists it (verify a new `TickerV1CategoryAnalysisResult` row).
- [ ] Repeat across all 8 stock report types for a sample stock to confirm each prompt-key + save path works.
- [ ] `yarn etfs:prompt --symbol SPY --exchange NYSEARCA --report-type performance-and-returns --out /tmp/etf.txt` for an ETF missing MOR data triggers the scrape and sleeps 10s before returning a prompt.
- [ ] Verify `triggeredKinds` in `/ensure-mor-info` response matches empty MOR tables in the DB.
- [ ] `yarn etfs:save --symbol SPY --exchange NYSEARCA --report-type performance-and-returns --in /tmp/etf-resp.json` persists to `EtfCategoryAnalysisResult`.
- [ ] Repeat across all 7 ETF report types.
- [ ] Re-running the ETF prompt script with MOR data already present should log "MOR data already present" and skip the sleep.
- [ ] `yarn lint`, `yarn prettier-check`, `yarn compile` all green (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)