### PR TITLE
stocks SEO: unblock /_next/, dedupe h1, sibling links, sitemap hygiene

### DIFF
--- a/insights-ui/src/app/robots.ts
+++ b/insights-ui/src/app/robots.ts
@@ -7,8 +7,10 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        // Let Google crawl but we ALSO noindex via meta/header as above
-        disallow: ['/public-equities', '/api', '/_next/'],
+        // Do NOT block /_next/ — Googlebot needs to fetch /_next/static/* (CSS/JS) and
+        // /_next/image (optimized images, including the logo) to render pages correctly.
+        // Blocking it strips styling and breaks images in Search Console's URL Inspection.
+        disallow: ['/public-equities', '/api'],
       },
     ],
     sitemap: 'https://koalagains.com/sitemap_index.xml',

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -226,7 +226,14 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
           </div>
         </section>
 
-        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug="management-team" />
+        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
+        <TickerRelatedSections
+          tickerId={tickerData.id}
+          exchange={tickerData.exchange}
+          symbol={tickerData.symbol}
+          companyName={tickerData.name}
+          currentSlug="management-team"
+        />
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -1,4 +1,5 @@
 import AdminTimestamp from '@/components/auth/AdminTimestamp';
+import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS, ManagementTeamAlignmentVerdict } from '@/types/ticker-typesv1';
@@ -224,6 +225,8 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
             <div className="markdown markdown-body text-gray-300" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.detailedAnalysis) }} />
           </div>
         </section>
+
+        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug="management-team" />
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -1,5 +1,5 @@
 import AdminTimestamp from '@/components/auth/AdminTimestamp';
-import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
+import TickerRelatedSections, { getAvailableSiblingSlugs } from '@/components/ticker-reportsv1/TickerRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS, ManagementTeamAlignmentVerdict } from '@/types/ticker-typesv1';
@@ -14,6 +14,7 @@ import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, permanentRedirect } from 'next/navigation';
+import { Suspense } from 'react';
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -188,6 +189,10 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
   const verdict = report.alignmentVerdict as ManagementTeamAlignmentVerdict;
   const verdictLabel = MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS[verdict] || report.alignmentVerdict;
 
