### PR TITLE
Add Mor period selector to ETF filters and add Mor stats API

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/mor-stats/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/mor-stats/route.ts
@@ -1,0 +1,110 @@
+import { prisma } from '@/prisma';
+import { extractCaptureRatioForPeriod, extractRiskLevelForPeriod, MOR_PERIODS, MorFieldKind, MorPeriodKey } from '@/utils/etf-filter-utils';
+import {
+  computeCategoricalStats,
+  computeNumericStats,
+  isNumericMorField,
+  MOR_STATS_FIELDS,
+  MorFieldStats,
+  MorStatsByFieldByPeriod,
+  MorStatsByPeriod,
+} from '@/utils/etf-mor-stats-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+export interface MorStatsAllResponse {
+  scope: 'all';
+  totalEtfsWithMorRisk: number;
+  stats: MorStatsByFieldByPeriod;
+}
+
+export interface MorStatsByFieldResponse {
+  scope: 'field';
+  field: MorFieldKind;
+  totalEtfsWithMorRisk: number;
+  stats: MorStatsByPeriod;
+}
+
+export interface MorStatsByFieldPeriodResponse {
+  scope: 'field+period';
+  field: MorFieldKind;
+  period: MorPeriodKey;
+  totalEtfsWithMorRisk: number;
+  stats: MorFieldStats;
+}
+
+export type MorStatsResponse = MorStatsAllResponse | MorStatsByFieldResponse | MorStatsByFieldPeriodResponse;
+
+function isValidField(v: string | null): v is MorFieldKind {
+  return v === 'upside' || v === 'downside' || v === 'risk';
+}
+
+function isValidPeriod(v: string | null): v is MorPeriodKey {
+  return v === '3-Yr' || v === '5-Yr' || v === '10-Yr';
+}
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<MorStatsResponse> {
+  const { spaceId } = await context.params;
+  const { searchParams } = new URL(req.url);
+  const fieldParam = searchParams.get('field');
+  const periodParam = searchParams.get('period');
+
+  if (fieldParam !== null && !isValidField(fieldParam)) {
+    throw new Error(`Invalid field "${fieldParam}". Must be one of: upside, downside, risk`);
+  }
+  if (periodParam !== null && !isValidPeriod(periodParam)) {
+    throw new Error(`Invalid period "${periodParam}". Must be one of: 3-Yr, 5-Yr, 10-Yr`);
+  }
+
+  const rows = await prisma.etfMorRiskInfo.findMany({
+    where: { etf: { spaceId } },
+    select: { riskPeriods: true },
+  });
+
+  const totalEtfsWithMorRisk = rows.length;
+
+  const computeStatsFor = (field: MorFieldKind, period: MorPeriodKey): MorFieldStats => {
+    if (isNumericMorField(field)) {
+      const rowLabel = field;
+      const values: Array<number | null> = rows.map((r) => extractCaptureRatioForPeriod(r.riskPeriods, period, rowLabel));
+      return computeNumericStats(values, field, period);
+    }
+    const values: Array<string | null> = rows.map((r) => extractRiskLevelForPeriod(r.riskPeriods, period));
+    return computeCategoricalStats(values, field, period);
+  };
+
+  if (fieldParam && periodParam) {
+    return {
+      scope: 'field+period',
+      field: fieldParam,
+      period: periodParam,
+      totalEtfsWithMorRisk,
+      stats: computeStatsFor(fieldParam, periodParam),
+    };
+  }
+
+  if (fieldParam) {
+    const byPeriod = {} as MorStatsByPeriod;
+    for (const p of MOR_PERIODS) byPeriod[p] = computeStatsFor(fieldParam, p);
+    return {
+      scope: 'field',
+      field: fieldParam,
+      totalEtfsWithMorRisk,
+      stats: byPeriod,
+    };
+  }
+
+  const all = {} as MorStatsByFieldByPeriod;
+  for (const f of MOR_STATS_FIELDS) {
+    const byPeriod = {} as MorStatsByPeriod;
+    for (const p of MOR_PERIODS) byPeriod[p] = computeStatsFor(f, p);
+    all[f] = byPeriod;
+  }
+  return {
+    scope: 'all',
+    totalEtfsWithMorRisk,
+    stats: all,
+  };
+}
+
+export const GET = withErrorHandlingV2<MorStatsResponse>(getHandler);

