### PR TITLE
Add ETF listing pages by asset class, category, and group

### DIFF
--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -1,16 +1,17 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
-import { EtfFilterParamKey, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { EtfFilterParamKey, EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
 type PageProps = {
   params: Promise<{ assetClass: string }>;
+  searchParams: Promise<EtfSearchParams>;
 };
 
-export async function generateMetadata(props: PageProps): Promise<Metadata> {
+export async function generateMetadata(props: { params: Promise<{ assetClass: string }> }): Promise<Metadata> {
   const { assetClass } = await props.params;
   const decoded = decodeURIComponent(assetClass);
   return {
@@ -19,15 +20,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
-export default async function EtfsByAssetClassPage({ params }: PageProps) {
+export default async function EtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { assetClass } = await params;
+  const searchParams = await searchParamsPromise;
   const decodedAssetClass = decodeURIComponent(assetClass);
 
   const matchingOption = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value.toLowerCase() === decodedAssetClass.toLowerCase());
   const displayAssetClass = matchingOption?.label ?? decodedAssetClass;
   const filterValue = matchingOption?.value ?? decodedAssetClass;
 
-  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.ASSET_CLASS]: filterValue });
+  const dataPromise = fetchEtfListingData({
+    ...searchParams,
+    [EtfFilterParamKey.ASSET_CLASS]: filterValue,
+  });
 
   return (
     <EtfPageLayout

--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -1,0 +1,41 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ assetClass: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { assetClass } = await props.params;
+  const decoded = decodeURIComponent(assetClass);
+  return {
+    title: `${decoded} ETFs | KoalaGains`,
+    description: `Browse US ETFs in the ${decoded} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function EtfsByAssetClassPage({ params }: PageProps) {
+  const { assetClass } = await params;
+  const decodedAssetClass = decodeURIComponent(assetClass);
+
+  const matchingOption = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value.toLowerCase() === decodedAssetClass.toLowerCase());
+  const displayAssetClass = matchingOption?.label ?? decodedAssetClass;
+  const filterValue = matchingOption?.value ?? decodedAssetClass;
+
+  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.ASSET_CLASS]: filterValue });
+
+  return (
+    <EtfPageLayout
+      title={`${displayAssetClass} ETFs`}
+      description={`Explore US ETFs in the ${displayAssetClass} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+      extraBreadcrumbs={[{ name: displayAssetClass, href: `/etfs/asset-classes/${encodeURIComponent(filterValue)}`, current: true }]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/categories/[category]/page.tsx
@@ -1,0 +1,51 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey } from '@/utils/etf-filter-utils';
+import { getEtfGroupName, getEtfCategoryByName } from '@/utils/etf-categorization-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ category: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { category } = await props.params;
+  const decoded = decodeURIComponent(category);
+  return {
+    title: `${decoded} ETFs | KoalaGains`,
+    description: `Browse US ETFs in the ${decoded} category with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function EtfsByCategoryPage({ params }: PageProps) {
+  const { category } = await params;
+  const decodedCategory = decodeURIComponent(category);
+
+  // If we recognize the category, surface its parent group in the layout context.
+  const knownCategory = getEtfCategoryByName(decodedCategory);
+  const groupName = getEtfGroupName(decodedCategory);
+
+  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.CATEGORY]: decodedCategory });
+
+  const description = groupName
+    ? `Explore US ETFs in the ${decodedCategory} category (${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`
+    : `Explore US ETFs in the ${decodedCategory} category with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`;
+
+  return (
+    <EtfPageLayout
+      title={`${decodedCategory} ETFs`}
+      description={description}
+      extraBreadcrumbs={[{ name: decodedCategory, href: `/etfs/categories/${encodeURIComponent(decodedCategory)}`, current: true }]}
+    >
+      {knownCategory && groupName && (
+        <p className="text-sm text-gray-400 -mt-4 mb-4">
+          Part of <span className="text-white">{groupName}</span>
+        </p>
+      )}
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/categories/[category]/page.tsx
@@ -1,7 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
-import { EtfFilterParamKey } from '@/utils/etf-filter-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupName, getEtfCategoryByName } from '@/utils/etf-categorization-utils';
 import type { Metadata } from 'next';
 
@@ -9,9 +9,10 @@ export const dynamic = 'force-dynamic';
 
 type PageProps = {
   params: Promise<{ category: string }>;
+  searchParams: Promise<EtfSearchParams>;
 };
 
-export async function generateMetadata(props: PageProps): Promise<Metadata> {
+export async function generateMetadata(props: { params: Promise<{ category: string }> }): Promise<Metadata> {
   const { category } = await props.params;
   const decoded = decodeURIComponent(category);
   return {
@@ -20,15 +21,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
-export default async function EtfsByCategoryPage({ params }: PageProps) {
+export default async function EtfsByCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { category } = await params;
+  const searchParams = await searchParamsPromise;
   const decodedCategory = decodeURIComponent(category);
 
   // If we recognize the category, surface its parent group in the layout context.
   const knownCategory = getEtfCategoryByName(decodedCategory);
   const groupName = getEtfGroupName(decodedCategory);
 
-  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.CATEGORY]: decodedCategory });
+  const dataPromise = fetchEtfListingData({
+    ...searchParams,
+    [EtfFilterParamKey.CATEGORY]: decodedCategory,
+  });
 
   const description = groupName
     ? `Explore US ETFs in the ${decodedCategory} category (${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -1,7 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
-import { EtfFilterParamKey } from '@/utils/etf-filter-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -10,9 +10,10 @@ export const dynamic = 'force-dynamic';
 
 type PageProps = {
   params: Promise<{ group: string }>;
+  searchParams: Promise<EtfSearchParams>;
 };
 
-export async function generateMetadata(props: PageProps): Promise<Metadata> {
+export async function generateMetadata(props: { params: Promise<{ group: string }> }): Promise<Metadata> {
   const { group } = await props.params;
   const decoded = decodeURIComponent(group);
   const groupObj = getEtfGroupByKey(decoded);
@@ -23,14 +24,18 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
-export default async function EtfsByGroupPage({ params }: PageProps) {
+export default async function EtfsByGroupPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { group } = await params;
+  const searchParams = await searchParamsPromise;
   const decodedGroupKey = decodeURIComponent(group);
   const groupObj = getEtfGroupByKey(decodedGroupKey);
 
   if (!groupObj) notFound();
 
-  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.GROUP]: groupObj.key });
+  const dataPromise = fetchEtfListingData({
+    ...searchParams,
+    [EtfFilterParamKey.GROUP]: groupObj.key,
+  });
 
   return (
     <EtfPageLayout

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -1,0 +1,44 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey } from '@/utils/etf-filter-utils';
+import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ group: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { group } = await props.params;
+  const decoded = decodeURIComponent(group);
+  const groupObj = getEtfGroupByKey(decoded);
+  const displayName = groupObj?.name ?? decoded;
+  return {
+    title: `${displayName} ETFs | KoalaGains`,
+    description: `Browse US ETFs in the ${displayName} group with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function EtfsByGroupPage({ params }: PageProps) {
+  const { group } = await params;
+  const decodedGroupKey = decodeURIComponent(group);
+  const groupObj = getEtfGroupByKey(decodedGroupKey);
+
+  if (!groupObj) notFound();
+
+  const dataPromise = fetchEtfListingData({ [EtfFilterParamKey.GROUP]: groupObj.key });
+
+  return (
+    <EtfPageLayout
+      title={`${groupObj.name} ETFs`}
+      description={groupObj.description}
+      extraBreadcrumbs={[{ name: groupObj.name, href: `/etfs/groups/${encodeURIComponent(groupObj.key)}`, current: true }]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
@@ -1,4 +1,5 @@
-import { getEtfGroupName } from '@/utils/etf-categorization-utils';
+import Link from 'next/link';
+import { getEtfGroupName, getEtfGroupKey } from '@/utils/etf-categorization-utils';
 
 export interface EtfMetadataBadgesProps {
   assetClass?: string | null;
@@ -9,28 +10,50 @@ export interface EtfMetadataBadgesProps {
 interface BadgeItem {
   label: string;
   value: string;
+  href: string;
 }
 
 export default function EtfMetadataBadges({ assetClass, category, className }: EtfMetadataBadgesProps): JSX.Element | null {
   const groupName = getEtfGroupName(category);
+  const groupKey = getEtfGroupKey(category);
 
   const items: BadgeItem[] = [];
-  if (assetClass) items.push({ label: 'Asset Class', value: assetClass });
-  if (category) items.push({ label: 'Category', value: category });
-  if (groupName) items.push({ label: 'Group', value: groupName });
+  if (assetClass) {
+    items.push({
+      label: 'Asset Class',
+      value: assetClass,
+      href: `/etfs/asset-classes/${encodeURIComponent(assetClass)}`,
+    });
+  }
+  if (category) {
+    items.push({
+      label: 'Category',
+      value: category,
+      href: `/etfs/categories/${encodeURIComponent(category)}`,
+    });
+  }
+  if (groupName && groupKey) {
+    items.push({
+      label: 'Group',
+      value: groupName,
+      href: `/etfs/groups/${encodeURIComponent(groupKey)}`,
+    });
+  }
 
   if (items.length === 0) return null;
 
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className ?? ''}`}>
       {items.map((item) => (
-        <span
+        <Link
           key={item.label}
-          className="inline-flex items-center gap-1 rounded-full border border-color bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-color"
+          href={item.href}
+          className="inline-flex items-center gap-1 rounded-full border border-color bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-color hover:border-[#F59E0B] hover:bg-gray-700 transition-colors"
+          aria-label={`View all ETFs in ${item.label}: ${item.value}`}
         >
           <span className="text-muted-foreground">{item.label}:</span>
           <span>{item.value}</span>
-        </span>
+        </Link>
       ))}
     </div>
   );

--- a/insights-ui/src/components/etfs/EtfPageLayout.tsx
+++ b/insights-ui/src/components/etfs/EtfPageLayout.tsx
@@ -9,15 +9,20 @@ interface EtfPageLayoutProps {
   title: string;
   description: string;
   showAppliedFilters?: boolean;
+  extraBreadcrumbs?: BreadcrumbsOjbect[];
   children: ReactNode;
 }
 
-function buildBreadcrumbs(): BreadcrumbsOjbect[] {
-  return [{ name: 'US ETFs', href: '/etfs', current: true }];
+function buildBreadcrumbs(extraBreadcrumbs?: BreadcrumbsOjbect[]): BreadcrumbsOjbect[] {
+  if (!extraBreadcrumbs || extraBreadcrumbs.length === 0) {
+    return [{ name: 'US ETFs', href: '/etfs', current: true }];
+  }
+  const rootCrumb: BreadcrumbsOjbect = { name: 'US ETFs', href: '/etfs', current: false };
+  return [rootCrumb, ...extraBreadcrumbs];
 }
 
-export default function EtfPageLayout({ title, description, showAppliedFilters = false, children }: EtfPageLayoutProps) {
-  const breadcrumbs = buildBreadcrumbs();
+export default function EtfPageLayout({ title, description, showAppliedFilters = false, extraBreadcrumbs, children }: EtfPageLayoutProps) {
+  const breadcrumbs = buildBreadcrumbs(extraBreadcrumbs);
 
   return (
     <PageWrapper>

--- a/insights-ui/src/components/etfs/EtfPagination.tsx
+++ b/insights-ui/src/components/etfs/EtfPagination.tsx
@@ -23,13 +23,29 @@ export default function EtfPagination({ currentPage, totalPages }: EtfPagination
 
     const hasFilters = Array.from(params.keys()).some((k) => k !== 'page');
     const targetPage = page <= 1 ? 1 : page;
+    const qs = params.toString();
 
-    if (targetPage === 1 && !hasFilters) {
-      router.push('/etfs');
-    } else {
-      const qs = params.toString();
-      router.push(`/etfs-filtered?${qs}`);
+    // Special-case the static landing page: /etfs is force-static and ignores query params,
+    // so any non-trivial nav (page 2+, or any filter) is routed through /etfs-filtered, and
+    // a return to page 1 with no filters bounces back to the static page.
+    if (pathname === '/etfs') {
+      if (targetPage === 1 && !hasFilters) {
+        router.push('/etfs');
+      } else {
+        router.push(`/etfs-filtered${qs ? `?${qs}` : ''}`);
+      }
+      return;
     }
+
+    if (pathname === '/etfs-filtered' && targetPage === 1 && !hasFilters) {
+      router.push('/etfs');
+      return;
+    }
+
+    // Default: stay on the current path. Works for the new dynamic listing pages
+    // (/etfs/asset-classes/[…], /etfs/categories/[…], /etfs/groups/[…]) as well as
+    // /etfs-filtered with active filters.
+    router.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
   // Build visible page numbers: show first, last, current +/- 2, with ellipses

--- a/insights-ui/src/utils/etf-categorization-utils.ts
+++ b/insights-ui/src/utils/etf-categorization-utils.ts
@@ -1,5 +1,5 @@
 import etfCategoriesRaw from '@/etf-analysis-data/etf-analysis-categories.json';
-import { EtfCategoriesConfig } from '@/types/etf/etf-analysis-types';
+import { EtfCategoriesConfig, EtfCategoryToGroup, EtfGroup } from '@/types/etf/etf-analysis-types';
 
 const categoriesConfig = etfCategoriesRaw as EtfCategoriesConfig;
 
@@ -12,4 +12,23 @@ export function getEtfGroupName(category: string | null | undefined): string | u
   const groupKey = getEtfGroupKey(category);
   if (!groupKey) return undefined;
   return categoriesConfig.groups.find((g) => g.key === groupKey)?.name;
+}
+
+export function getEtfGroupByKey(key: string | null | undefined): EtfGroup | undefined {
+  if (!key) return undefined;
+  return categoriesConfig.groups.find((g) => g.key === key);
+}
+
+export function getAllEtfGroups(): ReadonlyArray<EtfGroup> {
+  return categoriesConfig.groups;
+}
+
+export function getCategoriesForGroupKey(key: string | null | undefined): EtfCategoryToGroup[] {
+  if (!key) return [];
+  return categoriesConfig.categories.filter((c) => c.group === key);
+}
+
+export function getEtfCategoryByName(name: string | null | undefined): EtfCategoryToGroup | undefined {
+  if (!name) return undefined;
+  return categoriesConfig.categories.find((c) => c.name === name);
 }

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { ReadonlyURLSearchParams } from 'next/navigation';
+import { getCategoriesForGroupKey, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 
 /** ----- Types and Enums ----- */
 
@@ -19,6 +20,8 @@ export enum EtfFilterType {
   RSI = 'rsi',
   DIVIDEND_YEARS = 'dividendYears',
   ASSET_CLASS = 'assetClass',
+  CATEGORY = 'category',
+  GROUP = 'group',
   ISSUER = 'issuer',
   SEARCH = 'search',
   // Advanced (Mor) filters — per period
@@ -48,6 +51,8 @@ export enum EtfFilterParamKey {
   RSI = 'rsi',
   DIVIDEND_YEARS = 'dividendYears',
   ASSET_CLASS = 'assetClass',
+  CATEGORY = 'category',
+  GROUP = 'group',
   ISSUER = 'issuer',
   SEARCH = 'search',
   // Advanced (Mor) filters — per period
@@ -98,6 +103,8 @@ type RangeFilterType =
 type SelectFilterType =
   | EtfFilterType.PAYOUT_FREQUENCY
   | EtfFilterType.ASSET_CLASS
+  | EtfFilterType.CATEGORY
+  | EtfFilterType.GROUP
   | EtfFilterType.ISSUER
   | EtfFilterType.MOR_RISK_3YR
   | EtfFilterType.MOR_RISK_5YR
@@ -320,6 +327,8 @@ const ALL_ETF_PARAM_KEYS: EtfFilterParamKey[] = [
   EtfFilterParamKey.RSI,
   EtfFilterParamKey.DIVIDEND_YEARS,
   EtfFilterParamKey.ASSET_CLASS,
+  EtfFilterParamKey.CATEGORY,
+  EtfFilterParamKey.GROUP,
   EtfFilterParamKey.ISSUER,
   EtfFilterParamKey.SEARCH,
   EtfFilterParamKey.MOR_UPSIDE_3YR,
@@ -434,6 +443,8 @@ export const MOR_ADVANCED_FILTERS: MorAdvancedFilterDef[] = [
 const SELECT_FILTER_TYPES: Set<string> = new Set([
   EtfFilterType.PAYOUT_FREQUENCY,
   EtfFilterType.ASSET_CLASS,
+  EtfFilterType.CATEGORY,
+  EtfFilterType.GROUP,
   EtfFilterType.ISSUER,
   EtfFilterType.MOR_RISK_3YR,
   EtfFilterType.MOR_RISK_5YR,
@@ -590,6 +601,29 @@ export function getAppliedEtfFilters(searchParams: ReadonlyURLSearchParams): App
       paramKey: EtfFilterParamKey.ASSET_CLASS,
       selectedValue: acRaw,
       label: matchingOption ? `Asset Class: ${matchingOption.label}` : `Asset Class: ${acRaw}`,
+    });
+  }
+
+  // Category
+  const categoryRaw = searchParams.get(EtfFilterParamKey.CATEGORY);
+  if (categoryRaw && categoryRaw.trim()) {
+    filters.push({
+      type: EtfFilterType.CATEGORY,
+      paramKey: EtfFilterParamKey.CATEGORY,
+      selectedValue: categoryRaw,
+      label: `Category: ${categoryRaw}`,
+    });
+  }
+
+  // Group (key, e.g. "broad-equity")
+  const groupRaw = searchParams.get(EtfFilterParamKey.GROUP);
+  if (groupRaw && groupRaw.trim()) {
+    const groupName = getEtfGroupByKey(groupRaw)?.name;
+    filters.push({
+      type: EtfFilterType.GROUP,
+      paramKey: EtfFilterParamKey.GROUP,
+      selectedValue: groupRaw,
+      label: `Group: ${groupName ?? groupRaw}`,
     });
   }
 
@@ -867,6 +901,25 @@ export function createEtfStockAnalyzerFilter(filters: EtfFilterParams): Prisma.E
   const assetClass = filters[EtfFilterParamKey.ASSET_CLASS]?.trim();
   if (assetClass) {
     where.assetClass = { equals: assetClass, mode: 'insensitive' };
+  }
+
+  const category = filters[EtfFilterParamKey.CATEGORY]?.trim();
+  if (category) {
+    where.category = { equals: category, mode: 'insensitive' };
+  }
+
+  // Group is not stored on the row — translate the group key into the set of
+  // category names that belong to it and match any of them.
+  const groupKey = filters[EtfFilterParamKey.GROUP]?.trim();
+  if (groupKey) {
+    const categoryNames = getCategoriesForGroupKey(groupKey).map((c) => c.name);
+    if (categoryNames.length === 0) {
+      // Unknown / empty group: force-empty result set so callers see "no matches"
+      // rather than the unfiltered listing.
+      where.category = { equals: '__no_match__' };
+    } else {
+      where.category = { in: categoryNames };
+    }
   }
 
   const issuer = filters[EtfFilterParamKey.ISSUER]?.trim();


### PR DESCRIPTION
## Summary
- Adds three dynamic listing routes — `/etfs/asset-classes/[assetClass]`, `/etfs/categories/[category]`, and `/etfs/groups/[group]` — so users can browse the ETF universe by the same metadata already surfaced on the ETF detail page.
- `EtfMetadataBadges` (Asset Class / Category / Group badges on the detail page) now renders each badge as a `Link` to the matching listing page, mirroring how stock industry chips behave on the stock pages.
- Adds `category` and `group` query-param filtering to `etf-filter-utils` (DB-level for category, set-of-categories `IN` filter for group via the static `etf-analysis-categories.json` mapping). The shared `EtfPageLayout` accepts an optional `extraBreadcrumbs` prop so each listing page renders a clean breadcrumb trail back to `/etfs`.

## Test plan
- [ ] Visit an ETF detail page and click the **Asset Class**, **Category**, and **Group** badges — each should land on a listing page filtered to that value.
- [ ] Hit `/etfs/asset-classes/Equity`, `/etfs/categories/Technology`, and `/etfs/groups/broad-equity` directly and confirm only matching ETFs render.
- [ ] On the Category page for a known category (e.g. Technology), confirm the parent group is shown ("Part of Sector & Thematic Equity").
- [ ] On the Group page, confirm the breadcrumb shows `US ETFs › <Group Name>` and the description matches the group definition.
- [ ] Open the filters modal from a listing page and verify clearing the auto-applied chip resets the URL.
- [ ] Hit `/etfs/groups/does-not-exist` — should 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)