### PR TITLE
Add Management Team Experience and Alignment report

### DIFF
--- a/docs/insights-ui/tasks/README.md
+++ b/docs/insights-ui/tasks/README.md
@@ -5,7 +5,7 @@ Active KoalaGains task lists — open work, closed work, per-surface roadmaps. T
 ## Open task lists
 
 - **[etfs.md](etfs.md)** — Top open ETF tasks (custom reports, ETFs listing page, active-management surfacing, prompt + factor improvements, comparison-base open questions, SEO, social media, trends).
-- **[stocks.md](stocks.md)** — Open stock-side tasks (scenarios Phase 2/3/4 + open questions, 10-bagger shortlist, founder/management lookups, social media, off-hours refresh, recategorization, internet-augmented Claude Code generation).
+- **[stocks.md](stocks.md)** — Open stock-side tasks (scenarios Phase 2/3/4 + open questions, 10-bagger shortlist, founder/management lookups, management team report, social media, off-hours refresh, recategorization, internet-augmented Claude Code generation).
 - **[tariffs.md](tariffs.md)** — Open tariff tasks.
 - **[optional_tariff_features.md](optional_tariff_features.md)** — Highest-value tariff features to consider next, with market mapping. Treat as a backlog of feature ideas, not committed work.
 

--- a/docs/insights-ui/tasks/README.md
+++ b/docs/insights-ui/tasks/README.md
@@ -5,7 +5,7 @@ Active KoalaGains task lists — open work, closed work, per-surface roadmaps. T
 ## Open task lists
 
 - **[etfs.md](etfs.md)** — Top open ETF tasks (custom reports, ETFs listing page, active-management surfacing, prompt + factor improvements, comparison-base open questions, SEO, social media, trends).
-- **[stocks.md](stocks.md)** — Open stock-side tasks (scenarios Phase 2/3/4 + open questions, 10-bagger shortlist, founder/management lookups, management team report, social media, off-hours refresh, recategorization, internet-augmented Claude Code generation).
+- **[stocks.md](stocks.md)** — Open stock-side tasks (scenarios Phase 2/3/4 + open questions, 10-bagger shortlist, founder/management lookups, management team experience and alignment report, social media, off-hours refresh, recategorization, internet-augmented Claude Code generation).
 - **[tariffs.md](tariffs.md)** — Open tariff tasks.
 - **[optional_tariff_features.md](optional_tariff_features.md)** — Highest-value tariff features to consider next, with market mapping. Treat as a backlog of feature ideas, not committed work.
 

--- a/docs/insights-ui/tasks/stocks.md
+++ b/docs/insights-ui/tasks/stocks.md
@@ -482,124 +482,182 @@ glance. This also feeds the **founder / owner-operator quality** dimension of th
     tickers (parent + sub); decide whether to model `Person` as its own table
     with stock links, or denormalize per ticker.
 
-## Management Team Report — new dedicated analysis category for stocks
+## Management Team Experience and Alignment — new optional report type
 
-Goal: ship a full **Management Team Report** as a new top-level analysis category for
-every stock — a sibling to Business & Moat, Financial Statement Analysis, Past
-Performance, Future Growth, Fair Value, Future Risk, and Vs Competition (see
-`TickerV1CategoryAnalysisResult` + `TickerV1GenerationRequest` in
-`insights-ui/prisma/schema.prisma`). Where the **Founder & management team —
-LinkedIn-sourced info** task above handles the *data layer* (Leadership block: who
-runs the company, photos, tenure, LinkedIn URLs), this task handles the *analytical
-layer* — Claude's structured opinion on **how good** the team actually is, scored
-and explained against repeatable factors so the verdict is comparable across
-tickers.
+Goal: add an **8th** stock report type — **Management Team Experience and Alignment** —
+alongside the existing seven (Business & Moat, Financial Statement Analysis, Past
+Performance, Future Growth, Fair Value, Future Risk, Vs Competition; see
+`TickerAnalysisCategory` + `TickerV1CategoryAnalysisResult` +
+`TickerV1GenerationRequest` in `insights-ui/prisma/schema.prisma`). Where the
+**Founder & management team — LinkedIn-sourced info** task above handles the *who*
+(Leadership block: photos, tenure, LinkedIn URLs), this report answers
+**"how experienced is this team and how aligned are they with long-term
+shareholders?"** in a focused, narrative format.
 
-- [ ] **Data model** (mirror the existing per-category pattern):
-  - Add `MANAGEMENT_TEAM` to the `TickerAnalysisCategory` enum so the report flows
-    through the existing `TickerV1CategoryAnalysisResult` /
-    `TickerV1AnalysisCategoryFactorResult` tables — no new top-level table needed
-    if we go this route. (The alternative — a dedicated `TickerV1ManagementTeam`
-    model like `TickerV1FutureRisk` — should be considered only if the output shape
-    diverges meaningfully from the standard `summary` + `overallAnalysisDetails` +
-    factor-results pattern.)
-  - Add `regenerateManagementTeam` to `TickerV1GenerationRequest` so the section
-    plugs into the existing batch regen pipeline.
-  - Add `managementTeamScore` to `TickerV1CachedScore` (Int, alongside
-    `businessAndMoatScore`, `fairValueScore`, etc.) so the management-team verdict
-    contributes to the `finalScore` rollup.
-- [ ] **Analysis factors** (seed `AnalysisCategoryFactor` rows per industry /
-  sub-industry, same shape as the existing categories):
-  - **Track record** — has this team executed against prior guidance / strategic
-    plans? Compare prior-period management commentary with realized results.
-  - **Capital allocation** — historical pattern of buybacks, dividends, M&A,
-    organic reinvestment. Quality of M&A integration, write-down history,
-    incremental ROIC.
-  - **Insider ownership + alignment** — % of shares held by insiders, recent
-    insider buys vs sells, comp structure (cash-heavy vs equity-heavy, LTI tied to
-    real performance metrics vs. fluffy ESG targets).
-  - **Tenure + stability** — average exec tenure, CEO/CFO churn rate, recent
-    departures, time since last leadership change.
-  - **Founder presence** — is the founder still in the seat / on the board /
-    significantly aligned by ownership? (Plumbs into the 10-bagger founder/
-    owner-operator dimension.)
-  - **Governance** — board independence, separation of CEO/Chair, related-party
-    transactions, audit/compensation committee composition, recent governance red
-    flags (restatements, SEC actions, lawsuits naming the team).
-  - **Succession risk** — single-point-of-failure dependency on one or two
-    individuals; documented succession plan (yes/no).
-  - **Communication quality** — earnings-call transparency vs spin, willingness to
-    address bad news, consistency of long-term messaging across cycles.
+This report is intentionally **optional** — no back-fill of stocks whose reports
+were generated before this category shipped. It only gets created for tickers that
+go through a "generate all reports" run *after* the category lands.
+
+### What the report covers
+
+Exactly four things, in this order:
+
+1. **Who's running the company** — names + titles of each key management team
+   member (CEO, CFO, COO/President, founder if separate, board chair if
+   distinct from CEO). Pulled from the Leadership block populated by the
+   "Founder & management team — LinkedIn-sourced info" task.
+2. **Tenure** — how long each person has been in their current role and at the
+   company overall. Flag founders, recent hires, and unusually short or long
+   tenures vs. industry norm.
+3. **Ownership + compensation alignment** — each named exec's stock ownership
+   as a % of shares outstanding (and approximate $ value), the structure of
+   their compensation (cash vs equity, performance-vested vs time-vested,
+   metrics that govern long-term incentive plans), and whether comp design
+   actually rewards long-term company growth (e.g. revenue / FCF / ROIC over
+   multi-year windows) vs. short-term proxies (single-year EPS, stock price,
+   ESG fluff).
+4. **Insider buying / selling** — net insider activity over the trailing
+   12 months (Form 4 filings), distinguishing planned 10b5-1 sales from
+   discretionary trades. Heavy buying = strong conviction signal; persistent
+   selling = a yellow flag worth surfacing.
+
+### Verdict scale (NOT 0–5)
+
+Use a categorical enum that names the overall *experience-and-alignment* posture
+of the team. Don't fall back to generic "Very Bad / Bad / Fair / Good" — pick
+labels that actually describe the construct. Recommended `AlignmentVerdict`
+enum:
+
+- `OWNER_OPERATOR` — founder(s) still in the seat, double-digit insider
+  ownership, recent buying or no selling, comp materially tied to long-term
+  metrics.
+- `STRONGLY_ALIGNED` — non-founder team but long-tenured, meaningful insider
+  ownership, LTI tied to multi-year performance metrics, no concerning
+  insider sales.
+- `ALIGNED` — typical professional management with reasonable tenure, modest
+  ownership, conventional comp structure; no red flags but nothing
+  exceptional either.
+- `WEAKLY_ALIGNED` — low insider ownership, short or churn-prone tenure,
+  comp dominated by short-term proxies, mixed insider activity.
+- `MISALIGNED` — concerning combination of insider selling, governance flags,
+  short tenures, and / or comp design that pays out regardless of long-term
+  outcomes.
+
+Render the verdict as a labeled pill on both the summary block and the detail
+page; use distinct colors per level so a reader can pattern-match across
+tickers at a glance.
+
+### Tasks
+
+- [ ] **Data model** — keep it simple, narrative-shaped (don't reach for the
+  factor pattern):
+  - Either add `MANAGEMENT_TEAM_EXPERIENCE_AND_ALIGNMENT` to
+    `TickerAnalysisCategory` and reuse `TickerV1CategoryAnalysisResult` for the
+    `summary` + `overallAnalysisDetails` markdown, **plus** a new
+    `alignmentVerdict` column on that table (or a dedicated companion table),
+    *or* add a fresh top-level model `TickerV1ManagementTeamReport` mirroring
+    `TickerV1FutureRisk`'s shape: `summary` (markdown, ~2 paragraphs),
+    `detailedAnalysis` (markdown, 5–7 paragraphs), `alignmentVerdict`
+    (enum), audit fields. Pick the model based on whether the verdict enum
+    fits the shared category result row or not.
+  - Add the new `AlignmentVerdict` enum to the Prisma schema (or
+    `src/types/`) with the five values above.
+  - Add `regenerateManagementTeamExperienceAndAlignment` to
+    `TickerV1GenerationRequest` so the "generate all reports" pipeline picks
+    this up by default for new runs.
+  - **Do NOT** add a corresponding score to `TickerV1CachedScore` — this
+    report uses a categorical verdict, not a 0–5 score, so it should not feed
+    the numeric `finalScore` rollup. Surface the verdict separately.
+- [ ] **No back-fill, opt-in by default for new generations**:
+  - Migration is purely additive — no historical data to populate.
+  - The "generate all reports" entry point flips
+    `regenerateManagementTeamExperienceAndAlignment = true` so newly-requested
+    full runs include it.
+  - Existing stock pages whose generation pre-dated this section keep
+    rendering as today; the UI hides the new section entirely when no row
+    exists (see UI tasks below — no half-empty card / no "coming soon"
+    placeholder).
 - [ ] **Prompt + inputs** (reuse `getLLMResponseForPromptViaInvocation`):
