### PR TITLE
Show Similar ETFs as a responsive comparison table

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route.ts
@@ -8,6 +8,20 @@ export interface SimilarEtf {
   symbol: string;
   exchange: string;
   name: string;
+  // Financial detail fields — same set we surface on the ETF detail page header.
+  aum: string | null;
+  expenseRatio: number | null;
+  pe: number | null;
+  sharesOut: string | null;
+  dividendTtm: number | null;
+  dividendYield: number | null;
+  payoutFrequency: string | null;
+  payoutRatio: number | null;
+  volume: number | null;
+  yearHigh: number | null;
+  yearLow: number | null;
+  beta: number | null;
+  holdings: number | null;
 }
 
 const MAX_RESULTS = 6;
@@ -29,22 +43,44 @@ async function getHandler(_req: NextRequest, context: { params: Promise<{ spaceI
   });
   if (stored.length === 0) return [];
 
-  // Name lives on the main Etf row — look it up by (symbol, exchange).
+  // Pull name + financial info for each peer in a single batched query.
   const etfs = await prisma.etf.findMany({
     where: {
       spaceId: sourceEtf.spaceId,
       OR: stored.map((s) => ({ symbol: s.symbol, exchange: s.exchange })),
     },
-    select: { symbol: true, exchange: true, name: true },
+    select: {
+      symbol: true,
+      exchange: true,
+      name: true,
+      financialInfo: true,
+    },
   });
-  const nameByKey: Map<string, string> = new Map<string, string>(etfs.map((e) => [`${e.symbol}|${e.exchange}`, e.name]));
+  const byKey = new Map<string, (typeof etfs)[number]>(etfs.map((e) => [`${e.symbol}|${e.exchange}`, e]));
 
-  return stored.map((s) => ({
-    id: s.id,
-    symbol: s.symbol,
-    exchange: s.exchange,
-    name: nameByKey.get(`${s.symbol}|${s.exchange}`) ?? s.symbol,
-  }));
+  return stored.map((s) => {
+    const match = byKey.get(`${s.symbol}|${s.exchange}`);
+    const fi = match?.financialInfo ?? null;
+    return {
+      id: s.id,
+      symbol: s.symbol,
+      exchange: s.exchange,
+      name: match?.name ?? s.symbol,
+      aum: fi?.aum ?? null,
+      expenseRatio: fi?.expenseRatio ?? null,
+      pe: fi?.pe ?? null,
+      sharesOut: fi?.sharesOut ?? null,
+      dividendTtm: fi?.dividendTtm ?? null,
+      dividendYield: fi?.dividendYield ?? null,
+      payoutFrequency: fi?.payoutFrequency ?? null,
+      payoutRatio: fi?.payoutRatio ?? null,
+      volume: fi?.volume ?? null,
+      yearHigh: fi?.yearHigh ?? null,
+      yearLow: fi?.yearLow ?? null,
+      beta: fi?.beta ?? null,
+      holdings: fi?.holdings ?? null,
+    };
+  });
 }
 
 export const GET = withErrorHandlingV2<SimilarEtf[]>(getHandler);

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -1,4 +1,6 @@
 import type { SimilarEtf } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/similar-etfs/route';
+import { formatNumber, formatPercentageDecimal, formatVolume } from '@/components/reportsv1/financialFormatters';
+import { formatCompactAmount, formatCompactMillions } from '@/utils/etf-display-format-utils';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 import { use } from 'react';
@@ -8,6 +10,67 @@ export interface SimilarEtfsProps {
   dataPromise: Promise<SimilarEtf[]>;
 }
 
