### PR TITLE
Add intermediate index breadcrumbs to ETF listing pages

### DIFF
--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -38,7 +38,10 @@ export default async function EtfsByAssetClassPage({ params, searchParams: searc
     <EtfPageLayout
       title={`${displayAssetClass} ETFs`}
       description={`Explore US ETFs in the ${displayAssetClass} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
-      extraBreadcrumbs={[{ name: displayAssetClass, href: `/etfs/asset-classes/${encodeURIComponent(filterValue)}`, current: true }]}
+      extraBreadcrumbs={[
+        { name: 'All Asset Classes', href: '/etfs/asset-classes', current: false },
+        { name: displayAssetClass, href: `/etfs/asset-classes/${encodeURIComponent(filterValue)}`, current: true },
+      ]}
     >
       <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
     </EtfPageLayout>

--- a/insights-ui/src/app/etfs/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/categories/[category]/page.tsx
@@ -43,7 +43,10 @@ export default async function EtfsByCategoryPage({ params, searchParams: searchP
     <EtfPageLayout
       title={`${decodedCategory} ETFs`}
       description={description}
-      extraBreadcrumbs={[{ name: decodedCategory, href: `/etfs/categories/${encodeURIComponent(decodedCategory)}`, current: true }]}
+      extraBreadcrumbs={[
+        { name: 'All Categories', href: '/etfs/categories', current: false },
+        { name: decodedCategory, href: `/etfs/categories/${encodeURIComponent(decodedCategory)}`, current: true },
+      ]}
     >
       {knownCategory && groupName && (
         <p className="text-sm text-gray-400 -mt-4 mb-4">

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -41,7 +41,10 @@ export default async function EtfsByGroupPage({ params, searchParams: searchPara
     <EtfPageLayout
       title={`${groupObj.name} ETFs`}
       description={groupObj.description}
-      extraBreadcrumbs={[{ name: groupObj.name, href: `/etfs/groups/${encodeURIComponent(groupObj.key)}`, current: true }]}
+      extraBreadcrumbs={[
+        { name: 'All Groups', href: '/etfs/groups', current: false },
+        { name: groupObj.name, href: `/etfs/groups/${encodeURIComponent(groupObj.key)}`, current: true },
+      ]}
     >
       <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
     </EtfPageLayout>


### PR DESCRIPTION
## Summary

Each dynamic ETF listing page (`/etfs/groups/[group]`, `/etfs/categories/[category]`, `/etfs/asset-classes/[assetClass]`) now shows an intermediate breadcrumb between the root and the leaf so users can step up to the index page that lists every value of that grouping:

- `US ETFs > All Groups > Sector & Thematic Equity`
- `US ETFs > All Categories > Large Blend`
- `US ETFs > All Asset Classes > Equity`

The intermediate crumb links to the index pages added in #1445 (`/etfs/groups`, `/etfs/categories`, `/etfs/asset-classes`).

## Test plan
- [ ] On `/etfs/groups/sector-thematic-equity`, breadcrumb shows `US ETFs > All Groups > Sector & Thematic Equity`
- [ ] Clicking "All Groups" navigates to `/etfs/groups`
- [ ] Same for `/etfs/categories/[category]` → "All Categories" → `/etfs/categories`
- [ ] Same for `/etfs/asset-classes/[assetClass]` → "All Asset Classes" → `/etfs/asset-classes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)