### PR TITLE
Fix Similar ETFs crash on cached responses missing new fields

### DIFF
--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -17,33 +17,43 @@ interface ColumnDef {
   align?: 'left' | 'right';
 }
 
-function formatInteger(value: number | null): string {
-  if (value === null) return 'N/A';
-  return value.toLocaleString('en-US');
+// Treat missing fields (undefined) the same as null. Cached responses from
+// before this column set was added can omit them entirely, and we'd rather
+// render "N/A" than crash inside a formatter.
+function n(value: number | null | undefined): number | null {
+  return value ?? null;
 }
 
-function formatRange(low: number | null, high: number | null): string {
-  if (low === null && high === null) return 'N/A';
-  return `${formatNumber(low)} - ${formatNumber(high)}`;
+function formatInteger(value: number | null | undefined): string {
+  const v = n(value);
+  if (v === null) return 'N/A';
+  return v.toLocaleString('en-US');
+}
+
+function formatRange(low: number | null | undefined, high: number | null | undefined): string {
+  const l = n(low);
+  const h = n(high);
+  if (l === null && h === null) return 'N/A';
+  return `${formatNumber(l)} - ${formatNumber(h)}`;
 }
 
 const COLUMNS: ColumnDef[] = [
   { key: 'aum', label: 'AUM', render: (e) => formatCompactAmount(e.aum), align: 'right' },
-  { key: 'expenseRatio', label: 'Expense Ratio', render: (e) => (e.expenseRatio !== null ? `${e.expenseRatio}%` : 'N/A'), align: 'right' },
-  { key: 'pe', label: 'P/E', render: (e) => formatNumber(e.pe), align: 'right' },
+  { key: 'expenseRatio', label: 'Expense Ratio', render: (e) => (e.expenseRatio != null ? `${e.expenseRatio}%` : 'N/A'), align: 'right' },
+  { key: 'pe', label: 'P/E', render: (e) => formatNumber(n(e.pe)), align: 'right' },
   { key: 'sharesOut', label: 'Shares Out', render: (e) => formatCompactMillions(e.sharesOut), align: 'right' },
   {
     key: 'dividendTtm',
     label: 'Div TTM',
-    render: (e) => (e.dividendTtm !== null && e.dividendTtm !== 0 ? `$${formatNumber(e.dividendTtm)}` : '--'),
+    render: (e) => (e.dividendTtm != null && e.dividendTtm !== 0 ? `$${formatNumber(e.dividendTtm)}` : '--'),
     align: 'right',
   },
-  { key: 'dividendYield', label: 'Div Yield', render: (e) => (e.dividendYield !== null ? formatPercentageDecimal(e.dividendYield) : '--'), align: 'right' },
+  { key: 'dividendYield', label: 'Div Yield', render: (e) => (e.dividendYield != null ? formatPercentageDecimal(e.dividendYield) : '--'), align: 'right' },
   { key: 'payoutFrequency', label: 'Payout Freq', render: (e) => e.payoutFrequency || 'N/A', align: 'left' },
-  { key: 'payoutRatio', label: 'Payout Ratio', render: (e) => (e.payoutRatio !== null ? formatPercentageDecimal(e.payoutRatio) : 'N/A'), align: 'right' },
-  { key: 'volume', label: 'Volume', render: (e) => formatVolume(e.volume), align: 'right' },
+  { key: 'payoutRatio', label: 'Payout Ratio', render: (e) => (e.payoutRatio != null ? formatPercentageDecimal(e.payoutRatio) : 'N/A'), align: 'right' },
+  { key: 'volume', label: 'Volume', render: (e) => formatVolume(n(e.volume)), align: 'right' },
   { key: 'yearRange', label: '52W Range', render: (e) => formatRange(e.yearLow, e.yearHigh), align: 'right' },
-  { key: 'beta', label: 'Beta', render: (e) => formatNumber(e.beta), align: 'right' },
+  { key: 'beta', label: 'Beta', render: (e) => formatNumber(n(e.beta)), align: 'right' },
   { key: 'holdings', label: 'Holdings', render: (e) => formatInteger(e.holdings), align: 'right' },
 ];
 


### PR DESCRIPTION
## Summary
- Production was throwing `Cannot read properties of undefined (reading 'toLocaleString')` on ETF detail pages because the page-level `fetch()` for `similar-etfs` is cached for a week, so old responses still in cache lacked the financial fields the new comparison table renders.
- Coerce nullish values up front and use loose null checks (`!= null`, `value ?? null`) so missing fields render as `N/A` / `--` instead of crashing while the cache rolls over.
- No API or schema changes — purely defensive on the rendering side.

## Test plan
- [ ] Visit an ETF detail page in production and confirm Similar ETFs renders with `N/A` placeholders if the cached response lacks the new fields.
- [ ] After cache revalidation, confirm rows fill in with real values for all 12 columns.
- [ ] Confirm no runtime errors in server logs for `/etfs/[exchange]/[etf]`.