### PR TITLE
docs(koala-gains): founder + management team task for stocks & active ETFs

### DIFF
--- a/tasks/koala-gains/etf-closed-tasks.md
+++ b/tasks/koala-gains/etf-closed-tasks.md
@@ -69,9 +69,11 @@ still pending. Organized under the same headings as `etfs.md` for traceability.
   - **Competition chart** (metric comparisons + tooltips, mirroring stocks).
   - **"Other similar ETFs" section** on the main ETF page — curated/auto-selected set
     with quick links and key stats, linking to the full competition page.
-
-> See the top-priorities block in `etfs.md` for the end-to-end QA task against this
-> shipped workflow.
+- [x] **End-to-end QA in production** — exercised the full workflow across ETFs from
+  different groups (equity, fixed-income, thematic, leveraged/inverse), spot-checked
+  edge cases (sparse categories, low-AUM ETFs, missing competitors), and confirmed
+  competitor selection, narrative, chart, separate competition page, and the "Other
+  similar ETFs" section all render with plausible data.
 
 ### 1.4) Admin — ETF generation requests page ✅
 
@@ -98,6 +100,27 @@ Page: https://koalagains.com/admin-v1/etf-generation-requests (+ `/admin-v1/etf-
   - Now enqueues generation requests for **every** supported report type (Performance,
     Cost & Team, Risk, Summary, Index & Strategy, Future Outlook).
   - Existing per-type generation options retained alongside it.
+- [x] **Wrap-up pass** — page is pleasant to operate day-to-day; rough edges from the
+  recent batch reconciled; behavior between `etf-reports` and `etf-generation-requests`
+  is consistent.
+
+### 1.7) Populate Canadian ETFs from Stock Analyzer ✅
+
+- [x] **Sourced the full Canadian ETF universe from Stock Analyzer** — TSX / NEO /
+  Cboe Canada listings ingested with symbol, exchange, name, issuer, category, AUM,
+  expense ratio, inception, and currency, alongside US ETFs in the same pipeline.
+- [x] **Schema / model adjustments** — `Etf` accommodates non-US listings (exchange,
+  currency, country); unique keys handle the same ticker on different exchanges; URL
+  shape settled for Canadian listings.
+- [x] **Wired Canadian ETFs into the generation pipeline** — mapped to category-groups
+  in `etf-analysis-categories.json` and run through the standard report flow
+  (Performance, Cost & Team, Risk, Summary, Index & Strategy, Future Outlook), gated
+  on the `Etf.isComplete` rule before appearing on the public list.
+- [x] **Backfill + ongoing refresh** — one-shot Canadian backfill done; new Canadian
+  ETFs and updates flow in via the off-hours / scheduled refresh.
+- [x] **Validation** — sample of Canadian ETFs spot-checked end-to-end (data, reports,
+  detail page, holdings where available), sitemap + SEO metadata correct for Canadian
+  URLs.
 
 ---
 

--- a/tasks/koala-gains/etfs.md
+++ b/tasks/koala-gains/etfs.md
@@ -44,6 +44,38 @@ list below — these are the four things to actually push on next.
   - Definition of done: a scheduled run that, with no human in the loop, produces
     a night's worth of refreshed reports across stocks + ETFs using Sonnet, with
     logs we can review the next morning.
