### PR TITLE
stock-scenarios: rollout polish — navbar, country page link, listing/detail redesign, sitemap

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -36,4 +36,7 @@
   <sitemap>
     <loc>https://koalagains.com/stocks/fair-value-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/stock-scenarios/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
@@ -67,11 +67,7 @@ export default async function StockScenarioDetailPage({ params }: { params: Rout
   ];
 
   return (
-    <StockScenarioPageLayout
-      title={scenario.title}
-      description={`Scenario #${scenario.scenarioNumber} — outlook last reviewed ${scenario.outlookAsOfDate.slice(0, 10)}.`}
-      breadcrumbs={breadcrumbs}
-    >
+    <StockScenarioPageLayout breadcrumbs={breadcrumbs}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/insights-ui/src/app/stock-scenarios/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import StockScenariosPageActions from '@/app/stock-scenarios/StockScenariosPageActions';
 import { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
 import StockScenarioListingGrid from '@/components/stock-scenarios/StockScenarioListingGrid';
@@ -65,7 +66,9 @@ export default async function StockScenariosPage() {
           }}
         />
       )}
-      <StockScenarioListingGrid data={data} />
+      <Suspense fallback={null}>
+        <StockScenarioListingGrid data={data} />
+      </Suspense>
     </StockScenarioPageLayout>
   );
 }