--- a/insights-ui/src/components/etfs/EtfFiltersButton.tsx
+++ b/insights-ui/src/components/etfs/EtfFiltersButton.tsx
@@ -21,13 +21,19 @@ import {
   ETF_DIVIDEND_YEARS_OPTIONS,
   ETF_ASSET_CLASS_OPTIONS,
   ETF_ISSUER_OPTIONS,
-  MOR_ADVANCED_FILTERS,
+  MOR_FIELD_KINDS,
+  MOR_PERIODS,
+  detectActiveMorPeriod,
+  getMorFilterDef,
+  getMorFilterShortLabel,
+  getMorParamKey,
   getAppliedEtfFilters,
   buildInitialEtfSelected,
   applySelectedEtfFiltersToParams,
   EtfFilterParamKey,
   type AppliedEtfFilter,
   type EtfSelectedFiltersMap,
+  type MorPeriodKey,
   type ThresholdOption,
 } from '@/utils/etf-filter-utils';
 
@@ -101,6 +107,7 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
   const pathname = usePathname();
 
   const [selectedFilters, setSelectedFilters] = useState<EtfSelectedFiltersMap>(() => ({ ...initialSelected }));
+  const [morPeriod, setMorPeriod] = useState<MorPeriodKey>(() => detectActiveMorPeriod(initialSelected));
 
   const handleChange = (paramKey: EtfFilterParamKey, value: string): void => {
     setSelectedFilters((prev) => {
@@ -110,6 +117,25 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
       }
       return { ...prev, [paramKey]: value };
     });
+  };
+
+  const handlePeriodChange = (newPeriod: MorPeriodKey): void => {
+    if (newPeriod === morPeriod) return;
+    setSelectedFilters((prev) => {
+      const next = { ...prev };
+      // Carry the user's selections over to the new period's paramKeys so a chosen
+      // upside / downside / risk threshold doesn't silently disappear when they switch.
+      for (const kind of MOR_FIELD_KINDS) {
+        const oldKey = getMorParamKey(kind, morPeriod);
+        const newKey = getMorParamKey(kind, newPeriod);
+        const value = prev[oldKey];
+        delete next[oldKey];
+        if (value) next[newKey] = value;
+        else delete next[newKey];
+      }
+      return next;
+    });
+    setMorPeriod(newPeriod);
   };
 
   const handleClearAll = (): void => {
@@ -132,12 +158,6 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
 
     onClose();
   };