+  // Kick off the sibling-presence query in parallel with the rest of render.
+  // The Promise is unwrapped via `use()` inside <TickerRelatedSections>, suspended by the boundary below.
+  const availableSlugsPromise = getAvailableSiblingSlugs(tickerData.id);
+
   return (
     <PageWrapper>
       <script
@@ -226,14 +231,15 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
           </div>
         </section>
 
-        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
-        <TickerRelatedSections
-          tickerId={tickerData.id}
-          exchange={tickerData.exchange}
-          symbol={tickerData.symbol}
-          companyName={tickerData.name}
-          currentSlug="management-team"
-        />
+        <Suspense fallback={null}>
+          <TickerRelatedSections
+            availableSlugsPromise={availableSlugsPromise}
+            exchange={tickerData.exchange}
+            symbol={tickerData.symbol}
+            companyName={tickerData.name}
+            currentSlug="management-team"
+          />
+        </Suspense>
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
@@ -18,6 +18,9 @@ async function generateBusinessAndMoatUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.BusinessAndMoat,
+      // Only include URLs whose analysis has actual content. Empty/placeholder
+      // records produce thin pages that GSC marks "Crawled - currently not indexed".
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
@@ -18,9 +18,12 @@ async function generateBusinessAndMoatUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.BusinessAndMoat,
-      // Only include URLs whose analysis has actual content. Empty/placeholder
-      // records produce thin pages that GSC marks "Crawled - currently not indexed".
+      // Mirror the page body: include only URLs whose Executive Summary
+      // (`summary`) AND Comprehensive Analysis (`overallAnalysisDetails`) are
+      // both populated. Either being empty leaves the page thin and GSC marks
+      // it "Crawled - currently not indexed".
       summary: { not: '' },
+      overallAnalysisDetails: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
@@ -14,7 +14,13 @@ async function generateCompetitionUrls(): Promise<SiteMapUrl[]> {
   const urls: SiteMapUrl[] = [];
 
   const competitionRecords = await prisma.tickerV1VsCompetition.findMany({
-    where: { spaceId: KoalaGainsSpaceId, summary: { not: '' } },
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      // The competition page renders `overallAnalysisDetails` (Comprehensive Analysis)
+      // and the competitorTickers cards — `summary` is never displayed. Filter on the
+      // field that actually drives the rendered body.
+      overallAnalysisDetails: { not: '' },
+    },
     select: {
       updatedAt: true,
       ticker: {

--- a/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
@@ -14,7 +14,7 @@ async function generateCompetitionUrls(): Promise<SiteMapUrl[]> {
   const urls: SiteMapUrl[] = [];
 
   const competitionRecords = await prisma.tickerV1VsCompetition.findMany({
-    where: { spaceId: KoalaGainsSpaceId },
+    where: { spaceId: KoalaGainsSpaceId, summary: { not: '' } },
     select: {
       updatedAt: true,
       ticker: {

--- a/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
@@ -18,6 +18,7 @@ async function generateFairValueUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FairValue,
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
@@ -18,7 +18,10 @@ async function generateFairValueUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FairValue,
+      // Both sections rendered by TickerCategoryReport must have content;
+      // either being empty produces a thin page (GSC "Crawled - currently not indexed").
       summary: { not: '' },
+      overallAnalysisDetails: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -18,7 +18,10 @@ async function generateFinancialStatementAnalysisUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FinancialStatementAnalysis,
+      // Both sections rendered by TickerCategoryReport must have content;
+      // either being empty produces a thin page (GSC "Crawled - currently not indexed").
       summary: { not: '' },
+      overallAnalysisDetails: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -18,6 +18,7 @@ async function generateFinancialStatementAnalysisUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FinancialStatementAnalysis,
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
@@ -18,6 +18,7 @@ async function generateFuturePerformanceUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FutureGrowth,
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
@@ -18,7 +18,10 @@ async function generateFuturePerformanceUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.FutureGrowth,
+      // Both sections rendered by TickerCategoryReport must have content;
+      // either being empty produces a thin page (GSC "Crawled - currently not indexed").
       summary: { not: '' },
+      overallAnalysisDetails: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -16,6 +16,7 @@ async function generateManagementTeamUrls(): Promise<SiteMapUrl[]> {
   const records = await prisma.tickerV1ManagementTeamReport.findMany({
     where: {
       spaceId: KoalaGainsSpaceId,
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -16,7 +16,10 @@ async function generateManagementTeamUrls(): Promise<SiteMapUrl[]> {
   const records = await prisma.tickerV1ManagementTeamReport.findMany({
     where: {
       spaceId: KoalaGainsSpaceId,
+      // The management-team page renders both `summary` and `detailedAnalysis`
+      // as markdown sections; either being empty makes the page thin.
       summary: { not: '' },
+      detailedAnalysis: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
@@ -18,7 +18,10 @@ async function generatePastPerformanceUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.PastPerformance,
+      // Both sections rendered by TickerCategoryReport must have content;
+      // either being empty produces a thin page (GSC "Crawled - currently not indexed").
       summary: { not: '' },
+      overallAnalysisDetails: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
@@ -18,6 +18,7 @@ async function generatePastPerformanceUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       categoryKey: TickerAnalysisCategory.PastPerformance,
+      summary: { not: '' },
     },
     select: {
       updatedAt: true,

--- a/insights-ui/src/components/ticker-reportsv1/BusinessAndMoat.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/BusinessAndMoat.tsx
@@ -25,6 +25,7 @@ export default function BusinessAndMoat({ tickerData, data }: BusinessAndMoatPro
       analysisTitle={analysisTitle}
       categoryBadgeText="Business & Moat"
       categoryBadgeClassName="bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300"
+      pageSlug="business-and-moat"
     />
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -1,12 +1,12 @@
 import { computeQuadrantScores, classifyStock, QuadrantDataPoint } from '@/util/quadrant-chart-utils';
 import CompetitionQuadrantChart from '@/components/ticker-reportsv1/CompetitionQuadrantChart';
 import CompetitorCard from '@/components/competition/CompetitorCard';
-import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
+import TickerRelatedSections, { getAvailableSiblingSlugs } from '@/components/ticker-reportsv1/TickerRelatedSections';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getCountryByExchange } from '@/utils/countryExchangeUtils';
 import type { CompetitionResponse } from '@/types/ticker-typesv1';
 import Link from 'next/link';
-import React from 'react';
+import React, { Suspense } from 'react';
 import AddTickerAdminButton from './AddTickerAdminButton';
 
 export interface CompetitionProps {
@@ -20,6 +20,10 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
   if (!tickerData || (!vsCompetition && (!competitorTickers || competitorTickers.length === 0))) {
     return null;
   }
+
+  // Kick off the sibling-presence query in parallel with the rest of render.
+  // The Promise is unwrapped via `use()` inside <TickerRelatedSections>, suspended by the boundary below.
+  const availableSlugsPromise = getAvailableSiblingSlugs(tickerData.id);
 
   // Derive dates from competition/ticker data
   const createdAtRaw = vsCompetition?.createdAt || data.ticker?.createdAt || new Date();
@@ -262,14 +266,15 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
           )}
         </div>
 
-        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
-        <TickerRelatedSections
-          tickerId={tickerData.id}
-          exchange={tickerData.exchange}
-          symbol={tickerData.symbol}
-          companyName={tickerData.name}
-          currentSlug="competition"
-        />
+        <Suspense fallback={null}>
+          <TickerRelatedSections
+            availableSlugsPromise={availableSlugsPromise}
+            exchange={tickerData.exchange}
+            symbol={tickerData.symbol}
+            companyName={tickerData.name}
+            currentSlug="competition"
+          />
+        </Suspense>
 
         {/* Article Footer */}
         <footer className="mt-8 pt-6 border-t border-color">

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -262,7 +262,14 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
           )}
         </div>
 
-        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug="competition" />
+        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
+        <TickerRelatedSections
+          tickerId={tickerData.id}
+          exchange={tickerData.exchange}
+          symbol={tickerData.symbol}
+          companyName={tickerData.name}
+          currentSlug="competition"
+        />
 
         {/* Article Footer */}
         <footer className="mt-8 pt-6 border-t border-color">

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -1,6 +1,7 @@
 import { computeQuadrantScores, classifyStock, QuadrantDataPoint } from '@/util/quadrant-chart-utils';
 import CompetitionQuadrantChart from '@/components/ticker-reportsv1/CompetitionQuadrantChart';
 import CompetitorCard from '@/components/competition/CompetitorCard';
+import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getCountryByExchange } from '@/utils/countryExchangeUtils';
 import type { CompetitionResponse } from '@/types/ticker-typesv1';
@@ -99,7 +100,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
             <div className="flex-1">
               <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-color mb-2" itemProp="headline">
-                {tickerData.name} <span className="text-muted-foreground">({ticker})</span>
+                {analysisTitle}
               </h1>
               <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
                 <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
@@ -123,13 +124,6 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
 
         {/* Article Body */}
         <div className="prose prose-invert max-w-none">
-          <section className="mb-6">
-            <h2 className="text-xl font-semibold text-color mb-3">Analysis Title</h2>
-            <p className="text-color" itemProp="description">
-              {analysisTitle}
-            </p>
-          </section>
-
           {quadrantDataPoints.length >= 2 ? (
             <section className="mb-6">
               <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
@@ -267,6 +261,8 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
             </section>
           )}
         </div>
+
+        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug="competition" />
 
         {/* Article Footer */}
         <footer className="mt-8 pt-6 border-t border-color">

--- a/insights-ui/src/components/ticker-reportsv1/FairValue.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FairValue.tsx
@@ -25,6 +25,7 @@ export default function FairValue({ tickerData, data }: FairValueProps): JSX.Ele
       analysisTitle={analysisTitle}
       categoryBadgeText="Fair Value"
       categoryBadgeClassName="bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300"
+      pageSlug="fair-value"
     />
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
@@ -25,6 +25,7 @@ export default function FinancialStatementAnalysis({ tickerData, data }: Financi
       analysisTitle={analysisTitle}
       categoryBadgeText="Financial Statements"
       categoryBadgeClassName="bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300"
+      pageSlug="financial-statement-analysis"
     />
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/FuturePerformance.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FuturePerformance.tsx
@@ -25,6 +25,7 @@ export default function FuturePerformance({ tickerData, data }: FuturePerformanc
       analysisTitle={analysisTitle}
       categoryBadgeText="Future Performance"
       categoryBadgeClassName="bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300"
+      pageSlug="future-performance"
     />
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/PastPerformance.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PastPerformance.tsx
@@ -25,6 +25,7 @@ export default function PastPerformance({ tickerData, data }: PastPerformancePro
       analysisTitle={analysisTitle}
       categoryBadgeText="Past Performance"
       categoryBadgeClassName="bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300"
+      pageSlug="past-performance"
     />
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
@@ -1,3 +1,4 @@
+import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
@@ -35,6 +36,8 @@ export interface TickerCategoryReportProps {
   analysisTitle: string;
   categoryBadgeText: string;
   categoryBadgeClassName: string;
+  /** Sub-page slug for sibling navigation (e.g. "business-and-moat"). */
+  pageSlug: string;
 }
 
 export default function TickerCategoryReport({
@@ -43,6 +46,7 @@ export default function TickerCategoryReport({
   analysisTitle,
   categoryBadgeText,
   categoryBadgeClassName,
+  pageSlug,
 }: TickerCategoryReportProps): JSX.Element | null {
   if (!tickerData || !categoryResult) {
     return null;
@@ -74,7 +78,7 @@ export default function TickerCategoryReport({
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
             <div className="flex-1">
               <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-color mb-2" itemProp="headline">
-                {tickerData.name} <span className="text-muted-foreground">({ticker})</span>
+                {analysisTitle}
               </h1>
               <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
                 <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
@@ -104,13 +108,6 @@ export default function TickerCategoryReport({
         </header>
 
         <div className="prose prose-invert max-w-none">
-          <section className="mb-6">
-            <h2 className="text-xl font-semibold text-color mb-3">Analysis Title</h2>
-            <p className="text-color" itemProp="description">
-              {analysisTitle}
-            </p>
-          </section>
-
           <section className="mb-6">
             <h2 className="text-xl font-semibold text-color mb-3">Executive Summary</h2>
             {categoryResult.summary ? (
@@ -163,6 +160,8 @@ export default function TickerCategoryReport({
             </section>
           )}
         </div>
+
+        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug={pageSlug} />
 
         <footer className="mt-8 pt-6 border-t border-color">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 const PASS_RESULT = 'Pass';
 
 type TickerDataLike = {
+  id: string;
   name: string;
   symbol: string;
   exchange: string;
@@ -161,7 +162,14 @@ export default function TickerCategoryReport({
           )}
         </div>
 
-        <TickerRelatedSections exchange={tickerData.exchange} symbol={tickerData.symbol} companyName={tickerData.name} currentSlug={pageSlug} />
+        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
+        <TickerRelatedSections
+          tickerId={tickerData.id}
+          exchange={tickerData.exchange}
+          symbol={tickerData.symbol}
+          companyName={tickerData.name}
+          currentSlug={pageSlug}
+        />
 
         <footer className="mt-8 pt-6 border-t border-color">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
@@ -1,8 +1,8 @@
-import TickerRelatedSections from '@/components/ticker-reportsv1/TickerRelatedSections';
+import TickerRelatedSections, { getAvailableSiblingSlugs } from '@/components/ticker-reportsv1/TickerRelatedSections';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 const PASS_RESULT = 'Pass';
 
@@ -69,6 +69,10 @@ export default function TickerCategoryReport({
 
   const passCount = categoryResult.factorResults?.filter((fr) => String(fr.result) === PASS_RESULT).length || 0;
   const totalCount = categoryResult.factorResults?.length || 0;
+
+  // Kick off the sibling-presence query in parallel with the rest of render.
+  // The Promise is unwrapped via `use()` inside <TickerRelatedSections>, suspended by the boundary below.
+  const availableSlugsPromise = getAvailableSiblingSlugs(tickerData.id);
 
   return (
     <div className="py-4">
@@ -162,14 +166,15 @@ export default function TickerCategoryReport({
           )}
         </div>
 
-        {/* @ts-expect-error Async Server Component (React 18 typing limitation) */}
-        <TickerRelatedSections
-          tickerId={tickerData.id}
-          exchange={tickerData.exchange}
-          symbol={tickerData.symbol}
-          companyName={tickerData.name}
-          currentSlug={pageSlug}
-        />
+        <Suspense fallback={null}>
+          <TickerRelatedSections
+            availableSlugsPromise={availableSlugsPromise}
+            exchange={tickerData.exchange}
+            symbol={tickerData.symbol}
+            companyName={tickerData.name}
+            currentSlug={pageSlug}
+          />
+        </Suspense>
 
         <footer className="mt-8 pt-6 border-t border-color">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import React from 'react';
+
+const SECTIONS: ReadonlyArray<{ slug: string; label: string }> = [
+  { slug: '', label: 'Full Stock Report' },
+  { slug: 'business-and-moat', label: 'Business & Moat' },
+  { slug: 'financial-statement-analysis', label: 'Financial Statements' },
+  { slug: 'past-performance', label: 'Past Performance' },
+  { slug: 'future-performance', label: 'Future Performance' },
+  { slug: 'fair-value', label: 'Fair Value' },
+  { slug: 'competition', label: 'Competition' },
+  { slug: 'management-team', label: 'Management Team' },
+];
+
+export interface TickerRelatedSectionsProps {
+  exchange: string;
+  symbol: string;
+  companyName: string;
+  /** Slug of the current page so it is excluded from the related list (use '' for the parent report). */
+  currentSlug: string;
+}
+
+export default function TickerRelatedSections({ exchange, symbol, companyName, currentSlug }: TickerRelatedSectionsProps): JSX.Element {
+  const ex = exchange.toUpperCase();
+  const tk = symbol.toUpperCase();
+  const others = SECTIONS.filter((s) => s.slug !== currentSlug);
+
+  return (
+    <nav aria-label={`More ${companyName} (${tk}) analyses`} className="mt-10 pt-6 border-t border-color">
+      <h2 className="text-lg font-semibold mb-3">
+        More {companyName} ({tk}) analyses
+      </h2>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {others.map((s) => {
+          const href = s.slug ? `/stocks/${ex}/${tk}/${s.slug}` : `/stocks/${ex}/${tk}`;
+          return (
+            <li key={s.slug || 'root'}>
+              <Link href={href} className="block rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors">
+                {companyName} ({tk}) {s.label} →
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -1,8 +1,13 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import Link from 'next/link';
 import React from 'react';
 
+const FULL_REPORT_SLUG = '';
+
 const SECTIONS: ReadonlyArray<{ slug: string; label: string }> = [
-  { slug: '', label: 'Full Stock Report' },
+  { slug: FULL_REPORT_SLUG, label: 'Full Stock Report' },
   { slug: 'business-and-moat', label: 'Business & Moat' },
   { slug: 'financial-statement-analysis', label: 'Financial Statements' },
   { slug: 'past-performance', label: 'Past Performance' },
@@ -12,7 +17,16 @@ const SECTIONS: ReadonlyArray<{ slug: string; label: string }> = [
   { slug: 'management-team', label: 'Management Team' },
 ];
 
+const CATEGORY_TO_SLUG: Readonly<Record<TickerAnalysisCategory, string>> = {
+  [TickerAnalysisCategory.BusinessAndMoat]: 'business-and-moat',
+  [TickerAnalysisCategory.FinancialStatementAnalysis]: 'financial-statement-analysis',
+  [TickerAnalysisCategory.PastPerformance]: 'past-performance',
+  [TickerAnalysisCategory.FutureGrowth]: 'future-performance',
+  [TickerAnalysisCategory.FairValue]: 'fair-value',
+};
+
 export interface TickerRelatedSectionsProps {
+  tickerId: string;
   exchange: string;
   symbol: string;
   companyName: string;
@@ -20,10 +34,50 @@ export interface TickerRelatedSectionsProps {
   currentSlug: string;
 }
 
-export default function TickerRelatedSections({ exchange, symbol, companyName, currentSlug }: TickerRelatedSectionsProps): JSX.Element {
+async function getAvailableSlugs(tickerId: string): Promise<ReadonlySet<string>> {
+  const [categoryRows, competitionRow, managementRow] = await Promise.all([
+    prisma.tickerV1CategoryAnalysisResult.findMany({
+      where: {
+        spaceId: KoalaGainsSpaceId,
+        tickerId,
+        summary: { not: '' },
+        overallAnalysisDetails: { not: '' },
+      },
+      select: { categoryKey: true },
+    }),
+    prisma.tickerV1VsCompetition.findFirst({
+      where: { spaceId: KoalaGainsSpaceId, tickerId, overallAnalysisDetails: { not: '' } },
+      select: { id: true },
+    }),
+    prisma.tickerV1ManagementTeamReport.findFirst({
+      where: { spaceId: KoalaGainsSpaceId, tickerId, summary: { not: '' }, detailedAnalysis: { not: '' } },
+      select: { id: true },
+    }),
+  ]);
+
+  const available = new Set<string>([FULL_REPORT_SLUG]);
+  for (const row of categoryRows) {
+    const slug = CATEGORY_TO_SLUG[row.categoryKey as TickerAnalysisCategory];
+    if (slug) available.add(slug);
+  }
+  if (competitionRow) available.add('competition');
+  if (managementRow) available.add('management-team');
+  return available;
+}
+
+export default async function TickerRelatedSections({
+  tickerId,
+  exchange,
+  symbol,
+  companyName,
+  currentSlug,
+}: TickerRelatedSectionsProps): Promise<JSX.Element | null> {
   const ex = exchange.toUpperCase();
   const tk = symbol.toUpperCase();
-  const others = SECTIONS.filter((s) => s.slug !== currentSlug);
+  const available = await getAvailableSlugs(tickerId);
+  const others = SECTIONS.filter((s) => s.slug !== currentSlug && available.has(s.slug));
+
+  if (others.length === 0) return null;
 
   return (
     <nav aria-label={`More ${companyName} (${tk}) analyses`} className="mt-10 pt-6 border-t border-color">

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -2,7 +2,7 @@ import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import Link from 'next/link';
-import React from 'react';
+import React, { use } from 'react';
 
 const FULL_REPORT_SLUG = '';
 
@@ -25,16 +25,17 @@ const CATEGORY_TO_SLUG: Readonly<Record<TickerAnalysisCategory, string>> = {
   [TickerAnalysisCategory.FairValue]: 'fair-value',
 };
 
-export interface TickerRelatedSectionsProps {
-  tickerId: string;
-  exchange: string;
-  symbol: string;
-  companyName: string;
-  /** Slug of the current page so it is excluded from the related list (use '' for the parent report). */
-  currentSlug: string;
-}
+export type AvailableSiblingSlugs = ReadonlySet<string>;
 
-async function getAvailableSlugs(tickerId: string): Promise<ReadonlySet<string>> {
+/**
+ * Server-side lookup of which sibling stock-detail pages have publishable
+ * content for this ticker. Mirrors the per-section sitemap filters so the
+ * in-page link graph and the sitemap stay in sync.
+ *
+ * Call this in a parent server component to kick off the query, then pass the
+ * returned Promise to {@link TickerRelatedSections}, wrapped in `<Suspense>`.
+ */
+export async function getAvailableSiblingSlugs(tickerId: string): Promise<AvailableSiblingSlugs> {
   const [categoryRows, competitionRow, managementRow] = await Promise.all([
     prisma.tickerV1CategoryAnalysisResult.findMany({
       where: {
@@ -65,16 +66,26 @@ async function getAvailableSlugs(tickerId: string): Promise<ReadonlySet<string>>
   return available;
 }
 
-export default async function TickerRelatedSections({
-  tickerId,
+export interface TickerRelatedSectionsProps {
+  /** Promise returned by {@link getAvailableSiblingSlugs}. Unwrapped with `use()` inside a `<Suspense>` boundary. */
+  availableSlugsPromise: Promise<AvailableSiblingSlugs>;
+  exchange: string;
+  symbol: string;
+  companyName: string;
+  /** Slug of the current page so it is excluded from the related list (use '' for the parent report). */
+  currentSlug: string;
+}
+
+export default function TickerRelatedSections({
+  availableSlugsPromise,
   exchange,
   symbol,
   companyName,
   currentSlug,
-}: TickerRelatedSectionsProps): Promise<JSX.Element | null> {
+}: TickerRelatedSectionsProps): JSX.Element | null {
   const ex = exchange.toUpperCase();
   const tk = symbol.toUpperCase();
-  const available = await getAvailableSlugs(tickerId);
+  const available = use(availableSlugsPromise);
   const others = SECTIONS.filter((s) => s.slug !== currentSlug && available.has(s.slug));
 
   if (others.length === 0) return null;


### PR DESCRIPTION
## Summary

Addresses items from `docs/insights-ui/tasks/stocks.md` "SEO Fixes" section, plus the renderer issue surfaced by Google Search Console's URL Inspection (e.g. `/stocks/AIM/AAU/financial-statement-analysis` rendering distorted, with missing icons and oversized empty regions).

### 1. `robots.ts` — unblock `/_next/`

The previous `robots.txt` disallowed `/_next/`, which prevents Googlebot from fetching:
- `/_next/static/css/*` — compiled Tailwind / Next.js CSS
- `/_next/static/chunks/*` — JS bundles needed for client-component hydration
- `/_next/image?url=...` — `next/image` optimised responses (logo, app icon, etc.)

Without those assets the renderer falls back to unstyled DOM (distorted layout), unhydrated client components (skeletons take huge space), and missing image responses (icons don't load). This matches Google's documented guidance: **don't block CSS, JS, or image files**.

### 2. Per-section pages — fix duplicate `h1` and add sibling links

`TickerCategoryReport.tsx` was rendering `{tickerData.name} ({ticker})` as the `h1` on all five category sub-pages (Business & Moat, Fair Value, Financial Statements, Past Performance, Future Performance) plus the parent stock page — six near-identical `h1`s per ticker, with the actual category name buried in a meaningless "Analysis Title" body section. Replaced with the category-specific `analysisTitle`, removed the dead section, and applied the same fix to the Competition page.

Added `TickerRelatedSections` — an SSR sibling-navigation block linking each category page to the parent report and the other categories. Wired into the five `TickerCategoryReport`-backed pages, the Competition page, and the Management Team page. Addresses the "orphan pages / poor internal linking" item.

### 3. Per-category sitemaps — filter empty summaries

Each per-category sitemap (`business-and-moat-sitemap.xml`, `competition-sitemap.xml`, `fair-value-sitemap.xml`, `financial-statement-analysis-sitemap.xml`, `future-performance-sitemap.xml`, `past-performance-sitemap.xml`, `management-team-sitemap.xml`) now filters records with `summary: { not: '' }`, so empty/placeholder analyses no longer appear. Thin pages were the most likely driver of GSC's "Crawled — currently not indexed" status.

## Test plan

- [ ] After deploy, fetch `https://koalagains.com/robots.txt` and confirm `/_next/` is no longer disallowed.
- [ ] Re-run "Test Live URL" in Search Console for `/stocks/AIM/AAU/financial-statement-analysis` and confirm the rendered screenshot now shows correct styling, icons, and layout.
- [ ] Spot-check 2-3 category sub-pages (e.g. `/stocks/NASDAQ/AAPL/business-and-moat`, `/stocks/NYSE/MSFT/fair-value`) and confirm: page-specific `h1`, sibling links rendered server-side, no duplicate "Analysis Title" section.
- [ ] Hit each per-category sitemap URL and confirm only records with non-empty summaries are listed.
- [ ] After indexing, re-submit "Validate fix" in GSC for the Business & Moat sitemap.