### PR TITLE
tariff-reports: admin page + chapter-keyed section APIs

### DIFF
--- a/insights-ui/src/app/admin-v1/AdminNav.tsx
+++ b/insights-ui/src/app/admin-v1/AdminNav.tsx
@@ -51,6 +51,11 @@ const analysisTemplatesSection: AdminNavSection = {
   ],
 };
 
+const tariffReportsSection: AdminNavSection = {
+  label: 'Tariff Reports',
+  items: [{ name: 'Tariff Chapter Reports', href: '/admin-v1/tariff-reports' }],
+};
+
 function AdminNavDropdown({ section }: { section: AdminNavSection }) {
   return (
     <Popover className="relative">
@@ -92,6 +97,7 @@ export default function AdminNav() {
         <AdminNavDropdown section={stockIndustryMgmtSection} />
         <AdminNavDropdown section={etfMgmtSection} />
         <AdminNavDropdown section={analysisTemplatesSection} />
+        <AdminNavDropdown section={tariffReportsSection} />
         <Link href="/admin-v1/users" className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md">
           Users
         </Link>

--- a/insights-ui/src/app/admin-v1/tariff-reports/TariffReportsAdminTable.tsx
+++ b/insights-ui/src/app/admin-v1/tariff-reports/TariffReportsAdminTable.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import type { ChapterReportAdminListResponse, ChapterReportAdminRow } from '@/app/api/industry-tariff-reports/chapters/route';
+import { CHAPTER_GENERATE_STEPS, ChapterGenerateStep, ChapterReportField } from '@/utils/tariff-reports/chapter-generate-sections';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import { usePostData } from '@dodao/web-core/ui/hooks/fetch/usePostData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { useState } from 'react';
+
+// Tracks per-row run progress. `currentStep` is the index of the running step in
+// `CHAPTER_GENERATE_STEPS`; `error` is set if a step fails. `localStatus` overlays
+// the server-fetched `fields` so completed steps flip to ✓ before the next refetch.
+interface RowRunState {
+  currentStep: number | null;
+  error: string | null;
+  localStatus: Partial<Record<ChapterReportField, boolean>>;
+}
+
+const EMPTY_RUN: RowRunState = { currentStep: null, error: null, localStatus: {} };
+
+function StatusPill({ filled }: { filled: boolean }): JSX.Element {
+  return (
+    <span
+      className={`inline-block min-w-[1.5rem] text-center px-2 py-0.5 rounded-full text-xs ${
+        filled ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'
+      }`}
+    >
+      {filled ? '✓' : '—'}
+    </span>
+  );
+}
+
+function RunningPill(): JSX.Element {
+  return <span className="inline-block min-w-[1.5rem] text-center px-2 py-0.5 rounded-full text-xs bg-blue-900 text-blue-200">…</span>;
+}
+
+interface RowProps {
+  row: ChapterReportAdminRow;
+  runState: RowRunState;
+  onGenerateAll: (slug: string) => Promise<void>;
+}
+
+function ChapterRow({ row, runState, onGenerateAll }: RowProps): JSX.Element {
+  const padded = row.chapter.number.toString().padStart(2, '0');
+  const isRunning = runState.currentStep !== null;
+
+  return (
+    <tr className="border-b border-gray-700">
+      <td className="px-3 py-3 align-top whitespace-nowrap text-sm">
+        <div className="font-medium">
+          {padded} — {row.chapter.title}
+        </div>
+        <div className="text-xs text-gray-400">slug: {row.slug}</div>
+        <div className="text-xs text-gray-400">oldUrl: {row.oldUrl ?? '—'}</div>
+      </td>
+      {CHAPTER_GENERATE_STEPS.map((step, idx) => {
+        const populated = runState.localStatus[step.field] ?? row.fields[step.field];
+        const stepRunning = runState.currentStep === idx;
+        return (
+          <td key={step.field} className="px-2 py-3 align-top text-center">
+            {stepRunning ? <RunningPill /> : <StatusPill filled={populated} />}
+          </td>
+        );
+      })}
+      <td className="px-3 py-3 align-top text-sm whitespace-nowrap">
+        <button
+          type="button"
+          onClick={() => onGenerateAll(row.slug)}
+          disabled={isRunning}
+          className="px-3 py-1.5 rounded-md bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs font-medium"
+        >
+          {isRunning ? `Running ${(runState.currentStep ?? 0) + 1}/${CHAPTER_GENERATE_STEPS.length}` : 'Generate all'}
+        </button>
+        {runState.error && <div className="mt-1 text-xs text-red-400">{runState.error}</div>}
+      </td>
+    </tr>
+  );
+}
+
+export default function TariffReportsAdminTable(): JSX.Element {
+  const apiUrl = `${getBaseUrl()}/api/industry-tariff-reports/chapters`;
+  const { data, loading, error, reFetchData } = useFetchData<ChapterReportAdminListResponse>(apiUrl, {}, 'Failed to fetch tariff chapter reports');
+
+  // Keyed by row.slug — each row tracks its own progress so multiple rows can run in series.
+  const [runStates, setRunStates] = useState<Record<string, RowRunState>>({});
+  // `usePostData` is generic enough to call any of the chapter-keyed generate routes.
+  const { postData } = usePostData<unknown, unknown>({ successMessage: '', errorMessage: '' });
+
+  const updateRun = (slug: string, patch: Partial<RowRunState>) => {
+    setRunStates((prev) => ({ ...prev, [slug]: { ...(prev[slug] ?? EMPTY_RUN), ...patch } }));
+  };
+
+  const generateAll = async (slug: string): Promise<void> => {
+    updateRun(slug, { currentStep: 0, error: null, localStatus: {} });
+    try {
+      for (let i = 0; i < CHAPTER_GENERATE_STEPS.length; i++) {
+        const step = CHAPTER_GENERATE_STEPS[i] as ChapterGenerateStep;
+        updateRun(slug, { currentStep: i });
+        await postData(`${getBaseUrl()}/api/industry-tariff-reports/chapters/${slug}/${step.apiPath}`, {});
+        // Mark this field as filled in the local overlay so the pill flips to ✓.
+        setRunStates((prev) => {
+          const cur = prev[slug] ?? EMPTY_RUN;
+          return { ...prev, [slug]: { ...cur, localStatus: { ...cur.localStatus, [step.field]: true } } };
+        });
+      }
+      updateRun(slug, { currentStep: null });
+      await reFetchData();
+    } catch (err) {
+      updateRun(slug, { currentStep: null, error: err instanceof Error ? err.message : 'Generation failed' });
+    }
+  };
+
+  if (loading) return <div className="py-8 text-sm">Loading tariff chapter reports...</div>;
+  if (error) return <div className="py-4 text-sm text-red-500">Error: {error}</div>;
+  if (!data || data.rows.length === 0) return <div className="py-4 text-sm">No tariff chapter reports found.</div>;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-700">
+      <table className="min-w-full divide-y divide-gray-700">
+        <thead className="bg-gray-800">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Chapter</th>
+            {CHAPTER_GENERATE_STEPS.map((step) => (
+              <th key={step.field} className="px-2 py-2 text-center text-xs font-medium text-gray-300 tracking-wider">
+                {step.label}
+              </th>
+            ))}
+            <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Action</th>
+          </tr>
+        </thead>
+        <tbody className="bg-gray-900 text-gray-200">
+          {data.rows.map((row) => (
+            <ChapterRow key={row.slug} row={row} runState={runStates[row.slug] ?? EMPTY_RUN} onGenerateAll={generateAll} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/insights-ui/src/app/admin-v1/tariff-reports/page.tsx
+++ b/insights-ui/src/app/admin-v1/tariff-reports/page.tsx
@@ -1,0 +1,21 @@
+import AdminNav from '@/app/admin-v1/AdminNav';
+import TariffReportsAdminTable from '@/app/admin-v1/tariff-reports/TariffReportsAdminTable';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+
+export const dynamic = 'force-dynamic';
+
+export default function TariffReportsAdminPage(): JSX.Element {
+  return (
+    <PageWrapper>
+      <AdminNav />
+      <div className="space-y-4">
+        <div className="text-3xl font-bold">Tariff Chapter Reports</div>
+        <p className="text-sm text-gray-400">
+          One row per `tariff_chapter_reports` entry. Each column shows whether that JSONB section is populated. &quot;Generate all&quot; runs every section
+          generator in order — same pipeline as `run-tariff-report.ts`, ending with SEO.
+        </p>
+        <TariffReportsAdminTable />
+      </div>
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler.ts
@@ -1,0 +1,27 @@
+import { readIndustryTariffReportBySlug } from '@/scripts/industry-tariff-reports/tariff-report-repository';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { NextRequest } from 'next/server';
+
+// Shared handler used by every `/api/industry-tariff-reports/chapters/[chapterSlug]/generate-*` route.
+// All section-generator functions take the chapter slug — keep route handlers to a single line by
+// wrapping the slug + body parsing + final read here.
+export function chapterGenerateRoute(
+  generate: (slug: string, body: unknown) => Promise<void>
+): (req: NextRequest, ctx: { params: Promise<{ chapterSlug: string }> }) => Promise<IndustryTariffReport> {
+  return async (req, { params }) => {
+    const { chapterSlug } = await params;
+    if (!chapterSlug) throw new Error('chapterSlug is required');
+
+    let body: unknown = {};
+    if (req.headers.get('content-length')) {
+      try {
+        body = await req.json();
+      } catch {
+        body = {};
+      }
+    }
+
+    await generate(chapterSlug, body);
+    return readIndustryTariffReportBySlug(chapterSlug);
+  };
+}

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-executive-summary/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-executive-summary/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getExecutiveSummaryAndSaveToFile } from '@/scripts/industry-tariff-reports/02-executive-summary';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getExecutiveSummaryAndSaveToFile(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-final-conclusion/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-final-conclusion/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getFinalConclusionAndSaveToFile } from '@/scripts/industry-tariff-reports/07-final-conclusion';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getFinalConclusionAndSaveToFile(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-headings/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-headings/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getAndWriteIndustryHeadings } from '@/scripts/industry-tariff-reports/00-industry-main-headings';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getAndWriteIndustryHeadings(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-industry-areas/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-industry-areas/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getAndWriteIndustryAreaSectionToJsonFile } from '@/scripts/industry-tariff-reports/05-industry-areas';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getAndWriteIndustryAreaSectionToJsonFile(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-report-cover/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-report-cover/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getReportCoverAndSaveToFile } from '@/scripts/industry-tariff-reports/01-industry-cover';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getReportCoverAndSaveToFile(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-seo-info/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-seo-info/route.ts
@@ -1,0 +1,10 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { generateAndSaveAllSeoDetails } from '@/scripts/industry-tariff-reports/08-report-seo-info';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(
+  chapterGenerateRoute(async (slug) => {
+    await generateAndSaveAllSeoDetails(slug);
+  })
+);

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-tariff-updates/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-tariff-updates/route.ts
@@ -1,0 +1,17 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getTariffUpdatesForIndustryAndSaveToFile } from '@/scripts/industry-tariff-reports/03-industry-tariffs';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { getTodayDateAsMonthDDYYYYFormat } from '@/util/get-date';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+interface GenerateTariffUpdatesBody {
+  date?: string;
+  countryName?: string;
+}
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(
+  chapterGenerateRoute(async (slug, body) => {
+    const { date, countryName } = (body as GenerateTariffUpdatesBody) ?? {};
+    await getTariffUpdatesForIndustryAndSaveToFile(slug, date ?? getTodayDateAsMonthDDYYYYFormat(), countryName);
+  })
+);

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-understand-industry/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-understand-industry/route.ts
@@ -1,0 +1,6 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getAndWriteUnderstandIndustryJson } from '@/scripts/industry-tariff-reports/04-understand-industry';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getAndWriteUnderstandIndustryJson(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/route.ts
@@ -1,0 +1,55 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { CHAPTER_GENERATE_STEPS, ChapterReportField } from '@/utils/tariff-reports/chapter-generate-sections';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export interface ChapterReportAdminRow {
+  slug: string;
+  oldUrl: string | null;
+  chapter: { number: number; title: string };
+  updatedAt: string;
+  // Per-field populated flag — keyed by JSONB column name, matches `ChapterReportField`.
+  fields: Record<ChapterReportField, boolean>;
+}
+
+export interface ChapterReportAdminListResponse {
+  rows: ChapterReportAdminRow[];
+}
+
+const CHAPTER_FIELDS = CHAPTER_GENERATE_STEPS.map((s) => s.field);
+
+async function getHandler(): Promise<ChapterReportAdminListResponse> {
+  const rows = await prisma.tariffChapterReport.findMany({
+    where: { spaceId: KoalaGainsSpaceId },
+    select: {
+      slug: true,
+      oldUrl: true,
+      updatedAt: true,
+      chapter: { select: { number: true, title: true } },
+      industryAreas: true,
+      introduction: true,
+      executiveSummary: true,
+      tariffUpdates: true,
+      understandIndustry: true,
+      industryAreasSections: true,
+      conclusion: true,
+      seoDetails: true,
+    },
+    orderBy: { chapter: { number: 'asc' } },
+  });
+
+  const out: ChapterReportAdminRow[] = rows.map((row) => {
+    const fields = Object.fromEntries(CHAPTER_FIELDS.map((field) => [field, row[field] != null])) as Record<ChapterReportField, boolean>;
+    return {
+      slug: row.slug,
+      oldUrl: row.oldUrl,
+      chapter: row.chapter,
+      updatedAt: row.updatedAt.toISOString(),
+      fields,
+    };
+  });
+
+  return { rows: out };
+}
+
+export const GET = withErrorHandlingV2<ChapterReportAdminListResponse>(getHandler);

--- a/insights-ui/src/utils/tariff-reports/chapter-generate-sections.ts
+++ b/insights-ui/src/utils/tariff-reports/chapter-generate-sections.ts
@@ -1,0 +1,36 @@
+// Definitions of every section step in the chapter-report generation pipeline.
+// The admin UI iterates this list to render per-row status pills and to fire the
+// "Generate all" sequence; the listing API uses the same `field` keys to compute
+// per-field populated/empty status. Order matches `run-tariff-report.ts`'s ALL
+// flow — headings first, every other section, SEO last.
+
+// JSONB column names on `tariff_chapter_reports` that store each section.
+export type ChapterReportField =
+  | 'industryAreas'
+  | 'introduction'
+  | 'executiveSummary'
+  | 'tariffUpdates'
+  | 'understandIndustry'
+  | 'industryAreasSections'
+  | 'conclusion'
+  | 'seoDetails';
+
+export interface ChapterGenerateStep {
+  // JSONB column on `tariff_chapter_reports` that this step populates.
+  field: ChapterReportField;
+  // Human-readable label used for column headers / progress UI.
+  label: string;
+  // Path segment under `/api/industry-tariff-reports/chapters/<slug>/`.
+  apiPath: string;
+}
+
+export const CHAPTER_GENERATE_STEPS: readonly ChapterGenerateStep[] = [
+  { field: 'industryAreas', label: 'industryAreas', apiPath: 'generate-headings' },
+  { field: 'understandIndustry', label: 'understandIndustry', apiPath: 'generate-understand-industry' },
+  { field: 'tariffUpdates', label: 'tariffUpdates', apiPath: 'generate-tariff-updates' },
+  { field: 'industryAreasSections', label: 'industryAreasSections', apiPath: 'generate-industry-areas' },
+  { field: 'executiveSummary', label: 'executiveSummary', apiPath: 'generate-executive-summary' },
+  { field: 'introduction', label: 'introduction', apiPath: 'generate-report-cover' },
+  { field: 'conclusion', label: 'conclusion', apiPath: 'generate-final-conclusion' },
+  { field: 'seoDetails', label: 'seoDetails', apiPath: 'generate-seo-info' },
+] as const;


### PR DESCRIPTION
## Summary
- Adds `/admin-v1/tariff-reports` listing every `tariff_chapter_reports` row with slug, oldUrl, and a populated/empty pill per JSONB section column (industryAreas, introduction, executiveSummary, tariffUpdates, understandIndustry, industryAreasSections, conclusion, seoDetails).
- Each row has a "Generate all" button that POSTs sequentially to eight new chapter-keyed routes under `/api/industry-tariff-reports/chapters/[chapterSlug]/generate-*` — order matches `run-tariff-report.ts`'s ALL flow, ending with SEO. The shared `chapterGenerateRoute` helper keeps each route to one line.
- `CHAPTER_GENERATE_STEPS` is the single source of truth for both the listing API's status flags and the admin UI's columns + run order.

## Why
Production cannot run the CLI script, so chapter rows without a legacy industryId could not be filled. The admin page exposes the same pipeline through HTTP.

## Test plan
- [ ] Sign in as admin → open `/admin-v1/tariff-reports` → verify the table lists every chapter row with the right per-field pills.
- [ ] Click "Generate all" on chapter 55 (man-made-staple-fibers) → watch each pill flip from — to … to ✓ in order.
- [ ] After completion, refresh and confirm the eight pills are all green; SEO column is populated.
- [ ] Confirm the existing `/industry-tariff-report/[industryId]/generate-all` flow still works (legacy industry routes were not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)