-
-  const morFiltersByPeriod = [
-    { period: '3 Yr', filters: MOR_ADVANCED_FILTERS.filter((f) => f.period === '3-Yr') },
-    { period: '5 Yr', filters: MOR_ADVANCED_FILTERS.filter((f) => f.period === '5-Yr') },
-    { period: '10 Yr', filters: MOR_ADVANCED_FILTERS.filter((f) => f.period === '10-Yr') },
-  ];
 
   return (
     <div className="space-y-4">
@@ -256,25 +276,42 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
       {/* Advanced (Mor) Filters */}
       <div>
         <h3 className="text-white font-semibold text-xs mb-1">Advanced Filters (Mor)</h3>
-        <p className="text-[#9CA3AF] text-[10px] mb-2">Only ETFs with Mor data shown when active</p>
+        <p className="text-[#9CA3AF] text-[10px] mb-2">Only ETFs with Mor data shown when active. Pick a time period; the three filters below apply to it.</p>
 
-        {morFiltersByPeriod.map(({ period, filters: periodFilters }) => (
-          <div key={period} className="mb-3">
-            <h4 className="text-gray-300 text-[10px] font-medium mb-1.5 uppercase tracking-wider">{period}</h4>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
-              {periodFilters.map((def) => (
-                <FilterDropdown
-                  key={def.paramKey}
-                  id={def.paramKey}
-                  label={def.kind === 'upside' ? 'Upside Capture' : def.kind === 'downside' ? 'Downside Capture' : 'Risk Level'}
-                  value={selectedFilters[def.paramKey] || ''}
-                  options={def.options}
-                  onChange={(v) => handleChange(def.paramKey, v)}
-                />
-              ))}
-            </div>
+        <div className="mb-3">
+          <span className="text-gray-300 text-[10px] font-medium uppercase tracking-wider mr-2">Time Period:</span>
+          <div className="inline-flex gap-1.5">
+            {MOR_PERIODS.map((p) => (
+              <button
+                key={p}
+                onClick={() => handlePeriodChange(p)}
+                type="button"
+                aria-pressed={morPeriod === p}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  morPeriod === p ? 'bg-[#F59E0B] text-black' : 'bg-[#374151] text-gray-300 hover:bg-[#4B5563]'
+                }`}
+              >
+                {p.replace('-', ' ')}
+              </button>
+            ))}
           </div>
-        ))}
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
+          {MOR_FIELD_KINDS.map((kind) => {
+            const def = getMorFilterDef(kind, morPeriod);
+            return (
+              <FilterDropdown
+                key={def.paramKey}
+                id={def.paramKey}
+                label={getMorFilterShortLabel(kind)}
+                value={selectedFilters[def.paramKey] || ''}
+                options={def.options}
+                onChange={(v) => handleChange(def.paramKey, v)}
+              />
+            );
+          })}
+        </div>
       </div>
 
       {/* Actions */}

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -355,12 +355,17 @@ export const ADVANCED_MOR_FILTER_KEYS: EtfFilterParamKey[] = [
 ];
 
 export type MorPeriodKey = '3-Yr' | '5-Yr' | '10-Yr';
+export type MorFieldKind = 'upside' | 'downside' | 'risk';
+
+export const MOR_PERIODS: ReadonlyArray<MorPeriodKey> = ['3-Yr', '5-Yr', '10-Yr'];
+export const MOR_FIELD_KINDS: ReadonlyArray<MorFieldKind> = ['upside', 'downside', 'risk'];
+export const DEFAULT_MOR_PERIOD: MorPeriodKey = '5-Yr';
 
 export interface MorAdvancedFilterDef {
   paramKey: EtfFilterParamKey;
   filterType: EtfFilterType;
   period: MorPeriodKey;
-  kind: 'upside' | 'downside' | 'risk';
+  kind: MorFieldKind;
   label: string;
   options: ReadonlyArray<ThresholdOption>;
 }
@@ -439,6 +444,36 @@ export const MOR_ADVANCED_FILTERS: MorAdvancedFilterDef[] = [
     options: ETF_MOR_RISK_LEVEL_OPTIONS,
   },
 ];
+
+export function getMorFilterDef(kind: MorFieldKind, period: MorPeriodKey): MorAdvancedFilterDef {
+  const def = MOR_ADVANCED_FILTERS.find((f) => f.kind === kind && f.period === period);
+  if (!def) throw new Error(`Missing Mor filter definition for kind=${kind}, period=${period}`);
+  return def;
+}
+
+export function getMorParamKey(kind: MorFieldKind, period: MorPeriodKey): EtfFilterParamKey {
+  return getMorFilterDef(kind, period).paramKey;
+}
+
+export function getMorFilterShortLabel(kind: MorFieldKind): string {
+  return kind === 'upside' ? 'Upside Capture' : kind === 'downside' ? 'Downside Capture' : 'Risk Level';
+}
+
+export function detectActiveMorPeriod(selected: EtfSelectedFiltersMap): MorPeriodKey {
+  const counts: Record<MorPeriodKey, number> = { '3-Yr': 0, '5-Yr': 0, '10-Yr': 0 };
+  for (const def of MOR_ADVANCED_FILTERS) {
+    if (selected[def.paramKey]) counts[def.period]++;
+  }
+  let bestPeriod: MorPeriodKey = DEFAULT_MOR_PERIOD;
+  let bestCount = 0;
+  for (const period of MOR_PERIODS) {
+    if (counts[period] > bestCount) {
+      bestCount = counts[period];
+      bestPeriod = period;
+    }
+  }
+  return bestPeriod;
+}
 
 const SELECT_FILTER_TYPES: Set<string> = new Set([
   EtfFilterType.PAYOUT_FREQUENCY,

--- a/insights-ui/src/utils/etf-mor-stats-utils.ts
+++ b/insights-ui/src/utils/etf-mor-stats-utils.ts
@@ -1,0 +1,144 @@
+import { MorFieldKind, MorPeriodKey } from '@/utils/etf-filter-utils';
+
+export const MOR_STATS_FIELDS: ReadonlyArray<MorFieldKind> = ['upside', 'downside', 'risk'];
+
+export function isNumericMorField(field: MorFieldKind): boolean {
+  return field === 'upside' || field === 'downside';
+}
+
+export interface MorNumericStats {
+  field: MorFieldKind;
+  period: MorPeriodKey;
+  kind: 'numeric';
+  count: number;
+  average: number | null;
+  median: number | null;
+  mode: number | null;
+  min: number | null;
+  max: number | null;
+  stdDev: number | null;
+  p25: number | null;
+  p75: number | null;
+}
+
+export interface MorCategoricalStats {
+  field: MorFieldKind;
+  period: MorPeriodKey;
+  kind: 'categorical';
+  count: number;
+  mode: string | null;
+  distribution: Record<string, number>;
+}
+
+export type MorFieldStats = MorNumericStats | MorCategoricalStats;
+
+export type MorStatsByPeriod = Record<MorPeriodKey, MorFieldStats>;
+export type MorStatsByFieldByPeriod = Record<MorFieldKind, MorStatsByPeriod>;
+
+function round2(v: number | null | undefined): number | null {
+  if (v === null || v === undefined || !Number.isFinite(v)) return null;
+  return Math.round(v * 100) / 100;
+}
+
+function median(sortedAsc: number[]): number | null {
+  const n = sortedAsc.length;
+  if (n === 0) return null;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 0 ? (sortedAsc[mid - 1] + sortedAsc[mid]) / 2 : sortedAsc[mid];
+}
+
+function percentile(sortedAsc: number[], p: number): number | null {
+  if (sortedAsc.length === 0) return null;
+  const idx = (sortedAsc.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sortedAsc[lo];
+  const w = idx - lo;
+  return sortedAsc[lo] * (1 - w) + sortedAsc[hi] * w;
+}
+
+function modeNumber(values: number[]): number | null {
+  if (values.length === 0) return null;
+  // Bucket to integers so noisy capture-ratio readings cluster sensibly.
+  const counts = new Map<number, number>();
+  for (const v of values) {
+    const bucket = Math.round(v);
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  let bestKey: number | null = null;
+  let bestCount = 0;
+  for (const [k, c] of counts) {
+    if (c > bestCount) {
+      bestCount = c;
+      bestKey = k;
+    }
+  }
+  return bestKey;
+}
+
+function modeString(values: string[]): string | null {
+  if (values.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let bestKey: string | null = null;
+  let bestCount = 0;
+  for (const [k, c] of counts) {
+    if (c > bestCount) {
+      bestCount = c;
+      bestKey = k;
+    }
+  }
+  return bestKey;
+}
+
+export function computeNumericStats(rawValues: ReadonlyArray<number | null>, field: MorFieldKind, period: MorPeriodKey): MorNumericStats {
+  const values: number[] = [];
+  for (const v of rawValues) {
+    if (v !== null && Number.isFinite(v)) values.push(v);
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const count = sorted.length;
+  if (count === 0) {
+    return {
+      field,
+      period,
+      kind: 'numeric',
+      count: 0,
+      average: null,
+      median: null,
+      mode: null,
+      min: null,
+      max: null,
+      stdDev: null,
+      p25: null,
+      p75: null,
+    };
+  }
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  const avg = sum / count;
+  const variance = sorted.reduce((acc, v) => acc + (v - avg) ** 2, 0) / count;
+  return {
+    field,
+    period,
+    kind: 'numeric',
+    count,
+    average: round2(avg),
+    median: round2(median(sorted)),
+    mode: modeNumber(sorted),
+    min: round2(sorted[0]),
+    max: round2(sorted[count - 1]),
+    stdDev: round2(Math.sqrt(variance)),
+    p25: round2(percentile(sorted, 0.25)),
+    p75: round2(percentile(sorted, 0.75)),
+  };
+}
+
+export function computeCategoricalStats(rawValues: ReadonlyArray<string | null>, field: MorFieldKind, period: MorPeriodKey): MorCategoricalStats {
+  const values: string[] = [];
+  for (const v of rawValues) {
+    if (v && v.trim()) values.push(v.trim());
+  }
+  const distribution: Record<string, number> = {};
+  for (const v of values) distribution[v] = (distribution[v] ?? 0) + 1;
+  return { field, period, kind: 'categorical', count: values.length, mode: modeString(values), distribution };
+}


### PR DESCRIPTION
## Summary
- Replace the three rows of Upside Capture / Downside Capture / Risk Level filters on `/etfs` with a single time-period toggle (3-Yr / 5-Yr / 10-Yr) plus three field dropdowns that apply to the selected period. Switching periods carries selected values across so user choices don't silently disappear, and the active period is detected from existing URL params on open.
- Add `GET /api/[spaceId]/etfs-v1/mor-stats` returning `average`, `median`, `mode`, `min`, `max`, `stdDev`, `p25`, `p75` plus the per-period `count` for capture ratios, and a `distribution` + `mode` for the categorical Risk Level. Three modes are supported via query params:
  - no params → all fields × all periods (nested as `stats.<field>.<period>`)
  - `?field=upside|downside|risk` → all three periods for that field
  - `?field=...&period=3-Yr|5-Yr|10-Yr` → single field+period

## Files changed
- `insights-ui/src/components/etfs/EtfFiltersButton.tsx` — period toggle + 3 dropdowns
- `insights-ui/src/utils/etf-filter-utils.ts` — `MOR_PERIODS`, `MOR_FIELD_KINDS`, `getMorParamKey`, `detectActiveMorPeriod`, etc.
- `insights-ui/src/utils/etf-mor-stats-utils.ts` — stats computation (numeric + categorical)
- `insights-ui/src/app/api/[spaceId]/etfs-v1/mor-stats/route.ts` — new endpoint

## Test plan
- [ ] Open `/etfs`, click Filters; verify three period buttons (3 Yr / 5 Yr / 10 Yr) and three dropdowns (Upside Capture / Downside Capture / Risk Level)
- [ ] Pick threshold values, switch period; values carry over to the new period
- [ ] Apply filters with one period set; URL contains only that period's keys, listing shows results
- [ ] `GET /api/koala_gains/etfs-v1/mor-stats` returns nested stats for all field+period combos with non-zero `totalEtfsWithMorRisk`
- [ ] `GET /api/koala_gains/etfs-v1/mor-stats?field=upside` returns three periods
- [ ] `GET /api/koala_gains/etfs-v1/mor-stats?field=risk&period=5-Yr` returns categorical stats with `distribution`
- [ ] Invalid field/period returns an error