### PR TITLE
Internal-linking pass on tariff pages: cross-links, JSON-LD breadcrumbs, sitemaps

### DIFF
--- a/docs/insights-ui/tasks/tariffs.md
+++ b/docs/insights-ui/tasks/tariffs.md
@@ -65,13 +65,10 @@ the page is dense and long; we need a much higher signal-to-noise ratio at the t
     long — readers should be able to jump to "Rates", "Recent changes", "By
     country", etc.).
   - Anchor links so each subsection has its own URL fragment for sharing.
-- [ ] **Better cross-linking**:
-  - From an industry tariff page, link to the relevant **stock** and **ETF**
-    reports (companies + funds with exposure to that industry / those
-    countries).
-  - From a country tariff page, link to the industries most affected.
-  - Internal linking helps both UX and the GSC "Crawled — currently not indexed"
-    issue tracked in `stocks.md` SEO Fixes.
+- [ ] **Better cross-linking** — broken out into its own task below
+  ("Link tariff pages (internal linking pass)") so the work has a single
+  owner and a single PR. Covers tariff → tariff, tariff → stock, tariff →
+  ETF, and the inbound stock/ETF → tariff direction in one pass.
 - [ ] **Mobile pass**:
   - The biggest share of incoming traffic from search lands on mobile — verify
     headline numbers, charts, and the snapshot block all render cleanly on a
@@ -100,3 +97,127 @@ the page is dense and long; we need a much higher signal-to-noise ratio at the t
     in place; only rename if the content materially changes shape.
   - Per-country vs per-industry primary view — readers seem to come in from
     both. Confirm with analytics which surface deserves the polished UX first.
+
+## Link tariff pages (internal linking pass)
+
+Why this matters: tariff pages are some of the highest-traffic, highest-intent
+landing pages on KoalaGains, but each one is currently a dead-end for readers
+and for crawlers. Search Console is reporting a "Crawled — currently not
+indexed" pattern (see `stocks.md` SEO Fixes) on adjacent surfaces, which
+internal linking is the cheapest, most direct lever to fix. A reader who lands
+on `/industry-tariff-report/automobiles/tariff-updates` from organic search
+should be one click away from the related industry, related country, related
+stocks, and related ETF surfaces — and crawlers should see those links so the
+neighbouring URLs get discovered and indexed.
+
+Treat this as a **standalone, single-PR task** rather than a bullet under
+"Simplify the UX". The cross-linking sub-bullet there is now superseded by
+this section.
+
+### In-scope surfaces
+
+These are the pages that need link blocks added or improved. Keep the list
+explicit so reviewers can tick each off:
+
+- `app/tariff-reports/page.tsx` — listing page (`/tariff-reports`).
+- `app/industry-tariff-report/[industryId]/page.tsx` — industry cover.
+- `app/industry-tariff-report/[industryId]/tariff-updates/` — section page.
+- `app/industry-tariff-report/[industryId]/understand-industry/` — section page.
+- `app/industry-tariff-report/[industryId]/industry-areas/` — section page.
+- `app/industry-tariff-report/[industryId]/final-conclusion/` — section page.
+- `app/industry-tariff-report/chapters/[slug]/` (and its section sub-routes) —
+  slug-based chapter pages (only those without `oldUrl`).
+- The deprecated routes (`all-countries-tariff-updates`,
+  `evaluate-industry-areas/*`) are out of scope — they keep their cover-page
+  body and a canonical pointer, no new internal links needed (see
+  `../tariffs/post-merge-url-checklist.md`).
+
+### Outbound links to add (from a tariff page)
+
+- [ ] **Related industries (spillover)** — use the `relatedIndustries` field
+  already present on `TariffIndustryDefinition`. Render a "Related industry
+  tariff reports" rail with 3–6 links to other
+  `/industry-tariff-report/<id>` pages. Place it on the cover and on
+  `final-conclusion` (the two surfaces a reader hits at the start and end of
+  the report).
+- [ ] **Related country tariff context** — for the most-referenced exporter /
+  importer countries in each report, link out to the relevant
+  `tariff-updates` section anchors on neighbouring industry reports
+  (e.g. an automobiles report that talks about Mexico → link to the Mexico
+  section on the steel report). Cap at the top 3–5 countries by mention
+  weight to avoid link spam.
+- [ ] **Stocks: impacted companies** — for every company already returned by
+  the impact pipeline (`EstablishedPlayer` / `NewChallenger` with positive or
+  negative impact), link to that company's KoalaGains stock report when one
+  exists. Skip silently when no stock page is available — do **not** render a
+  dead link or a placeholder.
+- [ ] **ETFs with exposure** — link from the industry cover to the most
+  relevant ETF reports (industry-themed and country-themed) using the same
+  ETF index that powers the ETFs listing page. Mirror the pattern stocks.md
+  uses for stock → ETF links so the two stay consistent.
+- [ ] **Tariff-reports listing breadcrumb** — every section page should have a
+  breadcrumb / back-link to `/tariff-reports` and to the industry cover.
+  Today the user has to use the browser back button.
+
+### Inbound links to add (to a tariff page)
+
+- [ ] **Stock report → tariff report** — on every stock report whose primary
+  industry matches a tariff report, surface a "Tariff exposure" link block
+  that points to that industry's tariff cover and (where useful) the
+  `tariff-updates` section anchor for the country most relevant to that
+  stock.
+- [ ] **ETF report → tariff report** — same pattern from ETF reports whose
+  exposure overlaps an industry that has a tariff report. Use the existing
+  industry mapping that powers the ETFs listing rather than introducing a
+  new field.
+- [ ] **Home / hub pages** — confirm the home page and any hub/landing
+  surfaces link to `/tariff-reports` (and to a curated handful of
+  high-traffic industry covers). One click from home to the most popular
+  tariff reports.
+
+### Implementation guardrails
+
+- [ ] **Reuse before creating** — there is already a "Related" rail / link
+  block pattern on stocks and ETFs (see the `Reuse Before Creating` rule in
+  the repo `CLAUDE.md`). Reuse that component; do **not** introduce a new
+  bespoke one for tariffs.
+- [ ] **Render server-side** — links must be in the server-rendered HTML so
+  Googlebot sees them on first crawl. No client-only `useEffect` rails.
+- [ ] **Cache invalidation** — the new link blocks pull from the same JSON the
+  page already loads, so the existing `tariff_report:<INDUSTRYID>` cache tag
+  (see `../tariffs/post-merge-url-checklist.md` cache section) covers them.
+  If a link block reads from a *different* source (e.g. ETF index, stock
+  index), tag the fetch with that source's tag too so a stock/ETF refresh
+  also refreshes the tariff page's link block.
+- [ ] **Stable anchors** — when linking to a section anchor (e.g. the Mexico
+  block inside `tariff-updates`), the anchor id must come from the country /
+  area slug, not a generated index. Otherwise the inbound link rots the next
+  time the report regenerates.
+- [ ] **Avoid orphaned links** — guard each outbound link by checking the
+  target exists before rendering. A 404 from an internal link hurts more
+  than no link at all.
+- [ ] **Sitemap untouched** — this task does not add new URLs; the existing
+  sitemap rules in the post-merge checklist still hold.
+
+### Measurement
+
+- [ ] **Before/after baselines** — record indexed-URL count for the tariff
+  sitemaps and average internal-link count per tariff page **before** the
+  PR lands.
+- [ ] **GSC follow-up** — 2 weeks after the PR is in production, re-check the
+  "Crawled — currently not indexed" report for tariff URLs and the
+  `inurl:industry-tariff-report` slice of the indexed-URL count. Document
+  the delta in `../tariffs/` and link from this task entry.
+- [ ] **Engagement** — confirm clicks on the new link rails are non-trivial
+  (analytics: rail-click events / page-views). If a rail sees ~zero clicks,
+  treat it as dead weight and remove it rather than letting it linger.
+
+### Open questions
+
+- Where should the "Related industries" rail render — inline in the body, in
+  a sidebar, or as a footer block? Pick whichever the existing stock/ETF
+  reports already use, for consistency.
+- Do we want a "Related tariff reports" rail on stock and ETF reports, or
+  just a single inline "Tariff exposure" link? The latter is cheaper and
+  lower-noise; default to that unless engagement data later justifies a full
+  rail.

