### PR TITLE
Cache chapter pages, drop heading stocks, improve SEO prompts

### DIFF
--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
@@ -4,12 +4,15 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterCoverHref } from '@/utils/tariff-reports/chapter-route-helpers';
+import { tariffReportTag } from '@/utils/tariff-report-tags';
 import type { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import type React from 'react';
 
 async function fetchChapterTariffReport(chapterSlug: string): Promise<ChapterTariffReportResponse | null> {
-  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`);
+  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`, {
+    next: { tags: [tariffReportTag(chapterSlug)] },
+  });
   return response.ok ? response.json() : null;
 }
 

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
@@ -7,13 +7,16 @@ import type { PageSeoDetails } from '@/scripts/industry-tariff-reports/tariff-ty
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
+import { tariffReportTag } from '@/utils/tariff-report-tags';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
 type SeoDetailsWithAliases = PageSeoDetails & { seoTitle?: string; metaDescription?: string; seo_title?: string; meta_description?: string };
 
 async function fetchChapterTariffReport(chapterSlug: string): Promise<ChapterTariffReportResponse | null> {
-  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`);
+  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`, {
+    next: { tags: [tariffReportTag(chapterSlug)] },
+  });
   return response.ok ? response.json() : null;
 }
 

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -11,6 +11,7 @@ import type { IndustryTariffReport, PageSeoDetails, TariffReportSeoDetails } fro
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { ChapterRouteInfo, chapterSectionHref, getChapterSectionCopy } from '@/utils/tariff-reports/chapter-route-helpers';
+import { tariffReportTag } from '@/utils/tariff-report-tags';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
@@ -34,7 +35,9 @@ function pickSectionSeo(seo: TariffReportSeoDetails | null | undefined, sectionS
 }
 
 async function fetchChapterTariffReport(chapterSlug: string): Promise<ChapterTariffReportResponse | null> {
-  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`);
+  const response = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/chapters/${chapterSlug}`, {
+    next: { tags: [tariffReportTag(chapterSlug)] },
+  });
   return response.ok ? response.json() : null;
 }
 

--- a/insights-ui/src/scripts/industry-tariff-reports/00-industry-main-headings.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/00-industry-main-headings.ts
@@ -9,15 +9,16 @@ import { z, ZodObject } from 'zod';
 import { getLlmResponse } from '../llm‑utils‑gemini';
 import { GeminiModel, LLMProvider } from '@/types/llmConstants';
 
