### PR TITLE
Add ETF index pages for groups, asset classes, and categories

### DIFF
--- a/insights-ui/src/app/etfs/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/page.tsx
@@ -1,0 +1,49 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'ETFs by Asset Class | KoalaGains',
+  description:
+    'Browse US ETFs by asset class — Equity, Fixed Income, Commodity, Alternatives, and more. Each card highlights the top-rated ETFs in that class.',
+};
+
+export default async function EtfsAssetClassesIndexPage() {
+  const assetClasses = ETF_ASSET_CLASS_OPTIONS.filter((opt) => opt.value !== '');
+
+  const valueToKey = new Map<string, string>();
+  for (const opt of assetClasses) {
+    valueToKey.set(opt.value, opt.value);
+  }
+
+  const { values, counts } = await fetchEtfsForGroupings({
+    spaceId: KoalaGainsSpaceId,
+    mode: 'assetClass',
+    valueToKey,
+  });
+
+  return (
+    <EtfPageLayout
+      title="ETFs by Asset Class"
+      description="Equity, fixed income, commodity, alternative, multi-asset and currency fund classes. Each card shows the top-rated ETFs in that asset class."
+      extraBreadcrumbs={[{ name: 'Asset Classes', href: '/etfs/asset-classes', current: true }]}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+        {assetClasses.map((opt) => (
+          <CompactEtfGroupingCard
+            key={opt.value}
+            title={opt.label}
+            href={`/etfs/asset-classes/${encodeURIComponent(opt.value)}`}
+            totalCount={counts.get(opt.value) ?? 0}
+            etfs={values.get(opt.value) ?? []}
+          />
+        ))}
+      </div>
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/categories/page.tsx
+++ b/insights-ui/src/app/etfs/categories/page.tsx
@@ -1,0 +1,72 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
+import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'ETFs by Category | KoalaGains',
+  description:
+    'Browse US ETFs by Morningstar-style category — Large Blend, Technology, High Yield Bond, and more. Each card highlights the top-rated ETFs in that category.',
+};
+
+export default async function EtfsCategoriesIndexPage() {
+  const groups = getAllEtfGroups();
+
+  const valueToKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const cat of getCategoriesForGroupKey(group.key)) {
+      valueToKey.set(cat.name, cat.name);
+    }
+  }
+
+  const { values, counts } = await fetchEtfsForGroupings({
+    spaceId: KoalaGainsSpaceId,
+    mode: 'category',
+    valueToKey,
+  });
+
+  return (
+    <EtfPageLayout
+      title="ETFs by Category"
+      description="Browse all ETF categories grouped by analysis group. Each card lists the top-rated ETFs in that category."
+      extraBreadcrumbs={[{ name: 'Categories', href: '/etfs/categories', current: true }]}
+    >
+      {groups.map((group) => {
+        const categories = getCategoriesForGroupKey(group.key);
+        if (categories.length === 0) return null;
+
+        return (
+          <div key={group.key} className="mb-8">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-bold text-white">{group.name}</h2>
+              <Link
+                href={`/etfs/groups/${encodeURIComponent(group.key)}`}
+                className="text-sm bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium px-3 py-1 rounded-lg shadow-md flex items-center"
+              >
+                View Group
+                <span className="ml-1">→</span>
+              </Link>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+              {categories.map((cat) => (
+                <CompactEtfGroupingCard
+                  key={cat.name}
+                  title={cat.name}
+                  href={`/etfs/categories/${encodeURIComponent(cat.name)}`}
+                  totalCount={counts.get(cat.name) ?? 0}
+                  etfs={values.get(cat.name) ?? []}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/groups/page.tsx
+++ b/insights-ui/src/app/etfs/groups/page.tsx
@@ -1,0 +1,50 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
+import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'ETFs by Group | KoalaGains',
+  description: 'Browse US ETFs organized by analysis group. Each group highlights top-rated ETFs by report score and AUM.',
+};
+
+export default async function EtfsGroupsIndexPage() {
+  const groups = getAllEtfGroups();
+
+  const valueToKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const cat of getCategoriesForGroupKey(group.key)) {
+      valueToKey.set(cat.name, group.key);
+    }
+  }
+
+  const { values, counts } = await fetchEtfsForGroupings({
+    spaceId: KoalaGainsSpaceId,
+    mode: 'category',
+    valueToKey,
+  });
+
+  return (
+    <EtfPageLayout
+      title="ETFs by Group"
+      description="Diversified, sector, fixed income, and alternative-strategy fund groups. Each card lists the top-rated ETFs in that group."
+      extraBreadcrumbs={[{ name: 'Groups', href: '/etfs/groups', current: true }]}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+        {groups.map((group) => (
+          <CompactEtfGroupingCard
+            key={group.key}
+            title={group.name}
+            href={`/etfs/groups/${encodeURIComponent(group.key)}`}
+            totalCount={counts.get(group.key) ?? 0}
+            etfs={values.get(group.key) ?? []}
+          />
+        ))}
+      </div>
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
+++ b/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
@@ -1,0 +1,63 @@
+import { EtfGroupingPreviewItem } from '@/utils/etf-grouping-utils';
+import Link from 'next/link';
+import React from 'react';
+
+interface CompactEtfGroupingCardProps {
+  title: string;
+  href: string;
+  totalCount?: number;
+  etfs: EtfGroupingPreviewItem[];
+}
+
+function getEtfScoreColorClasses(score: number | null): { textColorClass: string; bgColorClass: string } {
+  if (score === null) {
+    return { textColorClass: 'text-gray-400', bgColorClass: 'bg-gray-500' };
+  }
+  if (score >= 75) return { textColorClass: 'text-green-500', bgColorClass: 'bg-green-500' };
+  if (score >= 50) return { textColorClass: 'text-yellow-500', bgColorClass: 'bg-yellow-500' };
+  if (score >= 25) return { textColorClass: 'text-orange-500', bgColorClass: 'bg-orange-500' };
+  return { textColorClass: 'text-red-500', bgColorClass: 'bg-red-500' };
+}
+
+export default function CompactEtfGroupingCard({ title, href, totalCount, etfs }: CompactEtfGroupingCardProps): React.JSX.Element {
+  return (
+    <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
+      <Link href={href} className="block px-3 py-1.5 bg-[#374151] hover:bg-[#2D3748] transition-colors">
+        <h3 className="text-sm font-semibold heading-color leading-snug mb-0.5 text-left flex justify-between items-start gap-2" title={title}>
+          <span className="whitespace-normal break-words">{title}</span>
+          {typeof totalCount === 'number' && totalCount > 0 && <span className="text-xs font-normal text-gray-300 shrink-0">{totalCount} ETFs</span>}
+        </h3>
+      </Link>
+
+      {etfs.length > 0 ? (
+        <div className="px-3 py-1">
+          <ul className="space-y-1">
+            {etfs.map((etf) => {
+              const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
+              const scoreLabel = etf.finalScore !== null ? String(etf.finalScore) : '—';
+
+              return (
+                <li key={etf.id}>
+                  <Link
+                    href={`/etfs/${etf.exchange}/${etf.symbol}`}
+                    className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
+                  >
+                    <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[34px] text-right`}>
+                      <span className={`${textColorClass} text-xs font-mono`}>{scoreLabel}</span>
+                    </p>
+                    <span className="text-xs font-medium bg-[#4F46E5] text-white ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>
+                    <span className="text-xs text-white truncate">{etf.name}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <div className="px-3 py-2">
+          <p className="text-xs text-gray-400">No ETFs available.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -1,0 +1,119 @@
+import { prisma } from '@/prisma';
+import { parseNumericStringValue } from '@/utils/etf-filter-utils';
+
+export interface EtfGroupingPreviewItem {
+  id: string;
+  symbol: string;
+  exchange: string;
+  name: string;
+  finalScore: number | null;
+  hasDetailedReport: boolean;
+}
+
+export interface EtfGroupingPreview<TKey extends string = string> {
+  values: Map<TKey, EtfGroupingPreviewItem[]>;
+  counts: Map<TKey, number>;
+}
+
+const TOP_N_PER_GROUPING = 5;
+
+type GroupingMode = 'category' | 'assetClass';
+
+interface FetchEtfsForGroupingsArgs<TKey extends string> {
+  spaceId: string;
+  mode: GroupingMode;
+  // Maps the raw DB value (category name or assetClass label) to the output bucket key.
+  // Multiple raw values can share the same key (e.g. all categories in a group → group key).
+  valueToKey: Map<string, TKey>;
+}
+
+interface RawEtfRow {
+  id: string;
+  symbol: string;
+  name: string;
+  exchange: string;
+  assetClass: string | null;
+  category: string | null;
+  finalScore: number | null;
+  aum: string | null;
+}
+
+async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: string[]): Promise<RawEtfRow[]> {
+  if (dbValues.length === 0) return [];
+
+  const where =
+    mode === 'category'
+      ? { spaceId, stockAnalyzerInfo: { is: { category: { in: dbValues } } } }
+      : { spaceId, stockAnalyzerInfo: { is: { assetClass: { in: dbValues } } } };
+
+  const etfs = await prisma.etf.findMany({
+    where,
+    select: {
+      id: true,
+      symbol: true,
+      name: true,
+      exchange: true,
+      stockAnalyzerInfo: { select: { assetClass: true, category: true } },
+      financialInfo: { select: { aum: true } },
+      cachedScore: { select: { finalScore: true } },
+    },
+  });
+
+  return etfs.map((etf) => ({
+    id: etf.id,
+    symbol: etf.symbol,
+    name: etf.name,
+    exchange: etf.exchange,
+    assetClass: etf.stockAnalyzerInfo?.assetClass ?? null,
+    category: etf.stockAnalyzerInfo?.category ?? null,
+    finalScore: etf.cachedScore?.finalScore ?? null,
+    aum: etf.financialInfo?.aum ?? null,
+  }));
+}
+
+function selectTopFive(rows: RawEtfRow[]): EtfGroupingPreviewItem[] {
+  const withReport = rows.filter((r) => r.finalScore !== null).sort((a, b) => (b.finalScore ?? 0) - (a.finalScore ?? 0));
+
+  const withoutReport = rows.filter((r) => r.finalScore === null).sort((a, b) => (parseNumericStringValue(b.aum) ?? 0) - (parseNumericStringValue(a.aum) ?? 0));
+
+  const combined = [...withReport, ...withoutReport].slice(0, TOP_N_PER_GROUPING);
+
+  return combined.map((r) => ({
+    id: r.id,
+    symbol: r.symbol,
+    exchange: r.exchange,
+    name: r.name,
+    finalScore: r.finalScore,
+    hasDetailedReport: r.finalScore !== null,
+  }));
+}
+
+export async function fetchEtfsForGroupings<TKey extends string>({
+  spaceId,
+  mode,
+  valueToKey,
+}: FetchEtfsForGroupingsArgs<TKey>): Promise<EtfGroupingPreview<TKey>> {
+  const dbValues = Array.from(valueToKey.keys());
+  const rawRows = await loadRawEtfRows(spaceId, mode, dbValues);
+
+  const rowsByKey = new Map<TKey, RawEtfRow[]>();
+  const counts = new Map<TKey, number>();
+
+  for (const row of rawRows) {
+    const dbValue = mode === 'category' ? row.category : row.assetClass;
+    if (!dbValue) continue;
+    const outputKey = valueToKey.get(dbValue);
+    if (!outputKey) continue;
+    const bucket = rowsByKey.get(outputKey) ?? [];
+    bucket.push(row);
+    rowsByKey.set(outputKey, bucket);
+    counts.set(outputKey, (counts.get(outputKey) ?? 0) + 1);
+  }
+
+  const values = new Map<TKey, EtfGroupingPreviewItem[]>();
+  for (const [outputKey, rows] of rowsByKey.entries()) {
+    values.set(outputKey, selectTopFive(rows));
+  }
+
+  return { values, counts };
+}


### PR DESCRIPTION
## Summary

Adds three new index pages mirroring the `/stocks/industries/<slug>` design language:

- `/etfs/groups` — one card per analysis group (8 groups), with the top-rated ETFs in each
- `/etfs/asset-classes` — one card per asset class (Equity, Fixed Income, Commodity, Alternatives, Multi-Asset, Currency)
- `/etfs/categories` — categories grouped by analysis group; one card per category

Each card lists up to 5 top ETFs, selected as: ETFs with detailed reports sorted by cached `finalScore` (desc), padded if needed with remaining ETFs sorted by AUM (desc).

## Implementation

- New `fetchEtfsForGroupings` utility (`src/utils/etf-grouping-utils.ts`): single Prisma query covers all buckets for a page; AUM strings are parsed for in-memory sort fallback (since AUM is stored as a display string)
- New `CompactEtfGroupingCard` component (`src/components/etfs/CompactEtfGroupingCard.tsx`): reusable card modeled on `CompactSubIndustryCard`; header links to the existing dynamic listing page (e.g. `/etfs/groups/<key>`)
- All three pages use `EtfPageLayout` with breadcrumbs and the existing filters button
- "View Group →" CTA on each group section in the categories page jumps to the group listing

## Test plan
- [ ] `/etfs/groups` renders all 8 group cards, each with up to 5 ETFs
- [ ] `/etfs/asset-classes` renders 6 asset-class cards
- [ ] `/etfs/categories` renders categories grouped by group with section headers
- [ ] Card header links route to the corresponding `/etfs/<grouping>/<slug>` listing page
- [ ] Each ETF row links to its detail page at `/etfs/<exchange>/<symbol>`
- [ ] Cards with no detailed reports still show top ETFs by AUM
- [ ] Empty states render gracefully when a bucket has no ETFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)