+interface ColumnDef {
+  key: string;
+  label: string;
+  render: (etf: SimilarEtf) => string;
+  align?: 'left' | 'right';
+}
+
+function formatInteger(value: number | null): string {
+  if (value === null) return 'N/A';
+  return value.toLocaleString('en-US');
+}
+
+function formatRange(low: number | null, high: number | null): string {
+  if (low === null && high === null) return 'N/A';
+  return `${formatNumber(low)} - ${formatNumber(high)}`;
+}
+
+const COLUMNS: ColumnDef[] = [
+  { key: 'aum', label: 'AUM', render: (e) => formatCompactAmount(e.aum), align: 'right' },
+  { key: 'expenseRatio', label: 'Expense Ratio', render: (e) => (e.expenseRatio !== null ? `${e.expenseRatio}%` : 'N/A'), align: 'right' },
+  { key: 'pe', label: 'P/E', render: (e) => formatNumber(e.pe), align: 'right' },
+  { key: 'sharesOut', label: 'Shares Out', render: (e) => formatCompactMillions(e.sharesOut), align: 'right' },
+  {
+    key: 'dividendTtm',
+    label: 'Div TTM',
+    render: (e) => (e.dividendTtm !== null && e.dividendTtm !== 0 ? `$${formatNumber(e.dividendTtm)}` : '--'),
+    align: 'right',
+  },
+  { key: 'dividendYield', label: 'Div Yield', render: (e) => (e.dividendYield !== null ? formatPercentageDecimal(e.dividendYield) : '--'), align: 'right' },
+  { key: 'payoutFrequency', label: 'Payout Freq', render: (e) => e.payoutFrequency || 'N/A', align: 'left' },
+  { key: 'payoutRatio', label: 'Payout Ratio', render: (e) => (e.payoutRatio !== null ? formatPercentageDecimal(e.payoutRatio) : 'N/A'), align: 'right' },
+  { key: 'volume', label: 'Volume', render: (e) => formatVolume(e.volume), align: 'right' },
+  { key: 'yearRange', label: '52W Range', render: (e) => formatRange(e.yearLow, e.yearHigh), align: 'right' },
+  { key: 'beta', label: 'Beta', render: (e) => formatNumber(e.beta), align: 'right' },
+  { key: 'holdings', label: 'Holdings', render: (e) => formatInteger(e.holdings), align: 'right' },
+];
+
+function SimilarEtfMobileCard({ etf }: { etf: SimilarEtf }): JSX.Element {
+  return (
+    <div className="bg-gray-800 border border-gray-700 rounded-md p-4">
+      <Link href={`/etfs/${etf.exchange.toUpperCase()}/${etf.symbol.toUpperCase()}`} className="flex items-start justify-between gap-2 group">
+        <div className="min-w-0">
+          <h3 className="font-semibold text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{etf.name}</h3>
+          <div className="text-xs text-gray-400 mt-0.5">
+            {etf.symbol} • {etf.exchange.toUpperCase()}
+          </div>
+        </div>
+        <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0 mt-1" />
+      </Link>
+      <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+        {COLUMNS.map((col) => (
+          <div key={col.key} className="flex justify-between border-b border-gray-700/60 pb-1">
+            <dt className="text-gray-400">{col.label}</dt>
+            <dd className="text-white font-mono tabular-nums text-right ml-2 truncate">{col.render(etf)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
 export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Element | null {
   const similarEtfs: ReadonlyArray<SimilarEtf> = use(dataPromise);
   if (!similarEtfs || similarEtfs.length === 0) {
@@ -15,26 +78,53 @@ export default function SimilarEtfs({ dataPromise }: SimilarEtfsProps): JSX.Elem
   }
 
   return (
-    <div id="similar-etfs" className="bg-gray-900 rounded-lg shadow-sm p-6 mb-8">
+    <div id="similar-etfs" className="bg-gray-900 rounded-lg shadow-sm p-4 sm:p-6 mb-8">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
       <p className="text-gray-300 mb-4">True peers tracking the same or a very similar index in the same category:</p>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {similarEtfs.map((similarEtf) => (
-          <Link
-            key={similarEtf.id}
-            href={`/etfs/${similarEtf.exchange.toUpperCase()}/${similarEtf.symbol.toUpperCase()}`}
-            className="block bg-gray-800 p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
-          >
-            <div className="flex flex-col gap-y-2">
-              <div className="flex items-center gap-x-2 min-w-0">
-                <h3 className="font-semibold text-lg text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{similarEtf.name}</h3>
-                <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
-              </div>
-              <div className="text-sm text-gray-400">
-                {similarEtf.symbol} • {similarEtf.exchange.toUpperCase()}
-              </div>
-            </div>
-          </Link>
+
+      {/* Desktop / tablet — horizontally-scrollable table. */}
+      <div className="hidden md:block overflow-x-auto rounded-md border border-gray-700">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-800 text-gray-300">
+            <tr>
+              <th scope="col" className="sticky left-0 z-10 bg-gray-800 px-3 py-2 text-left font-semibold whitespace-nowrap">
+                ETF
+              </th>
+              {COLUMNS.map((col) => (
+                <th key={col.key} scope="col" className={`px-3 py-2 font-semibold whitespace-nowrap ${col.align === 'right' ? 'text-right' : 'text-left'}`}>
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700">
+            {similarEtfs.map((etf) => (
+              <tr key={etf.id} className="hover:bg-gray-800/60 transition-colors">
+                <td className="sticky left-0 z-10 bg-gray-900 hover:bg-gray-800/60 transition-colors px-3 py-2 whitespace-nowrap">
+                  <Link href={`/etfs/${etf.exchange.toUpperCase()}/${etf.symbol.toUpperCase()}`} className="group inline-flex items-center gap-1.5">
+                    <span className="font-medium bg-[#4F46E5] text-white text-xs px-1.5 py-0.5 rounded">{etf.symbol}</span>
+                    <span className="text-[#F59E0B] group-hover:text-[#F97316] transition-colors max-w-[16rem] truncate">{etf.name}</span>
+                    <ArrowTopRightOnSquareIcon className="size-3.5 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
+                  </Link>
+                </td>
+                {COLUMNS.map((col) => (
+                  <td
+                    key={col.key}
+                    className={`px-3 py-2 whitespace-nowrap font-mono tabular-nums text-white ${col.align === 'right' ? 'text-right' : 'text-left'}`}
+                  >
+                    {col.render(etf)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile — one stacked card per ETF. */}
+      <div className="md:hidden flex flex-col gap-3">
+        {similarEtfs.map((etf) => (
+          <SimilarEtfMobileCard key={etf.id} etf={etf} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace the Similar ETFs cards grid on the ETF detail page with a responsive comparison table.
- Surfaces the same 12 financial fields shown at the top of an ETF detail page: AUM, Expense Ratio, P/E, Shares Out, Dividend TTM, Dividend Yield, Payout Frequency, Payout Ratio, Volume, 52W Range, Beta, Holdings.
- Desktop/tablet: horizontally-scrollable table with a sticky first column for the ETF identity. Mobile: one stacked card per ETF with a label/value grid.
- Extends the `similar-etfs` API to include `financialInfo` so all 12 fields are populated in a single batched Prisma query.

## Test plan
- [ ] Visit an ETF detail page on desktop and confirm the Similar ETFs table renders with all 12 columns and horizontal scroll works while the ETF column stays sticky.
- [ ] Resize to a narrow viewport / use a phone and confirm the layout switches to one card per ETF with the same fields stacked.
- [ ] Confirm `--` / `N/A` placeholders show for missing values rather than empty cells.