-  - Register a new `promptKey: 'US/public-equities-v1/management-team'` with the
-    standard system prompt skeleton used by the other analysis categories.
-  - `inputJson` should carry: ticker symbol/name/industry, the **Leadership block**
-    data (`keyPeople[]` from the LinkedIn task above), recent **10-K / proxy /
-    DEF 14A** excerpts (compensation, ownership, related-party sections),
-    recent **insider transactions** (Form 4 summary), capital-allocation history
-    (buyback $, dividend $, M&A $, capex), and any prior management-team
-    commentary stored on the ticker.
-  - Output contract: `summary` (markdown) + `overallAnalysisDetails` (markdown)
-    + per-factor `{ result: PASS|FAIL|NEUTRAL, oneLineExplanation,
-    detailedExplanation }` rows that drop straight into
-    `TickerV1AnalysisCategoryFactorResult` — same shape as Business & Moat.
-  - Cite sources (10-K Item, proxy section, Form 4 filing date) in the detailed
-    explanation so claims are auditable.
+  - Register a new `promptKey:
+    'US/public-equities-v1/management-team-experience-and-alignment'`.
+  - `inputJson` carries: ticker symbol/name/industry, the **Leadership block**
+    rows (`keyPeople[]` with name, title, tenure, founder flag), recent
+    **proxy / DEF 14A** excerpts (compensation, ownership, related-party
+    sections), trailing-12-month **Form 4** insider transactions (buyer,
+    seller, $ amount, 10b5-1 flag).
+  - Output contract:
+    - `summary`: ~2 paragraphs (target ~150–250 words) suitable for the
+      main stock page.
+    - `detailedAnalysis`: 5–7 paragraphs (target ~600–900 words) covering
+      the four areas above in order. Each numbered exec mention should
+      include their tenure inline.
+    - `alignmentVerdict`: one of the 5 enum values.
+  - Cite sources (proxy section, Form 4 filing date) inline so claims are
+    auditable.
 - [ ] **API**:
