### PR TITLE
fix(stocks): escape apostrophe in whole-category schema YAML

### DIFF
--- a/insights-ui/schemas/analysis-factors/competition/competition-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/competition/competition-output.schema.yaml
@@ -4,7 +4,7 @@ additionalProperties: false
 properties:
   summary:
     type: string
-    description: '3–5 sentences summarizing the target company''s position relative to its peers. Highlight whether it is stronger, weaker, or mixed vs. competitors. End with a clear investor takeaway.'
+    description: "3–5 sentences summarizing the target company's position relative to its peers. Highlight whether it is stronger, weaker, or mixed vs. competitors. End with a clear investor takeaway."
   overallAnalysisDetails:
     type: string
     description: '3–4 paragraphs with a high-level overview of how the company compares to its competition. Must not repeat information or data points already covered in the competitionAnalysisArray entries.'

--- a/insights-ui/schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml
@@ -22,7 +22,7 @@ properties:
           description: '1 sentence giving the key takeaway or insight from this factor.'
         detailedExplanation:
           type: string
-          description: '1 paragraph of investor-focused analysis for this factor. Directly analyze the company's performance using available data. Clearly justify the Pass/Fail result, be critical in tone, and highlight risks or weaknesses along with strengths.'
+          description: "1 paragraph of investor-focused analysis for this factor. Directly analyze the company's performance using available data. Clearly justify the Pass/Fail result, be critical in tone, and highlight risks or weaknesses along with strengths."
         result:
           type: string
           enum: ['Pass', 'Fail']

--- a/insights-ui/src/scripts/tickers/get-report-prompt.ts
+++ b/insights-ui/src/scripts/tickers/get-report-prompt.ts
@@ -51,10 +51,8 @@ async function main(): Promise<void> {
   if (outPath) {
     await mkdir(path.dirname(outPath), { recursive: true });
     await writeFile(outPath, response.prompt, 'utf-8');
-    // Write the output schema to a companion .schema.json file so callers can reference
-    // the expected response shape without re-parsing the prompt text.
-    const schemaOutPath = outPath.replace(/\.txt$/, '.schema.json').replace(/([^.]+)$/, 'schema.json');
     if (response.schema) {
+      const schemaOutPath = outPath.replace(/\.txt$/, '.schema.json');
       await writeFile(schemaOutPath, response.schema, 'utf-8');
     }
     console.error(`Wrote prompt (${response.prompt.length} chars) → ${outPath} [${API_BASE} | ${symbol} ${exchange} ${reportType}]`);


### PR DESCRIPTION
## Summary

- Fixes a production bug introduced by 714389c70 ("refactor(stocks): derive prompt output schema from canonical YAML files") that broke 5 of 8 stock report saves.
- Line 25 of `schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml` had `company's` inside a single-quoted YAML scalar — YAML's grammar requires apostrophes inside single-quoted scalars to be doubled. js-yaml threw `bad indentation of a mapping entry (25:112)`, and the `save-json-report` route returned HTTP 500 before payload validation even ran.
- Switched the description to a double-quoted scalar so the apostrophe is just a literal character. Cleaner and removes the escape footgun for future edits.

## Impact

The 5 report types that share this schema were unsave-able in production:
- `FINANCIAL_ANALYSIS`
- `BUSINESS_AND_MOAT`
- `PAST_PERFORMANCE`
- `FUTURE_GROWTH`
- `FAIR_VALUE`

`COMPETITION`, `FUTURE_RISK`, and `FINAL_SUMMARY` use different schema files and were unaffected — confirmed by successful saves for both MAAS (NASDAQ) and CRBG (NYSE) on those three report types during today's run.

## Reproduction (against prod, before fix)

```
POST https://koalagains.com/api/koala_gains/tickers-v1/exchange/NASDAQ/TBLD/save-json-report
{"reportType":"business-and-moat","llmResponse":{"overallSummary":"x","overallAnalysisDetails":"x","factors":[]}}

→ 500 {"error":"Schema validation failed: Error parsing /var/task/insights-ui/schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml: bad indentation of a mapping entry (25:112)..."}
```

## Test plan

- [x] `prettier --check` passes on the file
- [x] All 4 schema YAML files parse with `js-yaml` (`whole-category`, `competition`, `future-risk`, `final-summary`)
- [x] Reproduced the 500 against prod with empty payload before the fix
- [ ] After Vercel redeploys: re-save the 5 blocked report types for MAAS & CRBG using the JSONs already on disk, then validate against a fresh oldest stock (TBLD)