### PR TITLE
stock detail pages: tighten mobile padding, fix horizontal overflow

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -205,7 +205,7 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
           </h1>
         </section>
 
-        <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-8" itemProp="articleBody">
+        <section className="bg-gray-900 rounded-lg shadow-sm px-2 py-4 sm:p-6 mb-8" itemProp="articleBody">
           <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
             <h2 className="text-xl font-bold">Alignment Verdict</h2>
             <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getVerdictBadgeClasses(verdict)}`}>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -294,7 +294,7 @@ function FinancialInfoSkeleton(): JSX.Element {
 
 function QuarterlyChartSkeleton(): JSX.Element {
   return (
-    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-3 py-4 sm:p-4 mt-6">
+    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
           <div className="h-6 w-48 rounded bg-gray-800 animate-pulse" />
@@ -313,7 +313,7 @@ function QuarterlyChartSkeleton(): JSX.Element {
 
 function PriceChartSkeleton(): JSX.Element {
   return (
-    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-3 py-4 sm:p-4 mt-6">
+    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
           <div className="h-6 w-36 rounded bg-gray-800 animate-pulse" />
@@ -539,13 +539,13 @@ function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): 
 
   return (
     <>
-      <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-8 sm:p-y6" itemProp="abstract">
+      <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-8 sm:py-6" itemProp="abstract">
         <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Summary Analysis</h2>
         <div className="space-y-4">
           {Object.values(TickerAnalysisCategory).map((categoryKey: TickerAnalysisCategory) => {
             const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
             return (
-              <div key={categoryKey} className="bg-gray-900 p-4 rounded-md shadow-sm">
+              <div key={categoryKey} className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
                 <div
                   className={`flex items-center gap-2 mb-2 ${
                     categoryKey === TickerAnalysisCategory.BusinessAndMoat ||
@@ -627,7 +627,7 @@ function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): 
               </div>
             );
           })}
-          <div key="management-team-summary" className="bg-gray-900 p-4 rounded-md shadow-sm">
+          <div key="management-team-summary" className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
             <div className="flex items-center justify-between gap-2 mb-2">
               <div className="flex items-center gap-2">
                 <h3 className="text-lg font-semibold">Management Team Experience &amp; Alignment</h3>
