### PR TITLE
stocks/scenarios/movers: extend cached fetch revalidate from 1w to 2w

### DIFF
--- a/insights-ui/src/app/daily-top-movers/top-gainers/country/[country]/page.tsx
+++ b/insights-ui/src/app/daily-top-movers/top-gainers/country/[country]/page.tsx
@@ -23,7 +23,7 @@ export default async function DailyTopGainersPage({ params }: PageProps) {
   const baseUrl = getBaseUrl();
   const cacheOptions = {
     next: {
-      revalidate: 604800,
+      revalidate: 1209600,
       tags: [getDailyMoversByCountryTag(country, DailyMoverType.GAINER)],
     },
   };

--- a/insights-ui/src/app/daily-top-movers/top-gainers/details/[topGainersId]/page.tsx
+++ b/insights-ui/src/app/daily-top-movers/top-gainers/details/[topGainersId]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   try {
     const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/daily-top-gainers/${topGainersId}`, {
       next: {
-        revalidate: 604800,
+        revalidate: 1209600,
         tags: [getDailyMoverDetailsTag(topGainersId)],
       },
     });
@@ -51,7 +51,7 @@ export default async function TopGainerDetailsPage({ params }: PageProps) {
   // Fetch top gainer details from the API with cache tag
   const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/daily-top-gainers/${topGainersId}`, {
     next: {
-      revalidate: 604800, // 7 days in seconds
+      revalidate: 1209600, // 14 days in seconds
       tags: [getDailyMoverDetailsTag(topGainersId)],
     },
   });

--- a/insights-ui/src/app/daily-top-movers/top-losers/country/[country]/page.tsx
+++ b/insights-ui/src/app/daily-top-movers/top-losers/country/[country]/page.tsx
@@ -23,7 +23,7 @@ export default async function DailyTopLosersPage({ params }: PageProps) {
   const baseUrl = getBaseUrl();
   const cacheOptions = {
     next: {
-      revalidate: 604800,
+      revalidate: 1209600,
       tags: [getDailyMoversByCountryTag(country, DailyMoverType.LOSER)],
     },
   };

--- a/insights-ui/src/app/daily-top-movers/top-losers/details/[topLosersId]/page.tsx
+++ b/insights-ui/src/app/daily-top-movers/top-losers/details/[topLosersId]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   try {
     const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/daily-top-losers/${topLosersId}`, {
       next: {
-        revalidate: 604800,
+        revalidate: 1209600,
         tags: [getDailyMoverDetailsTag(topLosersId)],
       },
     });
@@ -51,7 +51,7 @@ export default async function TopLoserDetailsPage({ params }: PageProps) {
   // Fetch top loser details from the API with cache tag
   const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/daily-top-losers/${topLosersId}`, {
     next: {
-      revalidate: 604800, // 7 days in seconds
+      revalidate: 1209600, // 14 days in seconds
       tags: [getDailyMoverDetailsTag(topLosersId)],
     },
   });

--- a/insights-ui/src/app/stock-scenarios/[slug]/detailed-analysis/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/detailed-analysis/page.tsx
@@ -14,13 +14,13 @@ export const revalidate = false;
 
 type RouteParams = Promise<Readonly<{ slug: string }>>;
 
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 async function fetchScenarioBySlug(slug: string): Promise<StockScenarioDetail | null> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/stock-scenarios/${slug}?allowNull=true`;
   try {
     const res = await fetch(url, {
-      next: { revalidate: WEEK_IN_SECONDS, tags: [stockScenarioBySlugTag(slug)] },
+      next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [stockScenarioBySlugTag(slug)] },
     });
     if (!res.ok) return null;
     return (await res.json()) as StockScenarioDetail | null;

--- a/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/[slug]/page.tsx
@@ -19,13 +19,13 @@ export const revalidate = false;
 
 type RouteParams = Promise<Readonly<{ slug: string }>>;
 
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 async function fetchScenarioBySlug(slug: string): Promise<StockScenarioDetail | null> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/stock-scenarios/${slug}?allowNull=true`;
   try {
     const res = await fetch(url, {
-      next: { revalidate: WEEK_IN_SECONDS, tags: [stockScenarioBySlugTag(slug)] },
+      next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [stockScenarioBySlugTag(slug)] },
     });
     if (!res.ok) return null;
     return (await res.json()) as StockScenarioDetail | null;

--- a/insights-ui/src/app/stock-scenarios/page.tsx
+++ b/insights-ui/src/app/stock-scenarios/page.tsx
@@ -18,7 +18,7 @@ export const dynamicParams = true;
 export const revalidate = 86400; // 24 hours
 
 const DEFAULT_PAGE_SIZE = 200; // dataset should stay under ~100 for the foreseeable future; 200 leaves headroom
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 export const metadata = generateStockScenarioListingMetadata();
 
@@ -26,7 +26,7 @@ async function fetchScenarioListing(): Promise<StockScenarioListingResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/stock-scenarios/listing?pageSize=${DEFAULT_PAGE_SIZE}`;
   try {
     const res = await fetch(url, {
-      next: { revalidate: WEEK_IN_SECONDS, tags: [STOCK_SCENARIO_LISTING_TAG] },
+      next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [STOCK_SCENARIO_LISTING_TAG] },
     });
     if (!res.ok) {
       console.error(`Failed to fetch stock scenarios listing: HTTP ${res.status}`);

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -23,7 +23,7 @@ export const revalidate = false;
 export type RouteParams = Promise<Readonly<{ exchange: string; ticker: string }>>;
 
 /** Cache revalidation constants */
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 /** Helpers */
 function truncateForMeta(text: string, maxLength: number = 155): string {
@@ -34,7 +34,7 @@ function truncateForMeta(text: string, maxLength: number = 155): string {
 /** Fetch competition data for a specific exchange+ticker (cached). Returns null ticker if exchange mismatch. */
 async function fetchCompetitionByExchange(exchange: string, ticker: string): Promise<CompetitionResponse> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/competition-tickers`;
-  const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
   if (!res.ok) {
     throw new Error(`fetchCompetitionByExchange failed (${res.status}): ${url}`);
   }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -25,7 +25,7 @@ export const revalidate = false;
 
 export type RouteParams = Promise<Readonly<{ exchange: string; ticker: string }>>;
 
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 function truncateForMeta(text: string, maxLength: number = 155): string {
   if (text.length <= maxLength) return text;
@@ -34,7 +34,7 @@ function truncateForMeta(text: string, maxLength: number = 155): string {
 
 async function fetchTickerByExchange(exchange: string, ticker: string): Promise<TickerV1FastResponse | null> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}?allowNull=true`;
-  const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
   if (!res.ok) {
     throw new Error(`fetchTickerByExchange failed (${res.status}): ${url}`);
   }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -63,7 +63,7 @@ export const revalidate = false;
 export type RouteParams = Promise<Readonly<{ exchange: string; ticker: string }>>;
 
 /** Cache revalidation constants */
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 /** Helpers */
 function truncateForMeta(text: string, maxLength: number = 155): string {
@@ -74,7 +74,7 @@ function truncateForMeta(text: string, maxLength: number = 155): string {
 /** Data fetchers */
 async function fetchTickerByExchange(exchange: string, ticker: string): Promise<TickerV1FastResponse | null> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}?allowNull=true`;
-  const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
   if (!res.ok) {
     // Server error (DB down, etc.) - throw to show error.tsx
     throw new Error(`fetchTickerByExchange failed (${res.status}): ${url}`);
@@ -127,7 +127,7 @@ async function getTickerOrRedirect(params: RouteParams): Promise<TickerV1FastRes
 async function fetchSimilar(exchange: string, ticker: string): Promise<SimilarTicker[]> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/similar-tickers`;
 
-  const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
   if (!res.ok) throw new Error(`fetchSimilar failed (${res.status}): ${url}`);
 
   const arr = (await res.json()) as SimilarTicker[];
@@ -138,7 +138,7 @@ async function fetchFinancialInfo(exchange: string, ticker: string): Promise<Fin
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/financial-info`;
 
   try {
-    const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
     if (!res.ok) {
       console.error(`fetchFinancialInfo failed (${res.status}): ${url}`);
       return null;
@@ -156,7 +156,7 @@ async function fetchQuarterlyChartData(exchange: string, ticker: string): Promis
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/quarterly-chart-data`;
 
   try {
-    const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
     if (!res.ok) {
       console.error(`fetchQuarterlyChartData failed (${res.status}): ${url}`);
       return null;
@@ -174,7 +174,7 @@ async function fetchPriceHistory(exchange: string, ticker: string): Promise<Pric
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/price-history`;
 
   try {
-    const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
     if (!res.ok) {
       console.error(`fetchPriceHistory failed (${res.status}): ${url}`);
       return null;
@@ -192,7 +192,7 @@ async function fetchCompetitionData(exchange: string, ticker: string): Promise<C
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/competition-tickers`;
 
   try {
-    const res: Response = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
     if (!res.ok) {
       console.error(`fetchCompetitionData failed (${res.status}): ${url}`);
       return null;

--- a/insights-ui/src/utils/performance-page-utils.ts
+++ b/insights-ui/src/utils/performance-page-utils.ts
@@ -7,7 +7,7 @@ import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/B
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, permanentRedirect } from 'next/navigation';
 
-const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60;
 
 const EMPTY_RESPONSE: PerformanceResponse = { categoryResult: null, ticker: undefined };
 
@@ -20,7 +20,7 @@ export function truncateForMeta(text: string, maxLength: number = 155): string {
 export async function fetchPerformanceByExchange(exchange: string, ticker: string, dataSlug: string): Promise<PerformanceResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/${dataSlug}`;
   try {
-    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tickerAndExchangeTag(ticker, exchange)] } });
     if (!res.ok) {
       console.warn(`fetchPerformanceByExchange failed (${res.status}): ${url}`);
       return EMPTY_RESPONSE;


### PR DESCRIPTION
## Summary
- Bump cached fetch `revalidate` from 1 week (604800s) to 2 weeks (1209600s) across stock-related routes: `/stocks/[exchange]/[ticker]` (and competition / management-team / category sub-pages via `performance-page-utils`), `/stock-scenarios` listing + detail + detailed-analysis, and `/daily-top-movers` top-gainers/losers country + details pages.
- Renamed the local `WEEK_IN_SECONDS` constant to `TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60` in each affected file (and updated literal `604800` → `1209600` + comment in the daily-movers details pages).
- ETF and etf-scenarios routes are intentionally excluded — scope is "stock related" only.

## Test plan
- [x] `yarn --ignore-engines lint`
- [x] `yarn --ignore-engines prettier-check`
- [x] `yarn --ignore-engines compile`
- [ ] Verify cached pages still revalidate correctly after deploy (existing on-demand cache-tag invalidation paths are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)