-export const PublicCompanySchema = z.object({
-  name: z.string().describe('Name of the public company.'),
-  ticker: z.string().describe('Ticker symbol of the public company.'),
-});
-
+// Headings drive the structure of every downstream section (cover, executive
+// summary, understand-industry, industry-areas, tariff-updates, conclusion).
+// Keep this lean: title + one-line summary is enough to scope the prompts
+// for an HTS chapter. We previously also asked for US public companies per
+// subarea for the (now-removed) "evaluate industry area" section; that data
+// is no longer consumed anywhere, so dropping it shrinks the JSON the LLM
+// has to produce and reduces hallucinations.
 export const IndustrySubAreaSchema = z.object({
   title: z.string().describe('Subarea title'),
   oneLineSummary: z.string().describe('One line summary of the subarea.'),
-  companies: z.array(PublicCompanySchema).describe('This is the id of the html element to which the hyperlink points'),
 });
 
 export const IndustryAreaSchema = z.object({
@@ -33,21 +34,20 @@ export const IndustryAreasSchema: ZodObject<any> = z.object({
 function getMainIndustryPrompt(ctx: ChapterPromptContext) {
   const chapterLabel = formatChapterLabel(ctx);
   const prompt: string = `
-  As an investor I want to learn everything about the products and trade scope of ${chapterLabel}.
+  Divide ${chapterLabel} into clean, non-overlapping product/trade areas suitable for an HTS-chapter
+  tariff report. The output drives the structure of every other section, so the areas must be
+  specific to the goods covered by this HTS chapter — not generic industry segments.
 
-  Give me the information based on the following rules:
-  - I want to divide this chapter into four main areas, with three sub areas under each of them.
-  - The Downstream areas should come at the end, then the Midstream areas and then the Upstream areas first.
-  - I want to make sure the whole scope of ${chapterLabel} is covered and there is no overlap between the areas.
-  - Tell me the top ${ctx.headingsCount} areas and ${ctx.subHeadingsCount} subareas under each that I should know.
-  - Number of areas should be ${ctx.headingsCount}
-  - Number of subareas under each area should be ${ctx.subHeadingsCount}.
-  - There should be almost no overlap between the areas and subareas.
+  Rules:
+  - Produce exactly ${ctx.headingsCount} top-level areas, each with exactly ${ctx.subHeadingsCount} sub-areas.
+  - Order: Upstream first, then Midstream, then Downstream.
+  - Together the areas must cover the full product scope of ${chapterLabel} with effectively no overlap.
+  - Each area/sub-area title should reference concrete goods or trade categories from this HTS chapter
+    (not generic terms like "Market Dynamics" or "Industry Overview").
+  - The "oneLineSummary" should be one sentence that names the goods covered and their role in the chapter.
 
-  Also under each subAreas give me the name and tickers of each
-  of the US public company that belongs under it.
-
-  I dont want anything like common chapter introduction or metrics or other things to be in the areas or subareas.
+  Do NOT include common-chapter introductions, generic metrics, regulatory overviews, or company lists —
+  those belong to other sections of the report.
   `;
 
   return prompt;

--- a/insights-ui/src/scripts/industry-tariff-reports/01-industry-cover.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/01-industry-cover.ts
@@ -1,4 +1,5 @@
 import {
+  chapterSeoGuidance,
   formatChapterLabel,
   getChapterPromptContext,
   readExecutiveSummary,
@@ -41,6 +42,12 @@ export async function getReportCoverAndSaveToFile(slug: string): Promise<void> {
   Create a cover page which is different from the executive summary and conclusions.
 
   Dont include the title in the reportCoverContent.
+
+  Title rules:
+  - The "title" field should be a search-friendly H1 (50-65 characters) that includes the chapter title and a high-intent keyword
+    (e.g. "${ctx.chapterTitle}: Tariff Rates, Duties & 2026 Updates"). Avoid generic phrases like "Tariff Report Cover".
+
+   ${chapterSeoGuidance(ctx)}
 
    ${outputInstructions}
 

--- a/insights-ui/src/scripts/industry-tariff-reports/02-executive-summary.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/02-executive-summary.ts
@@ -1,4 +1,5 @@
 import {
+  chapterSeoGuidance,
   formatChapterLabel,
   getChapterPromptContext,
   readIndustryHeadings,
@@ -44,8 +45,11 @@ export async function getExecutiveSummaryAndSaveToFile(slug: string): Promise<vo
   4. Dont use Katex or Latex or italics formatting in the response.
 
    Executive summary should include the following fields:
-    - title
+    - title (search-friendly H1, 50-65 characters, includes the chapter title and a high-intent keyword such as
+      "Tariff Impact", "Duty Rates", or "2026 Updates" — e.g. "${ctx.chapterTitle}: Tariff Impact Summary").
     - executiveSummary (a markdown string which is the summary of the report)
+
+   ${chapterSeoGuidance(ctx)}
 
    ${outputInstructions}
 

--- a/insights-ui/src/scripts/industry-tariff-reports/04-understand-industry.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/04-understand-industry.ts
@@ -1,4 +1,5 @@
 import {
+  chapterSeoGuidance,
   formatChapterLabel,
   getChapterPromptContext,
   readIndustryHeadings,
@@ -114,6 +115,7 @@ Below are the consolidated key areas to cover under each of the six headings.
 
 ${JSON.stringify(headings, null, 2)}
 
+${chapterSeoGuidance(ctx)}
 `;
 
   console.log('Invoking LLM for understanding industry');

--- a/insights-ui/src/scripts/industry-tariff-reports/05-industry-areas.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/05-industry-areas.ts
@@ -1,4 +1,5 @@
 import {
+  chapterSeoGuidance,
   formatChapterLabel,
   getChapterPromptContext,
   readIndustryHeadings,
@@ -36,6 +37,8 @@ export async function getAndWriteIndustryAreaSectionToJsonFile(slug: string): Pr
   - Give a detailed insightful explanation of the sub-areas and how they relate to the main headings in around 1500 words
 
   ${outputInstructions}
+
+  ${chapterSeoGuidance(ctx)}
 
   # Headings and Subheadings
   ${JSON.stringify(headings, null, 2)}

--- a/insights-ui/src/scripts/industry-tariff-reports/07-final-conclusion.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/07-final-conclusion.ts
@@ -1,4 +1,5 @@
 import {
+  chapterSeoGuidance,
   formatChapterLabel,
   getChapterPromptContext,
   readIndustryHeadings,
@@ -80,6 +81,8 @@ export async function getFinalConclusionAndSaveToFile(slug: string): Promise<voi
     - finalStatements (string)
 
     ${outputInstructions}
+
+    ${chapterSeoGuidance(ctx)}
 
    # Chapter Areas
    ${JSON.stringify(headings, null, 2)}

--- a/insights-ui/src/scripts/industry-tariff-reports/08-report-seo-info.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/08-report-seo-info.ts
@@ -9,6 +9,7 @@ import {
   readTariffUpdates,
   readUnderstandIndustry,
   writeSeoDetails,
+  type ChapterPromptContext,
 } from '@/scripts/industry-tariff-reports/tariff-report-repository';
 import { PageSeoDetails, ReportType, TariffReportSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { z } from 'zod';
@@ -21,17 +22,36 @@ const PageSeoDetailsSchema = z.object({
   keywords: z.array(z.string()).describe('Array of relevant keywords for the page (5-10 keywords)'),
 });
 
-async function generateSeoDetailsForSection(chapterLabel: string, sectionName: string, sectionContent: unknown): Promise<PageSeoDetails> {
+async function generateSeoDetailsForSection(
+  ctx: Pick<ChapterPromptContext, 'chapterNumber' | 'chapterTitle'>,
+  sectionName: string,
+  sectionContent: unknown
+): Promise<PageSeoDetails> {
+  const chapterLabel = formatChapterLabel(ctx);
+  const padded = ctx.chapterNumber.toString().padStart(2, '0');
   const prompt = `
-    Generate SEO metadata for the ${sectionName} section of the tariff report for ${chapterLabel}.
-    The section content is provided below.
+    Generate SEO metadata for the "${sectionName}" page of the tariff report covering ${chapterLabel}.
+    This is a public web page; the goal is to maximise organic clicks from importers, exporters,
+    investors, and policy researchers searching for tariff information on this chapter.
 
-    Please create:
-    1. A concise, descriptive SEO title (50-60 characters) that includes important keywords
-    2. A compelling meta description (150-160 characters) that summarizes the section content
-    3. 5-10 relevant keywords related to the section content
+    Title rules (50-65 characters, hard cap at 65):
+    - Include the chapter title ("${ctx.chapterTitle}") OR the chapter number ("HTS Chapter ${padded}").
+    - Include at least one high-intent keyword for this section: tariff rates, import duty, customs duty,
+      trade impact, tariff updates, country-specific tariffs, etc.
+    - End with a brand suffix like " | KoalaGains" only if it still fits the character budget.
+    - Avoid stop-word filler ("Comprehensive Analysis of…"). Be direct.
 
-    The SEO metadata should be optimized for search engines while accurately reflecting the content.
+    Meta description rules (150-160 characters, hard cap at 160):
+    - Plain language, written to drive a click. Include a concrete pull (a country name, a percentage,
+      a date, or "2026 updates") if the underlying content provides one.
+    - Reference ${ctx.chapterTitle} explicitly.
+    - Active voice, no "Learn about…" / "Find out…" filler.
+
+    Keyword rules (5-10 keywords):
+    - Mix short-tail ("${ctx.chapterTitle} tariff", "HTS Chapter ${padded}") and long-tail
+      ("${ctx.chapterTitle} import duty rates", "<country> tariff on ${ctx.chapterTitle}") phrases.
+    - Pull at least 2-3 entities from the actual content (countries, sub-products, agreements).
+    - Lower-case, no duplicates, no hashtags.
 
     Output must be a JSON object with EXACTLY these keys:
     - title
@@ -49,42 +69,42 @@ export async function generateReportCoverSeo(slug: string): Promise<PageSeoDetai
   const ctx = await getChapterPromptContext(slug);
   const reportCover = await readReportCover(slug);
   if (!reportCover) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.REPORT_COVER, reportCover);
+  return generateSeoDetailsForSection(ctx, ReportType.REPORT_COVER, reportCover);
 }
 
 export async function generateExecutiveSummarySeo(slug: string): Promise<PageSeoDetails | undefined> {
   const ctx = await getChapterPromptContext(slug);
   const executiveSummary = await readExecutiveSummary(slug);
   if (!executiveSummary) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.EXECUTIVE_SUMMARY, executiveSummary);
+  return generateSeoDetailsForSection(ctx, ReportType.EXECUTIVE_SUMMARY, executiveSummary);
 }
 
 export async function generateTariffUpdatesSeo(slug: string): Promise<PageSeoDetails | undefined> {
   const ctx = await getChapterPromptContext(slug);
   const tariffUpdates = await readTariffUpdates(slug);
   if (!tariffUpdates) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.TARIFF_UPDATES, tariffUpdates);
+  return generateSeoDetailsForSection(ctx, ReportType.TARIFF_UPDATES, tariffUpdates);
 }
 
 export async function generateUnderstandIndustrySeo(slug: string): Promise<PageSeoDetails | undefined> {
   const ctx = await getChapterPromptContext(slug);
   const understandIndustry = await readUnderstandIndustry(slug);
   if (!understandIndustry) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.UNDERSTAND_INDUSTRY, understandIndustry);
+  return generateSeoDetailsForSection(ctx, ReportType.UNDERSTAND_INDUSTRY, understandIndustry);
 }
 
 export async function generateIndustryAreasSeo(slug: string): Promise<PageSeoDetails | undefined> {
   const ctx = await getChapterPromptContext(slug);
   const industryAreas = await readIndustryAreaSection(slug);
   if (!industryAreas) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.INDUSTRY_AREA_SECTION, industryAreas);
+  return generateSeoDetailsForSection(ctx, ReportType.INDUSTRY_AREA_SECTION, industryAreas);
 }
 
 export async function generateFinalConclusionSeo(slug: string): Promise<PageSeoDetails | undefined> {
   const ctx = await getChapterPromptContext(slug);
   const finalConclusion = await readFinalConclusion(slug);
   if (!finalConclusion) return undefined;
-  return generateSeoDetailsForSection(formatChapterLabel(ctx), ReportType.FINAL_CONCLUSION, finalConclusion);
+  return generateSeoDetailsForSection(ctx, ReportType.FINAL_CONCLUSION, finalConclusion);
 }
 
 export async function generateAndSaveAllSeoDetails(slug: string): Promise<TariffReportSeoDetails> {

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
@@ -57,6 +57,27 @@ export function formatChapterLabel(ctx: Pick<ChapterPromptContext, 'chapterNumbe
   return `HTS Chapter ${padded} — ${ctx.chapterTitle}`;
 }
 
+// Shared SEO/engagement guidance injected into every section's content prompt.
+// We want the report to rank for high-intent tariff queries (rates, duties,
+// per-country impact) so the analysis is written *with* those search phrases
+// in headings and lead sentences instead of generic prose.
+export function chapterSeoGuidance(ctx: Pick<ChapterPromptContext, 'chapterNumber' | 'chapterTitle'>): string {
+  const padded = ctx.chapterNumber.toString().padStart(2, '0');
+  const title = ctx.chapterTitle;
+  return `
+# SEO and Reader-Engagement Rules
+- Write for readers actively searching for tariff information on "${title}" or "HTS Chapter ${padded}".
+- Naturally weave high-intent phrases into H2/H3 sub-headers and the first sentence of paragraphs, e.g.
+  "${title} tariff rates", "${title} import duty", "HTS Chapter ${padded} tariff updates",
+  "tariffs on ${title} imports", "<country> tariffs on ${title}".
+- Prefer keyword-rich sub-headings over generic ones ("Latest Tariff Rates on ${title}" beats "Latest Updates").
+- Front-load concrete specifics in every paragraph: percentage rates, dollar amounts, exact dates, HTS sub-headings.
+  Wrap numerical values in backticks.
+- Include at least one short, direct snippet-friendly answer per section (a 2–3 sentence "What is…?" / "How does…?" opener).
+- Avoid filler ("In conclusion", "It is important to note"). Be concrete, scannable, and specific.
+`;
+}
+
 // The chapter is the canonical subject of the report, regardless of whether the
 // caller arrived via the legacy `/industry-tariff-report/<industryId>` URL or a
 // chapter-keyed route. Prompts must reference the chapter title (and number) so
@@ -168,7 +189,11 @@ async function writeSection(slug: string, data: Prisma.TariffChapterReportUpdate
     data,
     select: { oldUrl: true },
   });
-  if (row.oldUrl) {
+  // Chapter routes (`/industry-tariff-report/chapters/<slug>`) cache their
+  // fetches under a slug-keyed tag; legacy industry routes (when oldUrl is
+  // set) cache under the oldUrl. Bust both so neither URL serves stale data.
+  revalidateTariffReport(slug);
+  if (row.oldUrl && row.oldUrl !== slug) {
     revalidateTariffReport(row.oldUrl);
   }
   // The /tariff-reports listing is cached via unstable_cache and shows the

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-types.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-types.ts
@@ -1,13 +1,7 @@
 // 00-industry-main-headings.ts
-interface PublicCompany {
-  name: string;
-  ticker: string;
-}
-
 export interface IndustrySubArea {
   title: string;
   oneLineSummary: string;
-  companies: PublicCompany[];
 }
 
 export interface IndustryArea {


### PR DESCRIPTION
## Summary
- Tag chapter UI fetches with `tariffReportTag(chapterSlug)` (in `chapters/[chapterSlug]/page.tsx`, `layout.tsx`, and the shared `chapter-section-page.tsx`) and have `writeSection` revalidate that tag in addition to the legacy `oldUrl` tag, so regenerating any chapter section busts both URL flavours.
- Drop the per-subarea `companies` schema/field from `00-industry-main-headings`. The evaluate-industry-area section that consumed it has been removed, so the LLM no longer wastes calls inventing stock tickers per HTS chapter.
- Add a shared `chapterSeoGuidance` helper and inject it into the cover / executive-summary / understand-industry / industry-areas / final-conclusion prompts so generated copy is written around high-intent tariff search phrases.
- Rework the SEO-metadata prompt to be chapter-aware (HTS chapter number + title in title), CTR-driven (lead with country, percentage, or date), and to surface a mix of short- and long-tail keywords.

## Test plan
- [ ] Regenerate a chapter section (e.g. cover or industry-areas) and confirm the chapter URL reflects the new content without manual revalidation.
- [ ] Regenerate a legacy industry-keyed section and confirm the `/industry-tariff-report/<industryId>` page still revalidates as before.
- [ ] Regenerate headings for a chapter and confirm the resulting `industryAreas` JSON no longer contains a `companies` array per subarea.
- [ ] Regenerate SEO metadata for a chapter section and spot-check title/description/keywords for chapter-specific, search-intent phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)