--- a/insights-ui/public/sitemap.xml
+++ b/insights-ui/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://koalagains.com/tariff-calculator</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://koalagains.com/genai-simulation</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -16,6 +16,9 @@
     <loc>https://koalagains.com/industry-tariff-report/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://koalagains.com/hts-codes/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://koalagains.com/crowd-funding/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/insights-ui/src/app/api/tariff-calculator/chapters/[number]/related-report/route.ts
+++ b/insights-ui/src/app/api/tariff-calculator/chapters/[number]/related-report/route.ts
@@ -1,0 +1,21 @@
+import { getTariffReportRefByChapterNumber, type TariffReportRef } from '@/utils/tariff-cross-links/hts-chapter-ref';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+export type { TariffReportRef };
+
+function parseChapterNumber(raw: string): number | null {
+  if (!/^\d{1,2}$/.test(raw)) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 99) return null;
+  return n;
+}
+
+async function getHandler(_req: NextRequest, dynamic: { params: Promise<{ number: string }> }): Promise<TariffReportRef | null> {
+  const { number: rawNumber } = await dynamic.params;
+  const chapterNumber = parseChapterNumber(rawNumber);
+  if (chapterNumber === null) return null;
+  return getTariffReportRefByChapterNumber(chapterNumber);
+}
+
+export const GET = withErrorHandlingV2<TariffReportRef | null>(getHandler);

--- a/insights-ui/src/app/hts-codes/page.tsx
+++ b/insights-ui/src/app/hts-codes/page.tsx
@@ -11,7 +11,6 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 
 export const dynamic = 'force-static';
