### PR TITLE
docs(insights-ui): add ETF home-page connectivity + categorization task

### DIFF
--- a/docs/insights-ui/tasks/etfs.md
+++ b/docs/insights-ui/tasks/etfs.md
@@ -805,3 +805,43 @@ analog. We should **borrow its schema and UI patterns** rather than invent new o
     identical — only the mapped assets differ.
   - Do trends need a separate "trend category" taxonomy (macro / demographic / generational /
     technological / regulatory) for filtering, beyond what scenarios have?
+
+## Suggestion — Connect ETFs to the home page + add categorization
+
+Right now ETFs feel disconnected from the rest of the site. We have detail pages for each ETF (`/etfs/[exchange]/[etf]` plus `competition`, `cost-efficiency-team`, `future-performance-outlook`, `holdings`, `performance-returns`, `risk-analysis`) and one flat listing page (`/etfs`), but:
+
+- The **home page** (`/`) only shows stocks by industry. There is no entry point to ETFs from there.
+- The **`/etfs` listing** dumps all 7,000+ ETFs in one page, with no grouping.
+- We have no **category pages** or **country pages** for ETFs, even though stocks have both (`/stocks/industries/[industry]`, `/stocks/countries/[country]`).
+
+Suggested next steps (small, in order):
+
+- [ ] **1. Add an ETF section on the home page**
+  - Mirror what we do for stocks: a small showcase block that links into ETFs.
+  - Group by **`category`** (Morningstar category — many values, useful), not `assetClass` (only 6, too coarse).
+  - Each card links to the matching category page.
+
+- [ ] **2. Group the `/etfs` listing by category**
+  - Stop showing all ETFs in one flat grid.
+  - Show top categories first, with a "View all" link per category.
+  - Keep the full search/filter for power users, but the default view should be category-led, like `/stocks` is industry-led.
+
+- [ ] **3. Add ETF category pages**
+  - New route: `/etfs/categories/[category]` (and an index `/etfs/categories`).
+  - Same shape as `/stocks/industries/[industry]`.
+  - Sitemap + SEO metadata per category.
+
+- [ ] **4. Add ETF country pages (later)**
+  - New route: `/etfs/countries/[country]` (mirrors `/stocks/countries/[country]`).
+  - We already store `country` and `region` on `EtfStockAnalyzerInfo`, so the data is there.
+  - Lower priority than category — most users will look up an ETF by what it holds, not where it's listed. Do this once category pages are live and we see demand.
+
+- [ ] **5. Cross-link from ETF detail pages**
+  - On every ETF detail page, link the category name to its category page, and (later) the country to its country page.
+  - Add a small "Related ETFs in this category" block at the bottom of the main detail page.
+
+**Open questions:**
+
+- Use `category` (Morningstar) or do we want our own taxonomy? `category` is good enough to start; revisit only if it gets messy.
+- Do we need both `/etfs/categories/[category]` *and* country pages on day one? Probably no — ship category first, see if country demand follows.
+- Should the home page show ETFs alongside stocks in the same showcase, or in a separate section? Separate section is clearer for users.


### PR DESCRIPTION
## Summary
- Add a new suggestion block at the bottom of `docs/insights-ui/tasks/etfs.md` capturing the connectivity gaps between the ETF detail pages, the flat `/etfs` listing, and the home page.
- Proposes (in simple language): show ETFs on the home page, group `/etfs` by category, add ETF category pages, optionally add ETF country pages later, and cross-link from detail pages.
- Calls out using `category` (Morningstar) over `assetClass` (only 6 values) for grouping the 7,000+ ETFs.

## Test plan
- [ ] Read the appended section at the bottom of `docs/insights-ui/tasks/etfs.md` and confirm it reads cleanly and reflects the intent.