-  - Add a `GET` route under
-    `/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/management-team` that
-    returns the cached `TickerV1CategoryAnalysisResult` + factor rows for the
-    `MANAGEMENT_TEAM` category, and a `POST` regenerate route that flips
-    `regenerateManagementTeam` on the next generation request (or invokes
-    synchronously, matching `future-risk/route.ts`).
+  - `GET /api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/management-team-experience-and-alignment`
+    — returns the row + verdict, or 404 if absent (caller treats 404 as "not
+    generated yet", not an error).
+  - `POST` regenerate route that mirrors `future-risk/route.ts` —
+    synchronous v1, flips the section's regen flag and invokes the prompt
+    end-to-end.
   - Wire the new section into the batch regeneration handler that consumes
-    `TickerV1GenerationRequest` so "regenerate all" picks it up automatically.
-- [ ] **UI**:
-  - On the main stock page (`app/stocks/[exchange]/[ticker]/page.tsx`) add a
-    **Management Team** summary block: score badge, one-paragraph summary, top
-    2–3 factor verdicts, and a "View full management-team analysis" CTA — same
-    shape as the other category summaries.
-  - New per-section detail page
-    `app/stocks/[exchange]/[ticker]/management-team/page.tsx` that renders the
-    full markdown + factor table + per-factor rationale, mirroring the
-    Business & Moat detail page.
-  - Surface the **Leadership block** (founders + key execs from the LinkedIn
-    task) at the top of the detail page so readers see *who* before reading
-    Claude's verdict on *how good*.
-  - Update sitemaps / metadata for the new detail route; unique title / meta
-    description per ticker (avoid the "Crawled — currently not indexed" trap
-    flagged in the SEO Fixes section below).
+    `TickerV1GenerationRequest`, but **only when the "generate all" flag is
+    set** — no implicit back-fill on individual-section regens of older
+    tickers.
+- [ ] **UI — main stock page**
+  (`app/stocks/[exchange]/[ticker]/page.tsx`):
+  - When the report exists, render a **Management Team Experience and
+    Alignment** summary card: section title, `alignmentVerdict` pill,
+    ~2-paragraph `summary` markdown, and a "View full management team
+    analysis" CTA linking to the detail page.
+  - When the report does **not** exist (older tickers), render nothing — no
+    placeholder, no "coming soon", no empty card. The section is silently
+    absent.
+- [ ] **UI — new detail page**
+  (`app/stocks/[exchange]/[ticker]/management-team-experience-and-alignment/page.tsx`):
+  - Header: ticker / company name / verdict pill.
+  - Body: full 5–7 paragraph `detailedAnalysis` markdown.
+  - Sidebar / top block: the **Leadership block** (founders + key execs from
+    the LinkedIn task) so readers see *who* before reading the assessment.
+  - Breadcrumbs back to the main stock page.
+  - SSR'd, indexable, unique `<title>` + `<meta description>` per ticker
+    (avoid the "Crawled — currently not indexed" trap flagged in the SEO
+    Fixes section below).
+  - Add the route to the relevant per-section sitemap.
 - [ ] **Integration with adjacent features**:
-  - **Business & Moat** prompt should now *consume* the management-team summary
-    as input (rather than re-deriving team quality inline), so the moat narrative
-    stops repeating team claims and the two reports stay consistent.
-  - **10-bagger lens** "founder / owner-operator quality" dimension should pull
-    its score from `managementTeamScore` rather than re-evaluating from scratch.
-  - **Custom Reports** — make sure the management-team factor rows are part of
-    the `inputJson` exposed to the generic custom-report prompt so user
-    questions about leadership get grounded in our own analysis.
+  - **Business & Moat** prompt input should optionally include the
+    `summary` + `alignmentVerdict` so the moat narrative grounds team-quality
+    claims in this report's verdict instead of re-deriving them inline.
+  - **10-bagger lens** "founder / owner-operator quality" dimension should
+    map to `alignmentVerdict` (e.g. `OWNER_OPERATOR` ⇒ top score, `MISALIGNED`
+    ⇒ bottom).
+  - **Custom Reports** — include the management-team report's `summary` +
+    `alignmentVerdict` in the generic custom-report prompt's `inputJson` so
+    user questions about leadership are grounded in our own analysis.
 - [ ] **Off-hours refresh**:
-  - Add the management-team section to the off-hours regeneration cron (see
-    "Off-hours automated report refresh" above) so it stays fresh on the same
-    cadence as other categories.
-  - Bump priority on tickers where leadership changed recently (CEO/CFO
-    departure, founder exit) — these reports should regenerate sooner than the
-    default staleness threshold.
+  - Add this section to the off-hours regeneration cron (see "Off-hours
+    automated report refresh" above) but only for tickers that already have a
+    populated row — don't use the cron to retro-back-fill the entire
+    universe.
+  - Bump priority on tickers where a CEO/CFO/founder departure was detected
+    (Form 8-K Item 5.02) so the verdict catches the change quickly.
 - [ ] **Open questions**:
-  - **Industry-specific factors** — should the factor list vary by industry
-    (e.g. for REITs, capital allocation is the dominant signal; for biotech,
-    scientific founder presence matters more)? Same `AnalysisCategoryFactor`
-    table supports per-industry rows already, so this is a content question,
-    not schema.
-  - **Coverage threshold** — if the Leadership block has fewer than N
-    verified rows (e.g. CEO unknown), should we suppress the
-    Management Team Report entirely instead of writing a low-confidence one?
-  - **Score weighting** — how heavily should `managementTeamScore` weight into
-    the rolled-up `finalScore`? Pick a default and document it; revisit once
-    we have data on whether the score correlates with subsequent returns.
-  - **Backfill strategy** — generate for the full universe in one off-hours
-    sweep, or gate on tickers that have a complete Leadership block first?
-    Probably the latter to avoid garbage-in reports.
+  - **Verdict-only-without-detail tickers** — if the Leadership block /
+    proxy data is too thin to write 5–7 paragraphs, do we suppress the
+    report entirely, or render a shorter version with a "limited data"
+    flag? Lean towards suppressing — a half-baked alignment verdict is
+    worse than no verdict.
+  - **Frequency of refresh** — proxy filings update annually, Form 4s
+    arrive continuously. Pick separate refresh cadences (e.g. annual full
+    regen post-proxy, lighter monthly regen that only updates the insider-
+    activity paragraph) or one combined cadence?
+  - **Verdict colour mapping** — settle the pill colours up front so they're
+    consistent across the summary card, detail page header, and any future
+    listing/filter UI.
+  - **Cross-ticker comparability** — do we want a future "leaderboard" view
+    of `OWNER_OPERATOR` tickers as a discovery surface? Out of scope for v1
+    but the schema should not preclude it.
 
 ## Social media content — convert reports into posts
 

--- a/docs/insights-ui/tasks/stocks.md
+++ b/docs/insights-ui/tasks/stocks.md
@@ -482,6 +482,125 @@ glance. This also feeds the **founder / owner-operator quality** dimension of th
     tickers (parent + sub); decide whether to model `Person` as its own table
     with stock links, or denormalize per ticker.
 
+## Management Team Report — new dedicated analysis category for stocks
+
+Goal: ship a full **Management Team Report** as a new top-level analysis category for
+every stock — a sibling to Business & Moat, Financial Statement Analysis, Past
+Performance, Future Growth, Fair Value, Future Risk, and Vs Competition (see
+`TickerV1CategoryAnalysisResult` + `TickerV1GenerationRequest` in
+`insights-ui/prisma/schema.prisma`). Where the **Founder & management team —
+LinkedIn-sourced info** task above handles the *data layer* (Leadership block: who
+runs the company, photos, tenure, LinkedIn URLs), this task handles the *analytical
+layer* — Claude's structured opinion on **how good** the team actually is, scored
+and explained against repeatable factors so the verdict is comparable across
+tickers.
+
+- [ ] **Data model** (mirror the existing per-category pattern):
+  - Add `MANAGEMENT_TEAM` to the `TickerAnalysisCategory` enum so the report flows
+    through the existing `TickerV1CategoryAnalysisResult` /
+    `TickerV1AnalysisCategoryFactorResult` tables — no new top-level table needed
+    if we go this route. (The alternative — a dedicated `TickerV1ManagementTeam`
+    model like `TickerV1FutureRisk` — should be considered only if the output shape
+    diverges meaningfully from the standard `summary` + `overallAnalysisDetails` +
+    factor-results pattern.)
+  - Add `regenerateManagementTeam` to `TickerV1GenerationRequest` so the section
+    plugs into the existing batch regen pipeline.
+  - Add `managementTeamScore` to `TickerV1CachedScore` (Int, alongside
+    `businessAndMoatScore`, `fairValueScore`, etc.) so the management-team verdict
+    contributes to the `finalScore` rollup.
+- [ ] **Analysis factors** (seed `AnalysisCategoryFactor` rows per industry /
+  sub-industry, same shape as the existing categories):
+  - **Track record** — has this team executed against prior guidance / strategic
+    plans? Compare prior-period management commentary with realized results.
+  - **Capital allocation** — historical pattern of buybacks, dividends, M&A,
+    organic reinvestment. Quality of M&A integration, write-down history,
+    incremental ROIC.
+  - **Insider ownership + alignment** — % of shares held by insiders, recent
+    insider buys vs sells, comp structure (cash-heavy vs equity-heavy, LTI tied to
+    real performance metrics vs. fluffy ESG targets).
+  - **Tenure + stability** — average exec tenure, CEO/CFO churn rate, recent
+    departures, time since last leadership change.
+  - **Founder presence** — is the founder still in the seat / on the board /
+    significantly aligned by ownership? (Plumbs into the 10-bagger founder/
+    owner-operator dimension.)
+  - **Governance** — board independence, separation of CEO/Chair, related-party
+    transactions, audit/compensation committee composition, recent governance red
+    flags (restatements, SEC actions, lawsuits naming the team).
+  - **Succession risk** — single-point-of-failure dependency on one or two
+    individuals; documented succession plan (yes/no).
+  - **Communication quality** — earnings-call transparency vs spin, willingness to
+    address bad news, consistency of long-term messaging across cycles.
+- [ ] **Prompt + inputs** (reuse `getLLMResponseForPromptViaInvocation`):
+  - Register a new `promptKey: 'US/public-equities-v1/management-team'` with the
+    standard system prompt skeleton used by the other analysis categories.
+  - `inputJson` should carry: ticker symbol/name/industry, the **Leadership block**
+    data (`keyPeople[]` from the LinkedIn task above), recent **10-K / proxy /
+    DEF 14A** excerpts (compensation, ownership, related-party sections),
+    recent **insider transactions** (Form 4 summary), capital-allocation history
+    (buyback $, dividend $, M&A $, capex), and any prior management-team
+    commentary stored on the ticker.
+  - Output contract: `summary` (markdown) + `overallAnalysisDetails` (markdown)
+    + per-factor `{ result: PASS|FAIL|NEUTRAL, oneLineExplanation,
+    detailedExplanation }` rows that drop straight into
+    `TickerV1AnalysisCategoryFactorResult` — same shape as Business & Moat.
+  - Cite sources (10-K Item, proxy section, Form 4 filing date) in the detailed
+    explanation so claims are auditable.
+- [ ] **API**:
+  - Add a `GET` route under
+    `/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/management-team` that
+    returns the cached `TickerV1CategoryAnalysisResult` + factor rows for the
+    `MANAGEMENT_TEAM` category, and a `POST` regenerate route that flips
+    `regenerateManagementTeam` on the next generation request (or invokes
+    synchronously, matching `future-risk/route.ts`).
+  - Wire the new section into the batch regeneration handler that consumes
+    `TickerV1GenerationRequest` so "regenerate all" picks it up automatically.
+- [ ] **UI**:
+  - On the main stock page (`app/stocks/[exchange]/[ticker]/page.tsx`) add a
+    **Management Team** summary block: score badge, one-paragraph summary, top
+    2–3 factor verdicts, and a "View full management-team analysis" CTA — same
+    shape as the other category summaries.
+  - New per-section detail page
+    `app/stocks/[exchange]/[ticker]/management-team/page.tsx` that renders the
+    full markdown + factor table + per-factor rationale, mirroring the
+    Business & Moat detail page.
+  - Surface the **Leadership block** (founders + key execs from the LinkedIn
+    task) at the top of the detail page so readers see *who* before reading
+    Claude's verdict on *how good*.
+  - Update sitemaps / metadata for the new detail route; unique title / meta
+    description per ticker (avoid the "Crawled — currently not indexed" trap
+    flagged in the SEO Fixes section below).
+- [ ] **Integration with adjacent features**:
+  - **Business & Moat** prompt should now *consume* the management-team summary
+    as input (rather than re-deriving team quality inline), so the moat narrative
+    stops repeating team claims and the two reports stay consistent.
+  - **10-bagger lens** "founder / owner-operator quality" dimension should pull
+    its score from `managementTeamScore` rather than re-evaluating from scratch.
+  - **Custom Reports** — make sure the management-team factor rows are part of
+    the `inputJson` exposed to the generic custom-report prompt so user
+    questions about leadership get grounded in our own analysis.
+- [ ] **Off-hours refresh**:
+  - Add the management-team section to the off-hours regeneration cron (see
+    "Off-hours automated report refresh" above) so it stays fresh on the same
+    cadence as other categories.
+  - Bump priority on tickers where leadership changed recently (CEO/CFO
+    departure, founder exit) — these reports should regenerate sooner than the
+    default staleness threshold.
+- [ ] **Open questions**:
+  - **Industry-specific factors** — should the factor list vary by industry
+    (e.g. for REITs, capital allocation is the dominant signal; for biotech,
+    scientific founder presence matters more)? Same `AnalysisCategoryFactor`
+    table supports per-industry rows already, so this is a content question,
+    not schema.
+  - **Coverage threshold** — if the Leadership block has fewer than N
+    verified rows (e.g. CEO unknown), should we suppress the
+    Management Team Report entirely instead of writing a low-confidence one?
+  - **Score weighting** — how heavily should `managementTeamScore` weight into
+    the rolled-up `finalScore`? Pick a default and document it; revisit once
+    we have data on whether the score correlates with subsequent returns.
+  - **Backfill strategy** — generate for the full universe in one off-hours
+    sweep, or gate on tickers that have a complete Leadership block first?
+    Probably the latter to avoid garbage-in reports.
+
 ## Social media content — convert reports into posts
 
 Goal: turn the work we already produce (stock reports, **stock scenarios**, the

--- a/insights-ui/prisma/migrations/20260501143912_add_management_team_report/migration.sql
+++ b/insights-ui/prisma/migrations/20260501143912_add_management_team_report/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "ManagementTeamAlignmentVerdict" AS ENUM ('OwnerOperator', 'StronglyAligned', 'Aligned', 'WeaklyAligned', 'Misaligned');
+
+-- CreateTable
+CREATE TABLE "ticker_v1_management_team_reports" (
+    "id" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "detailed_analysis" TEXT NOT NULL,
+    "alignment_verdict" "ManagementTeamAlignmentVerdict" NOT NULL,
+    "ticker_id" TEXT NOT NULL,
+    "space_id" TEXT NOT NULL DEFAULT 'koala_gains',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "created_by" TEXT,
+    "updated_by" TEXT,
+
+    CONSTRAINT "ticker_v1_management_team_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ticker_v1_management_team_reports_ticker_id_idx" ON "ticker_v1_management_team_reports"("ticker_id");
+
+-- CreateIndex
+CREATE INDEX "ticker_v1_management_team_reports_space_id_ticker_id_idx" ON "ticker_v1_management_team_reports"("space_id", "ticker_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ticker_v1_management_team_reports_space_id_ticker_id_key" ON "ticker_v1_management_team_reports"("space_id", "ticker_id");
+
+-- AddForeignKey
+ALTER TABLE "ticker_v1_management_team_reports" ADD CONSTRAINT "ticker_v1_management_team_reports_ticker_id_fkey" FOREIGN KEY ("ticker_id") REFERENCES "tickers_v1"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "ticker_v1_generation_requests" ADD COLUMN "regenerate_management_team" BOOLEAN NOT NULL DEFAULT false;

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -467,6 +467,14 @@ enum TickerAnalysisCategory {
   FairValue
 }
 
+enum ManagementTeamAlignmentVerdict {
+  OwnerOperator
+  StronglyAligned
+  Aligned
+  WeaklyAligned
+  Misaligned
+}
+
 // --------------------------
 // New Tables (convention-aligned)
 // --------------------------
@@ -530,6 +538,7 @@ model TickerV1 {
   factorResults           TickerV1AnalysisCategoryFactorResult[]
   investorAnalysisResults TickerV1InvestorAnalysisResult[]
   futureRisks             TickerV1FutureRisk[]
+  managementTeamReports   TickerV1ManagementTeamReport[]
   vsCompetition           TickerV1VsCompetition?
   generationRequests      TickerV1GenerationRequest[]
 
@@ -740,6 +749,26 @@ model TickerV1FutureRisk {
   @@map("ticker_v1_future_risks")
 }
 
+model TickerV1ManagementTeamReport {
+  id                String                         @id @default(uuid())
+  summary           String                         @map("summary")
+  detailedAnalysis  String                         @map("detailed_analysis")
+  alignmentVerdict  ManagementTeamAlignmentVerdict @map("alignment_verdict")
+  tickerId          String                         @map("ticker_id")
+  spaceId           String                         @default("koala_gains") @map("space_id")
+  createdAt         DateTime                       @default(now()) @map("created_at")
+  updatedAt         DateTime                       @updatedAt @map("updated_at")
+  createdBy         String?                        @map("created_by")
+  updatedBy         String?                        @map("updated_by")
+
+  ticker TickerV1 @relation(fields: [tickerId], references: [id])
+
+  @@unique([spaceId, tickerId])
+  @@index([tickerId])
+  @@index([spaceId, tickerId])
+  @@map("ticker_v1_management_team_reports")
+}
+
 model TickerV1VsCompetition {
   id                       String   @id @default(uuid())
   summary                  String   @map("summary")
@@ -775,6 +804,7 @@ model TickerV1GenerationRequest {
   regenerateFutureGrowth      Boolean @default(false) @map("regenerate_future_growth")
   regenerateFairValue         Boolean @default(false) @map("regenerate_fair_value")
   regenerateFutureRisk        Boolean @default(false) @map("regenerate_future_risk")
+  regenerateManagementTeam    Boolean @default(false) @map("regenerate_management_team")
 
   // Investor analyses
   regenerateWarrenBuffett Boolean @default(false) @map("regenerate_warren_buffett")

--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -37,6 +37,9 @@
     <loc>https://koalagains.com/stocks/fair-value-sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://koalagains.com/stocks/management-team-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://koalagains.com/stock-scenarios/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/insights-ui/schemas/analysis-factors/management-team/management-team-input.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/management-team/management-team-input.schema.yaml
@@ -1,0 +1,41 @@
+$schema: 'http://json-schema.org/draft-07/schema#'
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: string
+    description: 'The full name of the company or REIT being analyzed (e.g., AvalonBay Communities Inc.).'
+  symbol:
+    type: string
+    description: 'The stock ticker symbol of the company or REIT (e.g., AVB).'
+  exchange:
+    type: string
+    description: 'Exchange code, e.g. "NASDAQ" or "NYSE"'
+  industryKey:
+    type: string
+    description: 'The broad industry the stock belongs to (e.g., REITS).'
+  industryName:
+    type: string
+    description: 'Name of the industry'
+  industryDescription:
+    type: string
+    description: 'A few lines explaining the industry'
+  subIndustryKey:
+    type: string
+    description: 'The specific sub-industry of the stock (e.g., OFFICE_REITS).'
+  subIndustryName:
+    type: string
+    description: 'Name of the sub-industry'
+  subIndustryDescription:
+    type: string
+    description: 'A few lines explaining the sub-industry'
+required:
+  - name
+  - symbol
+  - exchange
+  - industryKey
+  - subIndustryKey
+  - industryDescription
+  - subIndustryDescription
+  - industryName
+  - subIndustryName

--- a/insights-ui/schemas/analysis-factors/management-team/management-team-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/management-team/management-team-output.schema.yaml
@@ -1,0 +1,23 @@
+$schema: 'http://json-schema.org/draft-07/schema#'
+type: object
+additionalProperties: false
+properties:
+  summary:
+    type: string
+    description: '~2 paragraph summary suitable for the main ticker page. Cover who is leading the company, how aligned they are with long-term shareholder value, and any standout signals from compensation or insider transactions. End with a one-sentence investor takeaway.'
+  detailedAnalysis:
+    type: string
+    description: '5–7 paragraphs covering: (1) the names, roles, and tenure of the key management team members; (2) ownership stakes (insider %), compensation structure, and how compensation incentives align with long-term company growth; (3) recent insider buying/selling activity and what it signals; (4) leadership track record and capital allocation history; (5) overall alignment verdict and the reasoning behind it.'
+  alignmentVerdict:
+    type: string
+    enum:
+      - OWNER_OPERATOR
+      - STRONGLY_ALIGNED
+      - ALIGNED
+      - WEAKLY_ALIGNED
+      - MISALIGNED
+    description: 'Categorical verdict capturing how strongly management''s incentives, ownership, and behavior align with long-term shareholder value. OWNER_OPERATOR = founder/large insider with significant skin in the game. STRONGLY_ALIGNED = meaningful ownership and compensation tied to long-term value. ALIGNED = standard alignment, no red flags. WEAKLY_ALIGNED = limited ownership or compensation skewed toward short-term metrics. MISALIGNED = significant red flags (heavy insider selling, weak ownership, short-term-focused incentives).'
+required:
+  - summary
+  - detailedAnalysis
+  - alignmentVerdict

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/creation-infos/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/creation-infos/route.ts
@@ -117,6 +117,7 @@ async function createTickerFomCompetition(req: NextRequest, context: { params: P
       regenerateFutureGrowth: true,
       regenerateFairValue: true,
       regenerateFutureRisk: true,
+      regenerateManagementTeam: true,
       regenerateFinalSummary: true,
     },
   });

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/generation-requests/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/[ticker]/generation-requests/route.ts
@@ -14,6 +14,7 @@ export interface GenerationRequestPayload {
   regenerateFutureGrowth: boolean;
   regenerateFairValue: boolean;
   regenerateFutureRisk: boolean;
+  regenerateManagementTeam: boolean;
   regenerateFinalSummary: boolean;
   regenerateCachedScore: boolean;
 }
@@ -62,6 +63,7 @@ async function postHandler(
         regenerateFutureGrowth: payload.regenerateFutureGrowth || existingRequest.regenerateFutureGrowth,
         regenerateFairValue: payload.regenerateFairValue || existingRequest.regenerateFairValue,
         regenerateFutureRisk: payload.regenerateFutureRisk || existingRequest.regenerateFutureRisk,
+        regenerateManagementTeam: payload.regenerateManagementTeam || existingRequest.regenerateManagementTeam,
         regenerateFinalSummary: payload.regenerateFinalSummary || existingRequest.regenerateFinalSummary,
 
         updatedAt: new Date(),
@@ -81,6 +83,7 @@ async function postHandler(
         regenerateFutureGrowth: payload.regenerateFutureGrowth,
         regenerateFairValue: payload.regenerateFairValue,
         regenerateFutureRisk: payload.regenerateFutureRisk,
+        regenerateManagementTeam: payload.regenerateManagementTeam,
         regenerateFinalSummary: payload.regenerateFinalSummary,
       },
     });
@@ -126,6 +129,7 @@ async function getHandler(req: NextRequest, { params }: { params: Promise<{ spac
       regenerateFutureGrowth: false,
       regenerateFairValue: false,
       regenerateFutureRisk: false,
+      regenerateManagementTeam: false,
       regenerateFinalSummary: false,
       status: GenerationRequestStatus.NotStarted,
       createdAt: new Date(),

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/management-team/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/management-team/route.ts
@@ -1,0 +1,44 @@
+import { getLLMResponseForPromptViaInvocation } from '@/util/get-llm-response';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+import { LLMManagementTeamResponse, TickerAnalysisResponse } from '@/types/public-equity/analysis-factors-types';
+import { fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
+import { prepareBaseTickerInputJson } from '@/utils/analysis-reports/report-input-json-utils';
+import { saveManagementTeamResponse } from '@/utils/analysis-reports/save-report-utils';
+
+async function postHandler(
+  req: NextRequest,
+  { params }: { params: Promise<{ spaceId: string; ticker: string; exchange: string }> }
+): Promise<TickerAnalysisResponse> {
+  const { spaceId, ticker, exchange } = await params;
+
+  // Get ticker from DB
+  const tickerRecord = await fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry(ticker.toUpperCase(), exchange.toUpperCase());
+
+  // Prepare input for the prompt
+  const inputJson = prepareBaseTickerInputJson(tickerRecord);
+
+  // Call the LLM
+  const result = await getLLMResponseForPromptViaInvocation({
+    spaceId,
+    inputJson,
+    promptKey: 'US/public-equities-v1/management-team',
+    requestFrom: 'ui',
+  });
+
+  if (!result) {
+    throw new Error('Failed to get response from LLM');
+  }
+
+  const response = result.response as LLMManagementTeamResponse;
+
+  // Save the analysis response using the utility function
+  await saveManagementTeamResponse(ticker.toLowerCase(), tickerRecord.exchange, response);
+
+  return {
+    success: true,
+    invocationId: result.invocationId,
+  };
+}
+
+export const POST = withErrorHandlingV2<TickerAnalysisResponse>(postHandler);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-json-report/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-json-report/route.ts
@@ -1,5 +1,5 @@
 import { ReportType, TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { LLMFactorAnalysisResponse } from '@/types/public-equity/analysis-factors-types';
+import { LLMFactorAnalysisResponse, LLMManagementTeamResponse } from '@/types/public-equity/analysis-factors-types';
 import {
   saveBusinessAndMoatFactorAnalysisResponse,
   saveCompetitionAnalysisResponse,
@@ -7,6 +7,7 @@ import {
   saveFinalSummaryResponse,
   saveFinancialAnalysisFactorAnalysisResponse,
   saveFutureGrowthFactorAnalysisResponse,
+  saveManagementTeamResponse,
   savePastPerformanceFactorAnalysisResponse,
 } from '@/utils/analysis-reports/save-report-utils';
 import { fetchAnalysisFactors, fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
@@ -28,6 +29,7 @@ export type LLMResponse =
   | LLMFactorAnalysisResponse // For BUSINESS_AND_MOAT, PAST_PERFORMANCE, FUTURE_GROWTH, FINANCIAL_ANALYSIS, FAIR_VALUE
   | CompetitionAnalysisResponse // For COMPETITION
   | FutureRiskResponse // For FUTURE_RISK
+  | LLMManagementTeamResponse // For MANAGEMENT_TEAM
   | FinalSummaryResponse; // For FINAL_SUMMARY
 
 export interface SaveJsonReportRequest {
@@ -94,6 +96,9 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
     case ReportType.FUTURE_RISK:
       schemaPath = path.join(process.cwd(), 'schemas', 'analysis-factors', 'future-risk', 'future-risk-output.schema.yaml');
       break;
+    case ReportType.MANAGEMENT_TEAM:
+      schemaPath = path.join(process.cwd(), 'schemas', 'analysis-factors', 'management-team', 'management-team-output.schema.yaml');
+      break;
     case ReportType.FINAL_SUMMARY:
       schemaPath = path.join(process.cwd(), 'schemas', 'analysis-factors', 'final-summary', 'final-summary-analysis-output.schema.yaml');
       break;
@@ -158,6 +163,9 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
       break;
     case ReportType.FUTURE_RISK:
       await saveFutureRiskResponse(ticker, exchange, llmResponse as FutureRiskResponse);
+      break;
+    case ReportType.MANAGEMENT_TEAM:
+      await saveManagementTeamResponse(ticker, exchange, llmResponse as LLMManagementTeamResponse);
       break;
     case ReportType.FAIR_VALUE:
       await saveFairValueFactorAnalysisResponse(ticker, exchange, llmResponse as LLMFactorAnalysisResponse, TickerAnalysisCategory.FairValue);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-report-callback/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-report-callback/route.ts
@@ -10,6 +10,7 @@ import {
   saveFutureGrowthFactorAnalysisResponse,
   saveFutureRiskResponse,
   saveInvestorAnalysisResponse,
+  saveManagementTeamResponse,
   savePastPerformanceFactorAnalysisResponse,
 } from '@/utils/analysis-reports/save-report-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
@@ -49,6 +50,9 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
       break;
     case ReportType.FUTURE_RISK:
       await saveFutureRiskResponse(ticker, exchange, llmResponse);
+      break;
+    case ReportType.MANAGEMENT_TEAM:
+      await saveManagementTeamResponse(ticker, exchange, llmResponse);
       break;
     case ReportType.FINAL_SUMMARY:
       await saveFinalSummaryResponse(ticker, exchange, llmResponse.finalSummary, llmResponse.metaDescription, llmResponse.aboutReport);

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/generation-requests/route.ts
@@ -22,6 +22,7 @@ export interface GenerationRequestPayload {
   regenerateFutureGrowth: boolean;
   regenerateFairValue: boolean;
   regenerateFutureRisk: boolean;
+  regenerateManagementTeam: boolean;
   regenerateFinalSummary: boolean;
 }
 
@@ -239,6 +240,7 @@ async function postHandler(
           regenerateFutureGrowth: regenerateOptions.regenerateFutureGrowth || existingRequest.regenerateFutureGrowth,
           regenerateFairValue: regenerateOptions.regenerateFairValue || existingRequest.regenerateFairValue,
           regenerateFutureRisk: regenerateOptions.regenerateFutureRisk || existingRequest.regenerateFutureRisk,
+          regenerateManagementTeam: regenerateOptions.regenerateManagementTeam || existingRequest.regenerateManagementTeam,
           regenerateFinalSummary: regenerateOptions.regenerateFinalSummary || existingRequest.regenerateFinalSummary,
           updatedAt: new Date(),
         },
@@ -255,6 +257,7 @@ async function postHandler(
           regenerateFutureGrowth: regenerateOptions.regenerateFutureGrowth,
           regenerateFairValue: regenerateOptions.regenerateFairValue,
           regenerateFutureRisk: regenerateOptions.regenerateFutureRisk,
+          regenerateManagementTeam: regenerateOptions.regenerateManagementTeam,
           regenerateFinalSummary: regenerateOptions.regenerateFinalSummary,
         },
       });

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -1,0 +1,230 @@
+import AdminTimestamp from '@/components/auth/AdminTimestamp';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS, ManagementTeamAlignmentVerdict } from '@/types/ticker-typesv1';
+import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges, SupportedCountries } from '@/utils/countryExchangeUtils';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import { generateManagementTeamArticleSchema, generateManagementTeamBreadcrumbSchema } from '@/utils/metadata-generators';
+import { TickerV1FastResponse } from '@/utils/ticker-v1-model-utils';
+import { parseMarkdown } from '@/util/parse-markdown';
+import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import { unstable_noStore as noStore } from 'next/cache';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+/**
+ * Static-by-default with on-demand invalidation.
+ */
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
+export type RouteParams = Promise<Readonly<{ exchange: string; ticker: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+
+function truncateForMeta(text: string, maxLength: number = 155): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength).replace(/\s+\S*$/, '') + '…';
+}
+
+async function fetchTickerByExchange(exchange: string, ticker: string): Promise<TickerV1FastResponse | null> {
+  const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}?allowNull=true`;
+  const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  if (!res.ok) {
+    throw new Error(`fetchTickerByExchange failed (${res.status}): ${url}`);
+  }
+  return (await res.json()) as TickerV1FastResponse | null;
+}
+
+async function fetchTickerAnyExchange(ticker: string): Promise<TickerV1FastResponse | null> {
+  const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/${ticker.toUpperCase()}?allowNull=true`;
+  const res: Response = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`fetchTickerAnyExchange failed (${res.status}): ${url}`);
+  }
+  return (await res.json()) as TickerV1FastResponse | null;
+}
+
+async function getTickerOrRedirect(exchange: string, ticker: string): Promise<TickerV1FastResponse> {
+  const data = await fetchTickerByExchange(exchange, ticker);
+  if (data) return data;
+
+  noStore();
+  const fallback = await fetchTickerAnyExchange(ticker);
+  if (!fallback) notFound();
+
+  const canonicalExchange: string = fallback.exchange.toUpperCase();
+  if (canonicalExchange !== exchange.toUpperCase()) {
+    permanentRedirect(`/stocks/${canonicalExchange}/${fallback.symbol.toUpperCase()}/management-team`);
+  }
+  return fallback;
+}
+
+function getVerdictBadgeClasses(verdict: ManagementTeamAlignmentVerdict): string {
+  switch (verdict) {
+    case ManagementTeamAlignmentVerdict.OWNER_OPERATOR:
+    case ManagementTeamAlignmentVerdict.STRONGLY_ALIGNED:
+      return 'bg-green-900 text-green-200';
+    case ManagementTeamAlignmentVerdict.ALIGNED:
+      return 'bg-blue-900 text-blue-200';
+    case ManagementTeamAlignmentVerdict.WEAKLY_ALIGNED:
+      return 'bg-yellow-900 text-yellow-200';
+    case ManagementTeamAlignmentVerdict.MISALIGNED:
+      return 'bg-red-900 text-red-200';
+    default:
+      return 'bg-gray-800 text-gray-200';
+  }
+}
+
+export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
+  const routeParams = await params;
+  const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
+
+  let companyName: string = ticker;
+  let industryName: string = '';
+  let createdTime: string;
+  let updatedTime: string;
+
+  try {
+    const data = await fetchTickerByExchange(exchange, ticker);
+    companyName = data?.name ?? companyName;
+    industryName = data?.industry?.name || data?.industryKey || '';
+    const report = data?.managementTeamReports?.[0];
+    const createdAt = report?.createdAt || data?.createdAt || new Date();
+    const updatedAt = report?.updatedAt || data?.updatedAt || new Date();
+    createdTime = new Date(createdAt).toISOString();
+    updatedTime = new Date(updatedAt).toISOString();
+  } catch {
+    const now = new Date().toISOString();
+    createdTime = now;
+    updatedTime = now;
+  }
+
+  const year = new Date().getFullYear();
+  const shortDesc = truncateForMeta(
+    `Management team experience and alignment analysis for ${companyName} (${ticker})${
+      industryName ? ` in the ${industryName} industry` : ''
+    }. Leadership tenure, insider ownership, compensation alignment, and insider trading activity.`
+  );
+  const canonicalUrl = `https://koalagains.com/stocks/${exchange}/${ticker}/management-team`;
+  const keywords: string[] = [
+    `${companyName} management team`,
+    `${companyName} leadership`,
+    `${ticker} management`,
+    `${companyName} insider ownership`,
+    `${companyName} executive compensation`,
+    `${ticker} insider trading`,
+    'management alignment',
+    'executive tenure',
+    'investment insights',
+    'KoalaGains',
+  ];
+
+  return {
+    title: `${companyName} (${ticker}) Management Team Experience & Alignment (${year})`,
+    description: shortDesc,
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: `${companyName} (${ticker}) Management Team Experience & Alignment | KoalaGains`,
+      description: shortDesc,
+      url: canonicalUrl,
+      siteName: 'KoalaGains',
+      type: 'article',
+      publishedTime: createdTime,
+      modifiedTime: updatedTime,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${companyName} (${ticker}) Management Team Experience & Alignment | KoalaGains`,
+      description: shortDesc,
+      site: '@koalagains',
+      creator: '@koalagains',
+    },
+    keywords,
+  };
+}
+
+export default async function ManagementTeamPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
+  const routeParams = await params;
+  const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
+
+  const tickerData = await getTickerOrRedirect(exchange, ticker);
+  const report = tickerData.managementTeamReports?.[0];
+  if (!report) {
+    notFound();
+  }
+
+  const country: SupportedCountries = getCountryByExchange(tickerData.exchange as USExchanges | CanadaExchanges | IndiaExchanges | UKExchanges);
+  const industryName: string = tickerData.industry?.name || tickerData.industryKey;
+
+  const articleSchema = generateManagementTeamArticleSchema(tickerData, report);
+  const breadcrumbSchema = generateManagementTeamBreadcrumbSchema(tickerData, country);
+
+  const breadcrumbs: BreadcrumbsOjbect[] =
+    country === 'US'
+      ? [
+          { name: 'US Stocks', href: '/stocks', current: false },
+          { name: industryName, href: `/stocks/industries/${tickerData.industryKey}`, current: false },
+          { name: ticker, href: `/stocks/${exchange}/${ticker}`, current: false },
+          { name: 'Management Team', href: `/stocks/${exchange}/${ticker}/management-team`, current: true },
+        ]
+      : country
+      ? [
+          { name: `${country} Stocks`, href: `/stocks/countries/${country}`, current: false },
+          { name: industryName, href: `/stocks/countries/${country}/industries/${tickerData.industryKey}`, current: false },
+          { name: ticker, href: `/stocks/${exchange}/${ticker}`, current: false },
+          { name: 'Management Team', href: `/stocks/${exchange}/${ticker}/management-team`, current: true },
+        ]
+      : [
+          { name: 'Stocks', href: '/stocks', current: false },
+          { name: ticker, href: `/stocks/${exchange}/${ticker}`, current: false },
+          { name: 'Management Team', href: `/stocks/${exchange}/${ticker}/management-team`, current: true },
+        ];
+
+  const verdict = report.alignmentVerdict as ManagementTeamAlignmentVerdict;
+  const verdictLabel = MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS[verdict] || report.alignmentVerdict;
+
+  return (
+    <PageWrapper>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([articleSchema, breadcrumbSchema]),
+        }}
+      />
+
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+
+      <article itemScope itemType="https://schema.org/Article">
+        <section className="mb-6">
+          <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-4xl" itemProp="headline">
+            {tickerData.name} ({tickerData.symbol}) — Management Team Experience &amp; Alignment
+          </h1>
+        </section>
+
+        <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-8" itemProp="articleBody">
+          <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
+            <h2 className="text-xl font-bold">Alignment Verdict</h2>
+            <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getVerdictBadgeClasses(verdict)}`}>
+              {verdictLabel}
+            </span>
+            {report.updatedAt && <AdminTimestamp date={report.updatedAt} />}
+          </div>
+
+          <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-2">Summary</h3>
+            <div className="markdown markdown-body text-gray-300" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.summary) }} />
+          </div>
+
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Detailed Analysis</h3>
+            <div className="markdown markdown-body text-gray-300" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.detailedAnalysis) }} />
+          </div>
+        </section>
+      </article>
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -18,7 +18,14 @@ import SimilarTickers from '@/components/ticker-reportsv1/SimilarTickers';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SpiderGraphForTicker, SpiderGraphPie } from '@/types/public-equity/ticker-report-types';
-import { CATEGORY_MAPPINGS, CompetitionResponse, EvaluationResult, TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import {
+  CATEGORY_MAPPINGS,
+  CompetitionResponse,
+  EvaluationResult,
+  MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS,
+  ManagementTeamAlignmentVerdict,
+  TickerAnalysisCategory,
+} from '@/types/ticker-typesv1';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getSpiderGraphScorePercentage } from '@/util/radar-chart-utils';
 import {
@@ -510,8 +517,25 @@ function TickerChartsInfo({
   );
 }
 
+function getManagementTeamVerdictBadgeClasses(verdict: ManagementTeamAlignmentVerdict): string {
+  switch (verdict) {
+    case ManagementTeamAlignmentVerdict.OWNER_OPERATOR:
+    case ManagementTeamAlignmentVerdict.STRONGLY_ALIGNED:
+      return 'bg-green-900 text-green-200';
+    case ManagementTeamAlignmentVerdict.ALIGNED:
+      return 'bg-blue-900 text-blue-200';
+    case ManagementTeamAlignmentVerdict.WEAKLY_ALIGNED:
+      return 'bg-yellow-900 text-yellow-200';
+    case ManagementTeamAlignmentVerdict.MISALIGNED:
+      return 'bg-red-900 text-red-200';
+    default:
+      return 'bg-gray-800 text-gray-200';
+  }
+}
+
 function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): JSX.Element {
   const d: TickerV1FastResponse = use(data);
+  const managementTeamReport = d.managementTeamReports?.[0];
 
   return (
     <>
@@ -603,6 +627,35 @@ function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): 
               </div>
             );
           })}