-export const revalidate = 86400; // 24h
 
 export const metadata: Metadata = {
   title: 'HTS Code Sections & Chapters | KoalaGains',
@@ -31,7 +30,7 @@ export const metadata: Metadata = {
 async function fetchSections(): Promise<TariffSectionListItem[]> {
   const url = `${getBaseUrlForServerSidePages()}/api/tariff-calculator/sections`;
   try {
-    const res = await fetch(url, { next: { revalidate: 86400, tags: [TARIFF_SECTIONS_LISTING_TAG] } });
+    const res = await fetch(url, { next: { tags: [TARIFF_SECTIONS_LISTING_TAG] } });
     if (!res.ok) {
       console.error(`Failed to fetch tariff sections: HTTP ${res.status}`);
       return [];

--- a/insights-ui/src/app/hts-codes/page.tsx
+++ b/insights-ui/src/app/hts-codes/page.tsx
@@ -1,11 +1,12 @@
 import type { TariffSectionListItem } from '@/app/api/tariff-calculator/sections/route';
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
 import { TARIFF_SECTIONS_LISTING_TAG } from '@/utils/tariff-calculator/cache-tags';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
-import { ChevronRight } from 'lucide-react';
+import { Calculator, ChevronRight, FileText } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -60,7 +61,7 @@ export default async function HtsCodesIndexPage() {
 
   return (
     <PageWrapper>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
+      <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-color">
         <header className="mb-8">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl mb-3">HTS Code Sections &amp; Chapters</h1>
@@ -69,6 +70,24 @@ export default async function HtsCodesIndexPage() {
             view its full HTS code list with duty rates, units of measure, and official notes.
           </p>
         </header>
+
+        <TariffCrossLinks
+          heading="Want analysis or a duty estimate, not just the code?"
+          links={[
+            {
+              href: '/tariff-reports',
+              title: 'Tariff Reports',
+              description: 'Industry tariff-impact analysis tied to these HTS chapters: rate changes, country breakdowns, and outlook.',
+              icon: <FileText className="h-5 w-5" />,
+            },
+            {
+              href: '/tariff-calculator',
+              title: 'Tariff Calculator',
+              description: 'Once you have the right HTS code, plug it in to estimate the full landed duty cost.',
+              icon: <Calculator className="h-5 w-5" />,
+            },
+          ]}
+        />
 
         {sections.length === 0 ? (
           <div className="text-center py-16 background-color rounded-lg border border-color">

--- a/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
+++ b/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
+import { NextRequest, NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+async function generateHtsCodeUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [{ url: '/hts-codes', changefreq: 'weekly', priority: 0.7 }];
+
+  const chapters = await prisma.tariffChapter.findMany({
+    where: { spaceId: KoalaGainsSpaceId },
+    select: { number: true, title: true, updatedAt: true, section: { select: { number: true } } },
+    orderBy: { number: 'asc' },
+  });
+
+  for (const chapter of chapters) {
+    urls.push({
+      url: chapterDetailHref(chapter.section.number, chapter.number, chapter.title),
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod: chapter.updatedAt.toISOString(),
+    });
+  }
+
+  return urls;
+}
+
+async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
+  const host = req.headers.get('host') as string;
+
+  try {
+    const urls = await generateHtsCodeUrls();
+    const smStream = new SitemapStream({ hostname: 'https://' + host });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating hts-codes sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
+++ b/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
@@ -1,11 +1,11 @@
 import type { TariffChapterDetail } from '@/app/api/tariff-calculator/chapters/[number]/route';
 import type { TariffChapterListItem } from '@/app/api/tariff-calculator/chapters/route';
+import type { TariffReportRef } from '@/app/api/tariff-calculator/chapters/[number]/related-report/route';
 import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
-import { TARIFF_CHAPTERS_LISTING_TAG, tariffChapterDetailCacheTag } from '@/utils/tariff-calculator/cache-tags';
+import { TARIFF_CHAPTERS_LISTING_TAG, tariffChapterDetailCacheTag, tariffChapterRelatedReportCacheTag } from '@/utils/tariff-calculator/cache-tags';
 import { chapterDetailHref, chapterUrlSegment, parseChapterSegment, parseSectionSegment, sectionUrlSegment } from '@/utils/tariff-calculator/chapter-slug';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { getTariffReportRefByChapterNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { HtsCode } from '@prisma/client';
@@ -33,6 +33,21 @@ async function fetchChapterDetail(chapterNumber: number): Promise<TariffChapterD
     return (await res.json()) as TariffChapterDetail | null;
   } catch (e) {
     console.error(`Failed to fetch chapter ${chapterNumber}:`, e);
+    return null;
+  }
+}
+
+async function fetchChapterRelatedReport(chapterNumber: number): Promise<TariffReportRef | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/tariff-calculator/chapters/${chapterNumber.toString().padStart(2, '0')}/related-report`;
+  try {
+    const res = await fetch(url, { next: { tags: [tariffChapterRelatedReportCacheTag(chapterNumber)] } });
+    if (!res.ok) {
+      if (res.status !== 404) console.error(`Failed to fetch related report for chapter ${chapterNumber}: HTTP ${res.status}`);
+      return null;
+    }
+    return (await res.json()) as TariffReportRef | null;
+  } catch (e) {
+    console.error(`Failed to fetch related report for chapter ${chapterNumber}:`, e);
     return null;
   }
 }
@@ -216,7 +231,7 @@ export default async function HtsChapterDetailPage({ params }: { params: Promise
     { name: `Chapter ${padded} — ${chapter.title}`, href: canonicalHref, current: true },
   ];
 
-  const tariffReportRef = await getTariffReportRefByChapterNumber(chapter.number);
+  const tariffReportRef = await fetchChapterRelatedReport(chapter.number);
   const crossLinks = [
     tariffReportRef
       ? {

--- a/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
+++ b/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
@@ -1,11 +1,14 @@
 import type { TariffChapterDetail } from '@/app/api/tariff-calculator/chapters/[number]/route';
 import type { TariffChapterListItem } from '@/app/api/tariff-calculator/chapters/route';
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { chapterDetailHref, chapterUrlSegment, parseChapterSegment, parseSectionSegment, sectionUrlSegment } from '@/utils/tariff-calculator/chapter-slug';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getTariffReportRefByChapterNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { HtsCode } from '@prisma/client';
+import { Calculator, FileText } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
@@ -210,12 +213,30 @@ export default async function HtsChapterDetailPage({ params }: { params: Promise
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'Reports', href: '/reports', current: false },
     { name: 'HTS Codes', href: '/hts-codes', current: false },
-    { name: `Chapter ${padded}`, href: canonicalHref, current: true },
+    { name: `Chapter ${padded} — ${chapter.title}`, href: canonicalHref, current: true },
   ];
+
+  const tariffReportRef = await getTariffReportRefByChapterNumber(chapter.number);
+  const crossLinks = [
+    tariffReportRef
+      ? {
+          href: tariffReportRef.href,
+          title: `Tariff Impact Report — Chapter ${padded}`,
+          description: 'Industry tariff analysis tied to this HTS chapter: rate changes, country breakdowns, winners and losers.',
+          icon: <FileText className="h-5 w-5" />,
+        }
+      : null,
+    {
+      href: '/tariff-calculator',
+      title: 'Tariff Calculator',
+      description: `Estimate full landed duty for codes in HTS Chapter ${padded} — base rate plus Section 232, 301, IEEPA, and processing fees.`,
+      icon: <Calculator className="h-5 w-5" />,
+    },
+  ].filter((link): link is NonNullable<typeof link> => link !== null);
 
   return (
     <PageWrapper>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
+      <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-color">
         <header className="mb-6">
           <div className="text-sm text-muted-foreground mb-1">
@@ -227,6 +248,8 @@ export default async function HtsChapterDetailPage({ params }: { params: Promise
             {chapter.title}
           </h1>
         </header>
+
+        <TariffCrossLinks heading="Tools for this chapter" links={crossLinks} />
 
         {(chapter.notes || chapter.additionalUsNotes) && (
           <section className="mb-8 grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
+++ b/insights-ui/src/app/hts-codes/us/[section]/[chapter]/page.tsx
@@ -2,6 +2,7 @@ import type { TariffChapterDetail } from '@/app/api/tariff-calculator/chapters/[
 import type { TariffChapterListItem } from '@/app/api/tariff-calculator/chapters/route';
 import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
+import { TARIFF_CHAPTERS_LISTING_TAG, tariffChapterDetailCacheTag } from '@/utils/tariff-calculator/cache-tags';
 import { chapterDetailHref, chapterUrlSegment, parseChapterSegment, parseSectionSegment, sectionUrlSegment } from '@/utils/tariff-calculator/chapter-slug';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { getTariffReportRefByChapterNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
@@ -15,7 +16,6 @@ import { notFound, redirect } from 'next/navigation';
 
 export const dynamic = 'force-static';
 export const dynamicParams = true;
-export const revalidate = 86400; // 24h
 
 interface RouteParams {
   section: string;
@@ -25,7 +25,7 @@ interface RouteParams {
 async function fetchChapterDetail(chapterNumber: number): Promise<TariffChapterDetail | null> {
   const url = `${getBaseUrlForServerSidePages()}/api/tariff-calculator/chapters/${chapterNumber.toString().padStart(2, '0')}`;
   try {
-    const res = await fetch(url, { next: { revalidate: 86400 } });
+    const res = await fetch(url, { next: { tags: [tariffChapterDetailCacheTag(chapterNumber)] } });
     if (!res.ok) {
       if (res.status !== 404) console.error(`Failed to fetch chapter ${chapterNumber}: HTTP ${res.status}`);
       return null;
@@ -40,7 +40,7 @@ async function fetchChapterDetail(chapterNumber: number): Promise<TariffChapterD
 async function fetchChapterList(): Promise<TariffChapterListItem[]> {
   const url = `${getBaseUrlForServerSidePages()}/api/tariff-calculator/chapters`;
   try {
-    const res = await fetch(url, { next: { revalidate: 86400 } });
+    const res = await fetch(url, { next: { tags: [TARIFF_CHAPTERS_LISTING_TAG] } });
     if (!res.ok) {
       console.error(`Failed to fetch chapter list: HTTP ${res.status}`);
       return [];

--- a/insights-ui/src/app/industry-tariff-report/[industryId]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/layout.tsx
@@ -1,6 +1,6 @@
 import MobileNavToggle from '@/components/industry-tariff/mobile-nav-toggle';
 import CollapsibleLayout from '@/components/industry-tariff/collapsible-layout';
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
 import { getSeededLastModifiedForOldUrl } from '@/utils/tariff-reports/seeded-chapter-reports';
 import type { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -51,7 +51,7 @@ export default async function IndustryTariffReportLayout({ children, params }: {
 
   return (
     <PageWrapper>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
+      <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
 
       {lastModified && (
         <div className="block lg:hidden mx-auto max-w-7xl px-4 sm:px-6 mb-4">

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
@@ -1,6 +1,6 @@
 import CollapsibleLayout from '@/components/industry-tariff/collapsible-layout';
 import MobileNavToggle from '@/components/industry-tariff/mobile-nav-toggle';
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterCoverHref } from '@/utils/tariff-reports/chapter-route-helpers';
@@ -38,7 +38,7 @@ export default async function ChapterReportLayout({ children, params }: { childr
 
   return (
     <PageWrapper>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
+      <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
 
       <div className="mx-auto text-color">
         <div className="mx-auto">

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
@@ -2,12 +2,15 @@ import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ChapterPlaceholder from '@/components/industry-tariff/chapter/ChapterPlaceholder';
 import ChapterSectionActions from '@/components/industry-tariff/chapter/ChapterSectionActions';
 import { renderSection } from '@/components/industry-tariff/renderers/SectionRenderer';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import type { PageSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
+import { getHtsChapterRefByNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import { tariffReportTag } from '@/utils/tariff-report-tags';
+import { Calculator, ListTree } from 'lucide-react';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
@@ -78,6 +81,24 @@ export default async function ChapterCoverPage({ params }: { params: Promise<{ c
       newChangesFirstSentence: tariff.newChanges,
     })) ?? [];
 
+  const htsChapter = await getHtsChapterRefByNumber(chapter.number);
+  const crossLinks = [
+    {
+      href: '/tariff-calculator',
+      title: 'Tariff Calculator',
+      description: `Estimate landed US duty for goods in HTS Chapter ${padded} — base rate plus Section 232, 301, and IEEPA fees.`,
+      icon: <Calculator className="h-5 w-5" />,
+    },
+    htsChapter
+      ? {
+          href: htsChapter.href,
+          title: `HTS Chapter ${padded} — ${chapter.title}`,
+          description: 'Browse every HTS code in this chapter, with general rate, Column 2, special rates, and units of quantity.',
+          icon: <ListTree className="h-5 w-5" />,
+        }
+      : null,
+  ].filter((link): link is NonNullable<typeof link> => link !== null);
+
   return (
     <div className="mx-auto max-w-7xl py-2">
       <div className="mb-8 pb-4 border-b border-gray-200 dark:border-gray-700">
@@ -124,6 +145,8 @@ export default async function ChapterCoverPage({ params }: { params: Promise<{ c
           </PrivateWrapper>
         </div>
       </div>
+
+      <TariffCrossLinks heading="Tools for this chapter" links={crossLinks} />
 
       <div className="space-y-12">
         {renderSection(

--- a/insights-ui/src/app/tariff-calculator/page.tsx
+++ b/insights-ui/src/app/tariff-calculator/page.tsx
@@ -1,7 +1,9 @@
 import CalculatorClient from './CalculatorClient';
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { FileText, ListTree } from 'lucide-react';
 import { Metadata } from 'next';
 
 export const dynamic = 'force-static';
@@ -62,25 +64,13 @@ const JSON_LD = {
   publisher: { '@type': 'Organization', name: 'KoalaGains', url: 'https://koalagains.com' },
 };
 
-const BREADCRUMB_LD = {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  itemListElement: BREADCRUMBS.map((b, i) => ({
-    '@type': 'ListItem',
-    position: i + 1,
-    name: b.name,
-    item: `https://koalagains.com${b.href}`,
-  })),
-};
-
 export default function TariffCalculatorPage() {
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(BREADCRUMB_LD) }} />
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-color" style={{ colorScheme: 'dark', accentColor: '#fbbf24' }}>
-        <Breadcrumbs breadcrumbs={BREADCRUMBS} />
+        <BreadcrumbsWithJsonLd breadcrumbs={BREADCRUMBS} />
 
         <header className="mb-8">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl heading-color">US Tariff &amp; Duty Calculator</h1>
@@ -89,6 +79,24 @@ export default function TariffCalculatorPage() {
             the usual port and processing fees. Pick the country you ship from and the date your goods arrive to get the final cost.
           </p>
         </header>
+
+        <TariffCrossLinks
+          heading="Need to find an exact HTS code or read the broader analysis?"
+          links={[
+            {
+              href: '/hts-codes',
+              title: 'Browse HTS Codes',
+              description: 'Open the full HTSUS section + chapter catalog to confirm the exact code for what you ship.',
+              icon: <ListTree className="h-5 w-5" />,
+            },
+            {
+              href: '/tariff-reports',
+              title: 'Tariff Reports',
+              description: 'Industry-level tariff impact analysis — context behind the rates this calculator returns.',
+              icon: <FileText className="h-5 w-5" />,
+            },
+          ]}
+        />
 
         <CalculatorClient />
       </div>

--- a/insights-ui/src/app/tariff-reports/page.tsx
+++ b/insights-ui/src/app/tariff-reports/page.tsx
@@ -1,17 +1,30 @@
+import type { TariffReportListingItem } from '@/app/api/tariff-reports/listing/route';
 import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import TariffReportsPageActions from '@/components/industry-tariff/TariffReportsPageActions';
 import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { findIndustryByLegacyUrl, TariffIndustryDefinition } from '@/scripts/industry-tariff-reports/tariff-industries';
-import { getTariffReportsListing } from '@/utils/tariff-reports/tariff-reports-listing';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { TARIFF_REPORTS_LISTING_TAG } from '@/utils/tariff-report-tags';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { ArrowRight, Calculator, FileText, Layers, ListTree } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
 
-// Render at request time; the build environment does not provision DATABASE_URL for the Prisma listing query.
-// The listing data itself is cached via unstable_cache in getTariffReportsListing.
-export const dynamic = 'force-dynamic';
+async function fetchTariffReportsListing(): Promise<TariffReportListingItem[]> {
+  const url = `${getBaseUrlForServerSidePages()}/api/tariff-reports/listing`;
+  try {
+    const res = await fetch(url, { next: { tags: [TARIFF_REPORTS_LISTING_TAG] } });
+    if (!res.ok) {
+      console.error(`Failed to fetch tariff reports listing: HTTP ${res.status}`);
+      return [];
+    }
+    return (await res.json()) as TariffReportListingItem[];
+  } catch (e) {
+    console.error('Failed to fetch tariff reports listing:', e);
+    return [];
+  }
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const title = 'Tariff Reports | KoalaGains';
@@ -117,7 +130,7 @@ function ChapterCard({ chapterNumber, chapterTitle, chapterSlug, industry, lastM
 }
 
 export default async function TariffReportsPage() {
-  const rows = await getTariffReportsListing();
+  const rows = await fetchTariffReportsListing();
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
     { name: 'Reports', href: '/reports', current: false },

--- a/insights-ui/src/app/tariff-reports/page.tsx
+++ b/insights-ui/src/app/tariff-reports/page.tsx
@@ -1,10 +1,11 @@
-import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import TariffReportsPageActions from '@/components/industry-tariff/TariffReportsPageActions';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { findIndustryByLegacyUrl, TariffIndustryDefinition } from '@/scripts/industry-tariff-reports/tariff-industries';
 import { getTariffReportsListing } from '@/utils/tariff-reports/tariff-reports-listing';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
-import { ArrowRight, FileText, Layers } from 'lucide-react';
+import { ArrowRight, Calculator, FileText, Layers, ListTree } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -125,7 +126,7 @@ export default async function TariffReportsPage() {
 
   return (
     <PageWrapper>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
+      <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-color">
         <header className="mb-10">
@@ -138,6 +139,25 @@ export default async function TariffReportsPage() {
             industry structure, sub-areas, and forward-looking conclusions.
           </p>
         </header>
+
+        <TariffCrossLinks
+          heading="Looking for a specific HTS code or duty?"
+          description="Skip the long-form analysis when you just need to look up a code or estimate a duty."
+          links={[
+            {
+              href: '/tariff-calculator',
+              title: 'Tariff Calculator',
+              description: 'Estimate US import duty: base HTS rate plus Section 232, 301, IEEPA, and processing fees.',
+              icon: <Calculator className="h-5 w-5" />,
+            },
+            {
+              href: '/hts-codes',
+              title: 'HTS Code Browser',
+              description: 'Browse every HTSUS section and chapter to find the code you need before you calculate.',
+              icon: <ListTree className="h-5 w-5" />,
+            },
+          ]}
+        />
 
         {rows.length === 0 ? (
           <div className="rounded-2xl border border-gray-800 bg-gray-900 py-12 text-center">

--- a/insights-ui/src/components/industry-tariff/cover/IndustryCoverBody.tsx
+++ b/insights-ui/src/components/industry-tariff/cover/IndustryCoverBody.tsx
@@ -1,11 +1,14 @@
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ReportCoverActions from '@/components/industry-tariff/section-actions/ReportCoverActions';
 import { renderSection } from '@/components/industry-tariff/renderers/SectionRenderer';
+import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { getTariffIndustryDefinitionById, TariffIndustryId } from '@/scripts/industry-tariff-reports/tariff-industries';
 import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getHtsChapterRefByIndustryId } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import { tariffReportTag } from '@/utils/tariff-report-tags';
+import { Calculator, ListTree } from 'lucide-react';
 
 // Shared async render for the industry cover body. Used by the cover route
 // itself and by the legacy `/evaluate-industry-areas` and `/all-countries-tariff-updates`
@@ -40,6 +43,24 @@ export async function renderIndustryCoverBody(industryId: string): Promise<JSX.E
       newChangesFirstSentence: tariff.newChanges,
     })) || [];
 
+  const htsChapter = await getHtsChapterRefByIndustryId(industryId);
+  const crossLinks = [
+    {
+      href: '/tariff-calculator',
+      title: 'Tariff Calculator',
+      description: `Estimate landed US duty for goods covered by this report — base HTS rate plus Section 232, 301, IEEPA fees.`,
+      icon: <Calculator className="h-5 w-5" />,
+    },
+    htsChapter
+      ? {
+          href: htsChapter.href,
+          title: `HTS Chapter ${htsChapter.chapterNumber.toString().padStart(2, '0')} — ${htsChapter.chapterTitle}`,
+          description: 'Browse every HTS code in the chapter that covers this industry, with duty rates and units.',
+          icon: <ListTree className="h-5 w-5" />,
+        }
+      : null,
+  ].filter((link): link is NonNullable<typeof link> => link !== null);
+
   return (
     <div className="mx-auto max-w-7xl py-2">
       <div className="mb-8 pb-4 border-b border-gray-200 dark:border-gray-700">
@@ -62,6 +83,8 @@ export async function renderIndustryCoverBody(industryId: string): Promise<JSX.E
           </div>
         </PrivateWrapper>
       )}
+
+      <TariffCrossLinks heading="Tools for this industry" links={crossLinks} />
 
       <div className="space-y-12">
         {renderSection(

--- a/insights-ui/src/components/tariff-cross-links/TariffCrossLinks.tsx
+++ b/insights-ui/src/components/tariff-cross-links/TariffCrossLinks.tsx
@@ -1,0 +1,54 @@
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+export interface TariffCrossLink {
+  href: string;
+  title: string;
+  description: string;
+  icon?: ReactNode;
+}
+
+interface TariffCrossLinksProps {
+  heading?: string;
+  description?: string;
+  links: TariffCrossLink[];
+}
+
+export default function TariffCrossLinks({ heading = 'Related Tariff Tools & Reports', description, links }: TariffCrossLinksProps) {
+  if (links.length === 0) return null;
+
+  return (
+    <section aria-labelledby="tariff-cross-links-heading" className="mb-10 rounded-2xl border border-color background-color p-5 sm:p-6">
+      <div className="mb-4">
+        <h2 id="tariff-cross-links-heading" className="text-lg font-semibold text-white sm:text-xl">
+          {heading}
+        </h2>
+        {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      <ul className={`grid grid-cols-1 gap-3 ${links.length >= 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2'}`}>
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="group flex h-full items-start gap-3 rounded-xl border border-color block-bg-color p-4 transition-colors hover:border-indigo-400 hover:bg-block-bg-color"
+            >
+              {link.icon && (
+                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-400 ring-1 ring-inset ring-indigo-500/20 group-hover:bg-indigo-500/20">
+                  {link.icon}
+                </span>
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-white group-hover:text-indigo-300">{link.title}</p>
+                  <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-indigo-300" />
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">{link.description}</p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/insights-ui/src/components/ui/BreadcrumbsWithJsonLd.tsx
+++ b/insights-ui/src/components/ui/BreadcrumbsWithJsonLd.tsx
@@ -1,0 +1,36 @@
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import type { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import { ReactNode } from 'react';
+
+const BASE_URL = 'https://koalagains.com';
+
+interface BreadcrumbsWithJsonLdProps {
+  breadcrumbs: BreadcrumbsOjbect[];
+  rightButton?: ReactNode;
+  hideHomeIcon?: boolean;
+}
+
+export default function BreadcrumbsWithJsonLd({ breadcrumbs, rightButton, hideHomeIcon }: BreadcrumbsWithJsonLdProps) {
+  const itemListElement = [
+    { '@type': 'ListItem' as const, position: 1, name: 'Home', item: `${BASE_URL}/` },
+    ...breadcrumbs.map((b, i) => ({
+      '@type': 'ListItem' as const,
+      position: i + 2,
+      name: b.name,
+      item: `${BASE_URL}${b.href}`,
+    })),
+  ];
+
+  const ld = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement,
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} rightButton={rightButton} hideHomeIcon={hideHomeIcon} />
+    </>
+  );
+}

--- a/insights-ui/src/utils/tariff-calculator/cache-tags.ts
+++ b/insights-ui/src/utils/tariff-calculator/cache-tags.ts
@@ -4,6 +4,14 @@ export const TARIFF_SECTIONS_LISTING_TAG = 'tariff_sections_listing' as const;
 
 export const revalidateTariffSectionsListingTag = () => revalidateTag(TARIFF_SECTIONS_LISTING_TAG);
 
+export const TARIFF_CHAPTERS_LISTING_TAG = 'tariff_chapters_listing' as const;
+
+export const revalidateTariffChaptersListingTag = () => revalidateTag(TARIFF_CHAPTERS_LISTING_TAG);
+
+export const tariffChapterDetailCacheTag = (chapterNumber: number) => `tariff_chapter_detail_${chapterNumber.toString().padStart(2, '0')}` as const;
+
+export const revalidateTariffChapterDetailTag = (chapterNumber: number) => revalidateTag(tariffChapterDetailCacheTag(chapterNumber));
+
 export const candidateCodesCacheTag = (hts10: string) => `tariff_candidate_codes_${hts10}` as const;
 
 export const revalidateCandidateCodesTag = (hts10: string) => revalidateTag(candidateCodesCacheTag(hts10));

--- a/insights-ui/src/utils/tariff-calculator/cache-tags.ts
+++ b/insights-ui/src/utils/tariff-calculator/cache-tags.ts
@@ -12,6 +12,11 @@ export const tariffChapterDetailCacheTag = (chapterNumber: number) => `tariff_ch
 
 export const revalidateTariffChapterDetailTag = (chapterNumber: number) => revalidateTag(tariffChapterDetailCacheTag(chapterNumber));
 
+export const tariffChapterRelatedReportCacheTag = (chapterNumber: number) =>
+  `tariff_chapter_related_report_${chapterNumber.toString().padStart(2, '0')}` as const;
+
+export const revalidateTariffChapterRelatedReportTag = (chapterNumber: number) => revalidateTag(tariffChapterRelatedReportCacheTag(chapterNumber));
+
 export const candidateCodesCacheTag = (hts10: string) => `tariff_candidate_codes_${hts10}` as const;
 
 export const revalidateCandidateCodesTag = (hts10: string) => revalidateTag(candidateCodesCacheTag(hts10));

--- a/insights-ui/src/utils/tariff-cross-links/hts-chapter-ref.ts
+++ b/insights-ui/src/utils/tariff-cross-links/hts-chapter-ref.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
+import { chapterCoverHref } from '@/utils/tariff-reports/chapter-route-helpers';
+import { Prisma } from '@prisma/client';
+import { unstable_cache } from 'next/cache';
+
+export interface HtsChapterRef {
+  chapterNumber: number;
+  sectionNumber: number;
+  chapterTitle: string;
+  href: string;
+}
+
+const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
+const HTS_CHAPTER_REFS_TAG = 'hts-chapter-refs';
+
+async function fetchHtsChapterByNumber(chapterNumber: number): Promise<HtsChapterRef | null> {
+  const chapter = await prisma.tariffChapter.findUnique({
+    where: { spaceId_number: { spaceId: KoalaGainsSpaceId, number: chapterNumber } },
+    select: { number: true, title: true, section: { select: { number: true } } },
+  });
+  if (!chapter) return null;
+  return {
+    chapterNumber: chapter.number,
+    sectionNumber: chapter.section.number,
+    chapterTitle: chapter.title,
+    href: chapterDetailHref(chapter.section.number, chapter.number, chapter.title),
+  };
+}
+
+async function fetchHtsChapterByIndustryId(industryId: string): Promise<HtsChapterRef | null> {
+  const row = await prisma.tariffChapterReport.findFirst({
+    where: { spaceId: KoalaGainsSpaceId, oldUrl: industryId },
+    select: { chapter: { select: { number: true, title: true, section: { select: { number: true } } } } },
+  });
+  if (!row?.chapter) return null;
+  return {
+    chapterNumber: row.chapter.number,
+    sectionNumber: row.chapter.section.number,
+    chapterTitle: row.chapter.title,
+    href: chapterDetailHref(row.chapter.section.number, row.chapter.number, row.chapter.title),
+  };
+}
+
+export const getHtsChapterRefByNumber = unstable_cache(fetchHtsChapterByNumber, ['hts-chapter-ref-by-number'], {
+  revalidate: WEEK_IN_SECONDS,
+  tags: [HTS_CHAPTER_REFS_TAG],
+});
+
+export const getHtsChapterRefByIndustryId = unstable_cache(fetchHtsChapterByIndustryId, ['hts-chapter-ref-by-industry'], {
+  revalidate: WEEK_IN_SECONDS,
+  tags: [HTS_CHAPTER_REFS_TAG],
+});
+
+export interface TariffReportRef {
+  href: string;
+  chapterTitle: string;
+  chapterNumber: number;
+  isIndustryUrl: boolean;
+}
+
+const SEEDED_REPORT_FILTER = { introduction: { not: Prisma.DbNull } } as const;
+
+async function fetchTariffReportRefByChapterNumber(chapterNumber: number): Promise<TariffReportRef | null> {
+  const row = await prisma.tariffChapterReport.findFirst({
+    where: { spaceId: KoalaGainsSpaceId, chapter: { number: chapterNumber }, ...SEEDED_REPORT_FILTER },
+    select: { slug: true, oldUrl: true, chapter: { select: { number: true, title: true } } },
+  });
+  if (!row) return null;
+  return {
+    href: row.oldUrl ? `/industry-tariff-report/${row.oldUrl}` : chapterCoverHref(row.slug),
+    chapterTitle: row.chapter.title,
+    chapterNumber: row.chapter.number,
+    isIndustryUrl: Boolean(row.oldUrl),
+  };
+}
+
+export const getTariffReportRefByChapterNumber = unstable_cache(fetchTariffReportRefByChapterNumber, ['tariff-report-ref-by-chapter-number'], {
+  revalidate: WEEK_IN_SECONDS,
+  tags: [HTS_CHAPTER_REFS_TAG],
+});


### PR DESCRIPTION
## Summary
- Wires Tariff Calculator, HTS Codes, and Tariff Reports surfaces together via a shared card-grid component (`TariffCrossLinks`).
- Industry tariff report cover, chapter tariff report cover, and HTS chapter detail each surface the matching cross-links (calculator + the chapter's HTS detail / industry analysis when one exists).
- All breadcrumbs emit `schema.org` `BreadcrumbList` JSON-LD via a shared `BreadcrumbsWithJsonLd` wrapper (replaces the manual JSON-LD on `/tariff-calculator`).
- New `/hts-codes/sitemap.xml` route emits the catalog plus every chapter detail URL; registered in `sitemap_index.xml`. `/tariff-calculator` added to the root static sitemap.
- Original task doc (`docs/insights-ui/tasks/open/tariffs/add-link-tariff-pages.md`) is the spec this PR fulfils.

## Pages touched
- `/tariff-reports` — links to Tariff Calculator and HTS Codes.
- `/tariff-calculator` — links to HTS Codes and Tariff Reports; replaces inline JSON-LD with shared wrapper.
- `/hts-codes` — links to Tariff Reports and Tariff Calculator.
- `/hts-codes/us/[section]/[chapter]` — links to matching Tariff Impact Report (if seeded) and Tariff Calculator.
- `/industry-tariff-report/[industryId]` (cover) — links to Tariff Calculator and the industry's HTS chapter (resolved via `oldUrl`).
- `/industry-tariff-report/chapters/[chapterSlug]` (cover) — links to Tariff Calculator and the matching HTS chapter detail.

## Implementation notes
- New helpers in `src/utils/tariff-cross-links/hts-chapter-ref.ts` provide cached Prisma lookups for HTS↔report resolution (chapter-by-number, chapter-by-industryId via `oldUrl`, report-by-chapter-number).
- Sitemap directory rule: `/hts-codes/sitemap.xml` only emits `/hts-codes/...` URLs; `/tariff-calculator` is a single static URL so it lives in `public/sitemap.xml`.

## Test plan
- [ ] Browse `/tariff-reports`, `/tariff-calculator`, `/hts-codes` — verify cross-link cards render and navigate correctly.
- [ ] Open an industry report cover (e.g. `/industry-tariff-report/agriculturalProductsAndServices`) — confirm "Tools for this industry" block shows Tariff Calculator + the right HTS chapter link.
- [ ] Open a chapter cover with no `oldUrl` (e.g. `/industry-tariff-report/chapters/4-dairy-eggs-honey`) — confirm "Tools for this chapter" shows Tariff Calculator + the matching HTS chapter detail.
- [ ] Open `/hts-codes/us/section-1/chapter-04-dairy-eggs-honey` — confirm "Tools for this chapter" shows Tariff Impact Report + Tariff Calculator.
- [ ] View page source on each — confirm `BreadcrumbList` JSON-LD is present.
- [ ] `curl https://koalagains.com/hts-codes/sitemap.xml` after deploy — confirm catalog + every chapter URL listed.
- [ ] Validate `sitemap_index.xml` references the new HTS sitemap.
