### PR TITLE
stock-scenarios: surface market cap, PE, and KoalaGains score on link cards

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
@@ -15,6 +15,16 @@ export interface StockScenarioLinkDto {
   expectedPriceChange: number | null;
   expectedPriceChangeExplanation: string | null;
   pricedInBucket: ScenarioPricedInBucket;
+  marketCap: number | null;
+  pe: number | null;
+  finalScore: number | null;
+}
+
+interface ResolvedTicker {
+  tickerId: string;
+  marketCap: number | null;
+  pe: number | null;
+  finalScore: number | null;
 }
 
 export interface StockScenarioDetail
@@ -31,17 +41,20 @@ export interface StockScenarioDetail
   mostExposed: StockScenarioLinkDto[];
 }
 
-function toLinkDto(link: StockScenarioStockLink, resolvedTickerId?: string | null): StockScenarioLinkDto {
+function toLinkDto(link: StockScenarioStockLink, resolved: ResolvedTicker | undefined): StockScenarioLinkDto {
   return {
     symbol: link.symbol,
     exchange: link.exchange,
-    tickerId: link.tickerId ?? resolvedTickerId ?? null,
+    tickerId: link.tickerId ?? resolved?.tickerId ?? null,
     role: link.role as ScenarioRole,
     sortOrder: link.sortOrder,
     roleExplanation: link.roleExplanation,
     expectedPriceChange: link.expectedPriceChange,
     expectedPriceChangeExplanation: link.expectedPriceChangeExplanation,
     pricedInBucket: link.pricedInBucket as ScenarioPricedInBucket,
+    marketCap: resolved?.marketCap ?? null,
+    pe: resolved?.pe ?? null,
+    finalScore: resolved?.finalScore ?? null,
   };
 }
 
@@ -62,22 +75,32 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const { stockLinks, outlookAsOfDate, createdAt, updatedAt, countries, ...rest } = scenario;
 
-  // Resolve any links that don't have `tickerId` set yet against the TickerV1
-  // table by (symbol, exchange) — matches the unique constraint
-  // `@@unique([spaceId, symbol, exchange])` on tickers_v1.
-  const unresolved = stockLinks.filter((l) => !l.tickerId).map((l) => ({ symbol: l.symbol.toUpperCase(), exchange: l.exchange.toUpperCase() }));
+  // Bulk-fetch every link's TickerV1 row (matches the unique constraint
+  // `@@unique([spaceId, symbol, exchange])` on tickers_v1) so we can:
+  //   1. resolve `tickerId` for legacy links that saved with tickerId=null
+  //   2. surface market cap / PE / final score on the link cards
+  // One query covers all links — no N+1, no per-link round-trips.
+  const linkKeys = stockLinks.map((l) => ({ symbol: l.symbol.toUpperCase(), exchange: l.exchange.toUpperCase() }));
 
-  const resolved = new Map<string, string>();
-  if (unresolved.length) {
+  const resolved = new Map<string, ResolvedTicker>();
+  if (linkKeys.length) {
     const tickers = await prisma.tickerV1.findMany({
-      where: {
-        spaceId,
-        OR: unresolved.map((u) => ({ symbol: u.symbol, exchange: u.exchange })),
+      where: { spaceId, OR: linkKeys },
+      select: {
+        id: true,
+        symbol: true,
+        exchange: true,
+        financialInfo: { select: { marketCap: true, pe: true } },
+        cachedScoreEntry: { select: { finalScore: true } },
       },
-      select: { id: true, symbol: true, exchange: true },
     });
     for (const t of tickers) {
-      resolved.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, t.id);
+      resolved.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, {
+        tickerId: t.id,
+        marketCap: t.financialInfo?.marketCap ?? null,
+        pe: t.financialInfo?.pe ?? null,
+        finalScore: t.cachedScoreEntry?.finalScore ?? null,
+      });
     }
   }
 

--- a/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
@@ -6,6 +6,7 @@ import { StockScenarioLinkDto } from '@/app/api/[spaceId]/stock-scenarios/[slug]
 import { ScenarioPricedInBucket } from '@/types/scenarioEnums';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { AllExchanges, ALL_SUPPORTED_COUNTRIES, EXCHANGE_TO_COUNTRY, isExchange, SupportedCountries } from '@/utils/countryExchangeUtils';
+import { getScoreColorClasses } from '@/utils/score-utils';
 
 const PRICED_IN_LABEL: Record<ScenarioPricedInBucket, string> = {
   NOT_PRICED_IN: 'Not priced in',
@@ -55,11 +56,33 @@ function formatExpectedPriceChange(value: number | null | undefined): string {
   return `${sign}${value}%`;
 }
 
+// Market cap arrives as a raw USD number from TickerV1FinancialInfo. Render
+// `$X.XB` / `$X.XM` / `$X.XK` so the card stays compact regardless of size.
+function formatMarketCapShort(value: number | null | undefined): string {
+  if (value === null || value === undefined || !isFinite(value)) return '—';
+  const abs = Math.abs(value);
+  if (abs >= 1e12) return `$${(value / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `$${(value / 1e3).toFixed(1)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+// PE is shown as a hyphen for negative values too: a negative PE ratio means
+// the company is unprofitable, and the number itself isn't meaningful — best
+// to flag it as "not applicable" rather than print misleading data.
+function formatPe(value: number | null | undefined): string {
+  if (value === null || value === undefined || !isFinite(value) || value < 0) return '—';
+  return value.toFixed(1);
+}
+
 function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
   const hasDetails = link.roleExplanation || link.expectedPriceChange !== null || link.expectedPriceChangeExplanation;
   const changeColor = link.expectedPriceChange === null ? '' : link.expectedPriceChange >= 0 ? 'text-emerald-300' : 'text-red-300';
   const pricedInLabel = PRICED_IN_LABEL[link.pricedInBucket];
   const pricedInClass = PRICED_IN_CLASS[link.pricedInBucket];
+  const score = link.finalScore;
+  const scoreClasses = score !== null ? getScoreColorClasses(score) : null;
 
   return (
     <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">
@@ -76,6 +99,30 @@ function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
         >
           {pricedInLabel}
         </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-400 mb-1">
+        <span title="Market cap">
+          <span className="text-gray-500">Mkt cap </span>
+          <span className="font-mono tabular-nums text-gray-200">{formatMarketCapShort(link.marketCap)}</span>
+        </span>
+        <span title="Price-to-earnings ratio (— for negative or unavailable)">
+          <span className="text-gray-500">PE </span>
+          <span className="font-mono tabular-nums text-gray-200">{formatPe(link.pe)}</span>
+        </span>
+        {score !== null && scoreClasses ? (
+          <span
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded ${scoreClasses.bgColorClass} bg-opacity-15 ${scoreClasses.textColorClass}`}
+            title={`KoalaGains score (${scoreClasses.scoreLabel})`}
+          >
+            <span className="text-[10px] uppercase tracking-wide">Score</span>
+            <span className="font-mono tabular-nums font-semibold">{score}/25</span>
+          </span>
+        ) : (
+          <span title="KoalaGains score not available yet">
+            <span className="text-gray-500">Score </span>
+            <span className="font-mono tabular-nums text-gray-200">—</span>
+          </span>
+        )}
       </div>
       {hasDetails && (
         <div className="space-y-1 mt-1">


### PR DESCRIPTION
## Summary

Each tagged stock card on a stock-scenario detail page now shows three extra
fields right under the priced-in bucket badge:

- **Market cap** (compact: `$X.XB` / `$X.XM` / `$X.XK`)
- **PE ratio** — renders as `—` for `null` *or* negative values (negative PE means the company is unprofitable; the multiple itself isn't meaningful)
- **KoalaGains score** — color-coded `X/25` pill using the same thresholds as `StockTickerItem` (red < 8, orange 8–13, yellow 14–19, green 20+)

This mirrors the at-a-glance stats readers already see on the main `/stocks` listing.

## Query efficiency

The detail API still issues exactly **2 queries** per scenario page load:

1. The scenario + its links (existing).
2. A single bulk `tickerV1.findMany` keyed by `(symbol, exchange)` for every link, now `include`-ing `financialInfo { marketCap, pe }` and `cachedScoreEntry { finalScore }`.

The new fields ride along with the existing `tickerId` resolution — no per-link round-trips, no N+1.

## Test plan

- [ ] Visit any stock-scenario detail page; confirm market cap / PE / score appear under each link card and match the values shown on that ticker's detail page.
- [ ] Verify links whose ticker is unprofitable (negative PE) render `PE —`.
- [ ] Verify a link whose `(symbol, exchange)` isn't in TickerV1 (legacy / unresolved) still renders, with `Mkt cap —`, `PE —`, `Score —` and the score chip falling back to the muted variant.
- [ ] Open Network tab on a scenario with ~10 stock links; confirm the API response includes the new fields and that no additional ticker queries fire.