+          {managementTeamReport && (
+            <div key="management-team-summary" className="bg-gray-900 p-4 rounded-md shadow-sm">
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-lg font-semibold">Management Team Experience &amp; Alignment</h3>
+                  <span
+                    className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getManagementTeamVerdictBadgeClasses(
+                      managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict
+                    )}`}
+                  >
+                    {MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS[managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict] ||
+                      managementTeamReport.alignmentVerdict}
+                  </span>
+                  {managementTeamReport.updatedAt && <AdminTimestamp date={managementTeamReport.updatedAt} />}
+                </div>
+                <Link
+                  href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/management-team`}
+                  className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                  style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
+                >
+                  View Detailed Analysis →
+                </Link>
+              </div>
+              <div
+                className="text-gray-300 markdown markdown-body"
+                dangerouslySetInnerHTML={{ __html: parseMarkdown(managementTeamReport.summary || 'No summary available.') }}
+              />
+            </div>
+          )}
         </div>
       </section>
     </>

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -1,0 +1,70 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { NextRequest, NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+async function generateManagementTeamUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  const records = await prisma.tickerV1ManagementTeamReport.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+    },
+    select: {
+      updatedAt: true,
+      ticker: {
+        select: {
+          symbol: true,
+          exchange: true,
+        },
+      },
+    },
+  });
+
+  for (const record of records) {
+    const url = `/stocks/${record.ticker.exchange}/${record.ticker.symbol}/management-team`;
+    urls.push({
+      url,
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod: record.updatedAt ? new Date(record.updatedAt).toISOString().split('T')[0] : undefined,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
+  const host = req.headers.get('host') as string;
+
+  try {
+    const urls = await generateManagementTeamUrls();
+    const smStream = new SitemapStream({ hostname: 'https://' + host });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating management team sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/hooks/useGenerateReports.ts
+++ b/insights-ui/src/hooks/useGenerateReports.ts
@@ -140,6 +140,7 @@ export const useGenerateReports = () => {
           regenerateFutureGrowth: false,
           regenerateFairValue: false,
           regenerateFutureRisk: false,
+          regenerateManagementTeam: false,
           regenerateFinalSummary: false,
         };
 
@@ -150,6 +151,8 @@ export const useGenerateReports = () => {
           else if (rt === ReportType.PAST_PERFORMANCE) payload.regeneratePastPerformance = true;
           else if (rt === ReportType.FUTURE_GROWTH) payload.regenerateFutureGrowth = true;
           else if (rt === ReportType.FAIR_VALUE) payload.regenerateFairValue = true;
+          else if (rt === ReportType.FUTURE_RISK) payload.regenerateFutureRisk = true;
+          else if (rt === ReportType.MANAGEMENT_TEAM) payload.regenerateManagementTeam = true;
           else if (rt === ReportType.FINAL_SUMMARY) payload.regenerateFinalSummary = true;
         });
 
@@ -180,6 +183,7 @@ export const useGenerateReports = () => {
         regenerateFutureGrowth: true,
         regenerateFairValue: true,
         regenerateFutureRisk: false,
+        regenerateManagementTeam: true,
         regenerateFinalSummary: true,
       }));
 
@@ -207,6 +211,7 @@ export const useGenerateReports = () => {
         regenerateFutureGrowth: true,
         regenerateFairValue: true,
         regenerateFutureRisk: false,
+        regenerateManagementTeam: true,
         regenerateFinalSummary: true,
       }));
 
