### PR TITLE
competition: migrate ticker competition schema to new field names

### DIFF
--- a/insights-ui/schemas/analysis-factors/competition/competition-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/competition/competition-output.schema.yaml
@@ -5,34 +5,36 @@ properties:
   summary:
     type: string
     description: '3–5 sentence conclusion on how the stock compares to its peers. Must highlight its relative strengths, weaknesses, and competitive positioning within its industry.'
-  overallAnalysisDetails:
-    type: string
-    description: 'Write 3-4 paragraphs explaining why it’s how overall this particular company compares to the comperetion.'
   competitionAnalysisArray:
     type: array
     description: 'Array of competitor comparisons.'
     items:
       type: object
       properties:
-        companyName:
+        tickerSymbol:
           type: string
-          description: 'Full name of the competitor company.'
-        companySymbol:
-          type: string
-          description: 'Ticker symbol of the competitor company.'
+          description: "Ticker symbol of the competitor company, or 'PRIVATE' if not publicly listed."
         exchangeSymbol:
           type: string
-          description: 'Exchange symbol (e.g., NASDAQ, NYSE) of the competitor.'
-        exchangeName:
+          description: "Exchange symbol (e.g., NASDAQ, NYSE) of the competitor, or 'PRIVATE' if not publicly listed."
+        competitorName:
           type: string
-          description: 'Readable exchange name (e.g., NASDAQ Global Select, NYSE Main Market).'
-        detailedComparison:
+          description: 'Full name of the competitor company.'
+        shortDescription:
           type: string
-          description: '2–3 paragraphs analyzing how this competitor compares with the target stock. Cover relative market cap, growth, profitability, risk, and positioning.'
+          description: 'One-sentence description of the competitor and its key differentiator.'
+        currency:
+          type: string
+          description: "Currency for financial figures (e.g., 'USD')."
+        marketCap:
+          type: string
+          description: "Market capitalisation as a human-readable string (e.g., '\\$X.XB') or 'PRIVATE' if not publicly listed."
+        financialDataSummary:
+          type: string
+          description: 'One paragraph summarizing this competitor relative to the target stock — cover key financials, market position, and competitive dynamics.'
       required:
-        - companyName
-        - detailedComparison
+        - competitorName
+        - financialDataSummary
 required:
   - summary
-  - overallAnalysisDetails
   - competitionAnalysisArray

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/competition/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/competition/route.ts
@@ -1,7 +1,6 @@
 import { prisma } from '@/prisma';
 import { getEtfWhereClause } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
-import type { EtfCompetitionResponse, EtfCompetitor } from '@/types/etf/etf-analysis-types';
-import { CompetitionAnalysis } from '@/types/public-equity/analysis-factors-types';
+import type { EtfCompetitionAnalysisItem, EtfCompetitionResponse, EtfCompetitor } from '@/types/etf/etf-analysis-types';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
@@ -25,7 +24,7 @@ async function getHandler(
     return { vsCompetition: null, competitors: [], etf: undefined };
   }
 
