### PR TITLE
stock-scenarios: fall back to scraper summary for missing market cap …

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/stock-scenarios/[slug]/route.ts
@@ -1,9 +1,32 @@
 import { prisma } from '@/prisma';
 import { ScenarioDirection, ScenarioPricedInBucket, ScenarioProbabilityBucket, ScenarioRole, ScenarioTimeframe } from '@/types/scenarioEnums';
+import { StockFundamentalsSummary } from '@/types/prismaTypes';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { StockScenario, StockScenarioStockLink } from '@prisma/client';
 import { NextRequest } from 'next/server';
+
+// Parse a human-formatted dollar magnitude like "633.80B" / "1.5T" / "850M"
+// into a raw USD number. The scraper summary stores market cap as a string in
+// this shape; `TickerV1FinancialInfo.marketCap` is a Float, but that table is
+// only populated for a subset of tickers — falling back to the scraper string
+// keeps cards from going blank for tickers whose financialInfo row hasn't
+// been synced yet.
+function parseHumanCap(input: string | null | undefined): number | null {
+  if (!input) return null;
+  const trimmed = input.trim().replace(/[$,\s]/g, '');
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(-?\d+(?:\.\d+)?)([KMBT])?$/i);
+  if (!match) {
+    const plain = Number(trimmed);
+    return Number.isFinite(plain) ? plain : null;
+  }
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const suffix = match[2]?.toUpperCase();
+  const mult = suffix === 'T' ? 1e12 : suffix === 'B' ? 1e9 : suffix === 'M' ? 1e6 : suffix === 'K' ? 1e3 : 1;
+  return value * mult;
+}
 
 export interface StockScenarioLinkDto {
   symbol: string;
@@ -92,13 +115,21 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
         exchange: true,
         financialInfo: { select: { marketCap: true, pe: true } },
         cachedScoreEntry: { select: { finalScore: true } },
+        // The scraper summary is the canonical, more-widely-populated source
+        // for market cap / PE. financialInfo is a derived cache that's missing
+        // for some tickers — without this fallback the cards render "—" even
+        // though the data is right there in the scraper summary.
+        stockAnalyzerScrapperInfo: { select: { summary: true } },
       },
     });
     for (const t of tickers) {
+      const summary = (t.stockAnalyzerScrapperInfo?.summary as StockFundamentalsSummary | null) ?? null;
+      const marketCapFromSummary = parseHumanCap(summary?.marketCap);
+      const peFromSummary = typeof summary?.peRatio === 'number' && Number.isFinite(summary.peRatio) ? summary.peRatio : null;
       resolved.set(`${t.symbol.toUpperCase()}|${t.exchange.toUpperCase()}`, {
         tickerId: t.id,
-        marketCap: t.financialInfo?.marketCap ?? null,
-        pe: t.financialInfo?.pe ?? null,
+        marketCap: t.financialInfo?.marketCap ?? marketCapFromSummary,
+        pe: t.financialInfo?.pe ?? peFromSummary,
         finalScore: t.cachedScoreEntry?.finalScore ?? null,
       });
     }


### PR DESCRIPTION
…/ PE

`TickerV1FinancialInfo` is a derived cache that's only populated for a subset of tickers — for the rest, the data lives in `tickerV1.stockAnalyzerScrapperInfo.summary` (the same source the live `/stocks/...` detail page uses). Without a fallback, some link cards rendered `Mkt cap —` / `PE —` even though the values were right there in the scraper summary.

The bulk lookup now also pulls `stockAnalyzerScrapperInfo: { select: { summary } }` in the same query (still 2 queries total, no N+1). When `financialInfo.marketCap` is null, we parse the summary's formatted string ("633.80B" → 633.8e9) via a new `parseHumanCap` helper. Same fallback for PE, which the summary stores as a number directly.

# Pull Request Template

Before submitting this PR, please make sure you have completed the following checklist. This helps ensure that our codebase remains high quality and that our features work well across all supported devices and themes.

### Code Review
- [ ] I have carefully reviewed my code and believe it is final from my side.
- [ ] I have ensured there is no hardcoded color in my changes. Colors should be defined in theme files and reused.

### Theme Compatibility
- [ ] I have tested the new feature or updates in both light and dark themes.
- [ ] I confirm that the visual aspects of the feature are compatible and appealing in both themes.

### Device Compatibility
- [ ] I have tested my changes on mobile screen sizes.
- [ ] I have tested my changes on tablet screen sizes.
- [ ] I have tested my changes on laptop screen sizes.

### Functional Testing
- [ ] I have thoroughly tested the functionality of my changes.
- [ ] I am confident that my changes do not negatively impact existing features.

### Testing Documentation
Please provide a brief description of the tests you have performed to verify your changes. Include any relevant scenarios or edge cases.

- Example test 1: Tested feature X by uploading the image
- Example test 2: Tested feature X by doing these things.

# Demo Video
Please provide a demo video of your changes. This helps reviewers understand the changes and verify the functionality.

You can record the video using tools like Loom(https://www.loom.com/), Clip by ClickUp(https://clickup.com/features/clips), Sendspark(https://www.sendspark.com/), etc.

Include the link to the video below and make sure the video covers
- [ ] Explain the task/bug you are solving
- [ ] Show the changes in the UI
- [ ] Show the changes in the codebase
- [ ] Show the changes you tested to make sure it works
- [ ] Show the changes in various screen sizes
- [ ] Show the changes in both light and dark themes
