### PR TITLE
scenarios: add 10 baggers, single summary field, admin cache-flush chrome

### DIFF
--- a/docs/insights-ui/scenario-authoring.md
+++ b/docs/insights-ui/scenario-authoring.md
@@ -63,21 +63,23 @@ A scenario is not done until every section below is populated with concrete numb
 - **EXCHANGE:SYMBOL** (+N%, <timeframe + priced-in bucket>) — <1–2 sentences on why
   this name is positioned to outperform under this scenario. Include exposure %,
   pricing-power lever, or earnings sensitivity if known.>
-- ... (exactly 5 names — see "Five winners, five losers" convention below)
+- ... (target 5 names; never exceed 7–8 — see convention section below)
 
 **Losers**
 - **EXCHANGE:SYMBOL** (-N%, <timeframe + priced-in bucket>) — <as above, but downside>
-- ... (exactly 5 names)
+- ... (target 5 names; OK to ship fewer if no clean candidates)
 
 **10 Baggers**    <!-- Stock scenarios only. Optional: omit for ETF scenarios
   and for stock scenarios where no plausible 10x candidate exists. -->
-- **EXCHANGE:SYMBOL** (+N%, <timeframe + priced-in bucket>) — <1–2 sentences on
+- **EXCHANGE:SYMBOL** (+N%, <timeframe to 10x>, not priced in) — <1–2 sentences on
   why this small/micro-cap could 5–10x under this scenario. Reference the
   value-chain layer it sits in (e.g., upstream miner, contract manufacturer)
   and the specific catalyst that would re-rate it.>