@@ -237,6 +242,7 @@ export const useGenerateReports = () => {
             regenerateFutureGrowth: false,
             regenerateFairValue: false,
             regenerateFutureRisk: false,
+            regenerateManagementTeam: false,
             regenerateFinalSummary: false,
           };
 
@@ -248,6 +254,7 @@ export const useGenerateReports = () => {
             else if (step === ReportType.FUTURE_GROWTH) p.regenerateFutureGrowth = true;
             else if (step === ReportType.FAIR_VALUE) p.regenerateFairValue = true;
             else if (step === ReportType.FUTURE_RISK) p.regenerateFutureRisk = true;
+            else if (step === ReportType.MANAGEMENT_TEAM) p.regenerateManagementTeam = true;
             else if (step === ReportType.FINAL_SUMMARY) p.regenerateFinalSummary = true;
           });
 

--- a/insights-ui/src/scripts/tickers/get-report-prompt.ts
+++ b/insights-ui/src/scripts/tickers/get-report-prompt.ts
@@ -17,6 +17,7 @@ const VALID_REPORT_TYPES: readonly ReportType[] = [
   ReportType.FUTURE_GROWTH,
   ReportType.FAIR_VALUE,
   ReportType.FUTURE_RISK,
+  ReportType.MANAGEMENT_TEAM,
   ReportType.FINAL_SUMMARY,
 ];
 

