### PR TITLE
stock detail page: reorder summary, drop dead Detailed Analysis section

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -44,7 +44,6 @@ import { FullTickerV1CategoryAnalysisResult, SimilarTicker, TickerV1FastResponse
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import { Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, permanentRedirect } from 'next/navigation';
@@ -533,221 +532,121 @@ function getManagementTeamVerdictBadgeClasses(verdict: ManagementTeamAlignmentVe
   }
 }
 
-function TickerAnalysisInfo({ data }: { data: Promise<TickerV1FastResponse> }): JSX.Element {
+const CATEGORY_DETAIL_LINKS: Record<TickerAnalysisCategory, { href: (exchange: string, symbol: string) => string; label: string }> = {
+  [TickerAnalysisCategory.BusinessAndMoat]: {
+    href: (exchange, symbol) => `/stocks/${exchange}/${symbol}/business-and-moat`,
+    label: 'View Detailed Analysis →',
+  },
+  [TickerAnalysisCategory.FinancialStatementAnalysis]: {
+    href: (exchange, symbol) => `/stocks/${exchange}/${symbol}/financial-statement-analysis`,
+    label: 'View Detailed Analysis →',
+  },
+  [TickerAnalysisCategory.PastPerformance]: {
+    href: (exchange, symbol) => `/stocks/${exchange}/${symbol}/past-performance`,
+    label: 'View Detailed Analysis →',
+  },
+  [TickerAnalysisCategory.FutureGrowth]: {
+    href: (exchange, symbol) => `/stocks/${exchange}/${symbol}/future-performance`,
+    label: 'Show Detailed Future Analysis →',
+  },
+  [TickerAnalysisCategory.FairValue]: {
+    href: (exchange, symbol) => `/stocks/${exchange}/${symbol}/fair-value`,
+    label: 'View Detailed Fair Value →',
+  },
+};
+
+function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCategory; d: TickerV1FastResponse }): JSX.Element {
+  const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
+  const link = CATEGORY_DETAIL_LINKS[categoryKey];
+  return (
+    <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-lg font-semibold">{CATEGORY_MAPPINGS[categoryKey]}</h3>
+          {categoryResult && (
+            <div
+              className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
+              style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
+            >
+              {categoryResult.factorResults?.filter((fr) => fr.result === EvaluationResult.Pass).length || 0}/5
+            </div>
+          )}
+          {categoryResult?.updatedAt && <AdminTimestamp date={categoryResult.updatedAt} />}
+        </div>
+        <Link
+          href={link.href(d.exchange.toUpperCase(), d.symbol.toUpperCase())}
+          className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+          style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
+        >
+          {link.label}
+        </Link>
+      </div>
+      <div
+        className="text-gray-300 markdown markdown-body"
+        dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult?.overallAnalysisDetails || 'No summary available.') }}
+      />
+    </div>
+  );
+}
+
+function TickerAnalysisInfo({
+  data,
+  competitionPromise,
+  exchange,
+  ticker,
+}: {
+  data: Promise<TickerV1FastResponse>;
+  competitionPromise: Promise<CompetitionResponse | null>;
+  exchange: string;
+  ticker: string;
+}): JSX.Element {
   const d: TickerV1FastResponse = use(data);
   const managementTeamReport = d.managementTeamReports?.[0];
 
   return (
-    <>
-      <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-8 sm:py-6" itemProp="abstract">
-        <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Summary Analysis</h2>
-        <div className="space-y-4">
-          {Object.values(TickerAnalysisCategory).map((categoryKey: TickerAnalysisCategory) => {
-            const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
-            return (
-              <div key={categoryKey} className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
-                <div
-                  className={`flex items-center gap-2 mb-2 ${
-                    categoryKey === TickerAnalysisCategory.BusinessAndMoat ||
-                    categoryKey === TickerAnalysisCategory.FinancialStatementAnalysis ||
-                    categoryKey === TickerAnalysisCategory.PastPerformance ||
-                    categoryKey === TickerAnalysisCategory.FutureGrowth ||
-                    categoryKey === TickerAnalysisCategory.FairValue
-                      ? 'justify-between'
-                      : ''
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <h3 className="text-lg font-semibold">{CATEGORY_MAPPINGS[categoryKey]}</h3>
-                    {categoryResult && (
-                      <div
-                        className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
-                        style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
-                      >
-                        {categoryResult.factorResults?.filter((fr) => fr.result === EvaluationResult.Pass).length || 0}/5
-                      </div>
-                    )}
-                    {categoryResult?.updatedAt && <AdminTimestamp date={categoryResult.updatedAt} />}
-                  </div>
+    <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-8 sm:py-6" itemProp="abstract">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Summary Analysis</h2>
+      <div className="space-y-4">
+        <CategorySummaryCard categoryKey={TickerAnalysisCategory.BusinessAndMoat} d={d} />
 
-                  {categoryKey === TickerAnalysisCategory.BusinessAndMoat && (
-                    <Link
-                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/business-and-moat`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
-                    >
-                      View Detailed Analysis →
-                    </Link>
-                  )}
+        <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
 
-                  {categoryKey === TickerAnalysisCategory.FinancialStatementAnalysis && (
-                    <Link
-                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/financial-statement-analysis`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
-                    >
-                      View Detailed Analysis →
-                    </Link>
-                  )}
-
-                  {categoryKey === TickerAnalysisCategory.PastPerformance && (
-                    <Link
-                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/past-performance`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
-                    >
-                      View Detailed Analysis →
-                    </Link>
-                  )}
-
-                  {categoryKey === TickerAnalysisCategory.FutureGrowth && (
-                    <Link
-                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/future-performance`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
-                    >
-                      Show Detailed Future Analysis →
-                    </Link>
-                  )}
-
-                  {categoryKey === TickerAnalysisCategory.FairValue && (
-                    <Link
-                      href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/fair-value`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                      style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
-                    >
-                      View Detailed Fair Value →
-                    </Link>
-                  )}
-                </div>
-                <div
-                  className="text-gray-300 markdown markdown-body"
-                  dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult?.overallAnalysisDetails || 'No summary available.') }}
-                />
-              </div>
-            );
-          })}
-          <div key="management-team-summary" className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
-            <div className="flex items-center justify-between gap-2 mb-2">
-              <div className="flex items-center gap-2">
+        {managementTeamReport && (
+          <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <h3 className="text-lg font-semibold">Management Team Experience &amp; Alignment</h3>
-                {managementTeamReport && (
-                  <span
-                    className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getManagementTeamVerdictBadgeClasses(
-                      managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict
-                    )}`}
-                  >
-                    {MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS[managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict] ||
-                      managementTeamReport.alignmentVerdict}
-                  </span>
-                )}
-                {managementTeamReport?.updatedAt && <AdminTimestamp date={managementTeamReport.updatedAt} />}
-              </div>
-              {managementTeamReport && (
-                <Link
-                  href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/management-team`}
-                  className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
-                  style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
+                <span
+                  className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getManagementTeamVerdictBadgeClasses(
+                    managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict
+                  )}`}
                 >
-                  View Detailed Analysis →
-                </Link>
-              )}
+                  {MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS[managementTeamReport.alignmentVerdict as ManagementTeamAlignmentVerdict] ||
+                    managementTeamReport.alignmentVerdict}
+                </span>
+                {managementTeamReport.updatedAt && <AdminTimestamp date={managementTeamReport.updatedAt} />}
+              </div>
+              <Link
+                href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/management-team`}
+                className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
+              >
+                View Detailed Analysis →
+              </Link>
             </div>
             <div
               className="text-gray-300 markdown markdown-body"
