### PR TITLE
Tariff data dedupe + HTSUS chapter download script

### DIFF
--- a/insights-ui/.gitignore
+++ b/insights-ui/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# generated HTSUS chapter exports (produced by scripts/tariff-calculator/download-hts-chapter.ts)
+/data/hts-chapters/

--- a/insights-ui/src/scripts/industry-tariff-reports/06-evaluate-industry-area.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/06-evaluate-industry-area.ts
@@ -287,7 +287,7 @@ Find the three *Established Players* in the ${subAreaInfo} sector  **but output 
 - Make sure the companies are active and are being publicly traded as of ${date} on Nasdaq or NYSE.
 - The company should be traded on US exchanges i.e. Nasdaq or NYSE.
 - Dont return duplicate companies.
-- Ignore companies like ${tariffIndustry.companiesToIgnore.join(', ')} as they are no longer active.
+- Ignore companies like ${(tariffIndustry.companiesToIgnore ?? []).join(', ')} as they are no longer active.
 - Make sure the company is not bankrupt or not active.
 - Try to find three established players that fall under this category of ${subArea.oneLineSummary} sector.
 
@@ -416,7 +416,7 @@ Find the *New Challengers* in the ${subAreaInfo} sector **but output only** each
 - Dont return duplicate companies.
 - The companies should have unique edge over established players which creates probability of huge success in the future.
 - Make sure to select the best of the best new players and they not be old established players.
-- Ignore challengers like ${tariffIndustry.companiesToIgnore.join(', ')} as they no longer active.
+- Ignore challengers like ${(tariffIndustry.companiesToIgnore ?? []).join(', ')} as they no longer active.
 - Make sure the new challenger is not in the established players list i.e. ${establishedPlayers
     .map((ep) => `${ep.companyName} (${ep.companyTicker})`)
     .join(', ')}

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-industries.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-industries.ts
@@ -42,16 +42,17 @@ export enum TariffIndustryId {
   tiresAndRubber = 'tires-and-rubber',
 }
 
+export const DEFAULT_HEADINGS_COUNT = 3;
+export const DEFAULT_SUB_HEADINGS_COUNT = 2;
+
 export interface TariffIndustryDefinition {
   name: string;
   industryId: TariffIndustryId;
   reportTitle: string;
   reportOneLiner: string;
-  headingsCount: number;
-  subHeadingsCount: number;
-  establishedPlayersCount: number;
-  newChallengersCount: number;
-  companiesToIgnore: string[];
+  headingsCount?: number;
+  subHeadingsCount?: number;
+  companiesToIgnore?: string[];
   relatedIndustryIds: TariffIndustryId[];
 }
 
@@ -61,10 +62,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.plastic,
     reportTitle: 'Impact of Tariffs on Plastic Industry',
     reportOneLiner: 'A comprehensive analysis of how tariffs affect the plastic industry, including supply chain disruptions and cost implications.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
     companiesToIgnore: ['Pactiv Evergreen Inc', 'Danimer Scientific(DNMR)', 'Zymergen Inc (ZY)', 'Amyris, Inc.'],
     relatedIndustryIds: [TariffIndustryId.metalGlassPlasticContainers, TariffIndustryId.diversifiedChemicals],
   },