--- a/insights-ui/src/scripts/tickers/save-report.ts
+++ b/insights-ui/src/scripts/tickers/save-report.ts
@@ -15,6 +15,7 @@ const VALID_REPORT_TYPES: readonly ReportType[] = [
   ReportType.FUTURE_GROWTH,
   ReportType.FAIR_VALUE,
   ReportType.FUTURE_RISK,
+  ReportType.MANAGEMENT_TEAM,
   ReportType.FINAL_SUMMARY,
 ];
 

--- a/insights-ui/src/scripts/tickers/trigger-generation.ts
+++ b/insights-ui/src/scripts/tickers/trigger-generation.ts
@@ -17,6 +17,7 @@ interface GenerationRequestPayload {
   regenerateFutureGrowth: boolean;
   regenerateFairValue: boolean;
   regenerateFutureRisk: boolean;
+  regenerateManagementTeam: boolean;
   regenerateFinalSummary: boolean;
 }
 
@@ -34,6 +35,7 @@ const ANALYSIS_CATEGORIES: readonly ReportType[] = [
   ReportType.FUTURE_GROWTH,
   ReportType.FAIR_VALUE,
   ReportType.FUTURE_RISK,
+  ReportType.MANAGEMENT_TEAM,
 ];
 
 const ALL_REPORT_TYPES: readonly ReportType[] = [...ANALYSIS_CATEGORIES, ReportType.FINAL_SUMMARY];
@@ -52,6 +54,7 @@ function buildPayload(ticker: TickerIdentifier, categories: ReportType[]): Gener
     regenerateFutureGrowth: set.has(ReportType.FUTURE_GROWTH),
     regenerateFairValue: set.has(ReportType.FAIR_VALUE),
     regenerateFutureRisk: set.has(ReportType.FUTURE_RISK),
+    regenerateManagementTeam: set.has(ReportType.MANAGEMENT_TEAM),
     regenerateFinalSummary: set.has(ReportType.FINAL_SUMMARY),
   };
 }
@@ -63,7 +66,7 @@ function buildPayload(ticker: TickerIdentifier, categories: ReportType[]): Gener
  *   1. `--all` (or `--categories=all`)                 → every report type (incl. final-summary)
  *   2. `--analysis` (or `--categories=analysis`)       → 7 analysis categories, skip final-summary
  *   3. `--categories=<csv>`                            → explicit comma-separated list