+- [ ] **5. Use the internet for missing + latest info during Claude Code generation**
+  - When Claude Code regenerates an ETF report on the off-hours runner, it should
+    **actively use the internet** to (a) fill in any **missing** data points the
+    prompt input lacks (issuer, AUM, expense ratio, holdings concentration,
+    Morningstar category, PM identity, etc.), and (b) pull the **latest**
+    information (recent prospectus supplements, fund-fact-sheet updates, PM
+    changes, 19a-1 distributions, regulatory actions, material news in the last
+    90 days) before producing the report.
+  - Update every report-generation prompt (Performance, Cost & Team, Risk,
+    Summary, Index & Strategy, Future Outlook, Famous-ETF comparison, Custom
+    Reports) to include an explicit instruction along the lines of:
+    *"If any input field you need is missing, blank, or stale, **use the
+    internet** to find it. Always also search for the **latest** information on
+    this ETF — recent prospectus supplements, fund-fact-sheet updates, PM
+    changes, distributions, news in the last 90 days — and incorporate it
+    before writing the section. Cite the source URL for every internet-sourced
+    fact."*
+  - Confirm the Claude Code invocation actually has web access on the runner;
+    a prompt instruction is a no-op if the session is headless without web /
+    fetch tools.
+  - Extend the output contract with a `sources: { url, title, accessedAt }[]`
+    array per section so we can render citations on the detail page and audit
+    which claims came from the internet, and include as-of dates inline for any
+    numeric / factual claim.
+  - Guardrails: restrict to reputable sources (issuer site, SEC EDGAR fund
+    filings, primary news outlets, official regulators); cap wall-clock per
+    internet call so a slow site doesn't blow the off-hours window; track an
+    `internetAugmented` flag + unique-URL count per run and surface it in the
+    admin generation-requests view (1.4) for auditability.
+  - Pairs with the stock-side equivalent in `stocks.md` ("Use the internet for
+    missing + latest info during Claude Code generation") — share the same
+    web-tool config + citation contract so we maintain one pipeline, not two.
 - [ ] **4. Split the Index & Strategy field into multiple structured fields**
   - Today **Index & Strategy** is a single blob that crams intro + strategy + other
     context into one field, which makes it hard to lay out cleanly on the detail

--- a/tasks/koala-gains/etfs.md
+++ b/tasks/koala-gains/etfs.md
@@ -761,6 +761,79 @@ to re-derive / second-guess category conclusions.
 
 ---
 
+## Social media content — convert ETF reports + scenarios into posts
+
+Goal: turn the work we already produce (ETF reports, **ETF scenarios**, competition
++ similar-ETF analysis, famous-ETF comparisons, target-investor-group fit, active-ETF
+team profiles, ETF trends) into a steady cadence of **social media content** that
+drives traffic back to KoalaGains. The content engine should be cheap to run (built
+on top of artifacts we already generate) and consistent enough that we ship something
+useful every week without a one-off scramble.
+
+Paired with the stock-side task in `stocks.md` — share templates, queue, and
+posting infra. Don't build two parallel systems; only the source artifacts differ.
+
+- [ ] **Content sources we can mine** (today + planned):
+  - **ETF scenarios** (already shipped — `EtfScenario` + `EtfScenarioEtfLink`):
+    each scenario card / detail page is a natural post — direction, timeframe,
+    probability, priced-in bucket, expected move, winners/losers list — a great
+    fit for hook + bullets + chart.
+  - **Competition / similar-ETF analysis** (1.2): "If you own X, also look at Y" —
+    cheaper-fee alternative, lower-risk substitute, narrower-mandate alternative,
+    etc. Each comparison row is post-worthy.
+  - **"Choose this ETF if…" output** from the famous-ETF comparison (1.3): when
+    we ship that section, "VOO vs SPY vs IVV in 2026" style posts write
+    themselves from the structured output.
+  - **Target-investor-group fit** (2.1): per-persona "best ETFs for the income
+    retiree / young DCA investor / corporate treasury" lists pulled directly from
+    the matched-target-group rows.
+  - **Active-ETF investment team profiles** (1.8): short LinkedIn-style "PM
+    spotlight" posts using the `keyPeople` data — strongest on LinkedIn given the
+    audience overlap.
+  - **ETF trends** (Trends page below): each trend → multiple posts (the trend
+    itself, ETF winners, ETF losers, "priced-in?" angle).
+  - **Verdict / Final-Summary changes** when an ETF is regenerated (3.3.f): the
+    diff itself is post-worthy.
+- [ ] **Content templates** — share with the stock pipeline; ETF-specific shapes:
+  - **Scenario card post** — same shape as stock-side, sourced from
+    `EtfScenario`.
+  - **"Cheaper / safer / narrower alternative to X"** — pull straight from the
+    competition + similar-ETF output.
+  - **"Best ETFs for {investor profile}"** — sourced from target-investor-group
+    matches; one post per persona.
+  - **PM spotlight** (active ETFs only — never for index/passive funds).
+  - **Trend post** — trend + 2–3 ETF winners + link to the trend page.
+- [ ] **Platform mix**: same primary (LinkedIn + X), same secondary tier as the
+  stock side. Stock + ETF content shares the same queue and the same week's
+  schedule — alternate / interleave so the audience sees both flavors and the
+  feed isn't all one asset class.
+- [ ] **Production pipeline**:
+  - Reuse the **post-draft generator** + **content queue** built for the stock
+    side (`stocks.md`); only the input adapter differs (ETF artifact id →
+    template inputs).
+  - Drafts → human review → schedule → publish → UTM-attributed traffic.
+- [ ] **Cadence + governance**:
+  - Mix into the same minimum-weekly cadence target as stocks — e.g. of the N
+    posts per week, ~half are ETF-sourced and ~half stock-sourced; tune by what
+    actually performs.
+  - Compliance pass on every post — no advice phrasing, disclaimers where
+    appropriate, claims grounded in the underlying ETF report.
+- [ ] **Measurement**:
+  - Per-platform engagement + per-ETF-artifact attribution into the same
+    dashboard the stock side uses.
+  - High-engagement scenarios / target-group lists feed back into off-hours
+    refresh prioritization (don't let a hit post link to a stale report).
+- [ ] **Open questions**:
+  - Active-ETF PM spotlights are LinkedIn-leaning; check whether they pull
+    enough engagement on X to be worth cross-posting or should stay
+    LinkedIn-only.
+  - Whether the "Best ETFs for {persona}" posts should link to a target-group
+    landing page (filter pre-applied on the ETF list — see 2.1) rather than
+    individual ETF reports — that page may need to ship before the post format
+    is worthwhile.
+  - Cross-link with the stock social pipeline (`stocks.md`): confirmed shared
+    queue + templates; ETF differs only in the input adapter.
+
 ## Trends page (ETFs)
 
 Goal: a dedicated page where we record long-running **trends** — macro, demographic,

--- a/tasks/koala-gains/etfs.md
+++ b/tasks/koala-gains/etfs.md
@@ -5,31 +5,10 @@
 
 ## Top priorities (active work)
 
-Work at the top of the stack right now. Everything here supersedes the phase-ordered
-list below — these are the four things to actually push on next.
+Work at the top of the stack right now — the items to push on next, ahead of the
+phase-ordered list below.
 
-- [ ] **1. End-to-end QA of the competition workflow + UI**
-  - The whole Competition + Similar ETFs pipeline (section 1.2) has shipped — see
-    `etf-closed-tasks.md`. Before moving on, actually exercise it in production:
-  - Pick a handful of ETFs across different groups (equity, fixed-income, thematic,
-    leveraged/inverse, etc.) and verify the competitor selection, the competition
-    analysis narrative, the competition chart, the separate competition page, and
-    the "Other similar ETFs" section on the main ETF page all render correctly and
-    with plausible data.
-  - Spot-check edge cases: ETFs with very few peers, ETFs in sparse categories, new
-    / low-AUM ETFs, ETFs where an obvious competitor is missing.
-  - File issues for any bad selections, broken charts, or weak narrative — feed
-    those back into the prompt / selection logic rather than shipping more features
-    on top.
-- [ ] **2. Finalize the Admin ETF generation requests page** (currently in progress)
-  - Most of 1.4 has landed (reload + auto-refresh, header columns, per-report-type
-    "Missing" options, per-ETF "Generate All Analysis", sort/pagination/top-filter)
-    — full list in `etf-closed-tasks.md`.
-  - This item is the wrap-up pass: make sure the page is pleasant to operate day to
-    day, catch anything rough edges that shipped with the recent batch, and
-    reconcile the page behavior with what `etf-reports` and `etf-generation-requests`
-    both expose.
-- [ ] **3. Claude-Code pipeline to auto-generate stock + ETF reports with the
+- [ ] **1. Claude-Code pipeline to auto-generate stock + ETF reports with the
   Sonnet model**
   - Build an off-hours pipeline where Claude Code (running the **Sonnet** model, not
     a heavier model) is the generator for both stock and ETF reports.
@@ -39,12 +18,12 @@ list below — these are the four things to actually push on next.
   - Leverages the `Prompt` / `PromptVersion` / `PromptInvocation` infra so we get
     versioning, status, raw I/O, and error capture for free.
   - Ties in with the stock "off-hours Claude Code cron" (see `stocks.md`) and the
-    ETF generation-requests queue (1.4) — the goal is one shared runner that
-    drains both queues.
+    ETF generation-requests queue (1.4, closed) — the goal is one shared runner
+    that drains both queues.
   - Definition of done: a scheduled run that, with no human in the loop, produces
     a night's worth of refreshed reports across stocks + ETFs using Sonnet, with
     logs we can review the next morning.
-- [ ] **5. Use the internet for missing + latest info during Claude Code generation**
+- [ ] **2. Use the internet for missing + latest info during Claude Code generation**
   - When Claude Code regenerates an ETF report on the off-hours runner, it should
     **actively use the internet** to (a) fill in any **missing** data points the
     prompt input lacks (issuer, AUM, expense ratio, holdings concentration,
@@ -53,8 +32,8 @@ list below — these are the four things to actually push on next.
     changes, 19a-1 distributions, regulatory actions, material news in the last
     90 days) before producing the report.
   - Update every report-generation prompt (Performance, Cost & Team, Risk,
-    Summary, Index & Strategy, Future Outlook, Famous-ETF comparison, Custom
-    Reports) to include an explicit instruction along the lines of:
+    Summary, Index & Strategy, Future Outlook, Custom Reports) to include an
+    explicit instruction along the lines of:
     *"If any input field you need is missing, blank, or stale, **use the
     internet** to find it. Always also search for the **latest** information on
     this ETF — recent prospectus supplements, fund-fact-sheet updates, PM
@@ -72,11 +51,11 @@ list below — these are the four things to actually push on next.
     filings, primary news outlets, official regulators); cap wall-clock per
     internet call so a slow site doesn't blow the off-hours window; track an
     `internetAugmented` flag + unique-URL count per run and surface it in the
