### PR TITLE
tariff-reports: fix Server Component crash after Generate All

### DIFF
--- a/insights-ui/src/app/industry-tariff-report/[industryId]/industry-areas/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/industry-areas/page.tsx
@@ -35,7 +35,8 @@ export default async function IndustryAreasPage({ params }: { params: Promise<{ 
   const seoDetails = report.reportSeoDetails?.industryAreasSeoDetails;
   const isSeoMissing = !seoDetails || !seoDetails.title || !seoDetails.shortDescription || !seoDetails.keywords?.length;
 
-  const content = report.industryAreasSections ? parseMarkdown(getMarkdownContentForIndustryAreas(report.industryAreasSections)) : 'No content available';
+  const markdown = report.industryAreasSections ? getMarkdownContentForIndustryAreas(report.industryAreasSections) : '';
+  const content = markdown ? parseMarkdown(markdown) : '';
 
   return (
     <div className="mx-auto max-w-7xl py-2">
@@ -65,7 +66,11 @@ export default async function IndustryAreasPage({ params }: { params: Promise<{ 
       <div className="space-y-12">
         <div className="bg-gray-900 rounded-lg p-2 shadow-sm">
           <div className="markdown-body prose max-w-none px-2">
-            <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: content }} />
+            {content ? (
+              <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: content }} />
+            ) : (
+              <p className="text-gray-500 italic p-4">No content available</p>
+            )}
           </div>
         </div>
       </div>

--- a/insights-ui/src/app/industry-tariff-report/[industryId]/tariff-updates/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/tariff-updates/page.tsx
@@ -37,6 +37,10 @@ export default async function TariffUpdatesPage({ params }: { params: Promise<{ 
   const seoDetails = report.reportSeoDetails?.tariffUpdatesSeoDetails;
   const isSeoMissing = !seoDetails || !seoDetails.title || !seoDetails.shortDescription || !seoDetails.keywords?.length;
 
+  const tariffUpdates = report.tariffUpdates;
+  const countryNames = Array.isArray(tariffUpdates?.countryNames) ? tariffUpdates?.countryNames ?? [] : [];
+  const countrySpecificTariffs = Array.isArray(tariffUpdates?.countrySpecificTariffs) ? tariffUpdates?.countrySpecificTariffs ?? [] : [];
+
   return (
     <div className="mx-auto max-w-7xl py-2">
       {/* Title and Actions */}
@@ -50,7 +54,7 @@ export default async function TariffUpdatesPage({ params }: { params: Promise<{ 
       </div>
 
       {/* SEO Warning Banner for Admins */}
-      {report.tariffUpdates && isSeoMissing && (
+      {tariffUpdates && isSeoMissing && (
         <PrivateWrapper>
           <div className="mb-8 p-4 bg-amber-100 border border-amber-300 rounded-md text-amber-800 shadow-sm">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -63,17 +67,17 @@ export default async function TariffUpdatesPage({ params }: { params: Promise<{ 
       )}
 
       <div className="space-y-4">
-        {/* Country Navigation */}
-        {report.tariffUpdates && report.tariffUpdates.countryNames && <CountryNavigation countries={report.tariffUpdates.countryNames} />}
+        {countryNames.length > 0 && <CountryNavigation countries={countryNames} />}
 
-        {report.tariffUpdates ? (
-          report.tariffUpdates.countrySpecificTariffs.map((countryTariff, index) => {
-            const sectionId = `country-${countryTariff.countryName.toLowerCase().replace(/\s+/g, '-')}`;
+        {countrySpecificTariffs.length > 0 ? (
+          countrySpecificTariffs.map((countryTariff, index) => {
+            const countryName = typeof countryTariff?.countryName === 'string' ? countryTariff.countryName : '';
+            const sectionId = `country-${countryName.toLowerCase().replace(/\s+/g, '-')}`;
             return (
               <div key={index} className="mb-6">
                 <div className="flex justify-end mb-4">
                   <PrivateWrapper>
-                    <TariffUpdatesActions industryId={industryId} tariffIndex={index} countryName={countryTariff.countryName} />
+                    <TariffUpdatesActions industryId={industryId} tariffIndex={index} countryName={countryName} />
                   </PrivateWrapper>
                 </div>
                 <CountryTariffRenderer countryTariff={countryTariff} sectionId={sectionId} />

--- a/insights-ui/src/components/industry-tariff/cover/IndustryCoverBody.tsx
+++ b/insights-ui/src/components/industry-tariff/cover/IndustryCoverBody.tsx
@@ -66,7 +66,7 @@ export async function renderIndustryCoverBody(industryId: string): Promise<JSX.E
       <div className="space-y-12">
         {renderSection(
           'Overview',
-          report.reportCover ? (
+          report.reportCover?.reportCoverContent ? (
             <div
               className="prose max-w-none markdown markdown-body"
               dangerouslySetInnerHTML={{ __html: parseMarkdown(report.reportCover.reportCoverContent) }}
@@ -101,7 +101,7 @@ export async function renderIndustryCoverBody(industryId: string): Promise<JSX.E
             </div>
           )}
 
-        {report.executiveSummary &&
+        {report.executiveSummary?.executiveSummary &&
           renderSection(
             'Executive Summary',
             <div

--- a/insights-ui/src/components/industry-tariff/renderers/FinalConclusionRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/FinalConclusionRenderer.tsx
@@ -11,53 +11,84 @@ interface FinalConclusionRendererProps {
  * This replaces the markdown generation logic from render-tariff-markdown.ts
  */
 export const FinalConclusionRenderer: React.FC<FinalConclusionRendererProps> = ({ finalConclusion }) => {
+  const title = typeof finalConclusion?.title === 'string' ? finalConclusion.title : '';
+  const conclusionBrief = typeof finalConclusion?.conclusionBrief === 'string' ? finalConclusion.conclusionBrief : '';
+  const positive = finalConclusion?.positiveImpacts;
+  const negative = finalConclusion?.negativeImpacts;
+  const finalStatements = typeof finalConclusion?.finalStatements === 'string' ? finalConclusion.finalStatements : '';
+
+  const positiveTitle = typeof positive?.title === 'string' ? positive.title : '';
+  const positiveBody = typeof positive?.positiveImpacts === 'string' ? positive.positiveImpacts : '';
+  const negativeTitle = typeof negative?.title === 'string' ? negative.title : '';
+  const negativeBody = typeof negative?.negativeImpacts === 'string' ? negative.negativeImpacts : '';
+
+  const hasAnyContent = title || conclusionBrief || positiveTitle || positiveBody || negativeTitle || negativeBody || finalStatements;
+
+  if (!hasAnyContent) {
+    return (
+      <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
+        <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
-      {/* Title and Conclusion Brief */}
-      <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-gray-800 p-4 border-b border-gray-700">
-          <h2 className="text-2xl font-bold heading-color">{finalConclusion.title}</h2>
+      {(title || conclusionBrief) && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          {title && (
+            <div className="bg-gray-800 p-4 border-b border-gray-700">
+              <h2 className="text-2xl font-bold heading-color">{title}</h2>
+            </div>
+          )}
+          {conclusionBrief && (
+            <div className="p-4">
+              <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(conclusionBrief) }} />
+            </div>
+          )}
         </div>
-        <div className="p-4">
-          <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(finalConclusion.conclusionBrief) }} />
-        </div>
-      </div>
+      )}
 
-      {/* Positive Impacts */}
-      <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-gray-800 p-4 border-b border-gray-700">
-          <h2 className="text-xl font-semibold heading-color">{finalConclusion.positiveImpacts.title}</h2>
+      {(positiveTitle || positiveBody) && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          {positiveTitle && (
+            <div className="bg-gray-800 p-4 border-b border-gray-700">
+              <h2 className="text-xl font-semibold heading-color">{positiveTitle}</h2>
+            </div>
+          )}
+          {positiveBody && (
+            <div className="p-4">
+              <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(positiveBody) }} />
+            </div>
+          )}
         </div>
-        <div className="p-4">
-          <div
-            className="prose max-w-none markdown markdown-body"
-            dangerouslySetInnerHTML={{ __html: parseMarkdown(finalConclusion.positiveImpacts.positiveImpacts) }}
-          />
-        </div>
-      </div>
+      )}
 
-      {/* Negative Impacts */}
-      <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-gray-800 p-4 border-b border-gray-700">
-          <h2 className="text-xl font-semibold heading-color">{finalConclusion.negativeImpacts.title}</h2>
+      {(negativeTitle || negativeBody) && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          {negativeTitle && (
+            <div className="bg-gray-800 p-4 border-b border-gray-700">
+              <h2 className="text-xl font-semibold heading-color">{negativeTitle}</h2>
+            </div>
+          )}
+          {negativeBody && (
+            <div className="p-4">
+              <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(negativeBody) }} />
+            </div>
+          )}
         </div>
-        <div className="p-4">
-          <div
-            className="prose max-w-none markdown markdown-body"
-            dangerouslySetInnerHTML={{ __html: parseMarkdown(finalConclusion.negativeImpacts.negativeImpacts) }}
-          />
-        </div>
-      </div>
+      )}
 
-      {/* Final Statements */}
-      <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-gray-800 p-4 border-b border-gray-700">
-          <h2 className="text-xl font-semibold heading-color">Final Statements</h2>
+      {finalStatements && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          <div className="bg-gray-800 p-4 border-b border-gray-700">
+            <h2 className="text-xl font-semibold heading-color">Final Statements</h2>
+          </div>
+          <div className="p-4">
+            <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(finalStatements) }} />
+          </div>
         </div>
-        <div className="p-4">
-          <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(finalConclusion.finalStatements) }} />
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/insights-ui/src/components/industry-tariff/renderers/UnderstandIndustryRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/UnderstandIndustryRenderer.tsx
@@ -11,30 +11,48 @@ interface UnderstandIndustryRendererProps {
  * This replaces the markdown generation logic from render-tariff-markdown.ts
  */
 export const UnderstandIndustryRenderer: React.FC<UnderstandIndustryRendererProps> = ({ understandIndustry }) => {
+  const sections = Array.isArray(understandIndustry?.sections) ? understandIndustry.sections : [];
+  const title = typeof understandIndustry?.title === 'string' ? understandIndustry.title : '';
+
+  if (!title && sections.length === 0) {
+    return (
+      <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
+        <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
-      {/* Title */}
-      <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-gray-800 p-4 border-b border-gray-700">
-          <h2 className="text-2xl font-bold heading-color">{understandIndustry.title}</h2>
-        </div>
-      </div>
-
-      {/* Sections */}
-      {understandIndustry.sections.map((section, index) => (
-        <div key={index} className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+      {title && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
           <div className="bg-gray-800 p-4 border-b border-gray-700">
-            <h3 className="text-xl font-semibold heading-color">{section.title}</h3>
+            <h2 className="text-2xl font-bold heading-color">{title}</h2>
           </div>
-          <div className="p-4">
-            <div className="prose max-w-none space-y-4">
-              {section.paragraphs.map((paragraph, pIndex) => (
-                <div key={pIndex} className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(paragraph) }} />
-              ))}
+        </div>
+      )}
+
+      {sections.map((section, index) => {
+        const paragraphs = Array.isArray(section?.paragraphs) ? section.paragraphs : [];
+        const sectionTitle = typeof section?.title === 'string' ? section.title : '';
+        if (!sectionTitle && paragraphs.length === 0) return null;
+        return (
+          <div key={index} className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+            {sectionTitle && (
+              <div className="bg-gray-800 p-4 border-b border-gray-700">
+                <h3 className="text-xl font-semibold heading-color">{sectionTitle}</h3>
+              </div>
+            )}
+            <div className="p-4">
+              <div className="prose max-w-none space-y-4">
+                {paragraphs.map((paragraph, pIndex) => (
+                  <div key={pIndex} className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(paragraph) }} />
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/insights-ui/src/scripts/industry-tariff-reports/render-tariff-markdown.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/render-tariff-markdown.ts
@@ -1,6 +1,8 @@
 import { IndustryAreaSection } from '@/scripts/industry-tariff-reports/tariff-types';
 
-export function getMarkdownContentForIndustryAreas(industryAreaSection: IndustryAreaSection) {
-  const markdownContent = `# ${industryAreaSection.title}\n\n${industryAreaSection.industryAreas}`;
-  return markdownContent;
+export function getMarkdownContentForIndustryAreas(industryAreaSection: IndustryAreaSection): string {
+  const title = typeof industryAreaSection?.title === 'string' ? industryAreaSection.title : '';
+  const body = typeof industryAreaSection?.industryAreas === 'string' ? industryAreaSection.industryAreas : '';
+  if (!title && !body) return '';
+  return title ? `# ${title}\n\n${body}` : body;
 }

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
@@ -13,7 +13,7 @@ import type {
   UnderstandIndustry,
 } from '@/scripts/industry-tariff-reports/tariff-types';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { revalidateTariffReport } from '@/utils/tariff-report-cache-utils';
+import { revalidateTariffReport, revalidateTariffReportsListing } from '@/utils/tariff-report-cache-utils';
 
 // Defaults for chapters that don't have a legacy `TariffIndustryDefinition`.
 // Used by the headings-generation prompt — must match the typical shape of
@@ -161,6 +161,10 @@ async function writeSection(slug: string, data: Prisma.TariffChapterReportUpdate
   if (row.oldUrl) {
     revalidateTariffReport(row.oldUrl);
   }
+  // The /tariff-reports listing is cached via unstable_cache and shows the
+  // updatedAt for every chapter; bust it on every write so the homepage card
+  // reflects the new generation time without waiting for the weekly TTL.
+  revalidateTariffReportsListing();
 }
 
 // Stored in the `industry_areas` JSONB column — this is the headings/sub-headings

--- a/insights-ui/src/util/parse-markdown.ts
+++ b/insights-ui/src/util/parse-markdown.ts
@@ -12,6 +12,11 @@ function escapeTildes(text: string): string {
   return text.replace(/~/g, '&#126;');
 }
 
-export function parseMarkdown(text: string) {
+// Section JSON occasionally lands with a missing or non-string leaf (LLM
+// structured output isn't always strictly Zod-validated, partial Generate All
+// runs leave gaps). Returning '' here keeps a single bad field from throwing
+// out of a Server Component and tripping the production error boundary.
+export function parseMarkdown(text: string | null | undefined) {
+  if (typeof text !== 'string' || text.length === 0) return '';
   return marked.parse(escapeTildes(recursivelyCleanOpenAiUrls(text)), { renderer });
 }


### PR DESCRIPTION
## Summary
- Cover render previously guarded only on the parent section object (e.g. `report.reportCover`) but then called `parseMarkdown` on the inner string field. When a LangChain/Gemini structured-output run left a leaf empty or undefined (no strict server-side Zod validation), `parseMarkdown(undefined)` crashed inside `escapeTildes` and tripped the production Server Component error boundary on `/industry-tariff-report/<id>`.
- `parseMarkdown` now returns `''` for null/undefined/empty input — a single bad leaf no longer kills the whole page.
- `IndustryCoverBody` guards on the actual content fields (`reportCoverContent`, `executiveSummary.executiveSummary`) so the "No content available" fallback shows when generation produced an empty leaf.
- `writeSection` now also calls `revalidateTariffReportsListing()`, so the `/tariff-reports` listing's `updatedAt` refreshes immediately on every generation rather than waiting for the weekly `unstable_cache` TTL.

## Test plan
- [ ] `yarn lint && yarn prettier-check && yarn compile` (passing locally)
- [ ] Open `/industry-tariff-report/agriculturalProductsAndServices` after Generate All — page renders without the "Something went wrong" error
- [ ] Trigger any single-section regenerate from the admin UI — `/tariff-reports` listing card shows the new `updatedAt` on next visit