- *   4. (no flag)                                       → defaults to all 8 report types
+ *   4. (no flag)                                       → defaults to all 9 report types
  *
  * Each token in a CSV must match a ReportType enum value (e.g. `financial-analysis`).
  */

--- a/insights-ui/src/types/public-equity/analysis-factors-types.ts
+++ b/insights-ui/src/types/public-equity/analysis-factors-types.ts
@@ -1,4 +1,4 @@
-import { InvestorKey, InvestorTypes, TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import { InvestorKey, InvestorTypes, ManagementTeamAlignmentVerdict, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { TickerV1GenerationRequest } from '@prisma/client';
 import { TopCompaniesToConsider } from '../prismaTypes';
 
@@ -53,6 +53,12 @@ export interface LLMFactorAnalysisResponse {
 export interface LLMFutureRiskResponse {
   summary: string;
   detailedAnalysis: string;
+}
+
+export interface LLMManagementTeamResponse {
+  summary: string;
+  detailedAnalysis: string;
+  alignmentVerdict: ManagementTeamAlignmentVerdict;
 }
 
 export interface LLMInvestorAnalysisResponse {

--- a/insights-ui/src/types/ticker-typesv1.ts
+++ b/insights-ui/src/types/ticker-typesv1.ts
@@ -144,6 +144,7 @@ export enum ReportType {
   FUTURE_GROWTH = 'future-growth',
   FAIR_VALUE = 'fair-value',
   FUTURE_RISK = 'future-risk',
+  MANAGEMENT_TEAM = 'management-team',
   FINAL_SUMMARY = 'final-summary',
 }
 
@@ -156,8 +157,28 @@ export const analysisTypes: AnalysisTypeInfo[] = [
   { key: ReportType.FUTURE_GROWTH, label: 'Future Growth' },
   { key: ReportType.FAIR_VALUE, label: 'Fair Value' },
   { key: ReportType.FUTURE_RISK, label: 'Future Risk' },
+  { key: ReportType.MANAGEMENT_TEAM, label: 'Management Team' },
   { key: ReportType.FINAL_SUMMARY, label: 'Final Summary' },
 ];
+
+// Verdict for the Management Team Experience and Alignment report.
+// String values mirror the Prisma `ManagementTeamAlignmentVerdict` enum so
+// they can be passed to the DB without translation.
+export enum ManagementTeamAlignmentVerdict {
+  OWNER_OPERATOR = 'OwnerOperator',
+  STRONGLY_ALIGNED = 'StronglyAligned',
+  ALIGNED = 'Aligned',
+  WEAKLY_ALIGNED = 'WeaklyAligned',
+  MISALIGNED = 'Misaligned',
+}
+
+export const MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS: Record<ManagementTeamAlignmentVerdict, string> = {
+  [ManagementTeamAlignmentVerdict.OWNER_OPERATOR]: 'Owner-Operator',
+  [ManagementTeamAlignmentVerdict.STRONGLY_ALIGNED]: 'Strongly Aligned',
+  [ManagementTeamAlignmentVerdict.ALIGNED]: 'Aligned',
+  [ManagementTeamAlignmentVerdict.WEAKLY_ALIGNED]: 'Weakly Aligned',
+  [ManagementTeamAlignmentVerdict.MISALIGNED]: 'Misaligned',
+};
 
 // Types for ticker analysis categories
 export enum TickerAnalysisCategory {

--- a/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
@@ -40,6 +40,7 @@ export const reportDependencyMap: Record<ReportType, ReportType[]> = {
   [ReportType.FUTURE_GROWTH]: [ReportType.BUSINESS_AND_MOAT],
   [ReportType.FAIR_VALUE]: [ReportType.BUSINESS_AND_MOAT, ReportType.FINANCIAL_ANALYSIS, ReportType.PAST_PERFORMANCE, ReportType.FUTURE_GROWTH],
   [ReportType.FUTURE_RISK]: [],
+  [ReportType.MANAGEMENT_TEAM]: [],
   [ReportType.FINAL_SUMMARY]: [
     ReportType.FINANCIAL_ANALYSIS,
     ReportType.COMPETITION,
@@ -62,6 +63,7 @@ export const dependencyBasedReportOrder: ReportType[] = [
   ReportType.FINANCIAL_ANALYSIS,
   ReportType.PAST_PERFORMANCE,
   ReportType.FUTURE_RISK,
+  ReportType.MANAGEMENT_TEAM,
 
   // Dependent reports (with dependencies)
   ReportType.FUTURE_GROWTH,
@@ -249,6 +251,25 @@ async function generateFutureRiskAnalysis(spaceId: string, tickerRecord: TickerV
   });
 }
 
+async function generateManagementTeamAnalysis(spaceId: string, tickerRecord: TickerV1WithIndustryAndSubIndustry, generationRequestId: string): Promise<void> {
+  // Prepare base input JSON
+  const inputJson = prepareBaseTickerInputJson(tickerRecord);
+
+  // Call the LLM
+  await getLLMResponseForPromptViaInvocationViaLambda({
+    symbol: tickerRecord.symbol,
+    exchange: tickerRecord.exchange,
+    generationRequestId,
+    params: {
+      spaceId,
+      inputJson,
+      promptKey: 'US/public-equities-v1/management-team',
+      requestFrom: 'ui',
+    },
+    reportType: ReportType.MANAGEMENT_TEAM,
+  });
+}
+
 async function generateFinalSummary(spaceId: string, tickerRecord: TickerV1WithIndustryAndSubIndustry, generationRequestId: string): Promise<void> {
   // Get ticker from DB with all related analysis data
   const tickerWithAnalysis = await fetchTickerRecordBySymbolAndExchangeWithAnalysisData(tickerRecord.symbol, tickerRecord.exchange);
@@ -398,6 +419,9 @@ export async function triggerGenerationOfAReportSimplified(symbol: string, excha
         break;
       case ReportType.FUTURE_RISK:
         await generateFutureRiskAnalysis(spaceId, tickerRecord, generationRequest.id);
+        break;
+      case ReportType.MANAGEMENT_TEAM:
+        await generateManagementTeamAnalysis(spaceId, tickerRecord, generationRequest.id);
         break;
       case ReportType.FINAL_SUMMARY:
         await generateFinalSummary(spaceId, tickerRecord, generationRequestId);

--- a/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
@@ -49,6 +49,7 @@ export const reportDependencyMap: Record<ReportType, ReportType[]> = {
     ReportType.FUTURE_GROWTH,
     ReportType.FAIR_VALUE,
     ReportType.FUTURE_RISK,
+    ReportType.MANAGEMENT_TEAM,
   ],
 };
 

--- a/insights-ui/src/utils/analysis-reports/prompt-generator-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/prompt-generator-utils.ts
@@ -42,6 +42,7 @@ const SCHEMA_PATHS: Partial<Record<ReportType, string>> = {
   [ReportType.FAIR_VALUE]: 'schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml',
   [ReportType.COMPETITION]: 'schemas/analysis-factors/competition/competition-output.schema.yaml',
   [ReportType.FUTURE_RISK]: 'schemas/analysis-factors/future-risk/future-risk-output.schema.yaml',
+  [ReportType.MANAGEMENT_TEAM]: 'schemas/analysis-factors/management-team/management-team-output.schema.yaml',
   [ReportType.FINAL_SUMMARY]: 'schemas/analysis-factors/final-summary/final-summary-analysis-output.schema.yaml',
 };
 
@@ -166,6 +167,11 @@ export async function generatePromptForReportType(symbol: string, exchange: stri
     case ReportType.FUTURE_RISK:
       inputJson = prepareBaseTickerInputJson(tickerRecord);
       promptKey = 'US/public-equities-v1/future-risk';
+      break;
+
+    case ReportType.MANAGEMENT_TEAM:
+      inputJson = prepareBaseTickerInputJson(tickerRecord);
+      promptKey = 'US/public-equities-v1/management-team';
       break;
 
     case ReportType.FINAL_SUMMARY:

--- a/insights-ui/src/utils/analysis-reports/report-generator-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/report-generator-utils.ts
@@ -19,6 +19,7 @@ export const createBackgroundGenerationRequest = async (
     regenerateFutureGrowth: true,
     regenerateFairValue: true,
     regenerateFutureRisk: true,
+    regenerateManagementTeam: true,
     regenerateFinalSummary: true,
   };
 
@@ -43,6 +44,7 @@ export const createSingleAnalysisBackgroundRequest = async (
     regenerateFutureGrowth: false,
     regenerateFairValue: false,
     regenerateFutureRisk: false,
+    regenerateManagementTeam: false,
     regenerateFinalSummary: false,
   };
 
@@ -68,6 +70,9 @@ export const createSingleAnalysisBackgroundRequest = async (
       break;
     case ReportType.FUTURE_RISK:
       payload.regenerateFutureRisk = true;
+      break;
+    case ReportType.MANAGEMENT_TEAM:
+      payload.regenerateManagementTeam = true;
       break;
     case ReportType.FINAL_SUMMARY:
       payload.regenerateFinalSummary = true;

--- a/insights-ui/src/utils/analysis-reports/report-status-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/report-status-utils.ts
@@ -21,6 +21,8 @@ export function shouldRegenerateReport(request: TickerV1GenerationRequest, repor
       return request.regenerateFairValue;
     case ReportType.FUTURE_RISK:
       return request.regenerateFutureRisk;
+    case ReportType.MANAGEMENT_TEAM:
+      return request.regenerateManagementTeam;
     case ReportType.FINAL_SUMMARY:
       return request.regenerateFinalSummary;
     default:

--- a/insights-ui/src/utils/analysis-reports/report-steps-statuses.ts
+++ b/insights-ui/src/utils/analysis-reports/report-steps-statuses.ts
@@ -99,6 +99,14 @@ export function calculatePendingSteps(request: TickerV1GenerationRequest): Repor
     pendingSteps.push(ReportType.FUTURE_RISK);
   }
 
+  if (
+    request.regenerateManagementTeam &&
+    !request.completedSteps.includes(ReportType.MANAGEMENT_TEAM) &&
+    !request.failedSteps.includes(ReportType.MANAGEMENT_TEAM)
+  ) {
+    pendingSteps.push(ReportType.MANAGEMENT_TEAM);
+  }
+
   if (request.regenerateFinalSummary && !request.completedSteps.includes(ReportType.FINAL_SUMMARY) && !request.failedSteps.includes(ReportType.FINAL_SUMMARY)) {
     pendingSteps.push(ReportType.FINAL_SUMMARY);
   }

--- a/insights-ui/src/utils/analysis-reports/save-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-utils.ts
@@ -1,6 +1,11 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { CompetitionAnalysis, LLMFactorAnalysisResponse, LLMInvestorAnalysisResponse } from '@/types/public-equity/analysis-factors-types';
+import {
+  CompetitionAnalysis,
+  LLMFactorAnalysisResponse,
+  LLMInvestorAnalysisResponse,
+  LLMManagementTeamResponse,
+} from '@/types/public-equity/analysis-factors-types';
 import { CATEGORY_MAPPINGS, InvestorTypes, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { fetchAnalysisFactors, fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
 import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
@@ -261,6 +266,38 @@ export async function saveFutureRiskResponse(
       tickerId: tickerRecord.id,
       summary: response.summary,
       detailedAnalysis: response.detailedAnalysis,
+    },
+  });
+
+  await bumpUpdatedAtAndInvalidateCache(tickerRecord);
+}
+
+/**
+ * Saves management team experience and alignment response
+ */
+export async function saveManagementTeamResponse(ticker: string, exchange: string, response: LLMManagementTeamResponse): Promise<void> {
+  const spaceId = KoalaGainsSpaceId;
+  const tickerRecord = await fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry(ticker, exchange);
+
+  await prisma.tickerV1ManagementTeamReport.upsert({
+    where: {
+      spaceId_tickerId: {
+        spaceId,
+        tickerId: tickerRecord.id,
+      },
+    },
+    update: {
+      summary: response.summary,
+      detailedAnalysis: response.detailedAnalysis,
+      alignmentVerdict: response.alignmentVerdict,
+      updatedAt: new Date(),
+    },
+    create: {
+      spaceId,
+      tickerId: tickerRecord.id,
+      summary: response.summary,
+      detailedAnalysis: response.detailedAnalysis,
+      alignmentVerdict: response.alignmentVerdict,
     },
   });
 

--- a/insights-ui/src/utils/metadata-generators.ts
+++ b/insights-ui/src/utils/metadata-generators.ts
@@ -1270,6 +1270,128 @@ export const generateFairValueBreadcrumbSchema = (ticker: TickerWithOptionalIndu
 };
 
 // ────────────────────────────────────────────────────────────────────────────────
+// Stock management team structured data generators
+// ────────────────────────────────────────────────────────────────────────────────
+
+export const generateManagementTeamArticleSchema = (
+  ticker: TickerWithOptionalIndustry,
+  report?: { createdAt?: string | Date; updatedAt?: string | Date } | null
+) => {
+  const stockUrl = `https://koalagains.com/stocks/${ticker.exchange}/${ticker.symbol}`;
+  const canonicalUrl = `${stockUrl}/management-team`;
+
+  const datePublished = report?.createdAt ? new Date(report.createdAt).toISOString() : new Date(ticker.createdAt).toISOString();
+  const dateModified = report?.updatedAt ? new Date(report.updatedAt).toISOString() : new Date(ticker.updatedAt).toISOString();
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${ticker.name} (${ticker.symbol}) Management Team Experience & Alignment`,
+    description: `Detailed analysis of ${ticker.name} (${ticker.symbol}) management team — leadership tenure, ownership stake, compensation alignment, and insider trading activity.`,
+    image: ['https://koalagains.com/koalagain_logo.png'],
+    datePublished,
+    dateModified,
+    author: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://koalagains.com/koalagain_logo.png',
+      },
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://koalagains.com/koalagain_logo.png',
+        width: 600,
+        height: 60,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    articleSection: 'Management Team Analysis',
+    keywords: [
+      ticker.name,
+      `${ticker.symbol} management team`,
+      `${ticker.name} leadership`,
+      `${ticker.symbol} insider trading`,
+      `${ticker.name} executive compensation`,
+      `${ticker.symbol} insider ownership`,
+      'management alignment',
+      'executive tenure',
+      'investment analysis',
+      `${ticker.exchange} stocks`,
+      ticker.industryKey,
+      ticker.industry?.name,
+      'KoalaGains',
+    ]
+      .filter(Boolean)
+      .join(', '),
+    about: {
+      '@type': 'Corporation',
+      name: ticker.name,
+      tickerSymbol: ticker.symbol,
+      exchange: ticker.exchange,
+    },
+    inLanguage: 'en-US',
+  };
+};
+
+export const generateManagementTeamBreadcrumbSchema = (ticker: TickerWithOptionalIndustry, country: string) => {
+  const stockUrl = `https://koalagains.com/stocks/${ticker.exchange}/${ticker.symbol}`;
+  const canonicalUrl = `${stockUrl}/management-team`;
+  const industryName = ticker.industry?.name || ticker.industryKey;
+
+  const breadcrumbItems: { '@type': string; position: number; name: string; item: string }[] = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://koalagains.com',
+    },
+  ];
+
+  if (country === 'US') {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: 'US Stocks', item: 'https://koalagains.com/stocks' },
+      { '@type': 'ListItem', position: 3, name: industryName, item: `https://koalagains.com/stocks/industries/${ticker.industryKey}` },
+      { '@type': 'ListItem', position: 4, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 5, name: 'Management Team', item: canonicalUrl }
+    );
+  } else if (country) {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: `${country} Stocks`, item: `https://koalagains.com/stocks/countries/${country}` },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: industryName,
+        item: `https://koalagains.com/stocks/countries/${country}/industries/${ticker.industryKey}`,
+      },
+      { '@type': 'ListItem', position: 4, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 5, name: 'Management Team', item: canonicalUrl }
+    );
+  } else {
+    breadcrumbItems.push(
+      { '@type': 'ListItem', position: 2, name: 'Stocks', item: 'https://koalagains.com/stocks' },
+      { '@type': 'ListItem', position: 3, name: `${ticker.symbol}`, item: stockUrl },
+      { '@type': 'ListItem', position: 4, name: 'Management Team', item: canonicalUrl }
+    );
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbItems,
+  };
+};
+
+// ────────────────────────────────────────────────────────────────────────────────
 // Common viewport configuration
 // ────────────────────────────────────────────────────────────────────────────────
 export const commonViewport = {

--- a/insights-ui/src/utils/ticker-v1-model-utils.ts
+++ b/insights-ui/src/utils/ticker-v1-model-utils.ts
@@ -13,6 +13,7 @@ import {
   TickerV1CategoryAnalysisResult,
   TickerV1FutureRisk,
   TickerV1Industry,
+  TickerV1ManagementTeamReport,
   TickerV1SubIndustry,
   TickerV1VsCompetition,
 } from '@prisma/client';
@@ -30,6 +31,7 @@ export const tickerV1IncludeWithRelations = {
   industry: true,
   subIndustry: true,
   cachedScoreEntry: true,
+  managementTeamReports: true,
 } as const;
 
 export type FullTickerV1CategoryAnalysisResult = TickerV1CategoryAnalysisResult & {
@@ -70,6 +72,7 @@ export interface CompetitorTicker {
 export type TickerV1WithRelations = TickerV1 & {
   categoryAnalysisResults: FullTickerV1CategoryAnalysisResult[];
   futureRisks?: TickerV1FutureRisk[];
+  managementTeamReports?: TickerV1ManagementTeamReport[];
   vsCompetition?: TickerV1VsCompetition | null;
   cachedScoreEntry?: TickerV1CachedScore | null;
 };
@@ -111,6 +114,7 @@ export async function getTickerWithAllDetailsForConditionsOpt(whereClause: Prism
       },
       investorAnalysisResults: true,
       futureRisks: true,
+      managementTeamReports: true,
       vsCompetition: true,
     },
   });


### PR DESCRIPTION
## Summary

Adds a new optional 8th report type — **Management Team Experience and Alignment** — for stock tickers. The report surfaces:

- Names and roles of management team members
- Tenure
- Stock ownership %, compensation structure, and alignment with long-term company growth
- Insider buying/selling activity

## What's included

- **Schema**: `TickerV1ManagementTeamReport` model + `ManagementTeamAlignmentVerdict` enum (`OwnerOperator` / `StronglyAligned` / `Aligned` / `WeaklyAligned` / `Misaligned`) and `regenerateManagementTeam` flag on generation requests. Migration `20260501143912_add_management_team_report` included.
- **Verdict scale**: 5-tier categorical instead of 0–5; values map to alignment concepts that are meaningful for this report.
- **API**: New POST route `/api/{spaceId}/tickers-v1/exchange/{exchange}/{ticker}/management-team` that runs the LLM prompt and saves the report.
- **Detail page**: `/stocks/{exchange}/{ticker}/management-team` rendering 5–7 paragraphs of detailed analysis with a verdict badge, JSON-LD article + breadcrumb schemas, metadata, and `force-static` rendering.
- **Summary card**: ~2 paragraph summary on the main ticker page (`/stocks/{exchange}/{ticker}`) with a verdict-colored badge and a link to the detail page.
- **Sitemap**: New `/stocks/management-team-sitemap.xml` route, registered in `public/sitemap_index.xml`.
- **Regen flag**: Wired through the generation request routes, the `useGenerateReports` hook, `report-generator-utils`, the `trigger-generation` script, and the new-ticker creation flow. The report is **optional** — existing tickers are not back-filled; it is generated only when the "generate all reports" path runs.

## Test plan

- [ ] Run migration `20260501143912_add_management_team_report` against the dev DB
- [ ] Trigger generation for a ticker via "generate all reports" and confirm the management-team report is produced
- [ ] Verify the summary card appears on `/stocks/{exchange}/{ticker}` once a report exists
- [ ] Verify the detail page at `/stocks/{exchange}/{ticker}/management-team` renders the verdict badge, summary, and detailed analysis
- [ ] Verify the new sitemap is reachable and listed in the sitemap index
- [ ] Verify older tickers (without a management team report) continue to render correctly with no broken UI