### PR TITLE
tariff-reports: cache listing + admin invalidate menu + dark card style

### DIFF
--- a/insights-ui/src/app/api/tariff-reports/listing/route.ts
+++ b/insights-ui/src/app/api/tariff-reports/listing/route.ts
@@ -1,33 +1,6 @@
-import { prisma } from '@/prisma';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getTariffReportsListing, TariffReportListingItem } from '@/utils/tariff-reports/tariff-reports-listing';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
-import { Prisma } from '@prisma/client';
 
-export interface TariffReportListingItem {
-  slug: string;
-  oldUrl: string | null;
-  updatedAt: string;
-  chapter: {
-    number: number;
-    title: string;
-  };
-}
+export type { TariffReportListingItem };
 
-const SEEDED_FILTER = { introduction: { not: Prisma.DbNull } } as const;
-
-async function getHandler(): Promise<TariffReportListingItem[]> {
-  const rows = await prisma.tariffChapterReport.findMany({
-    where: { spaceId: KoalaGainsSpaceId, ...SEEDED_FILTER },
-    select: { slug: true, oldUrl: true, updatedAt: true, chapter: { select: { number: true, title: true } } },
-    orderBy: { chapter: { number: 'asc' } },
-  });
-
-  return rows.map((row) => ({
-    slug: row.slug,
-    oldUrl: row.oldUrl,
-    updatedAt: row.updatedAt.toISOString(),
-    chapter: row.chapter,
-  }));
-}
-
-export const GET = withErrorHandlingV2<TariffReportListingItem[]>(getHandler);
+export const GET = withErrorHandlingV2<TariffReportListingItem[]>(async () => getTariffReportsListing());

--- a/insights-ui/src/app/tariff-reports/page.tsx
+++ b/insights-ui/src/app/tariff-reports/page.tsx
@@ -1,13 +1,16 @@
-import type { TariffReportListingItem } from '@/app/api/tariff-reports/listing/route';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import TariffReportsPageActions from '@/components/industry-tariff/TariffReportsPageActions';
 import { findIndustryByLegacyUrl, TariffIndustryDefinition } from '@/scripts/industry-tariff-reports/tariff-industries';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { TARIFF_REPORTS_LISTING_TAG } from '@/utils/tariff-report-tags';