-  const competitionArray = (etfRecord.vsCompetition?.competitionAnalysisArray ?? []) as unknown as CompetitionAnalysis[];
+  const competitionArray = (etfRecord.vsCompetition?.competitionAnalysisArray ?? []) as unknown as EtfCompetitionAnalysisItem[];
   const competitors = await hydrateEtfCompetitors(competitionArray);
 
   return {
@@ -62,7 +61,7 @@ async function getHandler(
  * UI can link to its report and plot its cached score on the quadrant chart.
  * Single batched query — no N+1.
  */
-async function hydrateEtfCompetitors(competitionArray: CompetitionAnalysis[]): Promise<EtfCompetitor[]> {
+async function hydrateEtfCompetitors(competitionArray: EtfCompetitionAnalysisItem[]): Promise<EtfCompetitor[]> {
   if (!competitionArray.length) return [];
 
   const symbolsToCheck = competitionArray.map((c) => c.companySymbol?.toUpperCase()).filter((symbol): symbol is string => !!symbol);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/creation-infos/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/creation-infos/route.ts
@@ -41,7 +41,7 @@ async function findByCompanySymbolCI(symbol: string): Promise<TickerV1VsCompetit
     WHERE EXISTS (
       SELECT 1
       FROM unnest(t.competition_analysis) AS elem
-      WHERE (elem ->> 'companySymbol') ILIKE ${symbol}
+      WHERE (elem ->> 'tickerSymbol') ILIKE ${symbol}
     )
   `);
 

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/competition/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/competition/route.ts
@@ -8,13 +8,14 @@ import { prepareBaseTickerInputJson } from '@/utils/analysis-reports/report-inpu
 
 export interface CompetitionAnalysisResponse {
   summary: string;
-  overallAnalysisDetails: string;
   competitionAnalysisArray: Array<{
-    companyName: string;
-    companySymbol?: string;
+    tickerSymbol?: string;
     exchangeSymbol?: string;
-    exchangeName?: string;
-    detailedComparison: string;
+    competitorName: string;
+    shortDescription?: string;
+    currency?: string;
+    marketCap?: string;
+    financialDataSummary?: string;
   }>;
 }
 

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -170,7 +170,7 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
 
   const country: SupportedCountries = getCountryByExchange(tickerData.exchange as USExchanges | CanadaExchanges | IndiaExchanges | UKExchanges);
 
-  const competitorNames: string[] = competitionData.competitorTickers?.map((c) => c.companyName) || [];
+  const competitorNames: string[] = competitionData.competitorTickers?.map((c) => c.competitorName) || [];
 
   const articleSchema = generateCompetitionArticleSchema(tickerData, competitorNames, competitionData.vsCompetition);
   const breadcrumbSchema = generateCompetitionBreadcrumbSchema(tickerData, country);

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/create/TickerCreationPage.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/create/TickerCreationPage.tsx
@@ -22,15 +22,15 @@ export interface TickerCreationPageProps {
 }
 
 function getCompetitionAnalysis(symbol: string, tickerCompetition: TickerV1VsCompetitionWithRelations): JSX.Element | null {
-  const competition = tickerCompetition.competitionAnalysisArray.find((c) => c.companySymbol?.toLowerCase() === symbol.toLowerCase()) || null;
+  const competition = tickerCompetition.competitionAnalysisArray.find((c) => c.tickerSymbol?.toLowerCase() === symbol.toLowerCase()) || null;
 
   return (
     competition && (
       <div>
         <div className="font-bold mt-2">
-          {competition.companyName} - {competition.companySymbol} ({competition.exchangeName} - {competition.exchangeSymbol})
+          {competition.competitorName} - {competition.tickerSymbol} ({competition.exchangeSymbol})
         </div>
-        <div>{competition.detailedComparison}</div>
+        <div>{competition.financialDataSummary}</div>
       </div>
     )
   );
@@ -71,13 +71,13 @@ export default function TickerCreationPage({ symbol, exchange }: TickerCreationP
   });
 
   const onOpenFromCard = (tc: TickerV1VsCompetitionWithRelations): void => {
-    const tickerToAdd = tc.competitionAnalysisArray.find((c) => c.companySymbol?.toLowerCase() === symbol.toLowerCase()) || null;
+    const tickerToAdd = tc.competitionAnalysisArray.find((c) => c.tickerSymbol?.toLowerCase() === symbol.toLowerCase()) || null;
     if (!tickerToAdd) return;
 
     // Seed defaults from the chosen card, fall back to props if needed
     const seededExchange = toExchange(tickerToAdd?.exchangeSymbol);
-    const seededName = tickerToAdd.companyName ?? '';
-    const seededSymbol = tickerToAdd.companySymbol?.toUpperCase() || '';
+    const seededName = tickerToAdd.competitorName ?? '';
+    const seededSymbol = tickerToAdd.tickerSymbol?.toUpperCase() || '';
 
     setActive(tc);
     setForm({

--- a/insights-ui/src/components/competition/CompetitorCard.tsx
+++ b/insights-ui/src/components/competition/CompetitorCard.tsx
@@ -7,13 +7,29 @@ import { ReactNode } from 'react';
 /**
  * Minimal shape shared by ticker (`CompetitorTicker`) and ETF (`EtfCompetitor`)
  * competitor records — the fields the card needs to render itself.
+ *
+ * Ticker competition uses the new field names (competitorName, tickerSymbol,
+ * financialDataSummary). ETF competition still uses the legacy names
+ * (companyName, companySymbol, detailedComparison). Both are accepted here
+ * so the card can be reused by both pages without duplication.
  */
 export interface CompetitorCardData {
-  companyName: string;
+  /** New ticker competition field — preferred display name. */
+  competitorName?: string;
+  /** Legacy ETF competition field — used as fallback when competitorName is absent. */
+  companyName?: string;
+  /** New ticker competition field — ticker symbol. */
+  tickerSymbol?: string;
+  /** Legacy ETF competition field — fallback when tickerSymbol is absent. */
   companySymbol?: string;
   exchangeSymbol?: string;
-  exchangeName?: string;
+  /** New ticker competition field — one-paragraph financial summary. */
+  financialDataSummary?: string;
+  /** Legacy ETF competition field — fallback when financialDataSummary is absent. */
   detailedComparison?: string;
+  shortDescription?: string;
+  currency?: string;
+  marketCap?: string;
 }
 
 export interface CompetitorCardProps {
@@ -27,16 +43,21 @@ export interface CompetitorCardProps {
 /**
  * Presentation card for a single peer used by both the ticker and ETF competition
  * sections. Renders the competitor's name (optionally linked), symbol + exchange pill,
- * any right-side action slot, and the markdown `detailedComparison` body.
+ * any right-side action slot, and the markdown body (financialDataSummary or
+ * detailedComparison).
  */
 export default function CompetitorCard({ competitor, href, actionSlot }: CompetitorCardProps): JSX.Element {
+  const displayName = competitor.competitorName ?? competitor.companyName ?? '';
+  const displaySymbol = competitor.tickerSymbol ?? competitor.companySymbol;
+  const displayBody = competitor.financialDataSummary ?? competitor.detailedComparison;
+
   const nameNode = href ? (
     <Link href={href} title="View detailed report" className="flex gap-x-2 items-center text-[#F59E0B] hover:text-[#F97316] transition-colors">
-      <h3 className="font-semibold">{competitor.companyName}</h3>
+      <h3 className="font-semibold">{displayName}</h3>
       <ArrowTopRightOnSquareIcon className="size-4 text-primary-text" />
     </Link>
   ) : (
-    <h3 className="font-semibold">{competitor.companyName}</h3>
+    <h3 className="font-semibold">{displayName}</h3>
   );
 
   return (
@@ -46,23 +67,19 @@ export default function CompetitorCard({ competitor, href, actionSlot }: Competi
           {nameNode}
           <div className="flex">
             <div className="flex items-center gap-x-2">
-              {competitor.companySymbol && (
+              {displaySymbol && displaySymbol !== 'PRIVATE' && (
                 <span className="text-sm text-gray-400">
-                  {competitor.companySymbol}
-                  {competitor.exchangeName ? ` • ${competitor.exchangeName.toUpperCase()}` : ''}
+                  {displaySymbol}
+                  {competitor.exchangeSymbol && competitor.exchangeSymbol !== 'PRIVATE' ? ` • ${competitor.exchangeSymbol.toUpperCase()}` : ''}
                 </span>
               )}
+              {competitor.marketCap && competitor.marketCap !== 'PRIVATE' && <span className="text-sm text-gray-500">Market Cap: {competitor.marketCap}</span>}
             </div>
             {actionSlot}
           </div>
         </div>
-        {competitor.detailedComparison && (
-          <div
-            id={slugify(competitor.companyName)}
-            className="markdown markdown-body"
-            dangerouslySetInnerHTML={{ __html: parseMarkdown(competitor.detailedComparison) }}
-          />
-        )}
+        {competitor.shortDescription && <p className="text-sm text-gray-400 italic">{competitor.shortDescription}</p>}
+        {displayBody && <div id={slugify(displayName)} className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(displayBody) }} />}
       </div>
     </li>
   );

--- a/insights-ui/src/components/ticker-reportsv1/AddTickerAdminButton.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/AddTickerAdminButton.tsx
@@ -13,8 +13,8 @@ interface AddTickerAdminButtonProps {
 export default function AddTickerAdminButton({ competitor }: AddTickerAdminButtonProps) {
   return (
     <PrivateWrapper>
-      {!competitor.existsInSystem && competitor.companySymbol && (
-        <Link className="ml-2" href={`/stocks/${competitor.exchangeSymbol || 'NYSE'}/${competitor.companySymbol}/create`}>
+      {!competitor.existsInSystem && competitor.tickerSymbol && competitor.tickerSymbol !== 'PRIVATE' && (
+        <Link className="ml-2" href={`/stocks/${competitor.exchangeSymbol || 'NYSE'}/${competitor.tickerSymbol}/create`}>
           <DocumentPlusIcon width={25} height={25} />
         </Link>
       )}

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -46,11 +46,11 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
   const competitorList =
     competitorTickers.length > 0
       ? competitorTickers.length === 1
-        ? competitorTickers[0].companyName
+        ? competitorTickers[0].competitorName
         : `${competitorTickers
             .slice(0, -1)
-            .map((c) => c.companyName)
-            .join(', ')} and ${competitorTickers[competitorTickers.length - 1].companyName}`
+            .map((c) => c.competitorName)
+            .join(', ')} and ${competitorTickers[competitorTickers.length - 1].competitorName}`
       : 'its key industry peers';
 
   const analysisTitle = `${tickerData.name} (${ticker}) Competitive Analysis`;
@@ -79,7 +79,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
     const { qualityScore, valueScore } = computeQuadrantScores(cached);
     quadrantDataPoints.push({
       ticker: competitor.tickerData!.symbol,
-      companyName: competitor.companyName,
+      companyName: competitor.competitorName,
       qualityScore,
       valueScore,
       classification: classifyStock(qualityScore, valueScore),
@@ -256,7 +256,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
                       : null;
                   return (
                     <CompetitorCard
-                      key={`${competitor.companyName}-${index}`}
+                      key={`${competitor.competitorName}-${index}`}
                       competitor={competitor}
                       href={href}
                       actionSlot={<AddTickerAdminButton competitor={competitor} />}

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -44,7 +44,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
     const { qualityScore, valueScore } = computeQuadrantScores(cached);
     quadrantDataPoints.push({
       ticker: competitor.tickerData!.symbol,
-      companyName: competitor.companyName,
+      companyName: competitor.competitorName,
       qualityScore,
       valueScore,
       classification: classifyStock(qualityScore, valueScore),

--- a/insights-ui/src/types/etf/etf-analysis-types.ts
+++ b/insights-ui/src/types/etf/etf-analysis-types.ts
@@ -62,6 +62,19 @@ export interface EtfCompetitorCachedScore {
 }
 
 /**
+ * Raw JSON shape stored in the ETF competition_analysis DB column.
+ * ETFs pre-date the ticker competition schema migration, so they still
+ * use the legacy field names (companyName / companySymbol / detailedComparison).
+ */
+export interface EtfCompetitionAnalysisItem {
+  companyName: string;
+  companySymbol?: string;
+  exchangeSymbol?: string;
+  exchangeName?: string;
+  detailedComparison?: string;
+}
+
+/**
  * ETF competitor record — mirrors the ticker `CompetitorTicker` shape but scoped to ETFs.
  * `companyName` is used as the peer name so the record stays shape-compatible with the
  * shared `CompetitorCard` rendering used on the stock competition page.

--- a/insights-ui/src/types/public-equity/analysis-factors-types.ts
+++ b/insights-ui/src/types/public-equity/analysis-factors-types.ts
@@ -21,11 +21,13 @@ export interface UpsertAnalysisFactorsRequest {
 }
 
 export interface CompetitionAnalysis {
-  companyName: string;
-  companySymbol?: string;
+  tickerSymbol?: string;
   exchangeSymbol?: string;
-  exchangeName?: string;
-  detailedComparison?: string;
+  competitorName: string;
+  shortDescription?: string;
+  currency?: string;
+  marketCap?: string;
+  financialDataSummary?: string;
 }
 
 export type CompetitionAnalysisArray = CompetitionAnalysis[];

--- a/insights-ui/src/utils/analysis-reports/save-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-utils.ts
@@ -188,13 +188,14 @@ export async function saveCompetitionAnalysisResponse(
   exchange: string,
   response: {
     summary: string;
-    overallAnalysisDetails: string;
     competitionAnalysisArray: Array<{
-      companyName: string;
-      companySymbol?: string;
+      tickerSymbol?: string;
       exchangeSymbol?: string;
-      exchangeName?: string;
-      detailedComparison: string;
+      competitorName: string;
+      shortDescription?: string;
+      currency?: string;
+      marketCap?: string;
+      financialDataSummary?: string;
     }>;
   }
 ): Promise<void> {
@@ -211,7 +212,7 @@ export async function saveCompetitionAnalysisResponse(
     },
     update: {
       summary: response.summary,
-      overallAnalysisDetails: response.overallAnalysisDetails,
+      overallAnalysisDetails: '',
       competitionAnalysisArray: response.competitionAnalysisArray,
       updatedAt: new Date(),
     },
@@ -219,7 +220,7 @@ export async function saveCompetitionAnalysisResponse(
       spaceId,
       tickerId: tickerRecord.id,
       summary: response.summary,
-      overallAnalysisDetails: response.overallAnalysisDetails,
+      overallAnalysisDetails: '',
       competitionAnalysisArray: response.competitionAnalysisArray,
       updatedAt: new Date(),
       createdAt: new Date(),
@@ -312,7 +313,7 @@ function getTopCompetitors(tickerRecord: TickerV1 & { vsCompetition?: { competit
     return { comp1: defaultComp1, comp2: defaultComp2, comp3: defaultComp3, totalCount: 3 };
   }
 
-  const allCompetitors = tickerRecord.vsCompetition.competitionAnalysisArray.filter((comp: CompetitionAnalysis) => comp.companyName && comp.companySymbol);
+  const allCompetitors = tickerRecord.vsCompetition.competitionAnalysisArray.filter((comp: CompetitionAnalysis) => comp.competitorName && comp.tickerSymbol);
 
   const competitors = allCompetitors.slice(0, 3); // Get first 3
   const totalCount = allCompetitors.length;
@@ -323,7 +324,7 @@ function getTopCompetitors(tickerRecord: TickerV1 & { vsCompetition?: { competit
 
   if (competitors.length === 1) {
     return {
-      comp1: `${competitors[0].companyName} (${competitors[0].companySymbol})`,
+      comp1: `${competitors[0].competitorName} (${competitors[0].tickerSymbol})`,
       comp2: defaultComp2,
       comp3: defaultComp3,
       totalCount,
@@ -332,17 +333,17 @@ function getTopCompetitors(tickerRecord: TickerV1 & { vsCompetition?: { competit
 
   if (competitors.length === 2) {
     return {
-      comp1: `${competitors[0].companyName} (${competitors[0].companySymbol})`,
-      comp2: `${competitors[1].companyName} (${competitors[1].companySymbol})`,
+      comp1: `${competitors[0].competitorName} (${competitors[0].tickerSymbol})`,
+      comp2: `${competitors[1].competitorName} (${competitors[1].tickerSymbol})`,
       comp3: defaultComp3,
       totalCount,
     };
   }
 
   return {
-    comp1: `${competitors[0].companyName} (${competitors[0].companySymbol})`,
-    comp2: `${competitors[1].companyName} (${competitors[1].companySymbol})`,
-    comp3: `${competitors[2].companyName} (${competitors[2].companySymbol})`,
+    comp1: `${competitors[0].competitorName} (${competitors[0].tickerSymbol})`,
+    comp2: `${competitors[1].competitorName} (${competitors[1].tickerSymbol})`,
+    comp3: `${competitors[2].competitorName} (${competitors[2].tickerSymbol})`,
     totalCount,
   };
 }

--- a/insights-ui/src/utils/ticker-v1-model-utils.ts
+++ b/insights-ui/src/utils/ticker-v1-model-utils.ts
@@ -52,11 +52,13 @@ export interface CompetitorTickerCachedScore {
 }
 
 export interface CompetitorTicker {
-  companyName: string;
-  companySymbol?: string;
+  competitorName: string;
+  tickerSymbol?: string;
   exchangeSymbol?: string;
-  exchangeName?: string;
-  detailedComparison?: string;
+  shortDescription?: string;
+  currency?: string;
+  marketCap?: string;
+  financialDataSummary?: string;
   existsInSystem?: boolean;
   tickerData?: {
     id: string;
@@ -140,7 +142,7 @@ export async function getCompetitorTickers(
   const competitionArray = tickerRecord.vsCompetition.competitionAnalysisArray;
 
   // Collect all symbols to query in a single batch (instead of N+1 queries)
-  const symbolsToCheck = competitionArray.map((c) => c.companySymbol?.toUpperCase()).filter((symbol): symbol is string => !!symbol);
+  const symbolsToCheck = competitionArray.map((c) => c.tickerSymbol?.toUpperCase()).filter((symbol): symbol is string => !!symbol);
 
   // Single batch query for all competitor tickers
   const existingTickers =
@@ -174,15 +176,17 @@ export async function getCompetitorTickers(
 
   // Build competitor list using the pre-fetched data
   return competitionArray.map((competition) => {
-    const symbolUpper = competition.companySymbol?.toUpperCase();
+    const symbolUpper = competition.tickerSymbol?.toUpperCase();
     const existingTicker = symbolUpper ? tickerMap.get(symbolUpper) : undefined;
 
     return {
-      companyName: competition.companyName,
-      companySymbol: competition.companySymbol,
+      competitorName: competition.competitorName,
+      tickerSymbol: competition.tickerSymbol,
       exchangeSymbol: competition.exchangeSymbol,
-      exchangeName: competition.exchangeName,
-      detailedComparison: competition.detailedComparison,
+      shortDescription: competition.shortDescription,
+      currency: competition.currency,
+      marketCap: competition.marketCap,
+      financialDataSummary: competition.financialDataSummary,
       existsInSystem: !!existingTicker,
       tickerData: existingTicker
         ? {


### PR DESCRIPTION
## Summary

- Replaces old ticker competition JSON field names (`companyName`, `companySymbol`, `detailedComparison`) with the corrected schema (`competitorName`, `tickerSymbol`, `financialDataSummary`) plus new fields (`shortDescription`, `currency`, `marketCap`)
- Updates `competition-output.schema.yaml`, `CompetitionAnalysis` TypeScript interface, all API routes, save utilities, and UI components
- ETF competition data retains its legacy field names via a new `EtfCompetitionAnalysisItem` type — ETF rendering is unaffected
- `CompetitorCard` component now accepts both old and new field names via optional fields for backward compatibility

## Test plan

- [ ] Verify competition report for PBPB saves successfully via `save-report.ts --report-type competition`
- [ ] Check competition page renders correctly for existing tickers with new field names
- [ ] Confirm ETF competition pages still render correctly (using legacy `EtfCompetitionAnalysisItem` type)
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] ESLint and Prettier pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)