-              dangerouslySetInnerHTML={{ __html: parseMarkdown(managementTeamReport?.summary || 'No summary available.') }}
+              dangerouslySetInnerHTML={{ __html: parseMarkdown(managementTeamReport.summary || 'No summary available.') }}
             />
           </div>
-        </div>
-      </section>
-    </>
-  );
-}
+        )}
 
-function TickerDetailsInfo({ data }: { data: Promise<TickerV1FastResponse> }): JSX.Element {
-  const d: TickerV1FastResponse = use(data);
-
-  // Question-based category mappings for better SEO
-  const CATEGORY_QUESTION_MAPPINGS = {
-    [TickerAnalysisCategory.BusinessAndMoat]: `Does ${d.name} Have a Strong Business Model and Competitive Moat?`,
-    [TickerAnalysisCategory.FinancialStatementAnalysis]: `How Strong Are ${d.name}'s Financial Statements?`,
-    [TickerAnalysisCategory.PastPerformance]: `How Has ${d.name} Performed Historically?`,
-    [TickerAnalysisCategory.FutureGrowth]: `What Are ${d.name}'s Future Growth Prospects?`,
-    [TickerAnalysisCategory.FairValue]: `Is ${d.name} Fairly Valued?`,
-  };
-
-  // Filter out categories that have their own dedicated detail pages
-  const categoriesToShow = Object.values(TickerAnalysisCategory).filter(
-    (key) =>
-      key !== TickerAnalysisCategory.BusinessAndMoat &&
-      key !== TickerAnalysisCategory.FinancialStatementAnalysis &&
-      key !== TickerAnalysisCategory.PastPerformance &&
-      key !== TickerAnalysisCategory.FutureGrowth &&
-      key !== TickerAnalysisCategory.FairValue
-  );
-
-  return (
-    <>
-      <section id="detailed-analysis" className="mb-8" itemProp="articleBody">
-        <h2 className="text-2xl font-bold mb-6">Detailed Analysis</h2>
-
-        {categoriesToShow.map((categoryKey: TickerAnalysisCategory) => {
-          const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
-          if (!categoryResult) return null;
-
-          return (
-            <div key={`detail-${categoryKey}`} id={`detailed-${categoryKey}`} className="bg-gray-900 rounded-lg shadow-sm px-2 py-4 sm:p-6 mb-8">
-              <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
-                <h3 className="text-xl font-bold">{CATEGORY_QUESTION_MAPPINGS[categoryKey]}</h3>
-                <div
-                  className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
-                  style={{ backgroundColor: 'var(--primary-color, #3b82f6)', color: 'white' }}
-                >
-                  {categoryResult.factorResults?.filter((fr) => fr.result === EvaluationResult.Pass).length || 0}/5
-                </div>
-                {categoryResult.updatedAt && <AdminTimestamp date={categoryResult.updatedAt} />}
-              </div>
-
-              {categoryResult.summary && (
-                <div className="mb-4">
-                  <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult.summary) }} />
-                </div>
-              )}
-
-              {categoryResult.factorResults?.length ? (
-                <ul className="space-y-3">
-                  {categoryResult.factorResults.map((factor) => (
-                    <li key={factor.id} className="bg-gray-800 px-2 py-4 sm:p-4 rounded-md">
-                      <div className="flex flex-col gap-y-2">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            {factor.result === EvaluationResult.Pass ? (
-                              <CheckCircleIcon className="h-6 w-6 text-green-500 flex-shrink-0" />
-                            ) : (
-                              <XCircleIcon className="h-6 w-6 text-red-500 flex-shrink-0" />
-                            )}
-                            <h4 className="font-semibold">{factor.analysisCategoryFactor?.factorAnalysisTitle}</h4>
-                          </div>
-                          <span
-                            className={`px-2 py-1 rounded-full text-sm font-medium ${
-                              factor.result === EvaluationResult.Pass ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'
-                            }`}
-                          >
-                            {factor.result}
-                          </span>
-                        </div>
-                        <p className="text-sm text-gray-400">{factor.oneLineExplanation}</p>
-                        <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(factor.detailedExplanation) }} />
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </div>
-          );
-        })}
-      </section>
-    </>
+        <CategorySummaryCard categoryKey={TickerAnalysisCategory.FinancialStatementAnalysis} d={d} />
+        <CategorySummaryCard categoryKey={TickerAnalysisCategory.PastPerformance} d={d} />
+        <CategorySummaryCard categoryKey={TickerAnalysisCategory.FutureGrowth} d={d} />
+        <CategorySummaryCard categoryKey={TickerAnalysisCategory.FairValue} d={d} />
+      </div>
+    </section>
   );
 }
 