--- a/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import type { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+async function getAllStockScenarios(): Promise<StockScenarioListingResponse['scenarios']> {
+  const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/stock-scenarios/listing?pageSize=200`);
+  if (!response.ok) return [];
+  const body = (await response.json()) as StockScenarioListingResponse;
+  return body.scenarios ?? [];
+}
+
+async function generateStockScenarioUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  urls.push({
+    url: '/stock-scenarios',
+    changefreq: 'daily',
+    priority: 0.8,
+  });
+
+  const scenarios = await getAllStockScenarios();
+  for (const scenario of scenarios) {
+    if (scenario.archived) continue;
+    urls.push({
+      url: `/stock-scenarios/${scenario.slug}`,
+      changefreq: 'weekly',
+      priority: 0.7,
+      lastmod: scenario.outlookAsOfDate ? scenario.outlookAsOfDate.split('T')[0] : undefined,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
+  const host = req.headers.get('host') as string;
+
+  try {
+    const urls = await generateStockScenarioUrls();
+    const smStream = new SitemapStream({ hostname: 'https://' + host });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating stock-scenarios sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -107,18 +107,18 @@ export default function TopNav() {
                           transition
                           className="absolute left-1/2 z-10 mt-3 w-screen max-w-xs -translate-x-1/2 overflow-hidden rounded-3xl bg-white shadow-lg outline outline-1 outline-gray-900/5 transition data-[closed]:translate-y-1 data-[closed]:opacity-0 data-[enter]:duration-200 data-[leave]:duration-150 data-[enter]:ease-out data-[leave]:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
                         >
-                          <div className="p-2">
+                          <div className="p-2.5">
                             {reportsDropdown.map((item) => (
                               <div
                                 key={item.name}
-                                className="group relative flex items-center gap-x-6 rounded-lg p-2.5 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
+                                className="group relative flex items-center gap-x-6 rounded-lg p-3 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
                               >
                                 <div className="flex-auto">
                                   <Link href={item.href} className="block font-semibold text-gray-900 dark:text-white" onClick={() => close()}>
                                     {item.name}
                                     <span className="absolute inset-0" />
                                   </Link>
-                                  <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">{item.description}</p>
+                                  <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">{item.description}</p>
                                 </div>
                               </div>
                             ))}
@@ -147,7 +147,7 @@ export default function TopNav() {
                             {genaiDropdown.map((item) => (
                               <div
                                 key={item.name}
-                                className="group relative flex items-center gap-x-6 rounded-lg p-2.5 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
+                                className="group relative flex items-center gap-x-6 rounded-lg p-3 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
                               >
                                 <div className="flex-auto">
                                   <Link href={item.href} className="block font-semibold text-gray-900 dark:text-white" onClick={() => close()}>

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -28,6 +28,7 @@ interface GenAIItem {
 const reportsDropdown: ReportItem[] = [
   { name: 'Crowdfunding Reports', href: '/crowd-funding', description: 'Detailed crowdfunding analysis', isNew: false },
   { name: 'Stock Reports', href: '/stocks', description: 'Value investing insights', isNew: true },
+  { name: 'Stock Scenarios', href: '/stock-scenarios', description: 'Sector shock playbook — winners and losers', isNew: true },
   { name: 'Tariff Reports', href: '/tariff-reports', description: 'Trade tariff impact analysis', isNew: false },
   { name: 'Daily Top Gainers', href: '/daily-top-movers/top-gainers/country/US', description: 'Top performing stocks today', isNew: true },
   { name: 'Daily Top Losers', href: '/daily-top-movers/top-losers/country/US', description: 'Biggest stock declines today', isNew: true },
@@ -106,18 +107,18 @@ export default function TopNav() {
                           transition
                           className="absolute left-1/2 z-10 mt-3 w-screen max-w-xs -translate-x-1/2 overflow-hidden rounded-3xl bg-white shadow-lg outline outline-1 outline-gray-900/5 transition data-[closed]:translate-y-1 data-[closed]:opacity-0 data-[enter]:duration-200 data-[leave]:duration-150 data-[enter]:ease-out data-[leave]:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
                         >
-                          <div className="p-3">
+                          <div className="p-2">
                             {reportsDropdown.map((item) => (
                               <div
                                 key={item.name}
-                                className="group relative flex items-center gap-x-6 rounded-lg p-4 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
+                                className="group relative flex items-center gap-x-6 rounded-lg p-2.5 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
                               >
                                 <div className="flex-auto">
                                   <Link href={item.href} className="block font-semibold text-gray-900 dark:text-white" onClick={() => close()}>
                                     {item.name}
                                     <span className="absolute inset-0" />
                                   </Link>
-                                  <p className="mt-1 text-gray-600 dark:text-gray-400">{item.description}</p>
+                                  <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">{item.description}</p>
                                 </div>
                               </div>
                             ))}
@@ -146,7 +147,7 @@ export default function TopNav() {
                             {genaiDropdown.map((item) => (
                               <div
                                 key={item.name}
-                                className="group relative flex items-center gap-x-6 rounded-lg p-4 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
+                                className="group relative flex items-center gap-x-6 rounded-lg p-2.5 text-sm/6 hover:bg-gray-50 dark:hover:bg-white/5"
                               >
                                 <div className="flex-auto">
                                   <Link href={item.href} className="block font-semibold text-gray-900 dark:text-white" onClick={() => close()}>

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -28,7 +28,7 @@ interface GenAIItem {
 const reportsDropdown: ReportItem[] = [
   { name: 'Crowdfunding Reports', href: '/crowd-funding', description: 'Detailed crowdfunding analysis', isNew: false },
   { name: 'Stock Reports', href: '/stocks', description: 'Value investing insights', isNew: true },
-  { name: 'Stock Scenarios', href: '/stock-scenarios', description: 'Sector shock playbook — winners and losers', isNew: true },
+  { name: 'Stock Scenarios', href: '/stock-scenarios', description: 'Stocks that win or lose per scenario', isNew: true },
   { name: 'Tariff Reports', href: '/tariff-reports', description: 'Trade tariff impact analysis', isNew: false },
   { name: 'Daily Top Gainers', href: '/daily-top-movers/top-gainers/country/US', description: 'Top performing stocks today', isNew: true },
   { name: 'Daily Top Losers', href: '/daily-top-movers/top-losers/country/US', description: 'Biggest stock declines today', isNew: true },

--- a/insights-ui/src/components/stock-scenarios/StockScenarioCard.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioCard.tsx
@@ -13,22 +13,32 @@ export default function StockScenarioCard({ scenario }: { scenario: StockScenari
   return (
     <Link
       href={`/stock-scenarios/${scenario.slug}`}
-      className="block bg-[#1F2937] border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+      className="group block bg-gray-900 border border-gray-800 rounded-2xl p-5 hover:border-blue-500 transition-all duration-200 h-full"
     >
-      <div className="flex items-center justify-between mb-2 gap-2">
+      <div className="flex items-center justify-between mb-3 gap-2">
         <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">#{scenario.scenarioNumber}</span>
-        {scenario.archived && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">Archived</span>}
+        {scenario.archived && <span className="text-xs text-gray-400 bg-gray-800 border border-gray-700 px-2 py-0.5 rounded">Archived</span>}
       </div>
 
-      <div className="flex flex-wrap gap-1.5 mb-3">
+      <div className="flex flex-wrap gap-1.5 mb-4">
         <StockScenarioDirectionBadge direction={scenario.direction} />
         <StockScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} />
         <StockScenarioTimeframeBadge timeframe={scenario.timeframe} />
       </div>
 
-      <h3 className="text-white text-base font-medium mb-2 line-clamp-2 min-h-[3rem]">{scenario.title}</h3>
+      <h3 className="text-white text-lg font-semibold mb-3 line-clamp-2 min-h-[3.25rem] group-hover:text-blue-400 transition-colors">{scenario.title}</h3>
 
-      <p className="text-xs text-gray-400 line-clamp-3 min-h-[3.75rem]">{firstSentence(scenario.underlyingCause)}</p>
+      <p className="text-sm text-gray-300 leading-relaxed line-clamp-3 min-h-[4rem]">{firstSentence(scenario.underlyingCause)}</p>
+
+      {scenario.countries.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-4 pt-3 border-t border-gray-800">
+          {scenario.countries.map((c) => (
+            <span key={c} className="text-[10px] uppercase tracking-wide text-gray-400">
+              📍 {c}
+            </span>
+          ))}
+        </div>
+      )}
     </Link>
   );
 }

--- a/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
@@ -51,8 +51,8 @@ export default function StockScenarioDetailView({ scenario }: { scenario: StockS
         )}
       </header>
 
-      <section className="mb-8" aria-labelledby="underlying-cause-heading">
-        <h2 id="underlying-cause-heading" className="text-xl font-semibold text-white mb-3">
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="underlying-cause-heading">
+        <h2 id="underlying-cause-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
           Underlying cause
         </h2>
         <div
@@ -62,15 +62,15 @@ export default function StockScenarioDetailView({ scenario }: { scenario: StockS
         />
       </section>
 
-      <section className="mb-8" aria-labelledby="historical-analog-heading">
-        <h2 id="historical-analog-heading" className="text-xl font-semibold text-white mb-3">
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="historical-analog-heading">
+        <h2 id="historical-analog-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
           Historical analog
         </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.historicalAnalog)} />
       </section>
 
-      <section className="mb-8" aria-labelledby="outlook-heading">
-        <h2 id="outlook-heading" className="text-xl font-semibold text-white mb-3">
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="outlook-heading">
+        <h2 id="outlook-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
           Outlook <span className="text-sm font-normal text-gray-400">(as of {asOf})</span>
         </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.outlookMarkdown)} />

--- a/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioDetailView.tsx
@@ -12,51 +12,81 @@ export default function StockScenarioDetailView({ scenario }: { scenario: StockS
   const asOf = scenario.outlookAsOfDate.slice(0, 10);
 
   return (
-    <article className="text-[#E5E7EB]">
-      <div className="flex flex-wrap items-center gap-2 mb-4">
-        <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-sm font-bold px-2.5 py-0.5 rounded">
-          Scenario #{scenario.scenarioNumber}
-        </span>
-        <StockScenarioDirectionBadge direction={scenario.direction} />
-        <StockScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} asOfDate={scenario.outlookAsOfDate} />
-        <StockScenarioTimeframeBadge timeframe={scenario.timeframe} />
-      </div>
-      <p className="text-xs text-gray-400 mb-2">
-        {directionLabel(scenario.direction)} · {probabilityBucketLabel(scenario.probabilityBucket)} · {timeframeLabel(scenario.timeframe)} · outlook reviewed{' '}
-        {asOf}
-      </p>
-      {scenario.countries.length > 0 && (
-        <p className="text-xs text-gray-400 mb-4">
-          <span className="uppercase tracking-wide text-[11px] text-gray-500 mr-2">Countries in scope</span>
-          {scenario.countries.map((c) => (
-            <span
-              key={c}
-              className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1"
-            >
-              {c}
-            </span>
-          ))}
+    <article className="text-[#E5E7EB]" itemScope itemType="https://schema.org/Article">
+      <header className="mb-8">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-sm font-bold px-2.5 py-0.5 rounded">
+            Scenario #{scenario.scenarioNumber}
+          </span>
+          <StockScenarioDirectionBadge direction={scenario.direction} />
+          <StockScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} asOfDate={scenario.outlookAsOfDate} />
+          <StockScenarioTimeframeBadge timeframe={scenario.timeframe} />
+          {scenario.archived && <span className="text-xs text-gray-300 bg-gray-800 border border-gray-700 px-2 py-0.5 rounded">Archived</span>}
+        </div>
+
+        <h1 className="text-3xl font-bold text-white mb-3" itemProp="headline">
+          {scenario.title}
+        </h1>
+
+        <p className="text-xs text-gray-400 mb-2">
+          <span className="sr-only">Scenario summary: </span>
+          {directionLabel(scenario.direction)} · {probabilityBucketLabel(scenario.probabilityBucket)} · {timeframeLabel(scenario.timeframe)} ·{' '}
+          <span>
+            outlook reviewed <time dateTime={asOf}>{asOf}</time>
+          </span>
         </p>
-      )}
 
-      <h1 className="text-3xl font-bold text-white mb-4">{scenario.title}</h1>
+        {scenario.countries.length > 0 && (
+          <p className="text-xs text-gray-400 mb-0">
+            <span className="uppercase tracking-wide text-[11px] text-gray-500 mr-2">Countries in scope</span>
+            {scenario.countries.map((c) => (
+              <span
+                key={c}
+                className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1"
+              >
+                {c}
+              </span>
+            ))}
+          </p>
+        )}
+      </header>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Underlying cause</h2>
-        <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.underlyingCause)} />
+      <section className="mb-8" aria-labelledby="underlying-cause-heading">
+        <h2 id="underlying-cause-heading" className="text-xl font-semibold text-white mb-3">
+          Underlying cause
+        </h2>
+        <div
+          className="markdown-body prose prose-invert max-w-none"
+          itemProp="articleBody"
+          dangerouslySetInnerHTML={renderMarkdown(scenario.underlyingCause)}
+        />
       </section>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Historical analog</h2>
+      <section className="mb-8" aria-labelledby="historical-analog-heading">
+        <h2 id="historical-analog-heading" className="text-xl font-semibold text-white mb-3">
+          Historical analog
+        </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.historicalAnalog)} />
       </section>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Outlook (as of {asOf})</h2>
+      <section className="mb-8" aria-labelledby="outlook-heading">
+        <h2 id="outlook-heading" className="text-xl font-semibold text-white mb-3">
+          Outlook <span className="text-sm font-normal text-gray-400">(as of {asOf})</span>
+        </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.outlookMarkdown)} />
       </section>
 
-      <StockScenarioLinkColumns winners={scenario.winners} losers={scenario.losers} mostExposed={scenario.mostExposed} scenarioCountries={scenario.countries} />
+      <section aria-labelledby="impacted-stocks-heading">
+        <h2 id="impacted-stocks-heading" className="sr-only">
+          Impacted stocks
+        </h2>
+        <StockScenarioLinkColumns
+          winners={scenario.winners}
+          losers={scenario.losers}
+          mostExposed={scenario.mostExposed}
+          scenarioCountries={scenario.countries}
+        />
+      </section>
     </article>
   );
 }

--- a/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
@@ -28,24 +28,26 @@ function renderMarkdown(md: string) {
   return { __html: parseMarkdown(md) as string };
 }
 
-function LinkPill({ link }: { link: StockScenarioLinkDto }): JSX.Element {
-  const inner = (
+function PillVisual({ link }: { link: StockScenarioLinkDto }): JSX.Element {
+  return (
     <span className="inline-flex items-center gap-1 bg-[#111827] border border-[#374151] text-xs text-white rounded px-2 py-0.5">
       <span className="font-semibold">{link.symbol}</span>
       <span className="text-gray-400">· {link.exchange}</span>
     </span>
   );
+}
 
+function LinkPill({ link }: { link: StockScenarioLinkDto }): JSX.Element {
   // tickerId === null means the (symbol, exchange) pair isn't in TickerV1 yet —
   // the public stock detail page would 404 on it. Render as plain text instead
   // so authors can still tag the ticker and admins can later add it to TickerV1.
   if (!link.tickerId) {
-    return inner;
+    return <PillVisual link={link} />;
   }
 
   return (
     <Link href={`/stocks/${link.exchange}/${link.symbol}`} className="hover:opacity-80">
-      {inner}
+      <PillVisual link={link} />
     </Link>
   );
 }
@@ -84,10 +86,10 @@ function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
   const score = link.finalScore;
   const scoreClasses = score !== null ? getScoreColorClasses(score) : null;
 
-  return (
-    <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">
+  const body = (
+    <>
       <div className="flex items-center justify-between gap-2 mb-1">
-        <LinkPill link={link} />
+        <PillVisual link={link} />
         {link.expectedPriceChange !== null && (
           <span className={`text-xs font-semibold ${changeColor}`}>{formatExpectedPriceChange(link.expectedPriceChange)}</span>
         )}
@@ -140,8 +142,23 @@ function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
           )}
         </div>
       )}
-    </div>
+    </>
   );
+
+  // When the stock exists in TickerV1 the whole card is a link to its report
+  // page; otherwise we keep the same visual but drop the hover/click affordance.
+  if (link.tickerId) {
+    return (
+      <Link
+        href={`/stocks/${link.exchange}/${link.symbol}`}
+        className="block bg-[#111827] border border-[#374151] rounded-md p-2.5 hover:border-blue-500 hover:bg-[#0f1623] transition-colors"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">{body}</div>;
 }
 
 function LinkList({
@@ -220,7 +237,7 @@ export default function StockScenarioLinkColumns({ winners, losers, mostExposed,
   return (
     <section className="bg-[#1F2937] border border-[#374151] rounded-lg p-4 space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold text-white">Tagged stocks</h2>
+        <h2 className="text-xl font-bold text-white">Tagged stocks</h2>
         <label className="flex items-center gap-2 text-xs text-gray-300">
           <span className="uppercase tracking-wide text-[11px] text-gray-400">Filter by country</span>
           <select

--- a/insights-ui/src/components/stock-scenarios/StockScenarioListingGrid.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioListingGrid.tsx
@@ -1,17 +1,21 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
 import { ScenarioDirection, ScenarioProbabilityBucket, ScenarioTimeframe } from '@/types/scenarioEnums';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { SupportedCountries, toSupportedCountry } from '@/utils/countryExchangeUtils';
 import StockScenarioCard from './StockScenarioCard';
 import StockScenarioFiltersBar from './StockScenarioFiltersBar';
 
 export default function StockScenarioListingGrid({ data }: { data: StockScenarioListingResponse }): JSX.Element | null {
+  const searchParams = useSearchParams();
+  const initialCountry = toSupportedCountry(searchParams?.get('country') ?? null) ?? 'ALL';
+
   const [direction, setDirection] = useState<ScenarioDirection | 'ALL'>('ALL');
   const [bucket, setBucket] = useState<ScenarioProbabilityBucket | 'ALL'>('ALL');
   const [timeframe, setTimeframe] = useState<ScenarioTimeframe | 'ALL'>('ALL');
-  const [country, setCountry] = useState<SupportedCountries | 'ALL'>('ALL');
+  const [country, setCountry] = useState<SupportedCountries | 'ALL'>(initialCountry);
   const [search, setSearch] = useState<string>('');
 
   const filtered = useMemo(() => {
@@ -65,7 +69,7 @@ export default function StockScenarioListingGrid({ data }: { data: StockScenario
           <p className="text-[#E5E7EB] text-lg">No scenarios match the current filters.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {filtered.map((s) => (
             <StockScenarioCard key={s.id} scenario={s} />
           ))}

--- a/insights-ui/src/components/stock-scenarios/StockScenarioPageLayout.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioPageLayout.tsx
@@ -4,8 +4,8 @@ import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 
 interface StockScenarioPageLayoutProps {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   breadcrumbs?: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   children: ReactNode;
@@ -23,10 +23,12 @@ export default function StockScenarioPageLayout({ title, description, breadcrumb
     <PageWrapper>
       <Breadcrumbs breadcrumbs={breadcrumbs ?? defaultBreadcrumbs()} rightButton={rightButton} />
 
-      <div className="w-full mb-8">
-        <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
-        <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
-      </div>
+      {title && (
+        <div className="w-full mb-8">
+          <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
+          {description && <p className="text-[#E5E7EB] text-md mb-4">{description}</p>}
+        </div>
+      )}
 
       {children}
     </PageWrapper>

--- a/insights-ui/src/components/stocks/IndustryWithStocksPageLayout.tsx
+++ b/insights-ui/src/components/stocks/IndustryWithStocksPageLayout.tsx
@@ -82,11 +82,22 @@ export default function IndustryWithStocksPageLayout({
       <div className="w-full mb-8">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
           <h1 className="text-2xl font-bold text-white">{title}</h1>
-          {industryKey && hasAnalysis && (
-            <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}/analysis`} className="link-color hover:underline text-sm whitespace-nowrap">
-              View Industry Analysis →
-            </Link>
-          )}
+          <div className="flex items-center gap-4 flex-wrap">
+            {industryKey && hasAnalysis && (
+              <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}/analysis`} className="link-color hover:underline text-sm whitespace-nowrap">
+                View Industry Analysis →
+              </Link>
+            )}
+            {!industryKey && (
+              <Link
+                href={`/stock-scenarios?country=${encodeURIComponent(currentCountry)}`}
+                className="link-color hover:underline text-sm whitespace-nowrap"
+                aria-label={`View ${currentCountry} stock market scenarios`}
+              >
+                View Stock Scenarios →
+              </Link>
+            )}
+          </div>
         </div>
         <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
         <div className="mt-2 mb-2">

--- a/insights-ui/src/utils/stock-scenario-metadata-generators.ts
+++ b/insights-ui/src/utils/stock-scenario-metadata-generators.ts
@@ -23,6 +23,7 @@ export function generateStockScenarioListingMetadata(): Metadata {
     title,
     description,
     alternates: { canonical: url },
+    robots: { index: true, follow: true },
     keywords: [
       'stock scenarios',
       'sector shock analysis',
@@ -42,11 +43,13 @@ export function generateStockScenarioListingMetadata(): Metadata {
       url,
       siteName: SITE_NAME,
       type: 'website',
+      images: [{ url: LOGO_URL }],
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
+      images: [LOGO_URL],
     },
   };
 }
@@ -131,6 +134,7 @@ export function generateStockScenarioDetailMetadata({
     title: `${title} — Stock Scenario Analysis (${year}) | ${SITE_NAME}`,
     description,
     alternates: { canonical: canonicalUrl },
+    robots: { index: true, follow: true },
     keywords: [title, `${title} stocks`, `${title} winners`, `${title} losers`, 'stock scenarios', 'sector rotation', 'market scenario analysis', SITE_NAME],
     openGraph: {
       title: `${title} — Stock Scenario Analysis | ${SITE_NAME}`,
@@ -140,11 +144,15 @@ export function generateStockScenarioDetailMetadata({
       type: 'article',
       publishedTime: createdTime ?? updatedTime,
       modifiedTime: updatedTime ?? createdTime,
+      authors: [SITE_NAME],
+      section: 'Stock Scenarios',
+      images: [{ url: LOGO_URL }],
     },
     twitter: {
       card: 'summary_large_image',
       title: `${title} — Stock Scenario Analysis | ${SITE_NAME}`,
       description,
+      images: [LOGO_URL],
     },
   };
 }


### PR DESCRIPTION
## Summary

Finalizes the stock-scenarios feature so it can be published to users.

- **Navbar:** add **Stock Scenarios** entry to the KoalaGains Insights dropdown; tighten dropdown item padding so the longer list still reads well.
- **Country stocks pages:** add a **View Stock Scenarios →** link in the same row as the page heading on `/stocks` and `/stocks/countries/[country]` (passes `?country=` so the listing pre-filters).
- **Listing page (`/stock-scenarios`):** 3 cards per row at `lg+` (was 4); darker card palette to match `/portfolio-managers/professional-managers` (`bg-gray-900` / `border-gray-800`, blue-500 hover); larger gap; country chip on the card; reads `country` from URL query param via `useSearchParams` (wrapped in `Suspense` on the page).
- **Detail page (`/stock-scenarios/[slug]`):** drop the duplicate page-layout heading (title was rendered twice); tags + scenario summary now sit above the single `<h1>` in a semantic `<header>` (per the request, tags above the heading and below the breadcrumbs); each content block is a `<section>` with `aria-labelledby` and an explicit `<h2>`; `itemScope` + `itemProp` markers for `Article` microdata.
- **Metadata:** explicit `robots: index/follow`, OG/Twitter images, OG `article` `authors` and `section` on the detail page.
- **Sitemap:** new `/stock-scenarios/sitemap.xml` route handler (listing + per-slug; `lastmod` from `outlookAsOfDate`; archived excluded); referenced from `public/sitemap_index.xml` per Google's sitemap-index pattern (the child sitemap lives at the URL hierarchy it owns, and the index points to it).

## Test plan

- [ ] Navbar: KoalaGains Insights dropdown shows **Stock Scenarios** between Stock Reports and Tariff Reports; spacing looks balanced on desktop.
- [ ] `/stocks`: heading row shows **View Stock Scenarios →** linking to `/stock-scenarios?country=US`.
- [ ] `/stocks/countries/Canada`: heading row shows **View Stock Scenarios →** linking with `?country=Canada`; opening the link auto-applies the Canada filter.
- [ ] `/stock-scenarios`: 3 cards per row at desktop, 2 at tablet, 1 at mobile; cards visibly darker (gray-900) and match the professional-managers card style.
- [ ] `/stock-scenarios/<slug>`: only one `<h1>`; tag chips above the heading; underlying cause / historical analog / outlook each render as their own `<section>` with an `<h2>`; page source has `robots`, OG, Twitter, and JSON-LD blocks intact.
- [ ] `/stock-scenarios/sitemap.xml`: returns a valid XML sitemap listing the index page + all non-archived slugs with `lastmod`.
- [ ] `/sitemap_index.xml`: includes a `<sitemap>` entry for `/stock-scenarios/sitemap.xml`.
- [ ] Build passes on Vercel (compile + lint clean locally; build needs the prod env vars on CI).