### PR TITLE
parseMarkdown: escape tildes so ~text~ doesn't render as strikethrough

### DIFF
--- a/insights-ui/src/util/parse-markdown.ts
+++ b/insights-ui/src/util/parse-markdown.ts
@@ -4,6 +4,14 @@ import { marked } from 'marked';
 
 const renderer = getMarkedRenderer();
 
+// GFM treats ~text~ / ~~text~~ as strikethrough. Tildes show up in our content
+// (math approximations like ~$5B, file paths, etc.) and shouldn't be struck
+// through. Swap them for the numeric HTML entity before parsing so marked
+// leaves them alone but the rendered output still shows a literal "~".
+function escapeTildes(text: string): string {
+  return text.replace(/~/g, '&#126;');
+}
+
 export function parseMarkdown(text: string) {
-  return marked.parse(recursivelyCleanOpenAiUrls(text), { renderer });
+  return marked.parse(escapeTildes(recursivelyCleanOpenAiUrls(text)), { renderer });
 }


### PR DESCRIPTION
## Summary
- GFM strikethrough was eating literal tildes (e.g. \`~$5B\`, file paths) in scenario summaries and similar copy
- Pre-escapes \`~\` to the HTML entity \`&#126;\` inside the shared \`parseMarkdown\` helper before handing the string to \`marked.parse\`
- Fix lives in one place — automatically applies to all 55 callsites that already use \`parseMarkdown\`

## Test plan
- [ ] Visually confirm a scenario page (or any markdown-rendered page) no longer strikes through text wrapped in single/double tildes
- [ ] Confirm tilde still renders as a literal "~" in the output