@@ -854,15 +753,11 @@ export default async function TickerDetailsPage({ params }: { params: RouteParam
         </Suspense>
 
         {/* Analysis info - server rendered, no skeleton needed */}
-        <TickerAnalysisInfo data={tickerInfo} />
+        <TickerAnalysisInfo data={tickerInfo} competitionPromise={competitionPromise} exchange={exchange} ticker={ticker} />
 
         <section className="mb-6">
           <SimilarTickers dataPromise={similarPromise} />
         </section>
-
-        <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
-
-        <TickerDetailsInfo data={tickerInfo} />
 
         <TickerArticleFooter modifiedDate={modifiedDate} formattedModifiedDate={formattedModifiedDate} />
       </article>

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -58,9 +58,9 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
   }
 
   return (
-    <section id="competition" className="mb-8">
+    <section id="competition">
       <div className="bg-gray-900 rounded-lg shadow-sm p-3 sm:p-6">
-        <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-700">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-gray-700">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link
             href={`/stocks/${exchange}/${ticker}/competition`}


### PR DESCRIPTION
## Summary

- Reorder Summary Analysis: Business & Moat → Competition chart → Management Team (only when present) → Financial Statement Analysis → Past Performance → Future Growth → Fair Value
- Remove the empty Detailed Analysis heading (TickerDetailsInfo's filter dropped all enum values, leaving the heading with no content)
- Make summary-card headers and the Competition card header use `flex-wrap` so the View Detailed Analysis / View Full Analysis buttons drop to a new line when the screen is too narrow
- Hide the Management Team summary card entirely when no report is present (no orphan heading)

## Test plan

- [ ] Visit a stock with a management-team report (e.g. NYSE/NOC) — Management Team card appears between Competition and Financial Statement Analysis
- [ ] Visit a stock without a management-team report — no Management Team card and no orphan heading
- [ ] Resize to mobile width — section buttons wrap to a new line, no horizontal scroll
- [ ] Confirm there is no empty "Detailed Analysis" heading just above the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)