-    admin generation-requests view (1.4) for auditability.
+    admin generation-requests view for auditability.
   - Pairs with the stock-side equivalent in `stocks.md` ("Use the internet for
     missing + latest info during Claude Code generation") — share the same
     web-tool config + citation contract so we maintain one pipeline, not two.
-- [ ] **4. Split the Index & Strategy field into multiple structured fields**
+- [ ] **3. Split the Index & Strategy field into multiple structured fields**
   - Today **Index & Strategy** is a single blob that crams intro + strategy + other
     context into one field, which makes it hard to lay out cleanly on the detail
     page.
@@ -89,54 +68,25 @@ list below — these are the four things to actually push on next.
     specifically about the **Index & Strategy** feed / data shape.
   - Update the prompt, the output JSON contract, persistence, and the detail-page
     rendering together so the UI can present each sub-field with its own heading
-    / layout slot. Run through the 3.2 tuning loop to sanity-check the split.
-
----
-
-## Priority order
-
-1. **Complete the ETF UI** — ETF details page, competition, similar ETFs, famous-ETFs comparison, admin pages.
-2. **Target audience / Goals**.
-3. **Prompt and analysis-factor improvements** (automated loop) — includes category-grouping review.
-4. **SEO, metadata, and sitemap automation**.
+    / layout slot. Run through the 3.2 tuning loop (closed) to sanity-check the
+    split.
+- [ ] **4. ETFs list page — `isComplete` filter + admin toggle**
+  - Detail in section **1.6** below — surfaced here because it's active work and
+    determines what first-time visitors see by default on the public ETFs list.
+  - Make sure the `Etf.isComplete` derivation, the public default filter, the
+    admin "include incomplete ETFs" toggle, and the per-row missing-data
+    indicators all ship together rather than landing piecemeal.
 
 ---
 
 ## Phase 1 — Complete the ETF UI
 
-> **1.1 ETF Details Page layout**, **1.2 Competition + Similar ETFs**, and **1.4 Admin
-> ETF generation requests page** have all shipped and moved to `etf-closed-tasks.md`.
-> The remaining Phase 1 items are listed below.
-
-### 1.3) Famous ETFs dataset + "Comparison with famous ETFs" section
-
-Goal: for each group, maintain a hand-curated set of "famous" ETFs, and generate a section
-that answers: "Why would we choose this ETF over those?"
-
-- [ ] **Famous-ETF dataset**:
-  - Identify the most famous ETFs under each group (AUM, liquidity/volume, popularity,
-    longevity, issuer reputation).
-  - Add a JSON dataset `groupKey -> famousEtfs[]` (symbol, exchange, name, issuer, why-famous,
-    optional AUM/expense ratio snapshot).
-  - Editable by humans, suitable for prompt conditioning.
-  - TS types required; runtime validation optional.
-- [ ] **Section input schema**:
-  - Current ETF summary (fees, AUM, performance, holdings concentration, tracking, risk).
-  - "Famous ETF set" from the JSON (optionally with live-fetched stats).
-  - Group context (what investors typically want from this group).
-- [ ] **Section output schema**:
-  - Comparisons table/list (current vs each famous ETF).
-  - "Choose this ETF if…" bullets.
-  - "Prefer competitor if…" bullets.
-  - Final recommendation + rationale + caveats.
-- [ ] **Finalize prompt** for this section.
-- [ ] **Database (Prisma) changes**:
-  - Model to store this section's output per ETF (per group/version).
-  - Decide structured columns vs JSON blob + derived fields.
-- [ ] **Pipeline changes**:
-  - New generation step (dependencies on the 3 category analyses if required).
-  - Callback saving + status tracking.
-- [ ] **UI**: new section on ETF report page showing comparisons and "why choose" reasoning.
+> **1.1 ETF Details Page layout**, **1.2 Competition + Similar ETFs**, **1.4 Admin
+> ETF generation requests page**, and **1.7 Populate Canadian ETFs from Stock
+> Analyzer** have all shipped and moved to `etf-closed-tasks.md`. The earlier
+> **1.3 Famous ETFs comparison** task was descoped and removed. The remaining
+> Phase 1 items below are: **1.5 Custom Reports**, **1.6 ETFs list page**, and
+> **1.8 Active-ETF management team**.
 
 ### 1.5) Custom Reports ("random reports") per ETF
 
@@ -227,7 +177,6 @@ that via a toggle instead of dropping the data from the page entirely.
     **Cost & Team**, **Risk**, **Summary**, **Index & Strategy**, **Future Outlook**
     (i.e. the full set referenced in 1.4's header-columns task).
   - **Final Summary** + `introParagraph` (3.3.d) are generated.
-  - Once 2.1 ships: at least one matched `EtfEtfTargetGroupLink` row exists.
   - Persist this as a derived boolean (e.g. `Etf.isComplete`) updated by the
     generation pipeline whenever a report/field lands, so the list query is a cheap
     index lookup rather than a multi-join per request.
@@ -251,55 +200,6 @@ that via a toggle instead of dropping the data from the page entirely.
     list, sitemap, and search results.
   - On their detail page, show a neutral "report in progress" state for the
     missing sections rather than broken / empty components.
-
-### 1.7) Populate Canadian ETFs from Stock Analyzer
-
-Goal: expand the ETF inventory beyond US-listed funds by ingesting **all Canadian
-ETFs** from **Stock Analyzer** (stockanalysis.com), so TSX / NEO / Cboe Canada-listed
-funds show up alongside US listings in the same pipeline.
-
-- [ ] **Source the full Canadian ETF universe from Stock Analyzer**:
-  - Pull the complete list of Canadian ETFs (e.g. via
-    `stockanalysis.com/list/exchange-traded-funds/` filtered to Canada, or the
-    Canadian-specific page if one exists).
-  - Capture per-ETF: symbol, exchange (TSX / NEO / Cboe Canada), name, issuer,
-    category, AUM, expense ratio, inception, currency, and anything else Stock
-    Analyzer surfaces that we already use for US ETFs.
-  - Land the raw extract in the `scraping-lambdas` repo (or wherever the existing
-    ETF scraping lives) — keep the implementation consistent with how US ETFs
-    are pulled today.
-- [ ] **Schema / model adjustments to support Canadian ETFs**:
-  - Confirm the `Etf` model has fields that already accommodate non-US listings
-    (exchange, currency, country) — extend if not.
-  - Make sure unique keys handle the same ticker on different exchanges (e.g.
-    a US `XYZ` and a TSX `XYZ.TO` must coexist).
-  - Decide URL/slug shape for Canadian ETFs (likely
-    `/etfs/TSX/<symbol>`, `/etfs/NEO/<symbol>`, `/etfs/CBOE/<symbol>`) and align
-    with the existing exchange-prefixed routes.
-- [ ] **Wire Canadian ETFs into the existing pipeline**:
-  - Map each ingested ETF to a category-group from
-    `etf-analysis-categories.json` (extend the categories if Canadian-specific
-    ones are needed — e.g. Canadian fixed-income, currency-hedged S&P/TSX
-    products).
-  - Run them through the standard generation flow (Performance, Cost & Team,
-    Risk, Summary, Index & Strategy, Future Outlook) so reports are produced
-    on the same cadence as US ETFs.
-  - Respect the `Etf.isComplete` rule from 1.6 — Canadian ETFs only appear on
-    the public list once their data + reports are fully populated.
-- [ ] **Backfill + ongoing refresh**:
-  - One-shot backfill for the full Canadian ETF list.
-  - Add to the off-hours / scheduled refresh so new Canadian ETFs (and updates
-    to existing ones) flow in automatically.
-- [ ] **Validation**:
-  - Spot-check a sample of Canadian ETFs end-to-end (data populated, reports
-    generated, detail page renders, holdings present where available).
-  - Confirm sitemap + SEO metadata are correct for the Canadian URLs (no
-    accidental cross-links to US-only canonicals).
-- [ ] **Open questions**:
-  - Holdings data for Canadian ETFs — does Stock Analyzer expose them, or do
-    we need a secondary source (issuer site, FTP feed)?
-  - Currency display — are Canadian-ETF prices shown in CAD by default, with
-    a USD toggle, or both?
 
 ### 1.8) Active-ETF management team — LinkedIn-sourced info
 
@@ -357,99 +257,6 @@ ingestion infra, and refresh cadence wherever it makes sense.
   - **Index ETFs** — confirm we never render the team block for purely passive
     products even if data exists; the goal is to highlight where the team
     *actually* drives outcomes.
-
----
-
-## Phase 2 — Target audience / Goals
-
-Goal: Tag each ETF with the investor goals it satisfies, and surface those goals in the
-analysis output.
-
-- [ ] **Define a goals/target-audience taxonomy** for ETFs. Examples:
-  - "Fixed income with no downside"
-  - "Fixed income with low risk"
-  - "High yield with moderate or high risk"
-- [ ] **Capture matching goals during ETF analysis**:
-  - When generating an ETF report, determine which goals from the taxonomy this ETF meets.
-  - Persist the matched goals on the ETF record.
-- [ ] **Open question — equity goal representation**:
-  - Decide how to represent goals for equity-style ETFs (e.g. country/region funds like
-    India / China ETFs) where the "goal" is more thematic/exposure-based than risk-return
-    based.
-  - Propose candidate goal labels for equity (e.g. "Emerging-market equity exposure",
-    "Single-country thematic exposure", "Sector tilt").
-
-### 2.1) Target-investor groups (data model + prompt wiring)
-
-Goal: tag each ETF with the **target investor groups** it fits — i.e. which kinds of
-investors (by goals / risk profile / mandate) should realistically consider this ETF.
-This is a concrete, persisted extension of the taxonomy above, covering **both retail
-and institutional** investors.
-
-Key shape:
-- **Many-to-many** — one ETF maps to **multiple** target groups, and one target group
-  maps to **many** ETFs.
-- A target group can also be linked to an ETF **category-group** (e.g. the whole
-  "short-duration treasuries" group fits "capital-preservation" target investors), so
-  matches can be inferred at the group level and then refined per ETF.
-- Covers retail personas (e.g. "Income-focused retiree", "Young DCA investor",
-  "High-yield / high-risk speculator") **and** institutional personas (e.g. "Corporate
-  treasury — cash management", "Pension fund — liability-matching", "Insurance — core
-  fixed income", "Endowment — long-duration equity growth").
-
-- [ ] **Decide granularity — group-level vs. category-level vs. per-ETF**:
-  - Open question: do target-groups attach to each **category-group** in
-    `etf-analysis-categories.json`, to each **individual ETF**, or **both** (category
-    sets the default, ETF can override / extend)?
-  - Resolve this before finalizing the Prisma schema.
-- [ ] **Define the target-group taxonomy** (seed data):
-  - Retail buckets — income, growth, capital preservation, speculation, thematic
-    exposure, tax-advantaged (munis), ESG, etc. Each bucket has a `key`, human label,
-    short description, and a risk/goal profile.
-  - Institutional buckets — corporate treasury, insurance general account, pension
-    (DB / DC), endowment, sovereign wealth, asset manager sleeve, family office,
-    RIA model-portfolio bucket, etc.
-  - Mark each bucket as `retail` | `institutional` | `both` via an
-    `investorType` enum so UI + prompts can filter.
-- [ ] **Prisma schema** — add new models for target groups and the many-to-many links:
-  - `EtfTargetGroup` — one row per target-group taxonomy entry. Fields: `id`, `key`
-    (stable slug), `label`, `description`, `investorType` enum
-    (`RETAIL` | `INSTITUTIONAL` | `BOTH`), `riskProfile` (e.g.
-    `LOW` | `MEDIUM` | `HIGH`), `goalProfile` (e.g. `INCOME` | `GROWTH` |
-    `PRESERVATION` | `SPECULATION` | `THEMATIC` | `TAX_ADVANTAGED` | `ESG` |
-    `LIABILITY_MATCHING` | `CASH_MANAGEMENT`), `displayOrder`, audit fields.
-  - `EtfEtfTargetGroupLink` — many-to-many between `Etf` and `EtfTargetGroup`.
-    Fields: `etfId`, `targetGroupId`, `source` enum (`MANUAL` | `PROMPT` |
-    `CATEGORY_GROUP`), `confidence` (`LOW` | `MEDIUM` | `HIGH`), optional
-    `rationale` text, audit fields.
-  - `EtfCategoryGroupTargetGroupLink` (only if we decide category-level attachment
-    is in scope) — many-to-many between an ETF category-group (from
-    `etf-analysis-categories.json`) and `EtfTargetGroup`.
-  - Backrefs: `Etf.targetGroups`, `EtfTargetGroup.etfs`.
-  - Seed the taxonomy via a migration / seed script so the list is versioned in the
-    repo, not typed into prod.
-- [ ] **Wire into prompts** so the LLM produces and reasons about target groups:
-  - Extend the ETF analysis prompt(s) (at minimum the Summary / Final-Summary prompt,
-    and ideally Index-&-Strategy + Performance + Risk) so the model is told the full
-    target-group taxonomy and asked to return the list of matching groups for this
-    ETF **with a 1-line rationale each**, plus a confidence tag.
-  - Update the output schema / JSON contract of those prompts to include a
-    `targetGroups: [{ key, rationale, confidence }]` array.
-  - On save, resolve `key` → `EtfTargetGroup.id` and upsert the
-    `EtfEtfTargetGroupLink` rows with `source = PROMPT`.
-  - Separately, allow an admin to manually add / remove target-group links
-    (`source = MANUAL`) that the prompt run won't overwrite.
-- [ ] **Surface target groups in the UI** (detail page + filters):
-  - Show matched target-groups as chips on the ETF detail page (section 1.1), grouped
-    by retail vs. institutional, each with its rationale in a tooltip / expandable row.
-  - Add a **"Find ETFs for this investor profile"** filter on ETF list / search pages
-    driven by `EtfTargetGroup.key`.
-- [ ] **Validation + QA loop**:
-  - Spot-check the prompt output across a handful of ETFs per category-group and
-    confirm the target-group assignments are sensible before turning on bulk
-    backfill.
-  - Add the target-group assignment into the **automated factor/prompt tuning loop**
-    (Phase 3.2) so we can iterate on it alongside the analysis factors.
 
 ---
 
@@ -564,28 +371,31 @@ appropriate.
 
 #### 3.3.c) Cross-check reports against the target-audience feature
 
-Goal: once the **target-investor-groups** feature (see section 2.1) is live, the
+Goal: if/when a **target-investor-groups** feature is brought back into scope, the
 reports themselves must let each targeted segment — specific slices of retail, plus
 specific slices of institutional — walk away with a clear **"yes, this fits me"** or
 **"no, skip this one"** verdict. Today the reports are written in a generic voice; a
 retiree looking for income and a pension fund doing liability-matching read the same
-paragraphs and neither gets a confident answer.
+paragraphs and neither gets a confident answer. (Note: the dedicated
+target-investor-groups data model is not currently on the roadmap — this sub-section
+is a placeholder for the prompt-quality work that would be needed once it is.)
 
 - [ ] **Make target-audience a live input to the prompts**:
-  - Pass the **matched target-groups** (`EtfEtfTargetGroupLink` rows from 2.1) into
-    the analysis prompts as structured input, not just as tags stored on the side.
+  - Pass the **matched target-groups** into the analysis prompts as structured input,
+    not just as tags stored on the side.
   - Extend the **Final Summary** prompt so it ends with a **per-target-group verdict
     block**: for each matched target-group, emit `{ targetGroupKey, fit:
     'Good'|'Acceptable'|'Poor', reason, cautions[] }`.
   - Where the report already says things like "this is suitable for income
     investors", require the prompt to name the **exact target-group key**, not a
     generic persona.
-- [ ] **Cross-check existing reports after target-groups ships**:
-  - After 2.1 is merged and back-filled, run a pass across generated reports to
-    verify every matched target-group is actually addressed in the narrative.
+- [ ] **Cross-check existing reports after target-groups data lands**:
+  - Once the target-group data model + back-fill exist, run a pass across generated
+    reports to verify every matched target-group is actually addressed in the
+    narrative.
   - Flag reports where the matched target-groups don't appear (or appear only as
     vague hand-waving) and route them back through regeneration.
-  - Add this check to the **automated factor/prompt tuning loop** (3.2) so future
+  - Add this check to the **automated factor/prompt tuning loop** (closed) so future
     regressions are caught.
 - [ ] **Surface per-audience verdicts in the UI**:
   - Add a **"Is this ETF right for you?"** panel to the ETF detail page (section
@@ -645,8 +455,7 @@ Tasks:
     main detail page.
 - [ ] **Update the detail-page component order** (section 1.1) to match:
   Final Summary → Intro paragraph → Charts → Strategy → Evaluation categories →
-  other sections (competition, similar, famous-ETF comparison, target-audience
-  panel, etc.).
+  other sections (competition, similar ETFs, etc.).
 - [ ] **Cross-check with section 1.1 and 3.3.c**:
   - Reconcile this ordering with the ordering currently listed in 1.1 so there is
     one canonical layout, not two.
@@ -796,11 +605,11 @@ to re-derive / second-guess category conclusions.
 ## Social media content — convert ETF reports + scenarios into posts
 
 Goal: turn the work we already produce (ETF reports, **ETF scenarios**, competition
-+ similar-ETF analysis, famous-ETF comparisons, target-investor-group fit, active-ETF
-team profiles, ETF trends) into a steady cadence of **social media content** that
-drives traffic back to KoalaGains. The content engine should be cheap to run (built
-on top of artifacts we already generate) and consistent enough that we ship something
-useful every week without a one-off scramble.
++ similar-ETF analysis, active-ETF team profiles, ETF trends) into a steady cadence
+of **social media content** that drives traffic back to KoalaGains. The content
+engine should be cheap to run (built on top of artifacts we already generate) and
+consistent enough that we ship something useful every week without a one-off
+scramble.
 
 Paired with the stock-side task in `stocks.md` — share templates, queue, and
 posting infra. Don't build two parallel systems; only the source artifacts differ.
@@ -810,15 +619,9 @@ posting infra. Don't build two parallel systems; only the source artifacts diffe
     each scenario card / detail page is a natural post — direction, timeframe,
     probability, priced-in bucket, expected move, winners/losers list — a great
     fit for hook + bullets + chart.
-  - **Competition / similar-ETF analysis** (1.2): "If you own X, also look at Y" —
-    cheaper-fee alternative, lower-risk substitute, narrower-mandate alternative,
-    etc. Each comparison row is post-worthy.
-  - **"Choose this ETF if…" output** from the famous-ETF comparison (1.3): when
-    we ship that section, "VOO vs SPY vs IVV in 2026" style posts write
-    themselves from the structured output.
-  - **Target-investor-group fit** (2.1): per-persona "best ETFs for the income
-    retiree / young DCA investor / corporate treasury" lists pulled directly from
-    the matched-target-group rows.
+  - **Competition / similar-ETF analysis** (1.2, closed): "If you own X, also look
+    at Y" — cheaper-fee alternative, lower-risk substitute, narrower-mandate
+    alternative, etc. Each comparison row is post-worthy.
   - **Active-ETF investment team profiles** (1.8): short LinkedIn-style "PM
     spotlight" posts using the `keyPeople` data — strongest on LinkedIn given the
     audience overlap.
@@ -831,8 +634,6 @@ posting infra. Don't build two parallel systems; only the source artifacts diffe
     `EtfScenario`.
   - **"Cheaper / safer / narrower alternative to X"** — pull straight from the
     competition + similar-ETF output.
-  - **"Best ETFs for {investor profile}"** — sourced from target-investor-group
-    matches; one post per persona.
   - **PM spotlight** (active ETFs only — never for index/passive funds).
   - **Trend post** — trend + 2–3 ETF winners + link to the trend page.
 - [ ] **Platform mix**: same primary (LinkedIn + X), same secondary tier as the
@@ -853,16 +654,12 @@ posting infra. Don't build two parallel systems; only the source artifacts diffe
 - [ ] **Measurement**:
   - Per-platform engagement + per-ETF-artifact attribution into the same
     dashboard the stock side uses.
-  - High-engagement scenarios / target-group lists feed back into off-hours
-    refresh prioritization (don't let a hit post link to a stale report).
+  - High-engagement scenarios feed back into off-hours refresh prioritization
+    (don't let a hit post link to a stale report).
 - [ ] **Open questions**:
   - Active-ETF PM spotlights are LinkedIn-leaning; check whether they pull
     enough engagement on X to be worth cross-posting or should stay
     LinkedIn-only.
-  - Whether the "Best ETFs for {persona}" posts should link to a target-group
-    landing page (filter pre-applied on the ETF list — see 2.1) rather than
-    individual ETF reports — that page may need to ship before the post format
-    is worthwhile.
   - Cross-link with the stock social pipeline (`stocks.md`): confirmed shared
     queue + templates; ETF differs only in the input adapter.
 

--- a/tasks/koala-gains/etfs.md
+++ b/tasks/koala-gains/etfs.md
@@ -269,6 +269,63 @@ funds show up alongside US listings in the same pipeline.
   - Currency display — are Canadian-ETF prices shown in CAD by default, with
     a USD toggle, or both?
 
+### 1.8) Active-ETF management team — LinkedIn-sourced info
+
+Goal: for **actively-managed** ETFs, surface the **portfolio managers + key
+investment team** with their LinkedIn profiles, tenure on the fund, and a short bio.
+Active-ETF outcomes are driven by the people running the strategy, so showing the
+team is essential context for readers. Skip this surface for **passive / index
+ETFs** — for those, the index methodology matters far more than any one person, so
+the leadership block would be noise.
+
+This is the ETF-side parallel of the stock task in `stocks.md` — share data shapes,
+ingestion infra, and refresh cadence wherever it makes sense.
+
+- [ ] **Eligibility — active ETFs only**:
+  - Add an `Etf.isActive` (or reuse an existing flag like `managementStyle =
+    'ACTIVE' | 'PASSIVE' | 'SEMI_ACTIVE'`) so we can filter cleanly.
+  - Render the leadership block only when active (or semi-active where a named
+    PM is publicly disclosed); suppress entirely otherwise.
+- [ ] **Data shape — per ETF** (mirror the stock model from `stocks.md`):
+  - `keyPeople: { role, name, title, linkedinUrl, photoUrl?, fundTenureSinceYear?,
+    isLeadPM: boolean, bio, source }[]`.
+  - Roles: **Lead PM**, **co-PMs**, optional **head of strategy / sector lead**.
+  - `source`, `updatedAt`, `verifiedAt` audit fields (same as stocks).
+- [ ] **Acquisition strategy** (no LinkedIn scraping):
+  - Primary sources: ETF **prospectus**, **Statement of Additional Information
+    (SAI)**, issuer **Leadership** / **Strategy team** page, fund fact sheets.
+  - Build the LinkedIn URL on top via the same resolver pattern used for stocks
+    — admin curation, paid people-data provider, or links the issuer publishes.
+  - Reuse the `scraping-lambdas` extractor that pulls the leadership table from
+    a structured page; ETF differs only in source URLs and field labels.
+- [ ] **Surfacing on the ETF detail page**:
+  - Add a **"Investment Team"** block on the active-ETF detail page (place under
+    Strategy or alongside Cost & Team — that's where the analysis already
+    references team quality).
+  - Card per person: photo (where licensed), name, title, "Lead PM" badge,
+    fund-tenure, 1–2 sentence bio, LinkedIn icon link (rel=`nofollow noopener
+    external`).
+- [ ] **Use the data in analysis**:
+  - Pass the team block into the **Cost & Team** prompt input so the team
+    narrative cites actual PM tenure / experience instead of vague language.
+  - Once 3.3.f is in place, the per-category `overallAnalysis` for Cost & Team
+    can reference these structured fields in the Final Summary.
+- [ ] **Refresh + verification**:
+  - Quarterly re-ingest on the same off-hours runner used for stocks — issuers
+    publish PM changes via prospectus supplements; pick those up.
+  - Admin verification UI flags rows older than N months for human review.
+- [ ] **Open questions / risks**:
+  - **Compliance** — same constraint as stocks: store the public LinkedIn URL,
+    do not cache scraped LinkedIn HTML / photos.
+  - **Coverage threshold** — minimum set of people required to render the block
+    (e.g. at least one named PM); below threshold, suppress.
+  - **Cross-fund PMs** — same PM often runs multiple ETFs at the same issuer.
+    Decide whether to model `Person` as its own table with ETF links (and
+    optionally cross-link to stock leadership rows), or denormalize per ETF.
+  - **Index ETFs** — confirm we never render the team block for purely passive
+    products even if data exists; the goal is to highlight where the team
+    *actually* drives outcomes.
+
 ---
 
 ## Phase 2 — Target audience / Goals

--- a/tasks/koala-gains/stocks.md
+++ b/tasks/koala-gains/stocks.md
@@ -124,6 +124,62 @@ Runs in the same off-hours window as the report-refresh cron (10 PM – 5 AM), b
     the same stock across runs? (e.g. hysteresis: require the new category to win twice in a
     row before applying.)
 
+## Stock scenarios — finish + roll out
+
+Goal: bring the **stock scenarios** feature to 100% complete and ship it publicly. ETF
+scenarios already exist end-to-end (`EtfScenario` + `EtfScenarioEtfLink` in
+`insights-ui/prisma/schema.prisma`, plus the `app/etf-scenarios`, `admin-v1/etf-scenarios`,
+`api/[spaceId]/etf-scenarios`, and `components/etf-scenarios` trees). The stock equivalent
+is partially done — finish parity and launch.
+
+- [ ] **Reach feature parity with ETF scenarios**:
+  - Confirm the stock-side Prisma models exist (`StockScenario` / `TickerV1Scenario` +
+    join table to stock tickers); add or finish whatever is missing so the shape mirrors
+    `EtfScenario` / `EtfScenarioEtfLink` (direction, timeframe, probabilityBucket,
+    probabilityPercentage, pricedInBucket, expectedPriceChange, role, historical analog,
+    archived flag, etc.).
+  - Public list page `app/stock-scenarios/` mirroring `app/etf-scenarios/` (filters,
+    cards, detail page).
+  - Admin tree `app/admin-v1/stock-scenarios/` with create / edit / archive flows
+    (mirror `UpsertEtfScenarioModal` + the etf-scenario admin pages).
+  - API routes under `app/api/[spaceId]/stock-scenarios/` — list, get, create,
+    update, archive, link/unlink stocks.
+  - Components folder `components/stock-scenarios/` with the same primitives as
+    `components/etf-scenarios/`.
+  - Optional bulk markdown import (mirror `etf-scenario-markdown-parser.ts`) so we can
+    seed scenarios from a markdown file.
+- [ ] **Add a sitemap for stock scenarios**:
+  - New sitemap file (e.g. `app/stocks/stock-scenarios-sitemap.xml/route.ts` or a
+    sibling under the existing stock sitemaps) that lists every public,
+    non-archived `StockScenario` URL.
+  - Wire it into the parent sitemap index alongside the other stock sitemaps.
+  - Confirm canonical, lastmod, and change-frequency are set correctly per entry.
+- [ ] **Surface stock scenarios on the home page**:
+  - Add a stock-scenarios entry point to the home page (e.g. a card / tile next to
+    the existing ETF scenarios entry, or a combined "Scenarios" section that
+    branches into stocks vs. ETFs).
+  - Pull a small set of featured / most-recent / highest-confidence scenarios for
+    the home-page preview.
+- [ ] **Link from the stocks pages**:
+  - Add a "Scenarios" link in the main stocks navigation / list page header.
+  - On each stock detail page, surface the scenarios this stock is tagged into
+    (mirror how the ETF detail page shows linked ETF scenarios) — chips / cards
+    with a click-through to the scenario detail page.
+- [ ] **Roll-out**:
+  - Seed the production DB with an initial batch of stock scenarios so the public
+    pages aren't empty on day one.
+  - Sanity-check the sitemap is picked up by Search Console (and that the new
+    URLs aren't subject to the same "Crawled — currently not indexed" issue
+    captured under SEO Fixes — pre-empt by ensuring real per-scenario content,
+    unique titles/meta, and internal links).
+  - Announce the feature (release notes / blog / homepage banner if appropriate).
+- [ ] **Definition of done**:
+  - A logged-out visitor can land on the home page, click into stock scenarios,
+    browse the list, open a detail page, and from there click through to the
+    related stocks — all SSR'd, indexable, and listed in the sitemap.
+  - An admin can create / edit / archive a stock scenario end-to-end via
+    `admin-v1/stock-scenarios` without touching the DB directly.
+
 ## Trends page (stocks)
 
 Goal: a dedicated page where we record long-running **trends** — macro, demographic,

--- a/tasks/koala-gains/stocks.md
+++ b/tasks/koala-gains/stocks.md
@@ -377,6 +377,85 @@ glance. This also feeds the **founder / owner-operator quality** dimension of th
     tickers (parent + sub); decide whether to model `Person` as its own table
     with stock links, or denormalize per ticker.
 
+## Social media content — convert reports into posts
+
+Goal: turn the work we already produce (stock reports, **stock scenarios**, the
+10-bagger shortlist, founder/management profiles, trends) into a steady cadence of
+**social media content** that drives traffic back to KoalaGains. The content engine
+should be cheap to run (built on top of artifacts we already generate) and consistent
+enough that we ship something useful every week without a one-off scramble.
+
+This task is paired with the ETF-side equivalent in `etfs.md` — they should share the
+templates, queue, and posting infra. Don't build two parallel systems.
+
+- [ ] **Content sources we can mine** (today + planned):
+  - **Stock scenarios** (the new feature being finished + rolled out — see "Stock
+    scenarios — finish + roll out" above): each scenario card / detail page is a
+    natural post — direction, timeframe, priced-in bucket, expected move, winners
+    / losers — formatted for a hook + 3–5 bullet points + chart.
+  - **10-bagger shortlist**: a quarterly "10 small-caps we think can 10x" thread is
+    one of the highest-share post shapes for retail finance; the lens scoring +
+    one-paragraph "why this could 10x" maps cleanly onto a numbered post.
+  - **Founder / management team profiles**: short LinkedIn-style "founder spotlight"
+    posts pulling from the new `keyPeople` data.
+  - **Off-hours-refreshed reports**: when a Business & Moat / Valuation / Custom
+    Report regenerates, the diff (verdict change, fair-value change, new risks
+    flagged) is itself post-worthy.
+  - **Stock trends** (once the trends page ships): each trend → multiple posts
+    (the trend itself, the winners list, the losers list, an "is it priced in?"
+    angle).
+- [ ] **Content templates** — codify a small set of repeatable shapes so we're not
+  reinventing every post:
+  - **Scenario card post** — hook, one-line setup, direction + timeframe +
+    probability + priced-in, 1–3 bullets on the thesis, link to scenario detail.
+  - **Top-N post** (10-baggers, top dividend payers, top moats by sector, etc.) —
+    numbered list, one line per name, link to the curated list page.
+  - **Founder spotlight** — photo, name + title + tenure, 2–3 sentence bio, why
+    they matter, link to the stock report.
+  - **Verdict-change post** — "We updated our view on X" — old verdict → new
+    verdict, what triggered the change, link to the report.
+  - **Trend post** — trend title + historical analog, 2–3 winners, link to the
+    trend page.
+- [ ] **Platform mix** (pick a primary + secondary, don't try to be everywhere):
+  - **Primary**: LinkedIn (matches the audience for value-investing + the
+    "leadership" angle from the founder data) and **X/Twitter** (the standard
+    finance-twitter loop).
+  - **Secondary**: Reddit (relevant subs only — `r/investing`, `r/stocks`,
+    `r/CanadianInvestor` once 1.7 unlocks Canadian coverage), Threads, YouTube
+    Shorts / Instagram Reels for chart-driven scenarios.
+  - Don't ship all of these at once — start with LinkedIn + X, add a third only
+    once the first two are humming.
+- [ ] **Production pipeline**:
+  - Build a small **post-draft generator** that, given a source artifact (scenario
+    id, ticker id, trend id, shortlist id), renders a draft post per template via
+    the existing prompt infra (`getLLMResponseForPromptViaInvocation`).
+  - Drafts land in a lightweight **content queue** (a new admin page) where a
+    human reviews, edits, picks platforms, schedules, and approves.
+  - Approved posts are pushed to a scheduling tool (Buffer / Hootsuite / Hypefury,
+    or a thin in-house scheduler) — start with whatever's cheapest, swap later.
+  - Every post carries a UTM-tagged link back to the relevant KoalaGains page so
+    we can attribute traffic.
+- [ ] **Cadence + governance**:
+  - Target a **minimum** weekly cadence (e.g. 1 scenario post + 1 founder
+    spotlight + 1 verdict-change or top-N post per week) on each primary platform
+    once the queue is live.
+  - One person owns the queue per week — don't let it become a free-for-all.
+  - Compliance pass on every post — no investment-advice phrasing, disclaimers
+    where appropriate, claims grounded in the underlying report.
+- [ ] **Measurement**:
+  - Per-platform impressions / engagement / clicks tracked in one dashboard.
+  - Per-source-artifact attribution: which scenario / stock / founder profile
+    actually drove sessions.
+  - Feed the winners back into the off-hours runner — if a scenario gets
+    high engagement, prioritize refreshing/expanding it.
+- [ ] **Open questions**:
+  - Build vs. buy on the scheduler — the cheapest path is probably an existing
+    SaaS until volume justifies our own.
+  - Voice / tone — single editorial voice across platforms, or platform-tailored?
+    Default: shared core + platform-specific opener.
+  - Cross-link with the ETF social pipeline (`etfs.md`) — confirmed shared queue
+    + shared templates; only the source artifacts differ.
+
 ## Custom Reports ("random reports") per stock
 
 Source: design doc `docs/ai-knowledge/projects/insights-ui/requirements/req-001-stock-custom-reports.md`

--- a/tasks/koala-gains/stocks.md
+++ b/tasks/koala-gains/stocks.md
@@ -70,6 +70,55 @@ usage.
   - Do we want the same mechanism for ETFs later (the ETF side has a separate "daily
     generation" task in SEO phase — decide whether to unify or keep separate).
 
+### Use the internet for missing + latest info during Claude Code generation
+
+Goal: when Claude Code regenerates a stock report on the off-hours runner, it should
+**actively use the internet** to (a) fill in any **missing** data points the prompt
+input lacks, and (b) pull the **latest** information (recent earnings, guidance,
+filings, executive changes, news, regulatory actions) before producing the report.
+Today the prompt is mostly fed pre-cached fields — that's why reports go stale fast
+and why some sections read like they were written from incomplete data.
+
+- [ ] **Update the report-generation prompts** (Business & Moat, Valuation, Financial
+  Statements, Future Outlook, Custom Reports — every long-form section) to include
+  an explicit instruction along the lines of:
+  *"If any input field you need is missing, blank, or stale, **use the internet** to
+  find it. Always also search for the **latest** information on this ticker —
+  recent earnings, guidance, 8-K filings, executive changes, lawsuits, regulatory
+  actions, material news in the last 90 days — and incorporate it before writing
+  the section. Cite the source URL for every internet-sourced fact."*
+- [ ] **Make sure the Claude Code invocation actually has web access**:
+  - Confirm the Claude Code session running on the off-hours runner has web /
+    fetch tools enabled — if it's running headless without web access, the prompt
+    instruction is a no-op.
+  - If we're running through `getLLMResponseForPromptViaInvocation` rather than
+    Claude Code, verify that path also exposes web search / fetch.
+- [ ] **Output contract additions**:
+  - Each section should return a `sources: { url, title, accessedAt }[]` array
+    alongside the existing markdown / structured output, so we can render
+    citations on the page and audit which claims came from the internet.
+  - For numeric or factual claims sourced online, include the **as-of date** in
+    the prose so readers don't assume a stale figure is current.
+- [ ] **Guardrails on internet use**:
+  - Restrict to reputable sources where possible: SEC EDGAR, company IR pages,
+    primary news outlets, official regulators. De-prioritize forum posts,
+    aggregators, and obvious AI-spam pages.
+  - Don't let internet-sourced text dominate the report — the analysis voice
+    should still be ours; the internet is an input, not a copy-paste source.
+  - Cap per-run wall-clock for internet calls so a single slow site doesn't blow
+    the off-hours window budget (ties into the cron's per-stock timeout).
+- [ ] **Track internet-augmented vs. pre-cached generation**:
+  - Persist a flag on each generated report indicating whether the run used
+    internet augmentation, plus a count of unique URLs cited.
+  - Surface it in the admin generation-requests view so we can see which reports
+    leaned on the internet vs. cached data only.
+- [ ] **Validate**:
+  - Spot-check a handful of regenerated reports — confirm latest earnings /
+    recent material news appear, sources resolve, and the prompt didn't
+    hallucinate citations.
+  - Compare a pre- and post-change report on the same ticker to confirm
+    freshness improved without quality regressing.
+
 ## Off-hours automated stock recategorization (Claude Code)
 
 Goal: during off-hours, let Claude Code sweep every stock ticker in our universe, verify

--- a/tasks/koala-gains/stocks.md
+++ b/tasks/koala-gains/stocks.md
@@ -317,6 +317,66 @@ survivors through a structured 10-bagger lens.
   - Geographic scope — US only at first, or also include Canadian small-caps once
     `etfs.md` 1.7 unlocks the broader Canadian universe?
 
+## Founder & management team — LinkedIn-sourced info
+
+Goal: founders and management teams are one of the most-cited reasons a great
+business stays great (or a mediocre one re-rates). For every stock we cover, surface
+the **founder + key executives** with their LinkedIn profiles, tenure, and a short
+human-readable bio, so readers can size up the people running the business at a
+glance. This also feeds the **founder / owner-operator quality** dimension of the
+10-bagger lens above.
+
+- [ ] **Data shape — per stock** (extend the existing ticker model):
+  - `keyPeople: { role, name, title, linkedinUrl, photoUrl?, tenureSinceYear?,
+    isFounder: boolean, bio: string, source }[]`.
+  - At minimum capture: **founder(s)**, **CEO**, **CFO**, **COO/President**, plus
+    any board chair / lead-director if distinct from CEO.
+  - `source` records where each row came from (e.g. company website, 10-K, proxy
+    statement, manual curation, scraping-lambdas extractor) so we can re-validate
+    later.
+  - Audit fields (`updatedAt`, `verifiedAt`) so we know how stale a row is.
+- [ ] **Acquisition strategy** (be deliberate — LinkedIn ToS bans scraping):
+  - **Do not scrape LinkedIn directly.** Instead, build a LinkedIn-URL **resolver**
+    that (a) takes the canonical name + company from official sources, then
+    (b) accepts a `linkedinUrl` either through a public company page that already
+    links it, an admin curation tool, or a paid people-data provider (PDL,
+    Clearbit, Crunchbase, etc.) that has its own LinkedIn licensing.
+  - Primary structured sources: company **About / Leadership** page, latest
+    **10-K / 20-F / proxy statement**, IR site, press releases.
+  - Use the existing `scraping-lambdas` infra to ingest the structured
+    leadership tables from these sources; LinkedIn URL is enriched on top, not the
+    primary key.
+- [ ] **Surfacing on the stock page**:
+  - Add a **"Leadership"** block to the stock detail page (place next to or under
+    Business & Moat — that's where the analysis already references management).
+  - Card per person: photo (where licensed), name, title, "Founder" badge if
+    applicable, tenure, 1–2 sentence bio, LinkedIn icon link (rel=`nofollow noopener
+    external`).
+  - Compact mode for the main stock page; full list on the per-section detail
+    page (mirrors the holdings pattern).
+- [ ] **Use the data in analysis**:
+  - Pass the leadership block into the **Business & Moat** prompt input (founder
+    presence, tenure, insider ownership signals) so the moat narrative grounds
+    its team-quality claims in actual data, not inference.
+  - Feed the same data into the **10-bagger lens** scoring (founder / owner-
+    operator dimension).
+- [ ] **Refresh + verification**:
+  - Schedule a quarterly re-ingest on the off-hours Claude-Code runner so people
+    who join / leave / change titles flow in.
+  - Provide an admin verification UI (mirror the per-ETF generation-requests page
+    pattern) that flags rows older than N months for human review.
+- [ ] **Open questions / risks**:
+  - **Compliance** — confirm with legal that storing publicly-listed LinkedIn
+    URLs (just the URL, not scraped profile content) is fine. Do not cache
+    photo / bio HTML pulled from LinkedIn — use issuer-supplied or licensed
+    photos.
+  - **Coverage** — what's the minimum set of people required before we render
+    the block? (e.g. CEO + at least one founder if applicable.) Suppress the
+    block entirely below threshold rather than rendering a half-empty card grid.
+  - **De-duplication** — same person can be on multiple boards / multiple
+    tickers (parent + sub); decide whether to model `Person` as its own table
+    with stock links, or denormalize per ticker.
+
 ## Custom Reports ("random reports") per stock
 
 Source: design doc `docs/ai-knowledge/projects/insights-ui/requirements/req-001-stock-custom-reports.md`

--- a/tasks/koala-gains/stocks.md
+++ b/tasks/koala-gains/stocks.md
@@ -251,6 +251,72 @@ than invent new ones.
   - Do trends need a separate "trend category" taxonomy (macro / demographic / generational /
     technological / regulatory) for filtering, beyond what scenarios have?
 
+## 10-bagger shortlist — small-cap candidates filtered by Business & Moat
+
+Goal: build a shortlist of potential **10-baggers** — stocks with a credible path to a
+~10x return — biased toward **small-caps**, where the upside math actually works. Use
+our existing **Business & Moat** score as the first-pass filter, then evaluate the
+survivors through a structured 10-bagger lens.
+
+- [ ] **Cast the initial pool** (cheap filter, run from the existing data):
+  - **Market cap**: small-cap band (e.g. roughly $300M – $2B; tune the upper bound
+    once we see how many candidates pass the moat filter).
+  - **Business & Moat score ≥ 4** (out of 5) from the existing per-ticker analysis.
+  - **Liquidity floor**: minimum average daily $-volume so the pick is actually
+    investable (e.g. ≥ $1M ADV) — drop OTC / dark stocks unless explicitly
+    desired.
+  - **Data completeness**: only include tickers where the Business & Moat report
+    is fully generated and recent (mirror the ETF `isComplete` pattern).
+- [ ] **Evaluate each candidate through the 10-bagger lens** (qualitative + a few
+  quantitative checks per ticker):
+  - **TAM / runway** — is the addressable market at least 10x the company's
+    current revenue? Without big TAM there's no 10x.
+  - **Unit economics + margin expansion path** — gross margin trend, operating
+    leverage on next-stage revenue, free-cash-flow inflection.
+  - **Reinvestment runway** — high incremental ROIC + room to redeploy
+    incremental capital at similar returns.
+  - **Founder / owner-operator quality** — founder still in the seat, insider
+    ownership, capital-allocation track record, alignment.
+  - **Niche dominance** — clear category leadership in a specific niche, not
+    a marginal player in a crowded one.
+  - **Optionality** — adjacent products / geographies / customer segments the
+    business can credibly expand into.
+  - **Customer / supplier / regulatory concentration risks** — fewer the
+    better; flag any single-point dependency.
+  - **Catalyst / inflection** — what specific change in the next 12–24 months
+    plausibly re-rates the multiple?
+  - **Why hasn't this rerated already?** — a real 10-bagger setup needs an
+    answer here (under-followed, micro-cap stigma, recent spin-out, recent
+    IPO lockup, post-restructuring, etc.).
+- [ ] **Scoring + shortlist**:
+  - Score each candidate 1–5 on the lens dimensions above; require an average
+    threshold (e.g. ≥ 3.5) before it makes the shortlist.
+  - Hand-pick the top **~10 names** for the published list — keep it short on
+    purpose; a shortlist of 50 isn't a shortlist.
+- [ ] **Output / surface**:
+  - Decide where the shortlist lives — a curated content page (e.g.
+    `/stocks/10-baggers` or under a "Watchlist" surface), with one card per name
+    showing Business & Moat score, market cap, and a 1-paragraph "why this could
+    10x" summary.
+  - Each card links to the existing stock report page (Business & Moat,
+    Valuation, Custom Reports) for the full analysis.
+  - Include the methodology (filters + lens) on the page so the picks are
+    transparent.
+- [ ] **Refresh cadence**:
+  - Re-run the filter + lens evaluation on a regular cadence (likely quarterly,
+    after the Business & Moat scores are themselves refreshed) on the off-hours
+    Claude-Code runner — don't let the list go stale.
+  - Track entries that get added / removed / promoted / cut, so the list has a
+    visible track record over time.
+- [ ] **Open questions**:
+  - Should the lens evaluation produce a **persisted** structured field on each
+    `TickerV1` (e.g. `tenBaggerScore` + per-dimension subscores) so it can be
+    queried / sorted independently of being on the shortlist? Likely yes — the
+    score is useful even for stocks that don't make the top 10.
+  - Do we want a "honorable mentions" tier (next 10) or a single hard cut?
+  - Geographic scope — US only at first, or also include Canadian small-caps once
+    `etfs.md` 1.7 unlocks the broader Canadian universe?
+
 ## Custom Reports ("random reports") per stock
 
 Source: design doc `docs/ai-knowledge/projects/insights-ui/requirements/req-001-stock-custom-reports.md`

--- a/tasks/koala-gains/tariffs.md
+++ b/tasks/koala-gains/tariffs.md
@@ -1,0 +1,102 @@
+# Tariff Reports — KoalaGains (Tasks)
+
+## Refresh + simplify the tariff reports
+
+Why this matters: the tariff reports drive a lot of organic traffic. They are one of
+our highest-visibility pages, so they're the most expensive thing to leave stale.
+Refresh content + ship a simpler, friendlier UX so first-time visitors can get the
+answer they came for in seconds.
+
+Existing surface (for reference, not to be redesigned blindly):
+- Public reports: `app/tariff-reports/`
+- Industry-scoped reports: `app/industry-tariff-report/[industryId]/`
+  - `tariff-updates/`
+  - `all-countries-tariff-updates/`
+- Generation API: `app/api/industry-tariff-reports/[industry]/generate-tariff-updates`
+  + `generate-all-countries-tariff-updates`
+- Sitemap: `app/industry-tariff-report/sitemap.xml`
+
+### Refresh the content
+
+- [ ] **Audit the current report set**:
+  - Pull every published tariff URL (from the sitemap + DB).
+  - Tag each by **last-refreshed date**, **traffic** (top-N first), and **factual
+    drift risk** (any tariff rate / policy / executive-order change since the
+    report was generated).
+  - Prioritize the refresh queue by `traffic × drift_risk`, not just calendar age.
+- [ ] **Re-run generation against the latest tariff state**:
+  - Confirm the generation pipeline pulls tariff rates / policy text from a
+    current source (not a snapshot frozen at generation time).
+  - Regenerate the top-traffic reports first; then sweep the long tail on the
+    off-hours runner.
+  - Capture a `lastRefreshedAt` field on each report so we can show "Updated
+    YYYY-MM-DD" on the page and rank/filter by it.
+- [ ] **Establish an ongoing refresh cadence**:
+  - Schedule a recurring refresh (likely daily for top-traffic, weekly for the
+    rest) on the Claude-Code off-hours runner — share infra with the stock + ETF
+    refresh pipeline rather than building a separate cron.
+  - Trigger an immediate refresh when a known upstream signal fires (e.g. a USTR
+    press release, EO change, or scraping-lambdas detector flag).
+- [ ] **Source-of-truth + citations**:
+  - Every numeric claim in a refreshed report should cite a verifiable source
+    (USTR / White House / official gazette / etc.) inline, with the date.
+  - Stale or unsourced claims are removed during the refresh, not just left in.
+
+### Simplify the UX
+
+Goal: a reader who lands on a tariff page should know **what's tariffed, by how much,
+since when, and what changed recently** within ~10 seconds, before they scroll. Today
+the page is dense and long; we need a much higher signal-to-noise ratio at the top.
+
+- [ ] **Top-of-page snapshot block** (above the fold, no scroll required):
+  - One-line "what this report covers" headline (industry + countries).
+  - Headline tariff numbers — current rate, rate as of N months ago, delta.
+  - "Last updated YYYY-MM-DD" badge.
+  - 3 key bullets: "What's new", "Who's affected", "What to watch".
+- [ ] **Cut the body length**:
+  - Identify boilerplate / repeated paragraphs across reports and remove or
+    consolidate them into shared explainer pages linked once.
+  - Replace dense tables with 1–2 focused charts where a chart conveys the same
+    info faster.
+  - Aim for a target word-count band per report (e.g. 800–1500 words) instead
+    of unbounded length.
+- [ ] **Improve in-page navigation**:
+  - Sticky table of contents / section jump nav (the report types are
+    long — readers should be able to jump to "Rates", "Recent changes", "By
+    country", etc.).
+  - Anchor links so each subsection has its own URL fragment for sharing.
+- [ ] **Better cross-linking**:
+  - From an industry tariff page, link to the relevant **stock** and **ETF**
+    reports (companies + funds with exposure to that industry / those
+    countries).
+  - From a country tariff page, link to the industries most affected.
+  - Internal linking helps both UX and the GSC "Crawled — currently not indexed"
+    issue tracked in `stocks.md` SEO Fixes.
+- [ ] **Mobile pass**:
+  - The biggest share of incoming traffic from search lands on mobile — verify
+    headline numbers, charts, and the snapshot block all render cleanly on a
+    phone before shipping.
+- [ ] **Reader actions**:
+  - Add a lightweight "subscribe for updates on this industry / country" CTA
+    that ties into the click-count login gate (`stocks.md` Login improvements).
+  - Optional "share" / "copy link" affordance for the most-shared sections.
+
+### Operational + measurement
+
+- [ ] **Track the impact**:
+  - Capture before/after baselines for: organic sessions, average time on page,
+    bounce rate, scroll depth, and indexed-URL count for the tariff sitemaps.
+  - Monitor Search Console for tariff URLs after the refresh — watch for the
+    same "Crawled — currently not indexed" pattern that hit the
+    business-and-moat sitemap.
+- [ ] **Sitemap hygiene**:
+  - Make sure `industry-tariff-report/sitemap.xml` only lists URLs whose content
+    has been refreshed and meets a minimum quality bar (mirror the `isComplete`
+    pattern in `etfs.md` 1.6).
+  - Add `lastmod` dates that actually reflect the refresh (not the build time).
+- [ ] **Open questions**:
+  - Should we keep the existing URLs and refresh in place (preserves SEO juice
+    + avoids redirects), or slug-rename to a cleaner scheme? Default: refresh
+    in place; only rename if the content materially changes shape.
+  - Per-country vs per-industry primary view — readers seem to come in from
+    both. Confirm with analytics which surface deserves the polished UX first.


### PR DESCRIPTION
## Summary
- Add **Founder & management team — LinkedIn-sourced info** task to `tasks/koala-gains/stocks.md`
- Add **section 1.8 Active-ETF management team — LinkedIn-sourced info** to `tasks/koala-gains/etfs.md` (gated to actively-managed funds; skipped for passive/index)
- Both sections cover data shape (`keyPeople[]`), acquisition strategy (no LinkedIn scraping — use 10-K / proxy / SAI / prospectus / IR pages + paid people-data providers), UI surfacing, analysis prompt wiring, refresh cadence, and open compliance questions

## Test plan
- [ ] Skim both task lists for parallelism + scope clarity
- [ ] Confirm the ETF section is restricted to active funds (no team block ever rendered for passive/index ETFs)
- [ ] Confirm the compliance posture (URLs only, no cached LinkedIn HTML) reads cleanly