+import { getTariffReportsListing } from '@/utils/tariff-reports/tariff-reports-listing';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { ArrowRight, FileText, Layers } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
+
+// Render at request time; the build environment does not provision DATABASE_URL for the Prisma listing query.
+// The listing data itself is cached via unstable_cache in getTariffReportsListing.
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata(): Promise<Metadata> {
   const title = 'Tariff Reports | KoalaGains';
@@ -75,57 +78,47 @@ function ChapterCard({ chapterNumber, chapterTitle, chapterSlug, industry, lastM
     `Tariff and trade-policy analysis for HTS Chapter ${padded} (${chapterTitle}). Browse tariff updates, country-level breakdowns, industry structure, and forward-looking conclusions.`;
 
   return (
-    <article className="group relative flex flex-col overflow-hidden rounded-2xl border border-color background-color transition-all duration-200 hover:border-indigo-500/60 hover:shadow-xl hover:shadow-indigo-500/5">
-      <div className="h-1 bg-gradient-to-r from-indigo-500 via-blue-500 to-cyan-500" />
-
-      <div className="flex flex-1 flex-col p-6">
-        <div className="mb-4 flex items-center justify-between text-xs">
-          <span className="inline-flex items-center gap-1.5 rounded-full bg-indigo-500/10 px-2.5 py-1 font-medium text-indigo-300 ring-1 ring-inset ring-indigo-500/20">
-            <Layers className="h-3 w-3" />
-            HTS Chapter {padded}
-          </span>
-          {lastModified && <span className="text-muted-foreground">Updated {formatDate(lastModified)}</span>}
-        </div>
-
-        <h3 className="mb-2 text-xl font-semibold leading-snug">
-          <Link href={href} className="transition-colors hover:text-indigo-400 focus-visible:text-indigo-400 focus-visible:outline-none">
-            {title}
-          </Link>
-        </h3>
-
-        {industry && <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">{chapterTitle}</p>}
-
-        <p className="mb-5 line-clamp-3 flex-1 text-sm text-muted-foreground">{description}</p>
-
-        <div className="mb-5 flex flex-wrap gap-1.5">
-          {REPORT_SECTIONS.map((section) => (
-            <Link
-              key={section.slug}
-              href={`${href}/${section.slug}`}
-              className="inline-flex items-center rounded-md border border-color px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-indigo-500/60 hover:bg-indigo-500/5 hover:text-indigo-300"
-            >
-              {section.label}
-            </Link>
-          ))}
-        </div>
-
-        <Link href={href} className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-indigo-400 transition-transform hover:translate-x-0.5">
-          Open report
-          <ArrowRight className="h-4 w-4" />
-        </Link>
+    <article className="group flex flex-col rounded-2xl bg-gray-900 border border-gray-800 transition-all hover:border-blue-500 p-6">
+      <div className="mb-4 flex items-center justify-between text-xs">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-500/10 px-2.5 py-1 font-medium text-blue-400 ring-1 ring-inset ring-blue-500/20">
+          <Layers className="h-3 w-3" />
+          HTS Chapter {padded}
+        </span>
+        {lastModified && <span className="text-gray-400">Updated {formatDate(lastModified)}</span>}
       </div>
+
+      <h3 className="mb-2 text-xl font-semibold leading-snug text-white">
+        <Link href={href} className="transition-colors group-hover:text-blue-400 focus-visible:text-blue-400 focus-visible:outline-none">
+          {title}
+        </Link>
+      </h3>
+
+      {industry && <p className="mb-2 text-xs uppercase tracking-wide text-gray-400">{chapterTitle}</p>}
+
+      <p className="mb-5 line-clamp-3 flex-1 text-sm text-gray-300">{description}</p>
+
+      <div className="mb-5 flex flex-wrap gap-1.5">
+        {REPORT_SECTIONS.map((section) => (
+          <Link
+            key={section.slug}
+            href={`${href}/${section.slug}`}
+            className="inline-flex items-center rounded-md border border-gray-800 px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:border-blue-500 hover:bg-blue-500/5 hover:text-blue-400"
+          >
+            {section.label}
+          </Link>
+        ))}
+      </div>
+
+      <Link href={href} className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-blue-400 transition-colors group-hover:text-blue-300">
+        Open report
+        <ArrowRight className="h-4 w-4" />
+      </Link>
     </article>
   );
 }
 
-const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
-
 export default async function TariffReportsPage() {
-  const res = await fetch(`${getBaseUrlForServerSidePages()}/api/tariff-reports/listing`, {
-    next: { revalidate: WEEK_IN_SECONDS, tags: [TARIFF_REPORTS_LISTING_TAG] },
-  });
-
-  const rows: TariffReportListingItem[] = res.ok ? await res.json() : [];
+  const rows = await getTariffReportsListing();
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'Reports', href: '/reports', current: false },
@@ -138,7 +131,10 @@ export default async function TariffReportsPage() {
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-color">
         <header className="mb-10">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Tariff Reports by HTS Chapter</h1>
+          <div className="flex items-start justify-between gap-3">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Tariff Reports by HTS Chapter</h1>
+            <TariffReportsPageActions />
+          </div>
           <p className="mt-3 max-w-3xl text-muted-foreground">
             Tariff and trade-policy analysis for chapters of the U.S. Harmonized Tariff Schedule (HTS). Each report covers tariff updates, country breakdowns,
             industry structure, sub-areas, and forward-looking conclusions.
@@ -146,16 +142,16 @@ export default async function TariffReportsPage() {
         </header>
 
         {rows.length === 0 ? (
-          <div className="rounded-2xl border border-color background-color py-12 text-center shadow-sm">
-            <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
-            <h3 className="mt-4 text-lg font-medium">No tariff reports available</h3>
-            <p className="mt-2 text-sm text-muted-foreground">Tariff reports will appear here once they are created.</p>
+          <div className="rounded-2xl border border-gray-800 bg-gray-900 py-12 text-center">
+            <FileText className="mx-auto h-12 w-12 text-gray-500" />
+            <h3 className="mt-4 text-lg font-medium text-white">No tariff reports available</h3>
+            <p className="mt-2 text-sm text-gray-400">Tariff reports will appear here once they are created.</p>
           </div>
         ) : (
           <section className="mb-14">
-            <div className="mb-6 flex items-baseline justify-between border-b border-color pb-2">
-              <h2 className="text-2xl font-semibold">All Chapters</h2>
-              <span className="text-sm text-muted-foreground">{rows.length} chapters</span>
+            <div className="mb-6 flex items-baseline justify-between border-b border-gray-800 pb-2">
+              <h2 className="text-2xl font-semibold text-white">All Chapters</h2>
+              <span className="text-sm text-gray-400">{rows.length} chapters</span>
             </div>
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {rows.map((row) => {

--- a/insights-ui/src/app/tariff-reports/page.tsx
+++ b/insights-ui/src/app/tariff-reports/page.tsx
@@ -93,8 +93,6 @@ function ChapterCard({ chapterNumber, chapterTitle, chapterSlug, industry, lastM
         </Link>
       </h3>
 
-      {industry && <p className="mb-2 text-xs uppercase tracking-wide text-gray-400">{chapterTitle}</p>}
-
       <p className="mb-5 line-clamp-3 flex-1 text-sm text-gray-300">{description}</p>
 
       <div className="mb-5 flex flex-wrap gap-1.5">

--- a/insights-ui/src/components/industry-tariff/TariffReportsPageActions.tsx
+++ b/insights-ui/src/components/industry-tariff/TariffReportsPageActions.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { revalidateTariffReportsListingCache } from '@/utils/cache-actions';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useRouter } from 'next/navigation';
+
+export default function TariffReportsPageActions() {
+  const router = useRouter();
+
+  const actions: EllipsisDropdownItem[] = [{ key: 'revalidate-listing-tag', label: 'Invalidate Cache' }];
+
+  return (
+    <PrivateWrapper>
+      <EllipsisDropdown
+        items={actions}
+        className="px-2 py-2"
+        onSelect={async (key) => {
+          if (key === 'revalidate-listing-tag') {
+            await revalidateTariffReportsListingCache();
+            router.refresh();
+            return;
+          }
+        }}
+      />
+    </PrivateWrapper>
+  );
+}

--- a/insights-ui/src/utils/cache-actions.ts
+++ b/insights-ui/src/utils/cache-actions.ts
@@ -10,6 +10,7 @@ import {
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
+import { revalidateTariffReportsListing } from '@/utils/tariff-report-cache-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { PortfolioManagerType } from '@/types/portfolio-manager';
 import { prisma } from '@/prisma';
@@ -73,4 +74,9 @@ export async function revalidateStockScenariosListingCache() {
 export async function revalidateStockScenarioCache(slug: string) {
   revalidateStockScenarioBySlugTag(slug);
   return { success: true, message: `Revalidated Stock scenario cache for ${slug}` };
+}
+
+export async function revalidateTariffReportsListingCache() {
+  revalidateTariffReportsListing();
+  return { success: true, message: 'Revalidated tariff reports listing cache' };
 }

--- a/insights-ui/src/utils/tariff-reports/tariff-reports-listing.ts
+++ b/insights-ui/src/utils/tariff-reports/tariff-reports-listing.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { TARIFF_REPORTS_LISTING_TAG } from '@/utils/tariff-report-tags';
+import { Prisma } from '@prisma/client';
+import { unstable_cache } from 'next/cache';
+
+export interface TariffReportListingItem {
+  slug: string;
+  oldUrl: string | null;
+  updatedAt: string;
+  chapter: {
+    number: number;
+    title: string;
+  };
+}
+
+const SEEDED_FILTER = { introduction: { not: Prisma.DbNull } } as const;
+const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
+
+async function fetchTariffReportsListing(): Promise<TariffReportListingItem[]> {
+  const rows = await prisma.tariffChapterReport.findMany({
+    where: { spaceId: KoalaGainsSpaceId, ...SEEDED_FILTER },
+    select: { slug: true, oldUrl: true, updatedAt: true, chapter: { select: { number: true, title: true } } },
+    orderBy: { chapter: { number: 'asc' } },
+  });
+
+  return rows.map((row) => ({
+    slug: row.slug,
+    oldUrl: row.oldUrl,
+    updatedAt: row.updatedAt.toISOString(),
+    chapter: row.chapter,
+  }));
+}
+
+export const getTariffReportsListing = unstable_cache(fetchTariffReportsListing, ['tariff-reports-listing'], {
+  revalidate: WEEK_IN_SECONDS,
+  tags: [TARIFF_REPORTS_LISTING_TAG],
+});


### PR DESCRIPTION
## Summary

- Wrap the tariff listing Prisma query in `unstable_cache` (tagged `TARIFF_REPORTS_LISTING_TAG`, weekly revalidate) so `/tariff-reports` no longer hits Prisma on every request — and so the cache survives `force-dynamic`, which disables Next.js fetch-cache.
- Page now calls the cached helper directly; removes the unnecessary self-fetch round-trip through `/api/tariff-reports/listing`. The API route still exists and reuses the same cached helper.
- Add `force-dynamic` so build-time prerender no longer requires `DATABASE_URL`.
- Add `TariffReportsPageActions`: `PrivateWrapper` + `EllipsisDropdown` (admin-only 3-dot menu) wired to a new `revalidateTariffReportsListingCache` server action, so admins can refresh the listing when stale data is showing on prod (which was the reported symptom).
- Restyle chapter cards to match the professional-managers look (`/portfolio-managers/professional-managers`): `bg-gray-900` with `border-gray-800` → `hover:border-blue-500`, blue accent text, dropped the indigo gradient strip. Grid still 3 cards per row at `lg`.

## Test plan

- [ ] `/tariff-reports` renders chapter cards with the new dark + blue-hover look
- [ ] Layout still shows 3 cards per row on `lg` screens, 2 on `sm`, 1 on mobile
- [ ] Admin sees the 3-dot menu in the top-right of the page header; non-admin does not
- [ ] Clicking "Invalidate Cache" refreshes the page with fresh listing data
- [ ] After a chapter report is added/updated, calling `revalidateTariffReportsListing()` (or the new menu) makes the new row appear without a redeploy
- [ ] CI build succeeds without `DATABASE_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)