### PR TITLE
etf-scenarios: parity polish with stock-scenarios

### DIFF
--- a/insights-ui/src/app/etf-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/etf-scenarios/[slug]/page.tsx
@@ -67,11 +67,7 @@ export default async function EtfScenarioDetailPage({ params }: { params: RouteP
   ];
 
   return (
-    <EtfScenarioPageLayout
-      title={scenario.title}
-      description={`Scenario #${scenario.scenarioNumber} — outlook last reviewed ${scenario.outlookAsOfDate.slice(0, 10)}.`}
-      breadcrumbs={breadcrumbs}
-    >
+    <EtfScenarioPageLayout breadcrumbs={breadcrumbs}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/insights-ui/src/app/etf-scenarios/page.tsx
+++ b/insights-ui/src/app/etf-scenarios/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import EtfScenariosPageActions from '@/app/etf-scenarios/EtfScenariosPageActions';
 import EtfScenarioListingGrid from '@/components/etf-scenarios/EtfScenarioListingGrid';
 import EtfScenarioPageLayout from '@/components/etf-scenarios/EtfScenarioPageLayout';
@@ -65,7 +66,9 @@ export default async function EtfScenariosPage() {
           }}
         />
       )}
-      <EtfScenarioListingGrid data={data} />
+      <Suspense fallback={null}>
+        <EtfScenarioListingGrid data={data} />
+      </Suspense>
     </EtfScenarioPageLayout>
   );
 }

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioCard.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioCard.tsx
@@ -13,22 +13,32 @@ export default function EtfScenarioCard({ scenario }: { scenario: EtfScenarioLis
   return (
     <Link
       href={`/etf-scenarios/${scenario.slug}`}
-      className="block bg-[#1F2937] border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+      className="group block bg-gray-900 border border-gray-800 rounded-2xl p-5 hover:border-blue-500 transition-all duration-200 h-full"
     >
-      <div className="flex items-center justify-between mb-2 gap-2">
+      <div className="flex items-center justify-between mb-3 gap-2">
         <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">#{scenario.scenarioNumber}</span>
-        {scenario.archived && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">Archived</span>}
+        {scenario.archived && <span className="text-xs text-gray-400 bg-gray-800 border border-gray-700 px-2 py-0.5 rounded">Archived</span>}
       </div>
 
-      <div className="flex flex-wrap gap-1.5 mb-3">
+      <div className="flex flex-wrap gap-1.5 mb-4">
         <EtfScenarioDirectionBadge direction={scenario.direction} />
         <EtfScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} />
         <EtfScenarioTimeframeBadge timeframe={scenario.timeframe} />
       </div>
 
-      <h3 className="text-white text-base font-medium mb-2 line-clamp-2 min-h-[3rem]">{scenario.title}</h3>
+      <h3 className="text-white text-lg font-semibold mb-3 line-clamp-2 min-h-[3.25rem] group-hover:text-blue-400 transition-colors">{scenario.title}</h3>
 
-      <p className="text-xs text-gray-400 line-clamp-3 min-h-[3.75rem]">{firstSentence(scenario.underlyingCause)}</p>
+      <p className="text-sm text-gray-300 leading-relaxed line-clamp-3 min-h-[4rem]">{firstSentence(scenario.underlyingCause)}</p>
+
+      {scenario.countries.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-4 pt-3 border-t border-gray-800">
+          {scenario.countries.map((c) => (
+            <span key={c} className="text-[10px] uppercase tracking-wide text-gray-400">
+              📍 {c}
+            </span>
+          ))}
+        </div>
+      )}
     </Link>
   );
 }

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioDetailView.tsx
@@ -1,32 +1,11 @@
-import Link from 'next/link';
-import { EtfScenarioDetail, EtfScenarioLinkDto } from '@/app/api/[spaceId]/etf-scenarios/[slug]/route';
+import { EtfScenarioDetail } from '@/app/api/[spaceId]/etf-scenarios/[slug]/route';
 import { parseMarkdown } from '@/util/parse-markdown';