-- ... (exactly 5 names; the % can exceed +100, e.g. +500 to +900 for a 10x.
-  Use NOT_PRICED_IN as the bucket — if a name is already partially priced in
-  for a 10x, it doesn't belong here.)
+- ... (target 5 names; OK to ship fewer. The % can exceed +100, e.g. +500 to
+  +900 for a 10x. Always use NOT_PRICED_IN as the bucket — if a name is
+  already partially priced in for a 10x, it doesn't belong here. The
+  parenthetical MUST include an explicit timeframe to 10x, e.g. "36–60 months",
+  so a reader can size the holding period against the magnitude.)
 
 **Countries:** USA, Canada    <!-- Stock scenarios only. Comma-separated list of
   SupportedCountries. Omit for ETF scenarios. -->
@@ -89,27 +91,41 @@ A scenario is not done until every section below is populated with concrete numb
   `docs/insights-ui/scenario-prompts/detailed-analysis.md` to generate this.>
 ```
 
-### Five winners, five losers (and up to five 10 baggers) — convention, not a hard limit
+### Five winners, five losers, five 10 baggers — convention with a hard cap
 
 The schema does **not** enforce a count on link rows, and the public detail
-page renders every link the parser stores. By convention, every scenario
-should ship with **exactly five winners and five losers** — no more, no less.
-Stock scenarios may additionally ship with **up to five 10 baggers**:
+page renders every link the parser stores. The editorial target is **five
+winners, five losers, and (for stock scenarios) five 10 baggers** — short,
+ranked lists that read like trade ideas, not coverage tables. The rules below
+are soft on the floor and hard on the ceiling:
 
-- A short, ranked list reads like a trade idea; a long tail reads like noise.
-- The intent is editorial relevance, not coverage. If you're reaching for a
-  sixth name, drop the weakest existing one instead.
-- Broad diversified ETFs / index ETFs (SPY, QQQ, VTI) are usually the weakest
-  link when a more targeted sector / industry ETF would qualify.
-- Same rule applies to stock scenarios — pick the cleanest 5+5.
-- 10 Baggers is **stock-only and optional**: include up to 5 small/micro caps
-  with plausible 5–10x upside drawn from the value-chain layers in the
-  detailed analysis. ETF scenarios never carry this list — ETF holdings are
+- **Winners — try for 5, never exceed 7–8.** Five is the target. If a
+  scenario genuinely has more clear top names, you may stretch to 7 or 8 — but
+  **no more**. Past 8 the list stops being a ranked trade idea and becomes a
+  coverage list. Drop the weakest pick before adding another.
+- **Losers — try for 5, fewer is fine.** Aim for 5; if the scenario doesn't
+  surface 5 clean loser candidates, ship what you have rather than padding
+  with marginal names. Two strong losers beats five weak ones.
+- **10 baggers (stock-only, optional) — try for 5, fewer is fine; each bullet
+  must state the timeframe to 10x.** Include up to 5 small/micro caps with
+  plausible 5–10x upside drawn from the value-chain layers in the detailed
+  analysis. Each bullet **must include the timeframe over which the 10x
+  thesis is expected to play out** (e.g. "36–60 months" inside the per-stock
+  parenthetical) so a reader can size the holding-period requirement against
+  the magnitude. ETF scenarios never carry this list — ETF holdings are
   pre-diversified, so a per-name 10x call would be misleading. Skip the
   section entirely if no candidate clears the bar.
+- **Always save partial sets.** Don't block a draft because you couldn't find
+  exactly 5 of every category. Save what you have — a scenario with 5 winners
+  and 2 losers is acceptable; a scenario with 5 winners and 3 ten baggers is
+  acceptable; a scenario with 9 winners is not.
+- **Broad diversified ETFs / index ETFs** (SPY, QQQ, VTI) are usually the
+  weakest link in an ETF scenario when a more targeted sector / industry ETF
+  would qualify; same instinct applies to mega-cap diversified names in stock
+  scenario winner lists.
 
 Claude Code (and any human author) MUST respect this convention when drafting
-or revising a scenario, even though no code path will reject a 7-winner list.
+or revising a scenario, even though no code path will reject a 9-winner list.
 The same convention is reiterated as a comment at the top of
 `insights-ui/src/scripts/import-etf-scenarios.ts` and
 `insights-ui/src/scripts/import-stock-scenarios.ts`.
@@ -162,8 +178,8 @@ A scenario is ready to import when:
 - Every required section is populated (no TODOs, no `<...>` placeholders).
 - The summary section names specific dates and at least one headline number.
 - Every per-industry impact in the summary has a numerical range (% margin, % revenue, $ amount, basis points — pick what fits).
-- Winners and losers each have **exactly 5** names with `EXCHANGE:SYMBOL` qualifiers; bullet form (with `(±N%, ...)` per stock) is preferred over inline form. See "Five winners, five losers" above.
-- For stock scenarios where 10 Baggers is included: **up to 5** small/micro-cap names, drawn from the value-chain layers of the detailed analysis, each with NOT_PRICED_IN bucket and a +500 to +2000% bullet. Skip the section entirely if no candidate clears the bar.
+- Winners aim for **5** names (hard cap **7–8**); losers aim for **5** but fewer is OK. Use bullet form (with `(±N%, ...)` per stock) — it carries the per-stock price target and explanation; inline form does not.
+- For stock scenarios where 10 Baggers is included: aim for **5** small/micro-cap names (fewer is OK), drawn from the value-chain layers of the detailed analysis, each with NOT_PRICED_IN bucket, a +500 to +2000% bullet, and an explicit **timeframe to 10x** in the parenthetical (e.g. "36–60 months"). Skip the section entirely if no candidate clears the bar.
 - The historical analog folded into the summary is a real, datable episode — not a hand-wave.
 - The outlook paragraph (also folded into the summary) is dated and states both probability and timeframe in language the parser recognizes.
 - Detailed analysis is either absent (acceptable) or follows the structure in `docs/insights-ui/scenario-prompts/detailed-analysis.md` — never a thin one-paragraph stub.

--- a/insights-ui/src/app/etf-scenarios/[slug]/EtfScenarioDetailActions.tsx
+++ b/insights-ui/src/app/etf-scenarios/[slug]/EtfScenarioDetailActions.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { revalidateEtfScenarioCache } from '@/utils/cache-actions';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+interface Props {
+  slug: string;
+}
+
+export default function EtfScenarioDetailActions({ slug }: Props) {
+  const router = useRouter();
+
+  const actions: EllipsisDropdownItem[] = [
+    { key: 'manage-scenarios', label: 'Manage Scenarios' },
+    { key: 'revalidate-detail-cache', label: "Revalidate This Scenario's Cache" },
+  ];
+
+  return (
+    <PrivateWrapper>
+      <EllipsisDropdown
+        items={actions}
+        className="px-2 py-2"
+        onSelect={async (key) => {
+          if (key === 'manage-scenarios') {
+            router.push('/admin-v1/etf-scenarios');
+            return;
+          }
+
+          if (key === 'revalidate-detail-cache') {
+            await revalidateEtfScenarioCache(slug);
+            router.refresh();
+            return;
+          }
+        }}
+      />
+    </PrivateWrapper>
+  );
+}

--- a/insights-ui/src/app/etf-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/etf-scenarios/[slug]/page.tsx
@@ -1,11 +1,12 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import type { EtfScenarioDetail } from '@/app/api/[spaceId]/etf-scenarios/[slug]/route';
+import EtfScenarioDetailActions from '@/app/etf-scenarios/[slug]/EtfScenarioDetailActions';
 import EtfScenarioDetailView from '@/components/etf-scenarios/EtfScenarioDetailView';
 import EtfScenarioPageLayout from '@/components/etf-scenarios/EtfScenarioPageLayout';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { etfScenarioBySlugTag } from '@/utils/etf-scenario-cache-utils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { humanizeScenarioSlug } from '@/utils/scenario-slug';
 import {
   generateEtfScenarioDetailArticleJsonLd,
   generateEtfScenarioDetailBreadcrumbJsonLd,
@@ -56,8 +57,27 @@ export default async function EtfScenarioDetailPage({ params }: { params: RouteP
   const { slug } = await params;
   const scenario = await fetchScenarioBySlug(slug);
 
+  // Render the layout chrome (breadcrumbs + 3-dot admin menu + title)
+  // unconditionally so that when the upstream fetch fails or the cache is
+  // stuck on a "not found" response, an admin can still reach the
+  // "Revalidate This Scenario's Cache" action and recover the page.
   if (!scenario) {
-    notFound();
+    const fallbackTitle = humanizeScenarioSlug(slug);
+    const breadcrumbs = [
+      { name: 'US ETFs', href: '/etfs', current: false },
+      { name: 'Scenarios', href: '/etf-scenarios', current: false },
+      { name: fallbackTitle, href: `/etf-scenarios/${slug}`, current: true },
+    ];
+    return (
+      <EtfScenarioPageLayout breadcrumbs={breadcrumbs} title={fallbackTitle} rightButton={<EtfScenarioDetailActions slug={slug} />}>
+        <div className="block-bg-color text-color rounded-md p-6">
+          <p className="mb-2 font-semibold">This scenario page is currently unavailable.</p>
+          <p className="text-sm opacity-80">
+            The most common cause is a stale cache entry. Admins can use the menu in the top right to revalidate this scenario&apos;s cache and reload the page.
+          </p>
+        </div>
+      </EtfScenarioPageLayout>
+    );
   }
 
   const breadcrumbs = [
@@ -67,7 +87,7 @@ export default async function EtfScenarioDetailPage({ params }: { params: RouteP
   ];
 
   return (
-    <EtfScenarioPageLayout breadcrumbs={breadcrumbs}>
+    <EtfScenarioPageLayout breadcrumbs={breadcrumbs} rightButton={<EtfScenarioDetailActions slug={scenario.slug} />}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/insights-ui/src/app/stock-scenarios/[slug]/StockScenarioDetailActions.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/StockScenarioDetailActions.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { revalidateStockScenarioCache } from '@/utils/cache-actions';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+interface Props {
+  slug: string;
+}
+
+export default function StockScenarioDetailActions({ slug }: Props) {
+  const router = useRouter();
+
+  const actions: EllipsisDropdownItem[] = [
+    { key: 'manage-scenarios', label: 'Manage Scenarios' },
+    { key: 'revalidate-detail-cache', label: "Revalidate This Scenario's Cache" },
+  ];
+
+  return (
+    <PrivateWrapper>
+      <EllipsisDropdown
+        items={actions}
+        className="px-2 py-2"
+        onSelect={async (key) => {
+          if (key === 'manage-scenarios') {
+            router.push('/admin-v1/stock-scenarios');
+            return;
+          }
+
+          if (key === 'revalidate-detail-cache') {
+            await revalidateStockScenarioCache(slug);
+            router.refresh();
+            return;
+          }
+        }}
+      />
+    </PrivateWrapper>
+  );
+}

--- a/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import type { StockScenarioDetail } from '@/app/api/[spaceId]/stock-scenarios/[slug]/route';
+import StockScenarioDetailActions from '@/app/stock-scenarios/[slug]/StockScenarioDetailActions';
 import StockScenarioDetailView from '@/components/stock-scenarios/StockScenarioDetailView';
 import StockScenarioPageLayout from '@/components/stock-scenarios/StockScenarioPageLayout';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { humanizeScenarioSlug } from '@/utils/scenario-slug';
 import { stockScenarioBySlugTag } from '@/utils/stock-scenario-cache-utils';
 import {
   generateStockScenarioDetailArticleJsonLd,
@@ -56,8 +57,27 @@ export default async function StockScenarioDetailPage({ params }: { params: Rout
   const { slug } = await params;
   const scenario = await fetchScenarioBySlug(slug);
 
+  // Render the layout chrome (breadcrumbs + 3-dot admin menu + title)
+  // unconditionally so that when the upstream fetch fails or the cache is
+  // stuck on a "not found" response, an admin can still reach the
+  // "Revalidate This Scenario's Cache" action and recover the page.
   if (!scenario) {
-    notFound();
+    const fallbackTitle = humanizeScenarioSlug(slug);
+    const breadcrumbs = [
+      { name: 'Stocks', href: '/stocks', current: false },
+      { name: 'Scenarios', href: '/stock-scenarios', current: false },
+      { name: fallbackTitle, href: `/stock-scenarios/${slug}`, current: true },
+    ];
+    return (
+      <StockScenarioPageLayout breadcrumbs={breadcrumbs} title={fallbackTitle} rightButton={<StockScenarioDetailActions slug={slug} />}>
+        <div className="block-bg-color text-color rounded-md p-6">
+          <p className="mb-2 font-semibold">This scenario page is currently unavailable.</p>
+          <p className="text-sm opacity-80">
+            The most common cause is a stale cache entry. Admins can use the menu in the top right to revalidate this scenario&apos;s cache and reload the page.
+          </p>
+        </div>
+      </StockScenarioPageLayout>
+    );
   }
 
   const breadcrumbs = [
@@ -67,7 +87,7 @@ export default async function StockScenarioDetailPage({ params }: { params: Rout
   ];
 
   return (
-    <StockScenarioPageLayout breadcrumbs={breadcrumbs}>
+    <StockScenarioPageLayout breadcrumbs={breadcrumbs} rightButton={<StockScenarioDetailActions slug={scenario.slug} />}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/insights-ui/src/scripts/import-etf-scenarios.ts
+++ b/insights-ui/src/scripts/import-etf-scenarios.ts
@@ -1,9 +1,10 @@
 // Editorial convention (NOT enforced by the schema or this script):
-// every ETF scenario ships with EXACTLY 5 winners and 5 losers. The DB will
-// happily accept more, but the public detail page is curated as a ranked
-// trade idea, not a coverage list. Drop the weakest existing pick before
-// adding a sixth. Broad diversified ETFs (SPY, QQQ, VTI) are usually the
-// weakest link when a more targeted sector ETF exists. See
+// target 5 winners and 5 losers. Winners are soft-floored at 5 with a HARD
+// cap at 7–8 — never exceed 8. Losers are soft-floored at 5 but acceptable
+// to ship fewer if no clean candidates exist. ETF scenarios never carry the
+// "10 Baggers" list (ETF holdings are pre-diversified, so a per-name 10x
+// call would be misleading). Broad diversified ETFs (SPY, QQQ, VTI) are
+// usually the weakest link when a more targeted sector ETF exists. See
 // `docs/insights-ui/scenario-authoring.md` for the full convention and
 // `docs/insights-ui/scenario-prompts/detailed-analysis.md` for the prompt
 // used to author the optional `detailedAnalysis` long-form section.

--- a/insights-ui/src/scripts/import-stock-scenarios.ts
+++ b/insights-ui/src/scripts/import-stock-scenarios.ts
@@ -1,7 +1,10 @@
 // Editorial convention (NOT enforced by the schema or this script):
-// every stock scenario ships with EXACTLY 5 winners and 5 losers, plus
-// optionally up to 5 "10 Baggers". See
-// `docs/insights-ui/scenario-authoring.md` for the full convention.
+// target 5 winners, 5 losers, and (optionally) 5 "10 Baggers". Winners are
+// soft-floored at 5 with a HARD cap at 7–8 — never exceed 8. Losers and
+// 10 baggers are soft-floored at 5 but acceptable to ship fewer if no clean
+// candidates exist. Each 10-bagger bullet must state the timeframe to 10x
+// in its parenthetical. See `docs/insights-ui/scenario-authoring.md` for the
+// full convention.
 import 'dotenv/config';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';

--- a/insights-ui/src/utils/scenario-slug.ts
+++ b/insights-ui/src/utils/scenario-slug.ts
@@ -6,3 +6,17 @@ export function slugifyScenarioTitle(title: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');
 }
+
+// Best-effort reverse of `slugifyScenarioTitle` used when the actual scenario
+// row is unavailable (failed fetch, stale "not found" cache) and we still
+// want a readable title in the page chrome so admins can flush the cache.
+// The original title is lost in slugification — punctuation and capitalization
+// can't be perfectly recovered — so this is intentionally just a humanized
+// approximation.
+export function humanizeScenarioSlug(slug: string): string {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- **10 Baggers (stock-only)**: third structured list parallel to Winners/Losers, with `TEN_BAGGER` role and required timeframe-to-10x.
- **Editorial convention**: target 5 winners / 5 losers / 5 ten-baggers; hard cap winners at 7-8; partial sets are fine — codified in `scenario-authoring.md` and import-script comments.
- **Single summary field**: collapsed `underlyingCause` / `historicalAnalog` / `outlookMarkdown` into one `summary` field (Prisma migration + zod + parser updates) so authors don't have to chunk a single narrative across three columns.
- **Always-rendered admin chrome**: stock and ETF detail pages now render breadcrumbs + 3-dot admin menu + title even when the upstream fetch fails, so a stale "not found" cache entry can be flushed via "Revalidate This Scenario's Cache" instead of leaving the page permanently dead.
- **ETF detail cap**: limit ETF scenario detail page to top 5 winners / top 5 losers.
- **Prompt updates**: value-chain expanded to 8-10 paragraphs; stock-only Paragraph C + 10 Baggers section; tilde-as-approximately ban.

## Test plan
- [x] `yarn lint && yarn prettier-check && yarn compile` clean
- [ ] Verify a stock scenario detail page (e.g., `/stock-scenarios/<slug>`) renders breadcrumbs + 3-dot menu when the slug is unknown
- [ ] As an admin, "Revalidate This Scenario's Cache" recovers a cached not-found page
- [ ] Verify TEN_BAGGER bullets render with timeframe in detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)