### PR TITLE
Add Tariff Engineering analysis to industry tariff reports

### DIFF
--- a/insights-ui/prisma/migrations/20260508120000_add_tariff_engineering_to_tariff_chapter_reports/migration.sql
+++ b/insights-ui/prisma/migrations/20260508120000_add_tariff_engineering_to_tariff_chapter_reports/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tariff_chapter_reports" ADD COLUMN "tariff_engineering" JSONB;

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -2098,6 +2098,8 @@ model TariffChapterReport {
   industryAreasSections Json? @map("industry_areas_sections")
   /// [TariffFinalConclusion]
   conclusion            Json? @map("conclusion")
+  /// [TariffEngineering]
+  tariffEngineering     Json? @map("tariff_engineering")
 
   /// [TariffReportSeoDetails]
   seoDetails Json? @map("seo_details")

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-tariff-engineering/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-tariff-engineering/route.ts
@@ -1,0 +1,8 @@
+import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
+import { getAndWriteTariffEngineeringJson } from '@/scripts/industry-tariff-reports/06-tariff-engineering';
+import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+
+export const maxDuration = 300;
+
+export const POST = withErrorHandlingV2<IndustryTariffReport>(chapterGenerateRoute((slug) => getAndWriteTariffEngineeringJson(slug)));

--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/route.ts
@@ -33,6 +33,7 @@ async function getHandler(): Promise<ChapterReportAdminListResponse> {
       understandIndustry: true,
       industryAreasSections: true,
       conclusion: true,
+      tariffEngineering: true,
       seoDetails: true,
     },
     orderBy: { chapter: { number: 'asc' } },

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/tariff-engineering/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/tariff-engineering/page.tsx
@@ -1,0 +1,14 @@
+import { buildChapterSectionMetadata, renderChapterSection } from '@/components/industry-tariff/chapter/chapter-section-page';
+import type { Metadata } from 'next';
+
+const SECTION_SLUG = 'tariff-engineering';
+
+export async function generateMetadata({ params }: { params: Promise<{ chapterSlug: string }> }): Promise<Metadata> {
+  const { chapterSlug } = await params;
+  return buildChapterSectionMetadata(chapterSlug, SECTION_SLUG);
+}
+
+export default async function Page({ params }: { params: Promise<{ chapterSlug: string }> }) {
+  const { chapterSlug } = await params;
+  return renderChapterSection(chapterSlug, SECTION_SLUG);
+}

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -4,6 +4,7 @@ import ChapterSectionActions, { type ChapterSectionAction } from '@/components/i
 import { CountryNavigation } from '@/components/industry-tariff/renderers/CountryNavigation';
 import { CountryTariffRenderer } from '@/components/industry-tariff/renderers/CountryTariffRenderer';
 import { FinalConclusionRenderer } from '@/components/industry-tariff/renderers/FinalConclusionRenderer';
+import { TariffEngineeringRenderer } from '@/components/industry-tariff/renderers/TariffEngineeringRenderer';
 import { UnderstandIndustryRenderer } from '@/components/industry-tariff/renderers/UnderstandIndustryRenderer';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import { getMarkdownContentForIndustryAreas } from '@/scripts/industry-tariff-reports/render-tariff-markdown';
@@ -24,6 +25,7 @@ const SECTION_SEO_KEY: Record<string, keyof TariffReportSeoDetails> = {
   'understand-industry': 'understandIndustrySeoDetails',
   'industry-areas': 'industryAreasSeoDetails',
   'final-conclusion': 'finalConclusionSeoDetails',
+  'tariff-engineering': 'tariffEngineeringSeoDetails',
 };
 
 type SeoDetailsWithAliases = PageSeoDetails & { seoTitle?: string; metaDescription?: string; seo_title?: string; meta_description?: string };
@@ -160,6 +162,18 @@ function getSectionActions(sectionSlug: string): ChapterSectionAction[] {
           successMessage: 'Final Conclusion regenerated.',
         },
       ];
+    case 'tariff-engineering':
+      return [
+        {
+          kind: 'simple',
+          key: 'regenerate-tariff-engineering',
+          label: 'Regenerate Tariff Engineering',
+          apiPath: 'generate-tariff-engineering',
+          modalTitle: 'Regenerate Tariff Engineering',
+          confirmationText: 'Regenerate the Tariff Engineering analysis? This replaces the current content.',
+          successMessage: 'Tariff Engineering regenerated.',
+        },
+      ];
     default:
       return [];
   }
@@ -200,6 +214,10 @@ function renderSectionBody(sectionSlug: string, report: IndustryTariffReport): J
     case 'final-conclusion': {
       if (!report.finalConclusion) return null;
       return <FinalConclusionRenderer finalConclusion={report.finalConclusion} />;
+    }
+    case 'tariff-engineering': {
+      if (!report.tariffEngineering) return null;
+      return <TariffEngineeringRenderer tariffEngineering={report.tariffEngineering} />;
     }
     default:
       return null;