-import { EtfScenarioDirectionBadge, EtfScenarioProbabilityBadge, EtfScenarioTimeframeBadge } from './EtfScenarioOutlookBadge';
 import { directionLabel, pricedInBucketLabel, probabilityBucketLabel, timeframeLabel } from '@/utils/etf-scenario-metadata-generators';
+import EtfScenarioLinkColumns from './EtfScenarioLinkColumns';
+import { EtfScenarioDirectionBadge, EtfScenarioProbabilityBadge, EtfScenarioTimeframeBadge } from './EtfScenarioOutlookBadge';
 
 function renderMarkdown(md: string) {
   return { __html: parseMarkdown(md) as string };
-}
-
-function LinkPill({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
-  const inner = (
-    <span className="inline-flex items-center gap-1 bg-[#111827] border border-[#374151] text-xs text-white rounded px-2 py-0.5">
-      <span className="font-semibold">{link.symbol}</span>
-      {link.exchange && <span className="text-gray-400">· {link.exchange}</span>}
-    </span>
-  );
-
-  // `etfId` is optional (depends on whether we could resolve the symbol in DB),
-  // but we can still route to the ETF page as long as exchange + symbol exist.
-  if (link.exchange) {
-    return (
-      <Link href={`/etfs/${link.exchange}/${link.symbol}`} className="hover:opacity-80">
-        {inner}
-      </Link>
-    );
-  }
-
-  return inner;
 }
 
 function formatExpectedPriceChange(value: number | null | undefined): string {
@@ -35,97 +14,74 @@ function formatExpectedPriceChange(value: number | null | undefined): string {
   return `${sign}${value}%`;
 }
 
-function LinkCard({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
-  const hasDetails = link.roleExplanation || link.expectedPriceChange !== null || link.expectedPriceChangeExplanation;
-  const changeColor = link.expectedPriceChange === null ? '' : link.expectedPriceChange >= 0 ? 'text-emerald-300' : 'text-red-300';
-
-  return (
-    <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">
-      <div className="flex items-center justify-between gap-2 mb-1">
-        <LinkPill link={link} />
-        {link.expectedPriceChange !== null && (
-          <span className={`text-xs font-semibold ${changeColor}`}>{formatExpectedPriceChange(link.expectedPriceChange)}</span>
-        )}
-      </div>
-      {hasDetails && (
-        <div className="space-y-1 mt-1">
-          {link.roleExplanation && (
-            <div
-              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-300"
-              dangerouslySetInnerHTML={renderMarkdown(link.roleExplanation)}
-            />
-          )}
-          {link.expectedPriceChangeExplanation && (
-            <div
-              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-400"
-              dangerouslySetInnerHTML={renderMarkdown(link.expectedPriceChangeExplanation)}
-            />
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function LinkList({ title, links, emptyLabel }: { title: string; links: EtfScenarioLinkDto[]; emptyLabel?: string }): JSX.Element {
-  const anyDetailed = links.some((l) => l.roleExplanation || l.expectedPriceChange !== null || l.expectedPriceChangeExplanation);
-  return (
-    <div>
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300 mb-2">{title}</h3>
-      {links.length === 0 ? (
-        <p className="text-xs text-gray-500">{emptyLabel ?? '—'}</p>
-      ) : anyDetailed ? (
-        <div className="flex flex-col gap-2">
-          {links.map((l) => (
-            <LinkCard key={`${l.symbol}-${l.role}`} link={l} />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {links.map((l) => (
-            <LinkPill key={`${l.symbol}-${l.role}`} link={l} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScenarioDetail }): JSX.Element {
   const asOf = scenario.outlookAsOfDate.slice(0, 10);
   const hasPricingContext =
     scenario.pricedInBucket || scenario.expectedPriceChange !== null || scenario.expectedPriceChangeExplanation || scenario.priceChangeTimeframeExplanation;
 
   return (
-    <article className="text-[#E5E7EB]">
-      <div className="flex flex-wrap items-center gap-2 mb-4">
-        <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-sm font-bold px-2.5 py-0.5 rounded">
-          Scenario #{scenario.scenarioNumber}
-        </span>
-        <EtfScenarioDirectionBadge direction={scenario.direction} />
-        <EtfScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} asOfDate={scenario.outlookAsOfDate} />
-        <EtfScenarioTimeframeBadge timeframe={scenario.timeframe} />
-      </div>
-      <p className="text-xs text-gray-400 mb-4">
-        {directionLabel(scenario.direction)} · {probabilityBucketLabel(scenario.probabilityBucket)} · {timeframeLabel(scenario.timeframe)} · outlook reviewed{' '}
-        {asOf}
-      </p>
+    <article className="text-[#E5E7EB]" itemScope itemType="https://schema.org/Article">
+      <header className="mb-8">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-sm font-bold px-2.5 py-0.5 rounded">
+            Scenario #{scenario.scenarioNumber}
+          </span>
+          <EtfScenarioDirectionBadge direction={scenario.direction} />
+          <EtfScenarioProbabilityBadge bucket={scenario.probabilityBucket} percentage={scenario.probabilityPercentage} asOfDate={scenario.outlookAsOfDate} />
+          <EtfScenarioTimeframeBadge timeframe={scenario.timeframe} />
+          {scenario.archived && <span className="text-xs text-gray-300 bg-gray-800 border border-gray-700 px-2 py-0.5 rounded">Archived</span>}
+        </div>
 
-      <h1 className="text-3xl font-bold text-white mb-4">{scenario.title}</h1>
+        <h1 className="text-3xl font-bold text-white mb-3" itemProp="headline">
+          {scenario.title}
+        </h1>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Underlying cause</h2>
-        <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.underlyingCause)} />
+        <p className="text-xs text-gray-400 mb-2">
+          <span className="sr-only">Scenario summary: </span>
+          {directionLabel(scenario.direction)} · {probabilityBucketLabel(scenario.probabilityBucket)} · {timeframeLabel(scenario.timeframe)} ·{' '}
+          <span>
+            outlook reviewed <time dateTime={asOf}>{asOf}</time>
+          </span>
+        </p>
+
+        {scenario.countries.length > 0 && (
+          <p className="text-xs text-gray-400 mb-0">
+            <span className="uppercase tracking-wide text-[11px] text-gray-500 mr-2">Countries in scope</span>
+            {scenario.countries.map((c) => (
+              <span
+                key={c}
+                className="inline-block text-[10px] uppercase tracking-wide text-gray-300 bg-[#111827] border border-[#374151] rounded px-1.5 py-0.5 mr-1"
+              >
+                {c}
+              </span>
+            ))}
+          </p>
+        )}
+      </header>
+
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="underlying-cause-heading">
+        <h2 id="underlying-cause-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
+          Underlying cause
+        </h2>
+        <div
+          className="markdown-body prose prose-invert max-w-none"
+          itemProp="articleBody"
+          dangerouslySetInnerHTML={renderMarkdown(scenario.underlyingCause)}
+        />
       </section>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Historical analog</h2>
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="historical-analog-heading">
+        <h2 id="historical-analog-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
+          Historical analog
+        </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.historicalAnalog)} />
       </section>
 
       {hasPricingContext && (
-        <section className="mb-6 bg-[#1F2937] border border-[#374151] rounded-lg p-4">
-          <h2 className="text-lg font-semibold text-white mb-3">Priced-in status & expected move</h2>
+        <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="priced-in-heading">
+          <h2 id="priced-in-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
+            Priced-in status &amp; expected move
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
             <div>
               <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">How much is already priced in</p>
@@ -138,7 +94,7 @@ export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScena
           </div>
           {scenario.expectedPriceChangeExplanation && (
             <div className="mb-3">
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Range & reasoning</p>
+              <p className="text-xs uppercase tracking-wide text-gray-400 mb-1">Range &amp; reasoning</p>
               <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.expectedPriceChangeExplanation)} />
             </div>
           )}
@@ -151,26 +107,34 @@ export default function EtfScenarioDetailView({ scenario }: { scenario: EtfScena
         </section>
       )}
 
-      <section className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <h2 className="text-lg font-semibold text-emerald-300 mb-2">Winners</h2>
-          <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.winnersMarkdown)} />
-        </div>
-        <div>
-          <h2 className="text-lg font-semibold text-red-300 mb-2">Losers</h2>
-          <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.losersMarkdown)} />
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="winners-losers-heading">
+        <h2 id="winners-losers-heading" className="sr-only">
+          Winners and losers
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h3 className="text-lg font-semibold text-emerald-300 mb-2">Winners</h3>
+            <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.winnersMarkdown)} />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-red-300 mb-2">Losers</h3>
+            <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.losersMarkdown)} />
+          </div>
         </div>
       </section>
 
-      <section className="mb-6">
-        <h2 className="text-lg font-semibold text-white mb-2">Outlook (as of {asOf})</h2>
+      <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-6" aria-labelledby="outlook-heading">
+        <h2 id="outlook-heading" className="text-xl font-bold text-white mb-4 pb-2 border-b border-gray-700">
+          Outlook <span className="text-sm font-normal text-gray-400">(as of {asOf})</span>
+        </h2>
         <div className="markdown-body prose prose-invert max-w-none" dangerouslySetInnerHTML={renderMarkdown(scenario.outlookMarkdown)} />
       </section>
 
-      <section className="bg-[#1F2937] border border-[#374151] rounded-lg p-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-        <LinkList title="Winners (tagged)" links={scenario.winners} emptyLabel="No ETFs tagged as winners." />
-        <LinkList title="Losers (tagged)" links={scenario.losers} emptyLabel="No ETFs tagged as losers." />
-        <LinkList title="Most exposed right now" links={scenario.mostExposed} emptyLabel="No ETFs tagged as currently most exposed." />
+      <section aria-labelledby="impacted-etfs-heading">
+        <h2 id="impacted-etfs-heading" className="sr-only">
+          Impacted ETFs
+        </h2>
+        <EtfScenarioLinkColumns winners={scenario.winners} losers={scenario.losers} mostExposed={scenario.mostExposed} scenarioCountries={scenario.countries} />
       </section>
     </article>
   );

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioFiltersBar.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioFiltersBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { ETF_SUPPORTED_COUNTRIES, EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 
 const DIRECTION_OPTIONS: Array<{ value: EtfScenarioDirection | 'ALL'; label: string }> = [
   { value: 'ALL', label: 'All directions' },
@@ -29,6 +30,8 @@ interface EtfScenarioFiltersBarProps {
   onBucketChange: (v: EtfScenarioProbabilityBucket | 'ALL') => void;
   timeframe: EtfScenarioTimeframe | 'ALL';
   onTimeframeChange: (v: EtfScenarioTimeframe | 'ALL') => void;
+  country: EtfSupportedCountry | 'ALL';
+  onCountryChange: (v: EtfSupportedCountry | 'ALL') => void;
   search: string;
   onSearchChange: (s: string) => void;
 }
@@ -42,54 +45,70 @@ export default function EtfScenarioFiltersBar({
   onBucketChange,
   timeframe,
   onTimeframeChange,
+  country,
+  onCountryChange,
   search,
   onSearchChange,
 }: EtfScenarioFiltersBarProps): JSX.Element {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 bg-[#1F2937] border border-[#374151] rounded-lg p-3 mb-4">
-      <label className="flex flex-col gap-1 text-xs text-gray-300">
-        <span className="uppercase tracking-wide text-[11px] text-gray-400">Direction</span>
-        <select className={SELECT_CLASSES} value={direction} onChange={(e) => onDirectionChange(e.target.value as EtfScenarioDirection | 'ALL')}>
-          {DIRECTION_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
+    <div className="bg-[#1F2937] border border-[#374151] rounded-lg p-3 mb-4 flex flex-col gap-3">
+      <label className="flex flex-col gap-1 text-xs text-gray-300 sm:max-w-xs">
+        <span className="uppercase tracking-wide text-[11px] text-gray-400">Country</span>
+        <select className={SELECT_CLASSES} value={country} onChange={(e) => onCountryChange(e.target.value as EtfSupportedCountry | 'ALL')}>
+          <option value="ALL">All countries</option>
+          {ETF_SUPPORTED_COUNTRIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
             </option>
           ))}
         </select>
       </label>
 
-      <label className="flex flex-col gap-1 text-xs text-gray-300">
-        <span className="uppercase tracking-wide text-[11px] text-gray-400">Probability</span>
-        <select className={SELECT_CLASSES} value={bucket} onChange={(e) => onBucketChange(e.target.value as EtfScenarioProbabilityBucket | 'ALL')}>
-          {BUCKET_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </label>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <label className="flex flex-col gap-1 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Direction</span>
+          <select className={SELECT_CLASSES} value={direction} onChange={(e) => onDirectionChange(e.target.value as EtfScenarioDirection | 'ALL')}>
+            {DIRECTION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
 
-      <label className="flex flex-col gap-1 text-xs text-gray-300">
-        <span className="uppercase tracking-wide text-[11px] text-gray-400">Timeframe</span>
-        <select className={SELECT_CLASSES} value={timeframe} onChange={(e) => onTimeframeChange(e.target.value as EtfScenarioTimeframe | 'ALL')}>
-          {TIMEFRAME_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Probability</span>
+          <select className={SELECT_CLASSES} value={bucket} onChange={(e) => onBucketChange(e.target.value as EtfScenarioProbabilityBucket | 'ALL')}>
+            {BUCKET_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
 
-      <label className="flex flex-col gap-1 text-xs text-gray-300">
-        <span className="uppercase tracking-wide text-[11px] text-gray-400">Search</span>
-        <input
-          type="search"
-          className={SELECT_CLASSES}
-          placeholder="Filter by title or keyword…"
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-        />
-      </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Timeframe</span>
+          <select className={SELECT_CLASSES} value={timeframe} onChange={(e) => onTimeframeChange(e.target.value as EtfScenarioTimeframe | 'ALL')}>
+            {TIMEFRAME_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Search</span>
+          <input
+            type="search"
+            className={SELECT_CLASSES}
+            placeholder="Filter by title or keyword…"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioLinkColumns.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { EtfScenarioLinkDto } from '@/app/api/[spaceId]/etf-scenarios/[slug]/route';
+import { parseMarkdown } from '@/util/parse-markdown';
+import { AllEtfExchanges, ETF_EXCHANGE_TO_COUNTRY, ETF_SUPPORTED_COUNTRIES, EtfSupportedCountry, isEtfExchange } from '@/utils/etfCountryExchangeUtils';
+
+function renderMarkdown(md: string) {
+  return { __html: parseMarkdown(md) as string };
+}
+
+function PillVisual({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
+  return (
+    <span className="inline-flex items-center gap-1 bg-[#111827] border border-[#374151] text-xs text-white rounded px-2 py-0.5">
+      <span className="font-semibold">{link.symbol}</span>
+      {link.exchange && <span className="text-gray-400">· {link.exchange}</span>}
+    </span>
+  );
+}
+
+function formatExpectedPriceChange(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}%`;
+}
+
+function LinkCard({ link }: { link: EtfScenarioLinkDto }): JSX.Element {
+  const hasDetails = link.roleExplanation || link.expectedPriceChange !== null || link.expectedPriceChangeExplanation;
+  const changeColor = link.expectedPriceChange === null ? '' : link.expectedPriceChange >= 0 ? 'text-emerald-300' : 'text-red-300';
+
+  const body = (
+    <>
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <PillVisual link={link} />
+        {link.expectedPriceChange !== null && (
+          <span className={`text-xs font-semibold ${changeColor}`}>{formatExpectedPriceChange(link.expectedPriceChange)}</span>
+        )}
+      </div>
+      {hasDetails && (
+        <div className="space-y-1 mt-1">
+          {link.roleExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-300"
+              dangerouslySetInnerHTML={renderMarkdown(link.roleExplanation)}
+            />
+          )}
+          {link.expectedPriceChangeExplanation && (
+            <div
+              className="markdown-body prose prose-invert prose-xs max-w-none text-xs text-gray-400"
+              dangerouslySetInnerHTML={renderMarkdown(link.expectedPriceChangeExplanation)}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  // The ETF detail page only routes to /etfs/{exchange}/{symbol} when both are
+  // known. If exchange is null we keep the same visual but drop the click
+  // affordance — admins can still tag the symbol for editorial context.
+  if (link.exchange) {
+    return (
+      <Link
+        href={`/etfs/${link.exchange}/${link.symbol}`}
+        className="block bg-[#111827] border border-[#374151] rounded-md p-2.5 hover:border-blue-500 hover:bg-[#0f1623] transition-colors"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="bg-[#111827] border border-[#374151] rounded-md p-2.5">{body}</div>;
+}
+
+function LinkList({
+  title,
+  links,
+  filteredCount,
+  countryFilter,
+  emptyLabel,
+}: {
+  title: string;
+  links: EtfScenarioLinkDto[];
+  filteredCount: number;
+  countryFilter: EtfSupportedCountry | 'ALL';
+  emptyLabel: string;
+}): JSX.Element {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300 mb-2">
+        {title}{' '}
+        <span className="text-xs font-normal text-gray-500">
+          ({filteredCount}
+          {countryFilter !== 'ALL' ? ` in ${countryFilter}` : ''})
+        </span>
+      </h3>
+      {links.length === 0 ? (
+        <p className="text-xs text-gray-500">{emptyLabel}</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {links.map((l) => (
+            <LinkCard key={`${l.symbol}-${l.exchange ?? 'noex'}-${l.role}`} link={l} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function countryOfExchange(exchange: string | null): EtfSupportedCountry | null {
+  if (!exchange || !isEtfExchange(exchange)) return null;
+  return ETF_EXCHANGE_TO_COUNTRY[exchange as AllEtfExchanges];
+}
+
+interface EtfScenarioLinkColumnsProps {
+  winners: EtfScenarioLinkDto[];
+  losers: EtfScenarioLinkDto[];
+  mostExposed: EtfScenarioLinkDto[];
+  scenarioCountries: EtfSupportedCountry[];
+}
+
+export default function EtfScenarioLinkColumns({ winners, losers, mostExposed, scenarioCountries }: EtfScenarioLinkColumnsProps): JSX.Element {
+  const [countryFilter, setCountryFilter] = useState<EtfSupportedCountry | 'ALL'>('ALL');
+
+  const scenarioCountrySet = useMemo(() => new Set(scenarioCountries), [scenarioCountries]);
+
+  const filterByCountry = (links: EtfScenarioLinkDto[]): EtfScenarioLinkDto[] => {
+    if (countryFilter === 'ALL') return links;
+    return links.filter((l) => countryOfExchange(l.exchange) === countryFilter);
+  };
+
+  const filteredWinners = filterByCountry(winners);
+  const filteredLosers = filterByCountry(losers);
+  const filteredMostExposed = filterByCountry(mostExposed);
+
+  return (
+    <section className="bg-[#1F2937] border border-[#374151] rounded-lg p-4 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-xl font-bold text-white">Tagged ETFs</h2>
+        <label className="flex items-center gap-2 text-xs text-gray-300">
+          <span className="uppercase tracking-wide text-[11px] text-gray-400">Filter by country</span>
+          <select
+            className="bg-[#111827] border border-[#374151] rounded px-2 py-1 text-xs text-white focus:outline-none focus:border-[#F59E0B]"
+            value={countryFilter}
+            onChange={(e) => setCountryFilter(e.target.value as EtfSupportedCountry | 'ALL')}
+          >
+            <option value="ALL">All countries</option>
+            {ETF_SUPPORTED_COUNTRIES.map((c) => (
+              <option key={c} value={c} disabled={!scenarioCountrySet.has(c)}>
+                {c}
+                {!scenarioCountrySet.has(c) ? ' — not in this scenario' : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <LinkList
+          title="Winners"
+          links={filteredWinners}
+          filteredCount={filteredWinners.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No ETFs tagged as winners.' : `No winners listed on ${countryFilter} exchanges.`}
+        />
+        <LinkList
+          title="Losers"
+          links={filteredLosers}
+          filteredCount={filteredLosers.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No ETFs tagged as losers.' : `No losers listed on ${countryFilter} exchanges.`}
+        />
+        <LinkList
+          title="Most exposed right now"
+          links={filteredMostExposed}
+          filteredCount={filteredMostExposed.length}
+          countryFilter={countryFilter}
+          emptyLabel={countryFilter === 'ALL' ? 'No ETFs tagged as currently most exposed.' : `No most-exposed ETFs on ${countryFilter} exchanges.`}
+        />
+      </div>
+    </section>
+  );
+}

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioListingGrid.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioListingGrid.tsx
@@ -1,15 +1,21 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { EtfScenarioListingResponse } from '@/app/api/[spaceId]/etf-scenarios/listing/route';
 import { EtfScenarioDirection, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
+import { EtfSupportedCountry, toEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import EtfScenarioCard from './EtfScenarioCard';
 import EtfScenarioFiltersBar from './EtfScenarioFiltersBar';
 
 export default function EtfScenarioListingGrid({ data }: { data: EtfScenarioListingResponse }): JSX.Element | null {
+  const searchParams = useSearchParams();
+  const initialCountry = toEtfSupportedCountry(searchParams?.get('country') ?? null) ?? 'ALL';
+
   const [direction, setDirection] = useState<EtfScenarioDirection | 'ALL'>('ALL');
   const [bucket, setBucket] = useState<EtfScenarioProbabilityBucket | 'ALL'>('ALL');
   const [timeframe, setTimeframe] = useState<EtfScenarioTimeframe | 'ALL'>('ALL');
+  const [country, setCountry] = useState<EtfSupportedCountry | 'ALL'>(initialCountry);
   const [search, setSearch] = useState<string>('');
 
   const filtered = useMemo(() => {
@@ -18,13 +24,14 @@ export default function EtfScenarioListingGrid({ data }: { data: EtfScenarioList
       if (direction !== 'ALL' && s.direction !== direction) return false;
       if (bucket !== 'ALL' && s.probabilityBucket !== bucket) return false;
       if (timeframe !== 'ALL' && s.timeframe !== timeframe) return false;
+      if (country !== 'ALL' && !s.countries.includes(country)) return false;
       if (needle) {
         const hay = `${s.title} ${s.underlyingCause}`.toLowerCase();
         if (!hay.includes(needle)) return false;
       }
       return true;
     });
-  }, [data.scenarios, direction, bucket, timeframe, search]);
+  }, [data.scenarios, direction, bucket, timeframe, country, search]);
 
   if (data.scenarios.length === 0) {
     return (
@@ -44,6 +51,8 @@ export default function EtfScenarioListingGrid({ data }: { data: EtfScenarioList
         onBucketChange={setBucket}
         timeframe={timeframe}
         onTimeframeChange={setTimeframe}
+        country={country}
+        onCountryChange={setCountry}
         search={search}
         onSearchChange={setSearch}
       />
@@ -51,6 +60,7 @@ export default function EtfScenarioListingGrid({ data }: { data: EtfScenarioList
       <div className="flex items-center justify-between mb-4 mt-2">
         <p className="text-sm text-gray-400">
           Showing {filtered.length} of {data.totalCount.toLocaleString()} scenario{data.totalCount !== 1 ? 's' : ''}
+          {country !== 'ALL' && <span className="text-gray-500"> · filtered to {country}</span>}
         </p>
       </div>
 
@@ -59,7 +69,7 @@ export default function EtfScenarioListingGrid({ data }: { data: EtfScenarioList
           <p className="text-[#E5E7EB] text-lg">No scenarios match the current filters.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {filtered.map((s) => (
             <EtfScenarioCard key={s.id} scenario={s} />
           ))}

--- a/insights-ui/src/components/etf-scenarios/EtfScenarioPageLayout.tsx
+++ b/insights-ui/src/components/etf-scenarios/EtfScenarioPageLayout.tsx
@@ -4,8 +4,8 @@ import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 
 interface EtfScenarioPageLayoutProps {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   breadcrumbs?: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   children: ReactNode;
@@ -25,10 +25,12 @@ export default function EtfScenarioPageLayout({ title, description, breadcrumbs,
         <Breadcrumbs breadcrumbs={breadcrumbs ?? defaultBreadcrumbs()} rightButton={rightButton} />
       </div>
 
-      <div className="w-full mb-8">
-        <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
-        <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
-      </div>
+      {title && (
+        <div className="w-full mb-8">
+          <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
+          {description && <p className="text-[#E5E7EB] text-md mb-4">{description}</p>}
+        </div>
+      )}
 
       {children}
     </PageWrapper>


### PR DESCRIPTION
## Summary
- Bring `/etf-scenarios` listing and `/etf-scenarios/[slug]` detail pages to UI parity with the stock-scenarios surfaces shipped in PR #1400, so the two scenario products look and feel identical.
- Listing: redesigned card (gray-900/gray-800 palette, blue-500 hover, larger spacing), 3-up grid at lg+, country filter (US / Canada), country chips on card. Listing grid now reads `?country=` from URL via `useSearchParams`, page wraps the grid in `<Suspense>`.
- Detail: drop the duplicate page-layout heading, tags + h1 + summary + countries move into a semantic `<header>`. Article carries `itemScope`/`itemType` for schema.org Article markup. Each textual section (Underlying cause / Historical analog / Priced-in status / Winners-Losers narrative / Outlook) wrapped in `bg-gray-900 rounded-lg` panels with bordered h2s + `aria-labelledby`. Mirrors the panel rhythm already used on `/etfs` and `/stocks`.
- New `EtfScenarioLinkColumns` (mirrors `StockScenarioLinkColumns`): per-scenario country filter, "Tagged ETFs" heading, full-card Link tiles to `/etfs/{exchange}/{symbol}` with `hover:border-blue-500`. Cards without a known exchange remain non-clickable.
- Per request: no navbar entry change, no homepage / country-page link added.

## Test plan
- [ ] Visit `/etf-scenarios` — confirm 3-up grid at lg+, darker cards with blue hover, "📍 US" / "📍 Canada" chips on cards that have countries
- [ ] Use the country filter (US / Canada) — counts in the header line should update; URL-driven `?country=US` should pre-select on load
- [ ] Visit `/etf-scenarios/emerging-markets-currency-crisis` — header has tags, h1, scenario summary, countries; sections sit in dark panels with bordered headings
- [ ] Tagged ETFs section — clicking a card with a known exchange routes to `/etfs/{exchange}/{symbol}`; cards with no exchange stay non-clickable but still display
- [ ] Filter Tagged ETFs by country — disabled options should be greyed out for countries the scenario doesn't cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)