@@ -696,7 +696,7 @@ function TickerDetailsInfo({ data }: { data: Promise<TickerV1FastResponse> }): J
           if (!categoryResult) return null;
 
           return (
-            <div key={`detail-${categoryKey}`} id={`detailed-${categoryKey}`} className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mb-8">
+            <div key={`detail-${categoryKey}`} id={`detailed-${categoryKey}`} className="bg-gray-900 rounded-lg shadow-sm px-2 py-4 sm:p-6 mb-8">
               <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
                 <h3 className="text-xl font-bold">{CATEGORY_QUESTION_MAPPINGS[categoryKey]}</h3>
                 <div
@@ -856,15 +856,11 @@ export default async function TickerDetailsPage({ params }: { params: RouteParam
         {/* Analysis info - server rendered, no skeleton needed */}
         <TickerAnalysisInfo data={tickerInfo} />
 
-        <div className="mx-auto max-w-7xl">
-          <section className="mb-6">
-            <SimilarTickers dataPromise={similarPromise} />
-          </section>
-        </div>
+        <section className="mb-6">
+          <SimilarTickers dataPromise={similarPromise} />
+        </section>
 
-        <div className="mx-auto max-w-7xl">
-          <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
-        </div>
+        <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
 
         <TickerDetailsInfo data={tickerInfo} />
 

--- a/insights-ui/src/app/styles/markdown.scss
+++ b/insights-ui/src/app/styles/markdown.scss
@@ -955,3 +955,20 @@
 .markdown-body ::-webkit-calendar-picker-indicator {
   filter: invert(50%);
 }
+
+@media (max-width: 640px) {
+  .markdown-body figure {
+    margin: 1em 0;
+  }
+  .markdown-body ul,
+  .markdown-body ol {
+    padding-left: 1.25em;
+  }
+  .markdown-body dl dd {
+    padding: 0 8px;
+  }
+  .markdown-body table th,
+  .markdown-body table td {
+    padding: 4px 6px;
+  }
+}

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -59,7 +59,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
 
   return (
     <section id="competition" className="mb-8">
-      <div className="bg-gray-900 rounded-lg shadow-sm p-6">
+      <div className="bg-gray-900 rounded-lg shadow-sm p-3 sm:p-6">
         <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-700">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link

--- a/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
@@ -135,7 +135,7 @@ export default function PriceChart({ data }: PriceChartProps) {
   const metaLine = [data.currency, intervalNote].filter(Boolean).join(' • ');
 
   return (
-    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-3 py-4 sm:p-4 mb-6">
+    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
           <h3 className="text-lg font-semibold text-gray-100">Price History</h3>

--- a/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
@@ -132,7 +132,7 @@ export default function QuarterlyMetricsChart({ data }: QuarterlyMetricsChartPro
   }
 
   return (
-    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-3 py-4 sm:p-4 mb">
+    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
           <h3 className="text-lg font-semibold text-gray-100">

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
@@ -16,7 +16,7 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
   }
 
   return (
-    <div id="similar-tickers" className="bg-gray-900 rounded-lg shadow-sm p-6 mb-8">
+    <div id="similar-tickers" className="bg-gray-900 rounded-lg shadow-sm p-3 sm:p-6 mb-8">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Top Similar Companies</h2>
       <p className="text-gray-300 mb-4">Based on industry classification and performance score:</p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -28,7 +28,7 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
             <Link
               key={similarTicker.id}
               href={`/stocks/${similarTicker.exchange.toUpperCase()}/${similarTicker.symbol.toUpperCase()}`}
-              className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
+              className="block bg-gray-800 p-3 sm:p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
             >
               <div className="flex flex-col gap-y-2">
                 <div className="flex items-center justify-between">

--- a/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
@@ -66,8 +66,8 @@ export default function TickerCategoryReport({
   const totalCount = categoryResult.factorResults?.length || 0;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+    <div className="py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={publishedDate.toISOString()} />
 
         <header className="mb-6 pb-4 border-b border-color">


### PR DESCRIPTION
## Summary

The stock detail page (e.g. https://koalagains.com/stocks/NYSE/NOC) and its 5 subpages had wide mobile padding that limited readable line length and risked horizontal scroll. This trims mobile padding throughout while keeping desktop spacing unchanged.

### Changes

**Main detail page** (`stocks/[exchange]/[ticker]/page.tsx`):
- Detailed Analysis cards: `px-3 py-6 sm:p-6` → `px-2 py-4 sm:p-6`
- Summary Analysis cards (incl. management-team): `p-4` → `p-3 sm:p-4`
- Drop redundant nested `mx-auto max-w-7xl` wrappers (already provided by `PageWrapper` → `MainContainer`)
- Quarterly/Price chart skeletons: `px-3 py-4 sm:p-4` → `px-2 py-3 sm:p-4`
- Fix typo `sm:p-y6` → `sm:py-6`

**Shared report components**:
- `TickerCategoryReport.tsx` (used by business-and-moat, financial-statement-analysis, past-performance, future-performance, fair-value subpages): drop redundant `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8` wrapper, slim article from `p-6 md:p-8` → `p-3 sm:p-6 md:p-8`
- `CompetitionChartSection.tsx`: `p-6` → `p-3 sm:p-6`
- `SimilarTickers.tsx`: `p-6 mb-8` → `p-3 sm:p-6 mb-8`; cards `p-4` → `p-3 sm:p-4`
- `PriceChart.tsx`: `px-3 py-4 sm:p-4` → `px-2 py-3 sm:p-4`
- `QuarterlyMetricsChart.tsx`: `px-3 py-4 sm:p-4 mb` → `px-2 py-3 sm:p-4 mb-6` (also fixes incomplete `mb` class)

**management-team subpage**: section `px-3 py-6 sm:p-6` → `px-2 py-4 sm:p-6`

**markdown.scss**: add `@media (max-width: 640px)` overrides for `.markdown-body` tables (`6px 13px` → `4px 6px`), lists (`padding-left: 2em` → `1.25em`), `dl dd` (`0 16px` → `0 8px`), and figures (`1em 40px` → `1em 0`) so long-form analysis content uses screen width on mobile.

## Test plan

- [ ] Open https://koalagains.com/stocks/NYSE/NOC on a phone (or DevTools mobile view at 375px width) and confirm no horizontal scroll
- [ ] Confirm content lines reach close to the screen edge with only ~8px gutter
- [ ] Verify the same on /business-and-moat, /financial-statement-analysis, /past-performance, /future-performance, /fair-value, /management-team subpages
- [ ] Verify desktop layout (≥640px) is visually unchanged
- [ ] Check markdown tables wider than the screen still scroll horizontally inside their card without forcing the page to scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)