--- a/insights-ui/src/components/industry-tariff/renderers/TariffEngineeringRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/TariffEngineeringRenderer.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { TariffEngineering } from '@/scripts/industry-tariff-reports/tariff-types';
+import { parseMarkdown } from '@/util/parse-markdown';
+
+interface TariffEngineeringRendererProps {
+  tariffEngineering: TariffEngineering;
+}
+
+function MarkdownBlock({ markdown }: { markdown: string }): JSX.Element {
+  return <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(markdown) }} />;
+}
+
+function SectionCard({ heading, children }: { heading: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+      <div className="bg-gray-800 p-4 border-b border-gray-700">
+        <h2 className="text-xl font-semibold heading-color">{heading}</h2>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}
+
+export const TariffEngineeringRenderer: React.FC<TariffEngineeringRendererProps> = ({ tariffEngineering }) => {
+  const title = typeof tariffEngineering?.title === 'string' ? tariffEngineering.title : '';
+  const overview = typeof tariffEngineering?.overview === 'string' ? tariffEngineering.overview : '';
+  const classificationLevers = Array.isArray(tariffEngineering?.classificationLevers) ? tariffEngineering.classificationLevers : [];
+  const strategies = Array.isArray(tariffEngineering?.strategies) ? tariffEngineering.strategies : [];
+  const countryOfOriginPlaybook = typeof tariffEngineering?.countryOfOriginPlaybook === 'string' ? tariffEngineering.countryOfOriginPlaybook : '';
+  const valuationOpportunities = typeof tariffEngineering?.valuationOpportunities === 'string' ? tariffEngineering.valuationOpportunities : '';
+  const ftzAndDrawback = typeof tariffEngineering?.ftzAndDrawback === 'string' ? tariffEngineering.ftzAndDrawback : '';
+  const complianceGuardrails = typeof tariffEngineering?.complianceGuardrails === 'string' ? tariffEngineering.complianceGuardrails : '';
+  const bottomLine = typeof tariffEngineering?.bottomLine === 'string' ? tariffEngineering.bottomLine : '';
+
+  const hasAnyContent =
+    title ||
+    overview ||
+    classificationLevers.length > 0 ||
+    strategies.length > 0 ||
+    countryOfOriginPlaybook ||
+    valuationOpportunities ||
+    ftzAndDrawback ||
+    complianceGuardrails ||
+    bottomLine;
+
+  if (!hasAnyContent) {
+    return (
+      <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
+        <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {(title || overview) && (
+        <div className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          {title && (
+            <div className="bg-gray-800 p-4 border-b border-gray-700">
+              <h2 className="text-2xl font-bold heading-color">{title}</h2>
+            </div>
+          )}
+          {overview && (
+            <div className="p-4">
+              <MarkdownBlock markdown={overview} />
+            </div>
+          )}
+        </div>
+      )}
+
+      {classificationLevers.length > 0 && (
+        <SectionCard heading="Classification Levers">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-700 text-sm">
+              <thead className="bg-gray-800/60">
+                <tr>
+                  <th className="px-3 py-2 text-left font-semibold">Lever</th>
+                  <th className="px-3 py-2 text-left font-semibold">Current Classification</th>
+                  <th className="px-3 py-2 text-left font-semibold">Engineered Classification</th>
+                  <th className="px-3 py-2 text-left font-semibold">Basis</th>
+                  <th className="px-3 py-2 text-left font-semibold">Duty Delta</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700">
+                {classificationLevers.map((lever, idx) => {
+                  const leverTitle = typeof lever?.leverTitle === 'string' ? lever.leverTitle : '';
+                  const currentClassification = typeof lever?.currentClassification === 'string' ? lever.currentClassification : '';
+                  const engineeredClassification = typeof lever?.engineeredClassification === 'string' ? lever.engineeredClassification : '';
+                  const basisForReclassification = typeof lever?.basisForReclassification === 'string' ? lever.basisForReclassification : '';
+                  const dutyDelta = typeof lever?.dutyDelta === 'string' ? lever.dutyDelta : '';
+                  return (
+                    <tr key={idx} className="align-top">
+                      <td className="px-3 py-3 font-medium">{leverTitle}</td>
+                      <td className="px-3 py-3">
+                        <MarkdownBlock markdown={currentClassification} />
+                      </td>
+                      <td className="px-3 py-3">
+                        <MarkdownBlock markdown={engineeredClassification} />
+                      </td>
+                      <td className="px-3 py-3">
+                        <MarkdownBlock markdown={basisForReclassification} />
+                      </td>
+                      <td className="px-3 py-3">
+                        <MarkdownBlock markdown={dutyDelta} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </SectionCard>
+      )}
+
+      {strategies.length > 0 && (
+        <SectionCard heading="Tariff Engineering Strategies">
+          <div className="space-y-6">
+            {strategies.map((strategy, idx) => {
+              const stTitle = typeof strategy?.title === 'string' ? strategy.title : '';
+              const technique = typeof strategy?.technique === 'string' ? strategy.technique : '';
+              const applicability = typeof strategy?.applicabilityToChapter === 'string' ? strategy.applicabilityToChapter : '';
+              const dutyImpact = typeof strategy?.potentialDutyImpact === 'string' ? strategy.potentialDutyImpact : '';
+              const steps = Array.isArray(strategy?.implementationSteps) ? strategy.implementationSteps : [];
+              const risks = typeof strategy?.risksAndCaveats === 'string' ? strategy.risksAndCaveats : '';
+              const precedent = typeof strategy?.precedent === 'string' ? strategy.precedent : '';
+              return (
+                <div key={idx} className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
+                  {stTitle && <h3 className="text-lg font-semibold heading-color mb-2">{stTitle}</h3>}
+                  {technique && (
+                    <div className="mb-3">
+                      <MarkdownBlock markdown={technique} />
+                    </div>
+                  )}
+                  {applicability && (
+                    <div className="mb-3">
+                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Applicability to chapter</div>
+                      <MarkdownBlock markdown={applicability} />
+                    </div>
+                  )}
+                  {dutyImpact && (
+                    <div className="mb-3">
+                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Potential duty impact</div>
+                      <MarkdownBlock markdown={dutyImpact} />
+                    </div>
+                  )}
+                  {steps.length > 0 && (
+                    <div className="mb-3">
+                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Implementation steps</div>
+                      <ol className="list-decimal list-inside space-y-1">
+                        {steps.map((step, sIdx) => (
+                          <li key={sIdx}>
+                            <span className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(step) }} />
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  )}
+                  {risks && (
+                    <div className="mb-3">
+                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Risks &amp; caveats</div>
+                      <MarkdownBlock markdown={risks} />
+                    </div>
+                  )}
+                  {precedent && (
+                    <div>
+                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Precedent</div>
+                      <MarkdownBlock markdown={precedent} />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </SectionCard>
+      )}
+
+      {countryOfOriginPlaybook && (
+        <SectionCard heading="Country-of-Origin Playbook">
+          <MarkdownBlock markdown={countryOfOriginPlaybook} />
+        </SectionCard>
+      )}
+
+      {valuationOpportunities && (
+        <SectionCard heading="Valuation Opportunities">
+          <MarkdownBlock markdown={valuationOpportunities} />
+        </SectionCard>
+      )}
+
+      {ftzAndDrawback && (
+        <SectionCard heading="Foreign Trade Zones &amp; Duty Drawback">
+          <MarkdownBlock markdown={ftzAndDrawback} />
+        </SectionCard>
+      )}
+
+      {complianceGuardrails && (
+        <SectionCard heading="Compliance Guardrails">
+          <MarkdownBlock markdown={complianceGuardrails} />
+        </SectionCard>
+      )}
+
+      {bottomLine && (
+        <SectionCard heading="Bottom Line">
+          <MarkdownBlock markdown={bottomLine} />
+        </SectionCard>
+      )}
+    </div>
+  );
+};

--- a/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
+++ b/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
@@ -23,6 +23,7 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; section: string }> = [
   { title: 'Understand Industry', section: 'understand-industry' },
   { title: 'Industry Areas', section: 'industry-areas' },
   { title: 'Final Conclusion', section: 'final-conclusion' },
+  { title: 'Tariff Engineering', section: 'tariff-engineering' },
 ];
 
 export default function ReportLeftNavigation({

--- a/insights-ui/src/scripts/industry-tariff-reports/06-tariff-engineering.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/06-tariff-engineering.ts
@@ -1,0 +1,275 @@
+import {
+  chapterSeoGuidance,
+  formatChapterLabel,
+  getChapterPromptContext,
+  readIndustryHeadings,
+  readTariffUpdates,
+  writeTariffEngineering,
+} from '@/scripts/industry-tariff-reports/tariff-report-repository';
+import { TariffEngineering } from '@/scripts/industry-tariff-reports/tariff-types';
+import { z } from 'zod';
+import { getLlmResponse, outputInstructions } from '../llm‑utils‑gemini';
+import { GeminiModel, LLMProvider } from '@/types/llmConstants';
+
+const ClassificationLeverSchema = z.object({
+  leverTitle: z.string().describe('Short, descriptive name of the reclassification lever (e.g. "Reclassify men\'s anoraks as down-filled outerwear").'),
+  currentClassification: z
+    .string()
+    .describe(
+      'The HTS subheading commonly used today for the in-scope product, including the heading number, ' +
+        'a one-line description, and the current US general (Column 1) duty rate. Wrap rates and amounts in backticks.'
+    ),
+  engineeredClassification: z
+    .string()
+    .describe(
+      'The alternative HTS subheading the product can legitimately be classified under after a design, ' +
+        'composition, or feature change. Include heading number, description, and the duty rate. Wrap values in backticks.'
+    ),
+  basisForReclassification: z
+    .string()
+    .describe(
+      'The concrete product attribute (material composition, feature, function, weight threshold, etc.) that supports ' +
+        'the new classification under General Rules of Interpretation (GRI) or a CBP ruling. ' +
+        'Cite the specific GRI / Chapter Note / CBP ruling number where relevant, with markdown hyperlinks.'
+    ),
+  dutyDelta: z
+    .string()
+    .describe(
+      'Plain-language before-vs-after on duty exposure, e.g. "Drops the column-1 rate from `27.7%` to `4.4%`, plus avoids the ' +
+        '`Section 301 List 4A` `7.5%` add-on if the bill of materials shifts away from China." Wrap values in backticks.'
+    ),
+});
+
+const StrategySchema = z.object({
+  title: z.string().describe('Short strategy name (e.g. "First-sale-for-export valuation", "Substantial transformation in Vietnam").'),
+  technique: z
+    .string()
+    .describe(
+      'A 2-3 sentence plain-language description of what the strategy is and the legal/operational mechanism that makes it work. ' +
+        'Reference the relevant CBP regulation (19 CFR §xxxx), USMCA / GSP rule, or established trade-law doctrine.'
+    ),
+  applicabilityToChapter: z
+    .string()
+    .describe(
+      'Specifically which sub-areas / sub-headings of THIS HTS chapter the strategy applies to. ' +
+        'Name the in-scope products and any quantitative thresholds (volume, value, BOM percentage) that gate the strategy.'
+    ),
+  potentialDutyImpact: z
+    .string()
+    .describe(
+      'Concrete duty impact in numbers: rate before, rate after, dollar savings on a representative shipment value if available. ' +
+        'Wrap percentages and dollar amounts in backticks. Avoid vague phrases like "significant savings".'
+    ),
+  implementationSteps: z
+    .array(z.string())
+    .describe(
+      '3-6 ordered, actionable steps an importer/exporter must take to execute the strategy. ' +
+        'Each step is one sentence and references the specific document, ruling request, or supplier change involved ' +
+        '(e.g. "File a CBP ruling letter request via the eRulings program citing HQ ruling H299196").'
+    ),
+  risksAndCaveats: z
+    .string()
+    .describe(
+      'The substantive compliance risks: CBP audit triggers, recordkeeping burden, prior disclosure exposure, ' +
+        'misclassification penalties (19 USC §1592), AD/CVD circumvention concerns, anti-transshipment scrutiny, etc. ' +
+        'Be specific — name the regulation or enforcement program.'
+    ),
+  precedent: z
+    .string()
+    .describe(
+      'Real precedent supporting the strategy: a CBP ruling number (HQ/NY), a CIT/CAFC case, a published industry practice, ' +
+        'or a documented Section 301 exclusion. Include the citation in markdown link format where possible.'
+    ),
+});
+
+const TariffEngineeringSchema = z.object({
+  title: z.string().describe('Page H1, e.g. "Tariff Engineering Strategies for HTS Chapter 39 — Plastics and Articles".'),
+  overview: z
+    .string()
+    .describe(
+      '2-4 paragraphs of markdown introducing tariff engineering specifically for products in this HTS chapter. ' +
+        'Define tariff engineering, explain the legitimacy boundary (legal restructuring vs. fraudulent misclassification), ' +
+        'and frame why the current tariff landscape (Section 232 / 301 / IEEPA) makes this analysis valuable to importers right now. ' +
+        'Wrap percentages, dollar amounts, and rate values in backticks. Include at least 2 markdown citation links.'
+    ),
+  classificationLevers: z
+    .array(ClassificationLeverSchema)
+    .describe(
+      '3-6 concrete, chapter-specific classification levers. Each lever is a real product-design or product-attribute change that ' +
+        'shifts the good into a different HTS subheading with a materially different duty rate. ' +
+        'Pull the actual sub-headings from the chapter (e.g. for Chapter 61, the difference between knit-vs-woven, sweatshirt-vs-jacket, ' +
+        'cotton-vs-MMF), not generic examples. Cite real CBP rulings (HQ / NY series) or CIT cases where possible.'
+    ),
+  strategies: z
+    .array(StrategySchema)
+    .describe(
+      '5-7 distinct tariff-engineering strategies that go BEYOND classification. Cover the canonical toolkit: ' +
+        '(1) substantial transformation / country-of-origin engineering, ' +
+        '(2) first-sale-for-export valuation, ' +
+        '(3) unbundling / set-rule manipulation under GRI 3, ' +
+        '(4) Foreign Trade Zone (FTZ) and bonded-warehouse usage, ' +
+        '(5) duty drawback (manufacturing / unused-merchandise / substitution), ' +
+        '(6) FTA preferential origin (USMCA, KORUS, GSP where still active), ' +
+        '(7) Section 301 / 232 exclusion strategies, ' +
+        '(8) Chapter 98 provisions (US goods returned, repairs/alterations). ' +
+        'Each strategy must be tailored to the specific products in this HTS chapter — generic advice is not useful.'
+    ),
+  countryOfOriginPlaybook: z
+    .string()
+    .describe(
+      '4-6 paragraph markdown analysis on country-of-origin engineering for this chapter. ' +
+        'Discuss: (a) the substantial-transformation test as applied to the typical manufacturing process for this chapter; ' +
+        '(b) tariff-shift rules under USMCA/CAFTA/KORUS for the relevant tariff-shift level; ' +
+        '(c) realistic relocation candidates (Mexico, Vietnam, India, Malaysia, Thailand, Turkey) for sourcing teams ' +
+        'now subject to Section 301 / IEEPA / reciprocal tariffs on China-origin goods; ' +
+        "(d) anti-circumvention enforcement risk (CBP's focus on Vietnam/Cambodia/Malaysia transshipment). " +
+        'Wrap rates and amounts in backticks. Cite specific CBP guidance and CSMS messages where possible.'
+    ),
+  valuationOpportunities: z
+    .string()
+    .describe(
+      '3-5 paragraphs of markdown on valuation-side levers. ' +
+        'Cover first-sale-for-export (with the Nissho Iwai factors), assists, royalties/license fees that may be excluded under 19 USC §1401a, ' +
+        'related-party-transfer-pricing alignment with customs value, separately invoiced engineering and design costs, and ' +
+        'the impact on landed cost when duty is `25%` versus `7.5%`. Be specific about the documentation burden ' +
+        '(invoices, contracts, payment trails) required to defend each posture.'
+    ),
+  ftzAndDrawback: z
+    .string()
+    .describe(
+      '3-5 paragraphs of markdown on Foreign Trade Zone (FTZ) and duty drawback opportunities for products in this chapter. ' +
+        'Cover: FTZ inverted-tariff benefits when components carry a higher rate than the finished good (or vice versa), ' +
+        'weekly-entry savings under 19 CFR §146, manufacturing drawback (19 USC §1313(a)), unused-merchandise drawback (§1313(j)(1)), ' +
+        'substitution drawback (§1313(j)(2)) and the §1313(b) manufacturing-substitution variant. ' +
+        'Note where Section 301 duties and IEEPA tariffs are/are not eligible for drawback so readers do not over-claim.'
+    ),
+  complianceGuardrails: z
+    .string()
+    .describe(
+      '3-4 paragraphs of markdown on the compliance guardrails any tariff-engineering program must respect. ' +
+        'Cover: 19 USC §1592 (penalties for fraud / gross negligence / negligence), prior-disclosure mechanics, the binding-ruling ' +
+        '(eRulings) program as a safe harbor, recordkeeping (5 years; 19 CFR Part 163), AD/CVD scope-ruling and circumvention risk ' +
+        '(EAPA petitions), and reasonable-care obligations under the Mod Act. ' +
+        'Make clear the line between aggressive-but-legal tariff engineering and misclassification fraud.'
+    ),
+  bottomLine: z
+    .string()
+    .describe(
+      '2-3 paragraphs of markdown that close with a prioritized, prescriptive recommendation: which 2-3 levers from above are likely ' +
+        'the highest-ROI for a typical importer in this HTS chapter today, in what sequence to deploy them (e.g. classification review first, ' +
+        'then origin engineering, then drawback claim setup), and what data the importer needs to gather before acting. ' +
+        'Avoid filler; this should read like a partner-level memo conclusion.'
+    ),
+});
+
+export async function getAndWriteTariffEngineeringJson(slug: string): Promise<void> {
+  const ctx = await getChapterPromptContext(slug);
+  const chapterLabel = formatChapterLabel(ctx);
+  const padded = ctx.chapterNumber.toString().padStart(2, '0');
+  const headings = await readIndustryHeadings(slug);
+  if (!headings) throw new Error(`Headings not found for slug "${slug}"`);
+  // Tariff updates are best-effort context — the section is still useful even if
+  // tariff-updates haven't been generated, but the strategies are far more
+  // grounded when they reference the actual current rate environment.
+  const tariffUpdates = await readTariffUpdates(slug);
+
+  const prompt = `
+You are a senior US trade-compliance and customs strategy advisor writing a "Tariff Engineering" analysis
+for ${chapterLabel}. The audience is importers, sourcing leaders, customs brokers, and corporate trade
+counsel who need actionable, defensible duty-mitigation strategies — not a textbook overview.
+
+# What "Tariff Engineering" Means In This Report
+Tariff engineering is the legitimate practice of designing, manufacturing, sourcing, valuing, or routing
+a product so that — under the existing US Harmonized Tariff Schedule, customs valuation rules, and
+free-trade-agreement preferences — the lawful classification, country of origin, or dutiable value
+results in a lower duty burden. It is grounded in long-standing CBP and Court of International Trade
+(CIT) doctrine: see e.g. the Converse "felt-soled sneaker" reclassification (HQ ruling 950333) and the
+Ford Transit Connect "passenger van vs. cargo van" CIT decision (Ford Motor Co. v. United States,
+926 F.3d 741 (Fed. Cir. 2019)).
+
+It is NOT misclassification, transshipment fraud, or undervaluation. The report must keep that line
+clear and be useful to a legal/compliance reader.
+
+# Inputs (use these to ground every section)
+
+## Chapter Scope
+- **Chapter:** ${chapterLabel}
+- **Padded number:** HTS Chapter ${padded}
+- **Title:** ${ctx.chapterTitle}
+
+## Industry Areas / Sub-headings In Scope
+${JSON.stringify(headings, null, 2)}
+
+## Current Tariff Environment for This Chapter
+${
+  tariffUpdates
+    ? JSON.stringify(tariffUpdates, null, 2)
+    : "(Tariff-updates section not yet generated — fall back to the reader's general knowledge of Section 232, Section 301 List 1-4A, IEEPA reciprocal tariffs, and current MFN rates for this chapter.)"
+}
+
+# Output Requirements
+Output a JSON object that matches this EXACT schema:
+{
+  "title": string,
+  "overview": string (markdown),
+  "classificationLevers": [
+    {
+      "leverTitle": string,
+      "currentClassification": string,
+      "engineeredClassification": string,
+      "basisForReclassification": string,
+      "dutyDelta": string
+    }
+  ],
+  "strategies": [
+    {
+      "title": string,
+      "technique": string,
+      "applicabilityToChapter": string,
+      "potentialDutyImpact": string,
+      "implementationSteps": string[],
+      "risksAndCaveats": string,
+      "precedent": string
+    }
+  ],
+  "countryOfOriginPlaybook": string (markdown),
+  "valuationOpportunities": string (markdown),
+  "ftzAndDrawback": string (markdown),
+  "complianceGuardrails": string (markdown),
+  "bottomLine": string (markdown)
+}
+
+# Hard rules for the content
+1. Every classification lever and strategy MUST be specific to ${chapterLabel}. Generic advice
+   ("consider FTZs", "look at first sale") is NOT acceptable — name the products in the chapter,
+   the actual HTS subheadings, and the actual rate differential.
+2. Cite real authorities wherever possible: CBP HQ / NY ruling numbers, CIT / CAFC case names,
+   USTR exclusion notices, CBP CSMS messages, GRI numbers, 19 USC / 19 CFR sections. Use markdown
+   links (\`[citation](url)\`) when you have a source.
+3. Wrap every percentage, dollar amount, and tariff rate in backticks (e.g. \`27.7%\`, \`\\$1.2M\`).
+4. The classification levers must reflect the structure of THIS chapter's subheadings — read the
+   "Industry Areas / Sub-headings In Scope" input above and pick levers that move a product between
+   those subheadings (or into / out of the chapter entirely under GRI 1 or Chapter Notes).
+5. Strategies must collectively cover the canonical toolkit: classification, country-of-origin /
+   substantial-transformation, FTA preference, first-sale valuation, FTZ, drawback, exclusions,
+   Chapter 98 provisions. At minimum 5 distinct strategies.
+6. Be candid about risk. If a strategy historically draws CBP scrutiny (e.g. Vietnam transshipment of
+   China-origin goods, related-party first-sale challenges), call it out in \`risksAndCaveats\`.
+7. The "bottomLine" must read like a partner-level memo conclusion: prescriptive sequencing, not a
+   summary of what was just discussed.
+
+${outputInstructions}
+
+${chapterSeoGuidance(ctx)}
+`;
+
+  console.log('Invoking LLM for tariff engineering analysis');
+  const tariffEngineering = await getLlmResponse<TariffEngineering>(
+    prompt,
+    TariffEngineeringSchema,
+    LLMProvider.GEMINI_WITH_GROUNDING,
+    GeminiModel.GEMINI_3_PRO_PREVIEW
+  );
+
+  await writeTariffEngineering(slug, tariffEngineering);
+}

--- a/insights-ui/src/scripts/industry-tariff-reports/08-report-seo-info.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/08-report-seo-info.ts
@@ -6,6 +6,7 @@ import {
   readIndustryAreaSection,
   readReportCover,
   readSeoDetails,
+  readTariffEngineering,
   readTariffUpdates,
   readUnderstandIndustry,
   writeSeoDetails,
@@ -107,6 +108,13 @@ export async function generateFinalConclusionSeo(slug: string): Promise<PageSeoD
   return generateSeoDetailsForSection(ctx, ReportType.FINAL_CONCLUSION, finalConclusion);
 }
 
+export async function generateTariffEngineeringSeo(slug: string): Promise<PageSeoDetails | undefined> {
+  const ctx = await getChapterPromptContext(slug);
+  const tariffEngineering = await readTariffEngineering(slug);
+  if (!tariffEngineering) return undefined;
+  return generateSeoDetailsForSection(ctx, ReportType.TARIFF_ENGINEERING, tariffEngineering);
+}
+
 export async function generateAndSaveAllSeoDetails(slug: string): Promise<TariffReportSeoDetails> {
   const seoDetails: TariffReportSeoDetails = (await readSeoDetails(slug)) ?? {};
 
@@ -149,6 +157,13 @@ export async function generateAndSaveAllSeoDetails(slug: string): Promise<Tariff
   if (finalConclusion) {
     console.log(`Generating SEO details for ${ReportType.FINAL_CONCLUSION}...`);
     seoDetails.finalConclusionSeoDetails = await generateFinalConclusionSeo(slug);
+    await writeSeoDetails(slug, seoDetails);
+  }
+
+  const tariffEngineering = await readTariffEngineering(slug);
+  if (tariffEngineering) {
+    console.log(`Generating SEO details for ${ReportType.TARIFF_ENGINEERING}...`);
+    seoDetails.tariffEngineeringSeoDetails = await generateTariffEngineeringSeo(slug);
     await writeSeoDetails(slug, seoDetails);
   }
 

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
@@ -8,6 +8,7 @@ import type {
   IndustryAreasWrapper,
   IndustryTariffReport,
   ReportCover,
+  TariffEngineering,
   TariffReportSeoDetails,
   TariffUpdatesForIndustry,
   UnderstandIndustry,
@@ -137,6 +138,7 @@ const REPORT_SECTIONS_SELECT = {
   understandIndustry: true,
   industryAreasSections: true,
   conclusion: true,
+  tariffEngineering: true,
   seoDetails: true,
 } as const satisfies Prisma.TariffChapterReportSelect;
 
@@ -151,6 +153,7 @@ function rowToIndustryTariffReport(row: ReportSectionsRow): IndustryTariffReport
     understandIndustry: (row.understandIndustry as UnderstandIndustry | null) ?? undefined,
     industryAreasSections: (row.industryAreasSections as IndustryAreaSection | null) ?? undefined,
     finalConclusion: (row.conclusion as FinalConclusion | null) ?? undefined,
+    tariffEngineering: (row.tariffEngineering as TariffEngineering | null) ?? undefined,
     reportSeoDetails: (row.seoDetails as TariffReportSeoDetails | null) ?? undefined,
   };
 }
@@ -282,6 +285,16 @@ export async function writeFinalConclusion(slug: string, value: FinalConclusion)
   await writeSection(slug, { conclusion: toJsonField<'conclusion'>(normalizeMarkdownNewlines(value)) });
 }
 
+export async function readTariffEngineering(slug: string): Promise<TariffEngineering | undefined> {
+  return readSection<TariffEngineering>(slug, 'tariffEngineering');
+}
+
+export async function writeTariffEngineering(slug: string, value: TariffEngineering): Promise<void> {
+  await writeSection(slug, {
+    tariffEngineering: toJsonField<'tariffEngineering'>(normalizeMarkdownNewlines(value)),
+  });
+}
+
 export async function readSeoDetails(slug: string): Promise<TariffReportSeoDetails | undefined> {
   return readSection<TariffReportSeoDetails>(slug, 'seoDetails');
 }
@@ -325,6 +338,7 @@ export async function writeSeoDetails(slug: string, value: TariffReportSeoDetail
     understandIndustrySeoDetails: normalizePageSeoDetails(v.understandIndustrySeoDetails),
     industryAreasSeoDetails: normalizePageSeoDetails(v.industryAreasSeoDetails),
     finalConclusionSeoDetails: normalizePageSeoDetails(v.finalConclusionSeoDetails),
+    tariffEngineeringSeoDetails: normalizePageSeoDetails(v.tariffEngineeringSeoDetails),
   };
 
   await writeSection(slug, { seoDetails: toJsonField<'seoDetails'>(normalized) });

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-types.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-types.ts
@@ -82,6 +82,37 @@ export interface FinalConclusion {
   finalStatements: string;
 }
 
+// 06-tariff-engineering.ts
+export interface TariffEngineeringClassificationLever {
+  leverTitle: string;
+  currentClassification: string;
+  engineeredClassification: string;
+  basisForReclassification: string;
+  dutyDelta: string;
+}
+
+export interface TariffEngineeringStrategy {
+  title: string;
+  technique: string;
+  applicabilityToChapter: string;
+  potentialDutyImpact: string;
+  implementationSteps: string[];
+  risksAndCaveats: string;
+  precedent: string;
+}
+
+export interface TariffEngineering {
+  title: string;
+  overview: string;
+  classificationLevers: TariffEngineeringClassificationLever[];
+  strategies: TariffEngineeringStrategy[];
+  countryOfOriginPlaybook: string;
+  valuationOpportunities: string;
+  ftzAndDrawback: string;
+  complianceGuardrails: string;
+  bottomLine: string;
+}
+
 export interface ReportCover {
   title: string;
   reportCoverContent: string;
@@ -100,6 +131,7 @@ export interface TariffReportSeoDetails {
   understandIndustrySeoDetails?: PageSeoDetails;
   industryAreasSeoDetails?: PageSeoDetails;
   finalConclusionSeoDetails?: PageSeoDetails;
+  tariffEngineeringSeoDetails?: PageSeoDetails;
 }
 
 export interface IndustryTariffReport {
@@ -110,6 +142,7 @@ export interface IndustryTariffReport {
   understandIndustry?: UnderstandIndustry;
   industryAreasSections?: IndustryAreaSection;
   finalConclusion?: FinalConclusion;
+  tariffEngineering?: TariffEngineering;
   reportSeoDetails?: TariffReportSeoDetails;
 }
 
@@ -124,5 +157,6 @@ export enum ReportType {
   EXECUTIVE_SUMMARY = 'EXECUTIVE_SUMMARY',
   REPORT_COVER = 'REPORT_COVER',
   FINAL_CONCLUSION = 'FINAL_CONCLUSION',
+  TARIFF_ENGINEERING = 'TARIFF_ENGINEERING',
   ALL = 'ALL',
 }

--- a/insights-ui/src/scripts/run-tariff-report.ts
+++ b/insights-ui/src/scripts/run-tariff-report.ts
@@ -4,6 +4,7 @@ import { getExecutiveSummaryAndSaveToFile } from '@/scripts/industry-tariff-repo
 import { getTariffUpdatesForIndustryAndSaveToFile } from '@/scripts/industry-tariff-reports/03-industry-tariffs';
 import { getAndWriteUnderstandIndustryJson } from '@/scripts/industry-tariff-reports/04-understand-industry';
 import { getAndWriteIndustryAreaSectionToJsonFile } from '@/scripts/industry-tariff-reports/05-industry-areas';
+import { getAndWriteTariffEngineeringJson } from '@/scripts/industry-tariff-reports/06-tariff-engineering';
 import { getFinalConclusionAndSaveToFile } from '@/scripts/industry-tariff-reports/07-final-conclusion';
 import { generateAndSaveAllSeoDetails } from '@/scripts/industry-tariff-reports/08-report-seo-info';
 import { readIndustryHeadings } from '@/scripts/industry-tariff-reports/tariff-report-repository';
@@ -54,6 +55,10 @@ export async function doIt(reportType: ReportType, slug: string) {
 
     case ReportType.FINAL_CONCLUSION:
       await getFinalConclusionAndSaveToFile(slug);
+      break;
+
+    case ReportType.TARIFF_ENGINEERING:
+      await getAndWriteTariffEngineeringJson(slug);
       break;
 
     case ReportType.ALL:

--- a/insights-ui/src/utils/tariff-reports/chapter-generate-sections.ts
+++ b/insights-ui/src/utils/tariff-reports/chapter-generate-sections.ts
@@ -13,6 +13,7 @@ export type ChapterReportField =
   | 'understandIndustry'
   | 'industryAreasSections'
   | 'conclusion'
+  | 'tariffEngineering'
   | 'seoDetails';
 
 export interface ChapterGenerateStep {
@@ -32,5 +33,6 @@ export const CHAPTER_GENERATE_STEPS: readonly ChapterGenerateStep[] = [
   { field: 'executiveSummary', label: 'executiveSummary', apiPath: 'generate-executive-summary' },
   { field: 'introduction', label: 'introduction', apiPath: 'generate-report-cover' },
   { field: 'conclusion', label: 'conclusion', apiPath: 'generate-final-conclusion' },
+  { field: 'tariffEngineering', label: 'tariffEngineering', apiPath: 'generate-tariff-engineering' },
   { field: 'seoDetails', label: 'seoDetails', apiPath: 'generate-seo-info' },
 ] as const;

--- a/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
+++ b/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
@@ -8,6 +8,7 @@ export const CHAPTER_REPORT_SECTIONS: readonly ChapterReportSection[] = [
   { slug: 'understand-industry', label: 'Understand Industry' },
   { slug: 'industry-areas', label: 'Industry Areas' },
   { slug: 'final-conclusion', label: 'Final Conclusion' },
+  { slug: 'tariff-engineering', label: 'Tariff Engineering' },
 ] as const;
 
 export interface ChapterRouteInfo {
@@ -47,6 +48,10 @@ const SECTION_COPY: Record<string, (title: string, padded: string) => ChapterSec
   'final-conclusion': (title, padded) => ({
     pageTitle: 'Final Conclusion',
     description: `Forward-looking conclusion for HTS Chapter ${padded} (${title}) — what the latest tariff actions mean for sourcing, pricing, and strategic positioning.`,
+  }),
+  'tariff-engineering': (title, padded) => ({
+    pageTitle: 'Tariff Engineering',
+    description: `Tariff engineering strategies for HTS Chapter ${padded} (${title}) — classification levers, country-of-origin moves, first-sale valuation, FTZ usage, and duty drawback to lawfully reduce US duty exposure.`,
   }),
 };
 


### PR DESCRIPTION
## Summary
- Adds a new **Tariff Engineering** section to every industry tariff report (chapter-keyed). The section surfaces lawful duty-mitigation strategies — classification levers, country-of-origin engineering, first-sale valuation, FTZ/bonded-warehouse usage, duty drawback, FTA preference, and Chapter 98 provisions — tailored to the specific HTS chapter using its headings and current tariff updates as grounding.
- Mirrors the existing section scaffolding end-to-end: Prisma column + migration, `tariff-types.ts` interface + SEO key + ReportType enum, repository read/write helpers (with markdown-newline normalization and SEO normalization), generator script with a partner-memo-style prompt and richly described zod schema, API route at `POST /api/industry-tariff-reports/chapters/[chapterSlug]/generate-tariff-engineering`, admin row + status pill via `CHAPTER_GENERATE_STEPS`, section page at `/industry-tariff-report/chapters/<slug>/tariff-engineering` with a dedicated renderer, left-nav entry, per-section SEO generator, and `run-tariff-report` CLI wiring.
- Prompt is anchored in real US trade-law authorities (CBP HQ/NY rulings, CIT/CAFC cases, USMCA tariff-shift rules, 19 USC §1313 drawback variants, 19 USC §1592 penalties, Section 232/301/IEEPA enforcement) so output is genuinely useful to importers, customs brokers, and corporate trade counsel rather than generic.

## Test plan
- [ ] Run `pnpm install && yarn compile` in `insights-ui/` — passes locally
- [ ] Run `yarn lint && yarn prettier-check` — passes locally
- [ ] Apply the migration in a non-prod DB and confirm `tariff_engineering` JSONB column exists
- [ ] In `/admin-v1/tariff-reports`, hit "Generate all" on a seeded chapter and confirm the new pill turns green and the section becomes reachable
- [ ] Visit `/industry-tariff-report/chapters/<slug>/tariff-engineering` — confirm the renderer (overview, classification-lever table, strategy cards, COO playbook, valuation, FTZ/drawback, compliance guardrails, bottom line) matches the data
- [ ] Confirm the new "Tariff Engineering" link appears in the chapter left navigation
- [ ] Hit the per-section "Regenerate Tariff Engineering" admin action and confirm it replaces the content
- [ ] Run `generate-seo-info` and confirm `tariffEngineeringSeoDetails` is populated; visit the page and verify `<head>` metadata uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)