@@ -73,11 +70,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.aluminium,
     reportTitle: 'Impact of Tariffs on Aluminium Industry',
     reportOneLiner: 'An in-depth analysis of how tariffs affect the aluminium industry, including market dynamics and competitive landscape.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.ironandsteel, TariffIndustryId.diversifiedMetalsAndMining],
   },
   Automobiles: {
@@ -85,10 +77,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.automobiles,
     reportTitle: 'Impact of Tariffs on Automobile Industry',
     reportOneLiner: 'A comprehensive overview of how tariffs impact the automobile industry, focusing on supply chain changes and cost structures.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
     companiesToIgnore: [
       'Canoo Inc. (GOEVQ)',
       'Arrival SA (ARVL)',
@@ -110,11 +98,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.apparelandaccessories,
     reportTitle: 'Impact of Tariffs on Apparel & Accessories',
     reportOneLiner: 'Analysis of tariff changes affecting apparel & accessories trade.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.textiles, TariffIndustryId.footwear],
   },
   IronAndSteel: {
@@ -122,23 +105,13 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.ironandsteel,
     reportTitle: 'Impact of Tariffs on Iron & Steel Industry',
     reportOneLiner: 'An in-depth look at how tariffs are reshaping the iron & steel industry supply chains, costs, and competitiveness.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.diversifiedMetalsAndMining, TariffIndustryId.aluminium],
   },
   Copper: {
     name: 'Copper',
     industryId: TariffIndustryId.copper,
     reportTitle: 'Impact of Tariffs on Copper',
-    reportOneLiner: 'An analysis of the newly announced 50% Section 232 tariffs on copper imports and their effects on supply chains and pricing.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
+    reportOneLiner: 'An analysis of the newly announced 50% Section 232 tariffs on copper imports and their effects on supply chains and pricing.',
     relatedIndustryIds: [TariffIndustryId.electricalcomponentsandequipment, TariffIndustryId.diversifiedMetalsAndMining],
   },
   ElectricalComponentsAndEquipment: {
@@ -146,11 +119,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.electricalcomponentsandequipment,
     reportTitle: 'Impact of Tariffs on Electrical Components & Equipment',
     reportOneLiner: 'Analysis of how U.S. tariffs on imported electrical components and equipment affect supply chains, costs, and competitiveness.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.consumerElectronics, TariffIndustryId.industrialMachineryAndSupplies],
   },
   HomeFurnishings: {
@@ -158,11 +126,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.homefurnishings,
     reportTitle: 'Impact of Tariffs on Home Furnishings',
     reportOneLiner: 'A detailed look at the effects of import duties on home furniture, bedding, and related goods in the U.S. market.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.textiles, TariffIndustryId.householdAppliances],
   },
   Pharmaceuticals: {
@@ -170,11 +133,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.pharmaceuticals,
     reportTitle: 'Impact of Tariffs on Pharmaceuticals',
     reportOneLiner: 'Analysis of how U.S. tariffs on imported pharmaceutical products and APIs affect drug pricing and supply chains.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.consumerElectronics, TariffIndustryId.industrialMachineryAndSupplies],
   },
   Semiconductors: {
@@ -183,11 +141,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     reportTitle: 'Impact of Tariffs on Semiconductors & Equipment',
     reportOneLiner:
       'Analysis of Section 301 duties on semiconductor imports especially Chinese-made chips and their ripple effects on global supply chains and domestic manufacturing incentives.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.consumerElectronics, TariffIndustryId.electricalcomponentsandequipment],
   },
   AgriculturalProductsAndServices: {
@@ -195,11 +148,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.agriculturalProductsAndServices,
     reportTitle: 'Tariff Impact on Agricultural Products & Services',
     reportOneLiner: 'Includes live animals, oilseeds, cereals, and waste products affected by import duties.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.packagedFoodsAndMeats, TariffIndustryId.fertilizersAndAgriculturalChemicals],
   },
   PackagedFoodsAndMeats: {
@@ -207,11 +155,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.packagedFoodsAndMeats,
     reportTitle: 'Tariff Effects on the Packaged Foods & Meats Industry',
     reportOneLiner: 'Covers dairy, meats, beverages, cereals, oils, cocoa, and processed foods.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.agriculturalProductsAndServices, TariffIndustryId.brewers],
   },
   ForestProducts: {
@@ -219,11 +162,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.forestProducts,
     reportTitle: 'Impact of U.S. Tariffs on Forestry and Plant-Based Goods',
     reportOneLiner: 'Examines duties on live plants, cut flowers, wood-based and plaited materials.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.paperProducts, TariffIndustryId.constructionMaterials],
   },
   Tobacco: {
@@ -231,11 +169,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.tobacco,
     reportTitle: 'Trade Restrictions on Tobacco and Alternatives',
     reportOneLiner: 'Analyzes tariffs impacting cigarettes, cigars, and smokeless substitutes.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.packagedFoodsAndMeats, TariffIndustryId.commercialPrinting],
   },
   ConstructionMaterials: {
@@ -243,11 +176,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.constructionMaterials,
     reportTitle: 'U.S. Import Duties on Cement, Salt, and Lime',
     reportOneLiner: 'Impact of tariffs on mineral inputs essential for construction and infrastructure.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.diversifiedMetalsAndMining, TariffIndustryId.ironandsteel],
   },
   DiversifiedMetalsAndMining: {
@@ -255,11 +183,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.diversifiedMetalsAndMining,
     reportTitle: 'Tariff Environment for Ores, Ashes, and Raw Metal Inputs',
     reportOneLiner: 'Covers U.S. duties on raw materials critical to base metals and extractive industries.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.ironandsteel, TariffIndustryId.aluminium],
   },
   OilAndGasRefiningAndMarketing: {
@@ -267,11 +190,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.oilAndGasRefiningAndMarketing,
     reportTitle: 'Tariff Overview of Oil, Fuels, and Refined Petroleum Products',
     reportOneLiner: 'Evaluates duties on crude oil, diesel, gasoline, and other refined fuel imports.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.commodityChemicals, TariffIndustryId.industrialGases],
   },
   CommodityChemicals: {
@@ -279,11 +197,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.commodityChemicals,
     reportTitle: 'Tariffs on Inorganic and Bulk Chemical Inputs',
     reportOneLiner: 'Explores duties on foundational industrial chemicals including salts, acids, and fertilizers.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.specialtyChemicals, TariffIndustryId.diversifiedChemicals],
   },
   SpecialtyChemicals: {
@@ -291,11 +204,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.specialtyChemicals,
     reportTitle: 'U.S. Tariff Impact on Organic and Niche Chemical Products',
     reportOneLiner: 'Focuses on organic compounds, resins, and chemical derivatives under current tariff schedules.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.commodityChemicals, TariffIndustryId.plastic],
   },
   FertilizersAndAgriculturalChemicals: {
@@ -303,11 +211,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.fertilizersAndAgriculturalChemicals,
     reportTitle: 'Tariff Impact on Fertilizers and Agricultural Chemicals',
     reportOneLiner: 'Evaluates U.S. duties on fertilizer products and agricultural chemical imports.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.agriculturalProductsAndServices, TariffIndustryId.commodityChemicals],
   },
   IndustrialGases: {
@@ -315,11 +218,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.industrialGases,
     reportTitle: 'Tariffs on Industrial Gases',
     reportOneLiner: 'Analysis of import duties on gases like oxygen, nitrogen, and argon.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.commodityChemicals, TariffIndustryId.industrialMachineryAndSupplies],
   },
   DiversifiedChemicals: {
@@ -327,11 +225,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.diversifiedChemicals,
     reportTitle: 'Tariff Environment for Diversified Chemical Products',
     reportOneLiner: 'Covers duties on a broad range of chemical compounds beyond basic commodity chemicals.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.commodityChemicals, TariffIndustryId.plastic],
   },
   MetalGlassPlasticContainers: {
@@ -339,11 +232,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.metalGlassPlasticContainers,
     reportTitle: 'Tariffs on Packaging Containers',
     reportOneLiner: 'Impact of duties on containers used in food, beverage, and industrial packaging.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.plastic, TariffIndustryId.packagedFoodsAndMeats],
   },
   PaperPlasticPackagingProductsAndMaterials: {
@@ -351,11 +239,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.paperPlasticPackagingProductsAndMaterials,
     reportTitle: 'Tariff Effects on Paper and Plastic Packaging',
     reportOneLiner: 'Examines import duties on packaging materials for consumer and industrial goods.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.plastic, TariffIndustryId.metalGlassPlasticContainers],
   },
   PaperProducts: {
@@ -363,11 +246,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.paperProducts,
     reportTitle: 'Import Duties on Paper and Board Products',
     reportOneLiner: 'Analysis of tariffs on paper, board, and printing materials.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.forestProducts, TariffIndustryId.commercialPrinting],
   },
   ConsumerElectronics: {
@@ -375,11 +253,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.consumerElectronics,
     reportTitle: 'Tariff Impact on Consumer Electronic Goods',
     reportOneLiner: 'Evaluates duties on smartphones, TVs, and personal electronic devices.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.semiconductors, TariffIndustryId.electricalcomponentsandequipment],
   },
   HouseholdAppliances: {
@@ -387,11 +260,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.householdAppliances,
     reportTitle: 'Import Duties on Household Appliances',
     reportOneLiner: 'Covers tariffs on refrigerators, washing machines, and kitchen appliances.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.consumerElectronics, TariffIndustryId.electricalcomponentsandequipment],
   },
   LeisureProducts: {
@@ -399,11 +267,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.leisureProducts,
     reportTitle: 'Tariff Effects on Sports and Leisure Goods',
     reportOneLiner: 'Analysis of duties on sporting equipment, toys, and recreational products.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.textiles, TariffIndustryId.footwear],
   },
   Footwear: {
@@ -411,11 +274,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.footwear,
     reportTitle: 'Import Duties on Footwear and Related Products',
     reportOneLiner: 'Evaluates tariffs on shoes, boots, and related footwear.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.apparelandaccessories, TariffIndustryId.textiles],
   },
   Textiles: {
@@ -423,11 +281,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.textiles,
     reportTitle: 'Tariffs on Textile Fabrics and Yarns',
     reportOneLiner: 'Covers duties on textile fibers, fabrics, and woven materials.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.apparelandaccessories, TariffIndustryId.footwear],
   },
   Brewers: {
@@ -435,11 +288,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.brewers,
     reportTitle: 'Tariff Impact on Brewing Industry',
     reportOneLiner: 'Examines duties on beer, malt, and brewing ingredients.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.packagedFoodsAndMeats, TariffIndustryId.distillersAndVintners],
   },
   DistillersAndVintners: {
@@ -447,11 +295,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.distillersAndVintners,
     reportTitle: 'Tariff Effects on Distilled Spirits and Wines',
     reportOneLiner: 'Analyzes import duties on spirits, wines, and related beverages.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.brewers, TariffIndustryId.softDrinksAndNonAlcoholicBeverages],
   },
   SoftDrinksAndNonAlcoholicBeverages: {
@@ -459,11 +302,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.softDrinksAndNonAlcoholicBeverages,
     reportTitle: 'Tariffs on Non-Alcoholic Beverages',
     reportOneLiner: 'Evaluates duties on carbonated drinks, juices, and other non-alcoholic beverages.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.packagedFoodsAndMeats, TariffIndustryId.brewers],
   },
   CommercialPrinting: {
@@ -471,11 +309,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.commercialPrinting,
     reportTitle: 'Tariffs on Printed Materials',
     reportOneLiner: 'Examines duties on printed books, magazines, and publication services.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.paperProducts, TariffIndustryId.paperPlasticPackagingProductsAndMaterials],
   },
   HeavyElectricalEquipment: {
@@ -483,11 +316,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.heavyElectricalEquipment,
     reportTitle: 'Import Duties on Heavy Electrical Machinery',
     reportOneLiner: 'Covers tariffs on generators, transformers, and large electrical apparatus.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.electricalcomponentsandequipment, TariffIndustryId.industrialMachineryAndSupplies],
   },
   IndustrialMachineryAndSupplies: {
@@ -495,11 +323,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.industrialMachineryAndSupplies,
     reportTitle: 'Tariffs on Industrial Machinery and Components',
     reportOneLiner: 'Analysis of duties on industrial equipment and machine parts.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.heavyElectricalEquipment, TariffIndustryId.constructionMachineryAndHeavyTransportationEquipment],
   },
   AerospaceAndDefense: {
@@ -507,11 +330,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.aerospaceAndDefense,
     reportTitle: 'Tariff Effects on Aerospace Products',
     reportOneLiner: 'Evaluates import duties on aircraft, spacecraft, and defense equipment.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.industrialMachineryAndSupplies, TariffIndustryId.semiconductors],
   },
   ConstructionMachineryAndHeavyTransportationEquipment: {
@@ -519,11 +337,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.constructionMachineryAndHeavyTransportationEquipment,
     reportTitle: 'Tariffs on Construction and Heavy Transport Machinery',
     reportOneLiner: 'Covers duties on excavators, bulldozers, and heavy transport vehicles.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.automobiles, TariffIndustryId.industrialMachineryAndSupplies],
   },
   HealthCareEquipment: {
@@ -531,11 +344,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.healthCareEquipment,
     reportTitle: 'Impact of Tariffs on Health Care Equipment',
     reportOneLiner: 'Analysis of how import duties affect medical devices and health care equipment supply chains.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.pharmaceuticals, TariffIndustryId.industrialMachineryAndSupplies],
   },
   HousewaresAndSpecialties: {
@@ -543,11 +351,6 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.housewaresAndSpecialties,
     reportTitle: 'Impact of Tariffs on Housewares & Specialties',
     reportOneLiner: 'A look at how U.S. tariffs on home goods and specialty housewares affect costs and market access.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.homefurnishings, TariffIndustryId.householdAppliances],
   },
   TiresAndRubber: {
@@ -555,21 +358,20 @@ export const TariffIndustries: Record<string, TariffIndustryDefinition> = {
     industryId: TariffIndustryId.tiresAndRubber,
     reportTitle: 'Impact of Tariffs on Tires & Rubber',
     reportOneLiner: 'Analysis of how import duties affect tire manufacturing and rubber products supply chains.',
-    headingsCount: 3,
-    subHeadingsCount: 2,
-    establishedPlayersCount: 3,
-    newChallengersCount: 3,
-    companiesToIgnore: [],
     relatedIndustryIds: [TariffIndustryId.automobiles, TariffIndustryId.industrialMachineryAndSupplies],
   },
 };
 
 export function getNumberOfHeadings(industryId: TariffIndustryId): number {
-  return getTariffIndustryDefinitionById(industryId).headingsCount;
+  return getTariffIndustryDefinitionById(industryId).headingsCount ?? DEFAULT_HEADINGS_COUNT;
 }
 
 export function getNumberOfSubHeadings(industryId: TariffIndustryId): number {
-  return getTariffIndustryDefinitionById(industryId).subHeadingsCount;
+  return getTariffIndustryDefinitionById(industryId).subHeadingsCount ?? DEFAULT_SUB_HEADINGS_COUNT;
+}
+
+export function getCompaniesToIgnore(industryId: TariffIndustryId): string[] {
+  return getTariffIndustryDefinitionById(industryId).companiesToIgnore ?? [];
 }
 
 export function getTariffIndustryDefinitionById(industryId: TariffIndustryId): TariffIndustryDefinition {
@@ -594,11 +396,12 @@ export interface HeadingSubheadingCombination {
 }
 
 export function getAllHeadingSubheadingCombinations(industryId: TariffIndustryId): HeadingSubheadingCombination[] {
-  const industry = getTariffIndustryDefinitionById(industryId);
+  const headingsCount = getNumberOfHeadings(industryId);
+  const subHeadingsCount = getNumberOfSubHeadings(industryId);
   const combinations: HeadingSubheadingCombination[] = [];
 
-  for (let headingIndex = 0; headingIndex < industry.headingsCount; headingIndex++) {
-    for (let subHeadingIndex = 0; subHeadingIndex < industry.subHeadingsCount; subHeadingIndex++) {
+  for (let headingIndex = 0; headingIndex < headingsCount; headingIndex++) {
+    for (let subHeadingIndex = 0; subHeadingIndex < subHeadingsCount; subHeadingIndex++) {
       combinations.push({
         headingIndex,
         subHeadingIndex,

--- a/insights-ui/src/scripts/tariff-calculator/download-hts-chapter.ts
+++ b/insights-ui/src/scripts/tariff-calculator/download-hts-chapter.ts
@@ -1,0 +1,306 @@
+/**
+ * Download Harmonized Tariff Schedule (HTSUS) data per chapter from the
+ * official USITC REST endpoint and emit a normalized, hierarchical JSON
+ * file for each chapter.
+ *
+ * Upstream API
+ * ------------
+ *   https://hts.usitc.gov/reststop/exportList?from=<startCode>&to=<endCode>&format=JSON&styles=true
+ *
+ * The endpoint returns a *flat* array of rows. Hierarchy is implicit: each
+ * row carries a string `indent` (0..6), and a row at indent N is a child of
+ * the most recent row at indent N-1. Header rows (group/subgroup labels)
+ * have an empty `htsno` and exist only to nest the rows below them.
+ *
+ * What "normalized" means here
+ * ----------------------------
+ * 1. Convert the flat list into a tree using the indent levels.
+ * 2. Convert string fields like indent to numbers, normalize empty strings
+ *    to `null`, drop the upstream typo field `addiitionalDuties`.
+ * 3. Prune dead branches:
+ *      - A node is "empty" when it carries no useful data of its own (no
+ *        htsno, no rates, no units, no quotaQuantity, no additionalDuties)
+ *        AND every descendant under it is also empty.
+ *      - Empty nodes are dropped from their parent's children array.
+ *      - If after pruning a parent ends up with zero children, its
+ *        `children` is set to `null` rather than an empty array, so callers
+ *        can tell "leaf" apart from "had children, all dead".
+ *      - If the parent itself is empty *and* would now have null children,
+ *        the parent is pruned too. This bubbles upward.
+ *
+ *    Rationale: the USITC export occasionally contains placeholder heading
+ *    rows whose entire subtree carries no rates, no units, and no leaf HTS
+ *    numbers. Those headings don't add any tariff information and just
+ *    bloat the output, so we drop them.
+ *
+ * Usage
+ * -----
+ *   tsx src/scripts/tariff-calculator/download-hts-chapter.ts            # all chapters 1..99
+ *   tsx src/scripts/tariff-calculator/download-hts-chapter.ts 1          # just chapter 1
+ *   tsx src/scripts/tariff-calculator/download-hts-chapter.ts 1 2 3      # specific chapters
+ *   tsx src/scripts/tariff-calculator/download-hts-chapter.ts 1-5        # a range
+ *
+ * Output goes to `insights-ui/data/hts-chapters/chapter-NN.json`.
+ */
+
+import { mkdir, writeFile } from 'fs/promises';
+import { dirname, resolve } from 'path';
+
+// Shape of a single row as the USITC API returns it. All values are
+// optional/loose because the API is loose — empty strings, nulls, and
+// missing fields all show up.
+interface RawHtsRow {
+  htsno?: string | null;
+  indent?: string | null;
+  description?: string | null;
+  superior?: string | null;
+  units?: string[] | null;
+  general?: string | null;
+  special?: string | null;
+  other?: string | null;
+  footnotes?: Array<{ columns?: string[]; value?: string; type?: string }> | null;
+  quotaQuantity?: string | null;
+  additionalDuties?: string | null;
+  // The upstream API has both `additionalDuties` and a misspelled
+  // `addiitionalDuties` field. Carry it on the input type so we can ignore
+  // it explicitly during normalization.
+  addiitionalDuties?: string | null;
+}
+
+interface Footnote {
+  columns: string[];
+  value: string;
+  type: string;
+}
+
+// Normalized tree node we emit. Strings that came back as "" upstream are
+// stored as null so consumers don't have to distinguish "absent" from
+// "empty string".
+export interface HtsNode {
+  htsno: string | null;
+  indent: number;
+  description: string;
+  superior: boolean;
+  units: string[];
+  general: string | null;
+  special: string | null;
+  other: string | null;
+  footnotes: Footnote[];
+  quotaQuantity: string | null;
+  additionalDuties: string | null;
+  // null when this node has no surviving children after pruning. An empty
+  // array is never emitted — see file header for why.
+  children: HtsNode[] | null;
+}
+
+const OUTPUT_DIR = resolve(process.cwd(), 'data/hts-chapters');
+
+// Build the upstream URL for a given chapter. The API takes 4-digit
+// boundaries, so chapter N corresponds to from=NN01..to=NN99.
+function buildChapterUrl(chapter: number): string {
+  const padded = chapter.toString().padStart(2, '0');
+  const from = `${padded}01`;
+  const to = `${padded}99`;
+  return `https://hts.usitc.gov/reststop/exportList?from=${from}&to=${to}&format=JSON&styles=true`;
+}
+
+// Normalize a string field: trim it, and treat empty as null so
+// downstream consumers can rely on `=== null` checks.
+function nullIfEmpty(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+// Convert the upstream's loose footnote shape to a strict one. Footnotes
+// without a value are useless and dropped.
+function normalizeFootnotes(raw: RawHtsRow['footnotes']): Footnote[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((f) => ({
+      columns: Array.isArray(f.columns) ? f.columns.filter((c): c is string => typeof c === 'string') : [],
+      value: typeof f.value === 'string' ? f.value.trim() : '',
+      type: typeof f.type === 'string' ? f.type : '',
+    }))
+    .filter((f) => f.value.length > 0);
+}
+
+// Convert a single raw row into our normalized shape. Children get
+// attached later when we build the tree.
+function toNode(raw: RawHtsRow): HtsNode {
+  const indent = Number.parseInt(raw.indent ?? '0', 10) || 0;
+  return {
+    htsno: nullIfEmpty(raw.htsno),
+    indent,
+    description: (raw.description ?? '').trim(),
+    superior: raw.superior === 'true',
+    units: Array.isArray(raw.units) ? raw.units.filter((u): u is string => typeof u === 'string' && u.trim().length > 0) : [],
+    general: nullIfEmpty(raw.general),
+    special: nullIfEmpty(raw.special),
+    other: nullIfEmpty(raw.other),
+    footnotes: normalizeFootnotes(raw.footnotes),
+    quotaQuantity: nullIfEmpty(raw.quotaQuantity),
+    additionalDuties: nullIfEmpty(raw.additionalDuties),
+    children: null,
+  };
+}
+
+// Build the tree from a flat list using the indent levels. We walk the
+// rows in order, keeping a stack where the top of the stack is the
+// current ancestor at indent N. When we see a row at indent M:
+//   - pop entries until the top of the stack is the row at indent M-1
+//     (or empty for top-level rows at indent 0)
+//   - attach the new row as a child of that parent
+//   - push the new row so its own children can attach in later iterations
+function buildTree(rows: RawHtsRow[]): HtsNode[] {
+  const roots: HtsNode[] = [];
+  // Stack of `[indent, node]` pairs. Indent strictly increases up the stack.
+  const stack: HtsNode[] = [];
+
+  for (const raw of rows) {
+    const node = toNode(raw);
+
+    // Find the parent by popping anything at >= node.indent. After this
+    // loop, stack top (if any) is the parent.
+    while (stack.length > 0 && stack[stack.length - 1].indent >= node.indent) {
+      stack.pop();
+    }
+
+    if (stack.length === 0) {
+      roots.push(node);
+    } else {
+      const parent = stack[stack.length - 1];
+      if (parent.children === null) parent.children = [];
+      parent.children.push(node);
+    }
+
+    stack.push(node);
+  }
+
+  return roots;
+}
+
+// A node is "self-empty" when it carries no tariff-relevant data of its
+// own. Description alone doesn't count — heading-only rows (e.g.
+// "Horses:") are pure structural labels and add no real value if the
+// rows under them carry nothing either.
+function isSelfEmpty(node: HtsNode): boolean {
+  return (
+    node.htsno === null &&
+    node.units.length === 0 &&
+    node.general === null &&
+    node.special === null &&
+    node.other === null &&
+    node.quotaQuantity === null &&
+    node.additionalDuties === null &&
+    node.footnotes.length === 0
+  );
+}
+
+// Recursively prune empty subtrees. Returns the pruned node, or null if
+// the entire subtree (this node + all descendants) carries no useful
+// data and should be dropped from the parent's children.
+function prune(node: HtsNode): HtsNode | null {
+  // Prune children first so we know whether anything survived below.
+  if (node.children !== null) {
+    const survivors = node.children.map(prune).filter((n): n is HtsNode => n !== null);
+    node.children = survivors.length > 0 ? survivors : null;
+  }
+
+  // If this node has no useful data of its own AND no surviving
+  // children, drop it entirely. This bubbles up so a chain of empty
+  // wrappers collapses to nothing.
+  if (isSelfEmpty(node) && node.children === null) {
+    return null;
+  }
+
+  return node;
+}
+
+// Top-level normalize: build the tree, then prune dead branches.
+function normalize(rows: RawHtsRow[]): HtsNode[] {
+  const tree = buildTree(rows);
+  return tree.map(prune).filter((n): n is HtsNode => n !== null);
+}
+
+// Count nodes in a forest, used for the after-pruning summary.
+function countNodes(forest: HtsNode[]): number {
+  let total = 0;
+  const stack = [...forest];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    total += 1;
+    if (node.children !== null) stack.push(...node.children);
+  }
+  return total;
+}
+
+async function fetchChapter(chapter: number): Promise<RawHtsRow[]> {
+  const url = buildChapterUrl(chapter);
+  const res = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`HTS API returned HTTP ${res.status} for chapter ${chapter} (${url})`);
+  }
+  const json = (await res.json()) as RawHtsRow[];
+  if (!Array.isArray(json)) {
+    throw new Error(`HTS API returned a non-array response for chapter ${chapter}`);
+  }
+  return json;
+}
+
+async function downloadChapter(chapter: number): Promise<{ chapter: number; rawRows: number; nodes: number }> {
+  const raw = await fetchChapter(chapter);
+  const tree = normalize(raw);
+
+  const padded = chapter.toString().padStart(2, '0');
+  const outPath = resolve(OUTPUT_DIR, `chapter-${padded}.json`);
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, JSON.stringify({ chapter, fetchedAt: new Date().toISOString(), tree }, null, 2), 'utf8');
+
+  return { chapter, rawRows: raw.length, nodes: countNodes(tree) };
+}
+
+// Parse "1", "1 2 3", or "1-5" into a list of chapter numbers. With no
+// args, return all chapters 1..99.
+function parseChapterArgs(args: string[]): number[] {
+  if (args.length === 0) {
+    return Array.from({ length: 99 }, (_, i) => i + 1);
+  }
+  const result = new Set<number>();
+  for (const arg of args) {
+    const rangeMatch = /^(\d{1,2})-(\d{1,2})$/.exec(arg);
+    if (rangeMatch) {
+      const start = Number.parseInt(rangeMatch[1], 10);
+      const end = Number.parseInt(rangeMatch[2], 10);
+      if (start < 1 || end > 99 || start > end) throw new Error(`Bad chapter range: ${arg}`);
+      for (let n = start; n <= end; n++) result.add(n);
+      continue;
+    }
+    const single = Number.parseInt(arg, 10);
+    if (!Number.isFinite(single) || single < 1 || single > 99) {
+      throw new Error(`Bad chapter argument: ${arg} (must be 1..99 or N-M)`);
+    }
+    result.add(single);
+  }
+  return [...result].sort((a, b) => a - b);
+}
+
+async function main(): Promise<void> {
+  const chapters = parseChapterArgs(process.argv.slice(2));
+  console.log(`Downloading ${chapters.length} chapter(s) → ${OUTPUT_DIR}`);
+
+  for (const chapter of chapters) {
+    try {
+      const { rawRows, nodes } = await downloadChapter(chapter);
+      const padded = chapter.toString().padStart(2, '0');
+      console.log(`  chapter ${padded}: ${rawRows} raw rows → ${nodes} nodes after prune`);
+    } catch (err) {
+      console.error(`  chapter ${chapter}: FAILED — ${(err as Error).message}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/insights-ui/src/types/industry-tariff/industry-tariff-report-types.ts
+++ b/insights-ui/src/types/industry-tariff/industry-tariff-report-types.ts
@@ -1,1 +1,0 @@
-// Industry Tariff Report Types


### PR DESCRIPTION
## Summary

This branch bundles two related tariff-data changes.

### 1. Remove duplicate data from tariff industry definitions
- Each of the 41 industries in `tariff-industries.ts` was repeating the same four count fields (`headingsCount: 3`, `subHeadingsCount: 2`, `establishedPlayersCount: 3`, `newChallengersCount: 3`) and 39 carried an empty `companiesToIgnore: []` placeholder. None of these values varied across industries, and `establishedPlayersCount` / `newChallengersCount` were not referenced anywhere.
- Dropped both dead fields entirely; made the other three fields optional, with module-level defaults (`DEFAULT_HEADINGS_COUNT`, `DEFAULT_SUB_HEADINGS_COUNT`, and a `getCompaniesToIgnore()` accessor that returns `[]` when omitted). Existing call sites in `tariff-industries.ts` and `06-evaluate-industry-area.ts` use the new defaults.
- Removed the dead `src/types/industry-tariff/industry-tariff-report-types.ts` stub (only a comment, no imports).

Net: ~200 lines of repeated property assignments removed with no behavior change.

### 2. New HTSUS chapter download script
- `src/scripts/tariff-calculator/download-hts-chapter.ts` fetches Harmonized Tariff Schedule data per chapter from the official USITC REST endpoint and emits a normalized hierarchical JSON file per chapter under `data/hts-chapters/` (gitignored).
- Builds a tree from the upstream's flat indent-based rows (stack algorithm), normalizes loose fields (empty strings → null, drops the upstream `addiitionalDuties` typo).
- Prunes dead branches: a node is dropped when it carries no tariff data of its own (no htsno, rates, units, footnotes, quota, or additional duties) AND its entire subtree is also empty. `children` is set to null rather than [] after pruning so callers can tell "leaf" apart from "had children, all dead". Pruning bubbles upward.
- CLI: no args → all 99 chapters. Single chapter, list, or range supported (`1`, `1 2 3`, `1-5`).

Tested against chapters 1, 50, 77 (reserved/empty), and 99 (3201 rows) — all succeed.

## Test plan
- [x] `yarn prettier-check`
- [x] `yarn lint`
- [x] `yarn compile` (prisma generate + tsc)
- [x] Smoke-tested the download script across small, empty, and large chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)