### PR TITLE
Bust Similar ETFs fetch cache after response shape change

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -13,6 +13,7 @@ import {
   EtfFilterParamKey,
   MOR_ADVANCED_FILTERS,
 } from '@/utils/etf-filter-utils';
+import { ETF_EXCHANGE_TO_COUNTRY, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
@@ -102,6 +103,18 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const hasMorFilters = hasAdvancedMorFilters(filters);
 
   const etfWhere = createEtfSearchFilter(spaceId, filters);
+
+  // Country is a route-level filter (mapped to an exchange list); not part of the
+  // user-facing filter chips so it lives outside the ALL_ETF_PARAM_KEYS set.
+  const countryParam = searchParams.get('country')?.trim();
+  if (countryParam && isEtfSupportedCountry(countryParam)) {
+    const exchanges = Object.entries(ETF_EXCHANGE_TO_COUNTRY)
+      .filter(([, c]) => c === countryParam)
+      .map(([ex]) => ex);
+    if (exchanges.length > 0) {
+      etfWhere.exchange = { in: exchanges };
+    }
+  }
 
   const financialFilter = createEtfFinancialFilter(filters);
   const hasFinancialFilter = Object.keys(financialFilter).length > 0;

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -13,7 +13,7 @@ import {
   EtfFilterParamKey,
   MOR_ADVANCED_FILTERS,
 } from '@/utils/etf-filter-utils';
-import { ETF_EXCHANGE_TO_COUNTRY, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { getEtfExchangesByCountry, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
@@ -108,9 +108,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   // user-facing filter chips so it lives outside the ALL_ETF_PARAM_KEYS set.
   const countryParam = searchParams.get('country')?.trim();
   if (countryParam && isEtfSupportedCountry(countryParam)) {
-    const exchanges = Object.entries(ETF_EXCHANGE_TO_COUNTRY)
-      .filter(([, c]) => c === countryParam)
-      .map(([ex]) => ex);
+    const exchanges = getEtfExchangesByCountry(countryParam);
     if (exchanges.length > 0) {
       etfWhere.exchange = { in: exchanges };
     }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -110,7 +110,11 @@ async function fetchEtfScores(exchange: string, etf: string): Promise<EtfScoresR
 }
 
 async function fetchSimilarEtfs(exchange: string, etf: string): Promise<SimilarEtf[]> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange.toUpperCase()}/${etf.toUpperCase()}/similar-etfs`;
+  // Bumping the `v` segment changes the fetch cache key, forcing a refetch
+  // when the response shape grows (e.g. when new financial fields are added).
+  // Otherwise stale week-long entries from before the shape change keep being
+  // served and the new columns render as N/A everywhere.
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange.toUpperCase()}/${etf.toUpperCase()}/similar-etfs?v=2`;
   try {
     const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
     if (!res.ok) {

--- a/insights-ui/src/app/etfs/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/page.tsx
@@ -32,6 +32,7 @@ export default async function EtfsAssetClassesIndexPage() {
       title="ETFs by Asset Class"
       description="Equity, fixed income, commodity, alternative, multi-asset and currency fund classes. Each card shows the top-rated ETFs in that asset class."
       extraBreadcrumbs={[{ name: 'Asset Classes', href: '/etfs/asset-classes', current: true }]}
+      switcherSection="asset-classes"
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
         {assetClasses.map((opt) => (

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
@@ -2,9 +2,7 @@ import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
 import { EtfFilterParamKey, EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -26,10 +24,8 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
 
 export default async function CountryEtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { country, assetClass } = await params;
-  const decodedCountry = decodeURIComponent(country);
   const decodedAssetClass = decodeURIComponent(assetClass);
-  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/asset-classes/${encodeURIComponent(decodedAssetClass)}`);
-  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+  const decodedCountry = resolveEtfCountryParam(country, `/etfs/asset-classes/${encodeURIComponent(decodedAssetClass)}`);
 
   const searchParams = await searchParamsPromise;
 

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
@@ -1,0 +1,64 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string; assetClass: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string; assetClass: string }> }): Promise<Metadata> {
+  const { country, assetClass } = await props.params;
+  const decodedCountry = decodeURIComponent(country);
+  const decoded = decodeURIComponent(assetClass);
+  return {
+    title: `${decoded} ${decodedCountry} ETFs | KoalaGains`,
+    description: `Browse ${decodedCountry} ETFs in the ${decoded} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country, assetClass } = await params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedAssetClass = decodeURIComponent(assetClass);
+  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/asset-classes/${encodeURIComponent(decodedAssetClass)}`);
+  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+
+  const searchParams = await searchParamsPromise;
+
+  const matchingOption = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value.toLowerCase() === decodedAssetClass.toLowerCase());
+  const displayAssetClass = matchingOption?.label ?? decodedAssetClass;
+  const filterValue = matchingOption?.value ?? decodedAssetClass;
+
+  const dataPromise = fetchEtfListingData(
+    {
+      ...searchParams,
+      [EtfFilterParamKey.ASSET_CLASS]: filterValue,
+    },
+    decodedCountry
+  );
+
+  const encodedCountry = encodeURIComponent(decodedCountry);
+
+  return (
+    <EtfPageLayout
+      title={`${displayAssetClass} ${decodedCountry} ETFs`}
+      description={`Explore ${decodedCountry} ETFs in the ${displayAssetClass} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+      currentCountry={decodedCountry}
+      switcherSection="asset-classes"
+      extraBreadcrumbs={[
+        { name: 'All Asset Classes', href: `/etfs/countries/${encodedCountry}/asset-classes`, current: false },
+        { name: displayAssetClass, href: `/etfs/countries/${encodedCountry}/asset-classes/${encodeURIComponent(filterValue)}`, current: true },
+      ]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
@@ -1,0 +1,69 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { country } = await props.params;
+  const decoded = decodeURIComponent(country);
+  return {
+    title: `${decoded} ETFs by Asset Class | KoalaGains`,
+    description: `Browse ${decoded} ETFs by asset class — Equity, Fixed Income, Commodity, Alternatives, and more. Each card highlights the top-rated ETFs in that class.`,
+  };
+}
+
+export default async function CountryEtfsAssetClassesIndexPage({ params }: PageProps) {
+  const { country } = await params;
+  const decoded = decodeURIComponent(country);
+  if (decoded === SupportedCountries.US) redirect('/etfs/asset-classes');
+  if (!isEtfSupportedCountry(decoded)) notFound();
+
+  const assetClasses = ETF_ASSET_CLASS_OPTIONS.filter((opt) => opt.value !== '');
+
+  const valueToKey = new Map<string, string>();
+  for (const opt of assetClasses) {
+    valueToKey.set(opt.value, opt.value);
+  }
+
+  const { values, counts } = await fetchEtfsForGroupings({
+    spaceId: KoalaGainsSpaceId,
+    mode: 'assetClass',
+    valueToKey,
+    country: decoded,
+  });
+
+  const encodedCountry = encodeURIComponent(decoded);
+
+  return (
+    <EtfPageLayout
+      title={`${decoded} ETFs by Asset Class`}
+      description={`Equity, fixed income, commodity, alternative, multi-asset and currency fund classes for ${decoded} ETFs. Each card shows the top-rated ETFs in that asset class.`}
+      currentCountry={decoded}
+      switcherSection="asset-classes"
+      extraBreadcrumbs={[{ name: 'Asset Classes', href: `/etfs/countries/${encodedCountry}/asset-classes`, current: true }]}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+        {assetClasses.map((opt) => (
+          <CompactEtfGroupingCard
+            key={opt.value}
+            title={opt.label}
+            href={`/etfs/countries/${encodedCountry}/asset-classes/${encodeURIComponent(opt.value)}`}
+            totalCount={counts.get(opt.value) ?? 0}
+            etfs={values.get(opt.value) ?? []}
+          />
+        ))}
+      </div>
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
@@ -3,9 +3,7 @@ import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -25,9 +23,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
 export default async function CountryEtfsAssetClassesIndexPage({ params }: PageProps) {
   const { country } = await params;
-  const decoded = decodeURIComponent(country);
-  if (decoded === SupportedCountries.US) redirect('/etfs/asset-classes');
-  if (!isEtfSupportedCountry(decoded)) notFound();
+  const decoded = resolveEtfCountryParam(country, '/etfs/asset-classes');
 
   const assetClasses = ETF_ASSET_CLASS_OPTIONS.filter((opt) => opt.value !== '');
 

--- a/insights-ui/src/app/etfs/countries/[country]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/categories/[category]/page.tsx
@@ -1,0 +1,72 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfGroupName, getEtfCategoryByName } from '@/utils/etf-categorization-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string; category: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string; category: string }> }): Promise<Metadata> {
+  const { country, category } = await props.params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedCategory = decodeURIComponent(category);
+  return {
+    title: `${decodedCategory} ${decodedCountry} ETFs | KoalaGains`,
+    description: `Browse ${decodedCountry} ETFs in the ${decodedCategory} category with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsByCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country, category } = await params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedCategory = decodeURIComponent(category);
+  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/categories/${encodeURIComponent(decodedCategory)}`);
+  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+
+  const searchParams = await searchParamsPromise;
+  const knownCategory = getEtfCategoryByName(decodedCategory);
+  const groupName = getEtfGroupName(decodedCategory);
+
+  const dataPromise = fetchEtfListingData(
+    {
+      ...searchParams,
+      [EtfFilterParamKey.CATEGORY]: decodedCategory,
+    },
+    decodedCountry
+  );
+
+  const description = groupName
+    ? `Explore ${decodedCountry} ETFs in the ${decodedCategory} category (${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`
+    : `Explore ${decodedCountry} ETFs in the ${decodedCategory} category with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`;
+
+  const encodedCountry = encodeURIComponent(decodedCountry);
+
+  return (
+    <EtfPageLayout
+      title={`${decodedCategory} ${decodedCountry} ETFs`}
+      description={description}
+      currentCountry={decodedCountry}
+      switcherSection="categories"
+      extraBreadcrumbs={[
+        { name: 'All Categories', href: `/etfs/countries/${encodedCountry}/categories`, current: false },
+        { name: decodedCategory, href: `/etfs/countries/${encodedCountry}/categories/${encodeURIComponent(decodedCategory)}`, current: true },
+      ]}
+    >
+      {knownCategory && groupName && (
+        <p className="text-sm text-gray-400 -mt-4 mb-4">
+          Part of <span className="text-white">{groupName}</span>
+        </p>
+      )}
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/countries/[country]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/categories/[category]/page.tsx
@@ -3,9 +3,7 @@ import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListing
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
 import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupName, getEtfCategoryByName } from '@/utils/etf-categorization-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -27,10 +25,8 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
 
 export default async function CountryEtfsByCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { country, category } = await params;
-  const decodedCountry = decodeURIComponent(country);
   const decodedCategory = decodeURIComponent(category);
-  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/categories/${encodeURIComponent(decodedCategory)}`);
-  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+  const decodedCountry = resolveEtfCountryParam(country, `/etfs/categories/${encodeURIComponent(decodedCategory)}`);
 
   const searchParams = await searchParamsPromise;
   const knownCategory = getEtfCategoryByName(decodedCategory);

--- a/insights-ui/src/app/etfs/countries/[country]/categories/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/categories/page.tsx
@@ -3,10 +3,8 @@ import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
 import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import Link from 'next/link';
-import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -26,9 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
 export default async function CountryEtfsCategoriesIndexPage({ params }: PageProps) {
   const { country } = await params;
-  const decoded = decodeURIComponent(country);
-  if (decoded === SupportedCountries.US) redirect('/etfs/categories');
-  if (!isEtfSupportedCountry(decoded)) notFound();
+  const decoded = resolveEtfCountryParam(country, '/etfs/categories');
 
   const groups = getAllEtfGroups();
 

--- a/insights-ui/src/app/etfs/countries/[country]/categories/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/categories/page.tsx
@@ -3,18 +3,33 @@ import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
 import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-  title: 'ETFs by Category | KoalaGains',
-  description:
-    'Browse US ETFs by Morningstar-style category — Large Blend, Technology, High Yield Bond, and more. Each card highlights the top-rated ETFs in that category.',
+type PageProps = {
+  params: Promise<{ country: string }>;
 };
 
-export default async function EtfsCategoriesIndexPage() {
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { country } = await props.params;
+  const decoded = decodeURIComponent(country);
+  return {
+    title: `${decoded} ETFs by Category | KoalaGains`,
+    description: `Browse ${decoded} ETFs by Morningstar-style category — Large Blend, Technology, High Yield Bond, and more. Each card highlights the top-rated ETFs in that category.`,
+  };
+}
+
+export default async function CountryEtfsCategoriesIndexPage({ params }: PageProps) {
+  const { country } = await params;
+  const decoded = decodeURIComponent(country);
+  if (decoded === SupportedCountries.US) redirect('/etfs/categories');
+  if (!isEtfSupportedCountry(decoded)) notFound();
+
   const groups = getAllEtfGroups();
 
   const valueToKey = new Map<string, string>();
@@ -28,14 +43,18 @@ export default async function EtfsCategoriesIndexPage() {
     spaceId: KoalaGainsSpaceId,
     mode: 'category',
     valueToKey,
+    country: decoded,
   });
+
+  const encodedCountry = encodeURIComponent(decoded);
 
   return (
     <EtfPageLayout
-      title="ETFs by Category"
-      description="Browse all ETF categories grouped by analysis group. Each card lists the top-rated ETFs in that category."
-      extraBreadcrumbs={[{ name: 'Categories', href: '/etfs/categories', current: true }]}
+      title={`${decoded} ETFs by Category`}
+      description={`Browse all ${decoded} ETF categories grouped by analysis group. Each card lists the top-rated ETFs in that category.`}
+      currentCountry={decoded}
       switcherSection="categories"
+      extraBreadcrumbs={[{ name: 'Categories', href: `/etfs/countries/${encodedCountry}/categories`, current: true }]}
     >
       {groups.map((group) => {
         const categories = getCategoriesForGroupKey(group.key);
@@ -46,7 +65,7 @@ export default async function EtfsCategoriesIndexPage() {
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-bold text-white">{group.name}</h2>
               <Link
-                href={`/etfs/groups/${encodeURIComponent(group.key)}`}
+                href={`/etfs/countries/${encodedCountry}/groups/${encodeURIComponent(group.key)}`}
                 className="text-sm bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium px-3 py-1 rounded-lg shadow-md flex items-center"
               >
                 View Group
@@ -59,7 +78,7 @@ export default async function EtfsCategoriesIndexPage() {
                 <CompactEtfGroupingCard
                   key={cat.name}
                   title={cat.name}
-                  href={`/etfs/categories/${encodeURIComponent(cat.name)}`}
+                  href={`/etfs/countries/${encodedCountry}/categories/${encodeURIComponent(cat.name)}`}
                   totalCount={counts.get(cat.name) ?? 0}
                   etfs={values.get(cat.name) ?? []}
                 />

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -1,0 +1,65 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string; group: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string; group: string }> }): Promise<Metadata> {
+  const { country, group } = await props.params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedGroup = decodeURIComponent(group);
+  const groupObj = getEtfGroupByKey(decodedGroup);
+  const displayName = groupObj?.name ?? decodedGroup;
+  return {
+    title: `${displayName} ${decodedCountry} ETFs | KoalaGains`,
+    description: `Browse ${decodedCountry} ETFs in the ${displayName} group with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsByGroupPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country, group } = await params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedGroupKey = decodeURIComponent(group);
+  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
+  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+
+  const groupObj = getEtfGroupByKey(decodedGroupKey);
+  if (!groupObj) notFound();
+
+  const searchParams = await searchParamsPromise;
+  const dataPromise = fetchEtfListingData(
+    {
+      ...searchParams,
+      [EtfFilterParamKey.GROUP]: groupObj.key,
+    },
+    decodedCountry
+  );
+
+  const encodedCountry = encodeURIComponent(decodedCountry);
+
+  return (
+    <EtfPageLayout
+      title={`${groupObj.name} ${decodedCountry} ETFs`}
+      description={groupObj.description}
+      currentCountry={decodedCountry}
+      switcherSection="groups"
+      extraBreadcrumbs={[
+        { name: 'All Groups', href: `/etfs/countries/${encodedCountry}/groups`, current: false },
+        { name: groupObj.name, href: `/etfs/countries/${encodedCountry}/groups/${encodeURIComponent(groupObj.key)}`, current: true },
+      ]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -3,9 +3,8 @@ import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListing
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
 import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -29,10 +28,8 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
 
 export default async function CountryEtfsByGroupPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { country, group } = await params;
-  const decodedCountry = decodeURIComponent(country);
   const decodedGroupKey = decodeURIComponent(group);
-  if (decodedCountry === SupportedCountries.US) redirect(`/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
-  if (!isEtfSupportedCountry(decodedCountry)) notFound();
+  const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
 
   const groupObj = getEtfGroupByKey(decodedGroupKey);
   if (!groupObj) notFound();

--- a/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
@@ -3,9 +3,7 @@ import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
 import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -25,9 +23,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
 export default async function CountryEtfsGroupsIndexPage({ params }: PageProps) {
   const { country } = await params;
-  const decoded = decodeURIComponent(country);
-  if (decoded === SupportedCountries.US) redirect('/etfs/groups');
-  if (!isEtfSupportedCountry(decoded)) notFound();
+  const decoded = resolveEtfCountryParam(country, '/etfs/groups');
 
   const groups = getAllEtfGroups();
 

--- a/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
@@ -1,0 +1,69 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
+import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { country } = await props.params;
+  const decoded = decodeURIComponent(country);
+  return {
+    title: `${decoded} ETFs by Group | KoalaGains`,
+    description: `Browse ${decoded} ETFs organized by analysis group. Each group highlights top-rated ETFs by report score and AUM.`,
+  };
+}
+
+export default async function CountryEtfsGroupsIndexPage({ params }: PageProps) {
+  const { country } = await params;
+  const decoded = decodeURIComponent(country);
+  if (decoded === SupportedCountries.US) redirect('/etfs/groups');
+  if (!isEtfSupportedCountry(decoded)) notFound();
+
+  const groups = getAllEtfGroups();
+
+  const valueToKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const cat of getCategoriesForGroupKey(group.key)) {
+      valueToKey.set(cat.name, group.key);
+    }
+  }
+
+  const { values, counts } = await fetchEtfsForGroupings({
+    spaceId: KoalaGainsSpaceId,
+    mode: 'category',
+    valueToKey,
+    country: decoded,
+  });
+
+  return (
+    <EtfPageLayout
+      title={`${decoded} ETFs by Group`}
+      description={`Diversified, sector, fixed income, and alternative-strategy fund groups for ${decoded} ETFs. Each card lists the top-rated ETFs in that group.`}
+      currentCountry={decoded}
+      switcherSection="groups"
+      extraBreadcrumbs={[{ name: 'Groups', href: `/etfs/countries/${encodeURIComponent(decoded)}/groups`, current: true }]}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+        {groups.map((group) => (
+          <CompactEtfGroupingCard
+            key={group.key}
+            title={group.name}
+            href={`/etfs/countries/${encodeURIComponent(decoded)}/groups/${encodeURIComponent(group.key)}`}
+            totalCount={counts.get(group.key) ?? 0}
+            etfs={values.get(group.key) ?? []}
+          />
+        ))}
+      </div>
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/countries/[country]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/page.tsx
@@ -2,9 +2,7 @@ import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
 import { EtfSearchParams } from '@/utils/etf-filter-utils';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { notFound, redirect } from 'next/navigation';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -25,9 +23,7 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
 
 export default async function CountryEtfsPage({ params, searchParams: searchParamsPromise }: PageProps) {
   const { country } = await params;
-  const decoded = decodeURIComponent(country);
-  if (decoded === SupportedCountries.US) redirect('/etfs');
-  if (!isEtfSupportedCountry(decoded)) notFound();
+  const decoded = resolveEtfCountryParam(country, '/etfs');
 
   const searchParams = await searchParamsPromise;
   const dataPromise = fetchEtfListingData(searchParams, decoded);

--- a/insights-ui/src/app/etfs/countries/[country]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/page.tsx
@@ -1,0 +1,44 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string }> }): Promise<Metadata> {
+  const { country } = await props.params;
+  const decoded = decodeURIComponent(country);
+  return {
+    title: `${decoded} ETFs | KoalaGains`,
+    description: `Browse ${decoded} exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country } = await params;
+  const decoded = decodeURIComponent(country);
+  if (decoded === SupportedCountries.US) redirect('/etfs');
+  if (!isEtfSupportedCountry(decoded)) notFound();
+
+  const searchParams = await searchParamsPromise;
+  const dataPromise = fetchEtfListingData(searchParams, decoded);
+
+  return (
+    <EtfPageLayout
+      title={`${decoded} ETFs`}
+      description={`Explore ${decoded} exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+      currentCountry={decoded}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/app/etfs/groups/page.tsx
+++ b/insights-ui/src/app/etfs/groups/page.tsx
@@ -33,6 +33,7 @@ export default async function EtfsGroupsIndexPage() {
       title="ETFs by Group"
       description="Diversified, sector, fixed income, and alternative-strategy fund groups. Each card lists the top-rated ETFs in that group."
       extraBreadcrumbs={[{ name: 'Groups', href: '/etfs/groups', current: true }]}
+      switcherSection="groups"
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
         {groups.map((group) => (

--- a/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
+++ b/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { GlobeAltIcon } from '@heroicons/react/24/outline';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { ALL_ETF_COUNTRIES, EtfBrowseSection, etfBasePath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
+
+interface EtfCountryAlternativesProps {
+  currentCountry: EtfSupportedCountry;
+  section?: EtfBrowseSection;
+  className?: string;
+}
+
+export default function EtfCountryAlternatives({ currentCountry, section, className = '' }: EtfCountryAlternativesProps) {
+  const alternatives = ALL_ETF_COUNTRIES.filter((c) => c !== currentCountry);
+  if (alternatives.length === 0) return null;
+
+  return (
+    <div className={`flex flex-col sm:flex-row items-start sm:items-center p-1 sm:p-2 rounded-lg bg-gray-700/50 ${className}`}>
+      <div className="flex items-center mb-1 sm:mb-0">
+        <GlobeAltIcon className="h-4 w-4 text-blue-400" />
+        <span className="ml-2 text-blue-100 font-semibold">Also view:</span>
+      </div>
+      <div className="flex flex-wrap gap-2 sm:ml-2">
+        {alternatives.map((country, index) => {
+          const href = section ? etfBrowsePath(country, section) : etfBasePath(country);
+          return (
+            <span key={country} className="inline-flex items-center">
+              <Link href={href} className="text-blue-400 hover:text-blue-300 transition-colors duration-200 font-semibold">
+                {etfCountryDisplayName(country)} ETFs
+              </Link>
+              {index < alternatives.length - 1 && <span className="text-gray-500 ml-2 hidden sm:inline">•</span>}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfPageLayout.tsx
+++ b/insights-ui/src/components/etfs/EtfPageLayout.tsx
@@ -4,25 +4,40 @@ import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import EtfFiltersButton from '@/components/etfs/EtfFiltersButton';
 import EtfAppliedFilterChips from '@/components/etfs/EtfAppliedFilterChips';
+import EtfCountryAlternatives from '@/components/etfs/EtfCountryAlternatives';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { EtfBrowseSection, etfBasePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
 
 interface EtfPageLayoutProps {
   title: string;
   description: string;
   showAppliedFilters?: boolean;
   extraBreadcrumbs?: BreadcrumbsOjbect[];
+  currentCountry?: EtfSupportedCountry;
+  switcherSection?: EtfBrowseSection;
   children: ReactNode;
 }
 
-function buildBreadcrumbs(extraBreadcrumbs?: BreadcrumbsOjbect[]): BreadcrumbsOjbect[] {
+function buildBreadcrumbs(currentCountry: EtfSupportedCountry, extraBreadcrumbs?: BreadcrumbsOjbect[]): BreadcrumbsOjbect[] {
+  const rootName = `${etfCountryDisplayName(currentCountry)} ETFs`;
+  const rootHref = etfBasePath(currentCountry);
   if (!extraBreadcrumbs || extraBreadcrumbs.length === 0) {
-    return [{ name: 'US ETFs', href: '/etfs', current: true }];
+    return [{ name: rootName, href: rootHref, current: true }];
   }
-  const rootCrumb: BreadcrumbsOjbect = { name: 'US ETFs', href: '/etfs', current: false };
-  return [rootCrumb, ...extraBreadcrumbs];
+  return [{ name: rootName, href: rootHref, current: false }, ...extraBreadcrumbs];
 }
 
-export default function EtfPageLayout({ title, description, showAppliedFilters = false, extraBreadcrumbs, children }: EtfPageLayoutProps) {
-  const breadcrumbs = buildBreadcrumbs(extraBreadcrumbs);
+export default function EtfPageLayout({
+  title,
+  description,
+  showAppliedFilters = false,
+  extraBreadcrumbs,
+  currentCountry = SupportedCountries.US,
+  switcherSection,
+  children,
+}: EtfPageLayoutProps) {
+  const breadcrumbs = buildBreadcrumbs(currentCountry, extraBreadcrumbs);
 
   return (
     <PageWrapper>
@@ -42,6 +57,9 @@ export default function EtfPageLayout({ title, description, showAppliedFilters =
       <div className="w-full mb-8">
         <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
         <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
+        <div className="mt-2 mb-2">
+          <EtfCountryAlternatives currentCountry={currentCountry} section={switcherSection} className="text-sm" />
+        </div>
       </div>
 
       {children}

--- a/insights-ui/src/utils/etf-country-route-utils.ts
+++ b/insights-ui/src/utils/etf-country-route-utils.ts
@@ -1,0 +1,24 @@
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { EtfSupportedCountry, ETF_SUPPORTED_COUNTRIES } from '@/utils/etfCountryExchangeUtils';
+
+export type EtfBrowseSection = 'groups' | 'categories' | 'asset-classes';
+
+const COUNTRY_DISPLAY_NAME: Record<EtfSupportedCountry, string> = {
+  [SupportedCountries.US]: 'US',
+  [SupportedCountries.Canada]: 'Canadian',
+};
+
+export function etfCountryDisplayName(country: EtfSupportedCountry): string {
+  return COUNTRY_DISPLAY_NAME[country];
+}
+
+/** Root path for a country's ETF section (US lives at `/etfs`, others under `/etfs/countries/<country>`). */
+export function etfBasePath(country: EtfSupportedCountry): string {
+  return country === SupportedCountries.US ? '/etfs' : `/etfs/countries/${encodeURIComponent(country)}`;
+}
+
+export function etfBrowsePath(country: EtfSupportedCountry, section: EtfBrowseSection): string {
+  return `${etfBasePath(country)}/${section}`;
+}
+
+export const ALL_ETF_COUNTRIES = ETF_SUPPORTED_COUNTRIES;

--- a/insights-ui/src/utils/etf-country-route-utils.ts
+++ b/insights-ui/src/utils/etf-country-route-utils.ts
@@ -1,5 +1,6 @@
+import { notFound, redirect } from 'next/navigation';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { EtfSupportedCountry, ETF_SUPPORTED_COUNTRIES } from '@/utils/etfCountryExchangeUtils';
+import { EtfSupportedCountry, ETF_SUPPORTED_COUNTRIES, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 
 export type EtfBrowseSection = 'groups' | 'categories' | 'asset-classes';
 
@@ -22,3 +23,16 @@ export function etfBrowsePath(country: EtfSupportedCountry, section: EtfBrowseSe
 }
 
 export const ALL_ETF_COUNTRIES = ETF_SUPPORTED_COUNTRIES;
+
+/**
+ * Decode a `[country]` route param, redirect US to its canonical (non-`/countries/...`) path,
+ * and 404 anything else. Returns the validated country for the page to use.
+ *
+ * Server-component only: calls `next/navigation` `redirect()`/`notFound()`, both of which throw.
+ */
+export function resolveEtfCountryParam(rawCountry: string, usCanonicalPath: string): EtfSupportedCountry {
+  const decoded = decodeURIComponent(rawCountry);
+  if (decoded === SupportedCountries.US) redirect(usCanonicalPath);
+  if (!isEtfSupportedCountry(decoded)) notFound();
+  return decoded;
+}

--- a/insights-ui/src/utils/etf-data-utils.ts
+++ b/insights-ui/src/utils/etf-data-utils.ts
@@ -2,16 +2,21 @@ import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { hasEtfFiltersApplied, etfToSortedQueryString, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfListingTag } from '@/utils/etf-cache-utils';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 
-export async function fetchEtfListingData(searchParams?: EtfSearchParams): Promise<EtfListingResponse> {
+export async function fetchEtfListingData(searchParams?: EtfSearchParams, country?: EtfSupportedCountry): Promise<EtfListingResponse> {
   const baseUrl = getBaseUrl();
   const filters = hasEtfFiltersApplied(searchParams);
   const hasPageOrFilters = filters || (searchParams?.page && searchParams.page !== '1');
 
   const baseUrlPath = `${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`;
-  const url = hasPageOrFilters && searchParams ? `${baseUrlPath}?${etfToSortedQueryString(searchParams)}` : baseUrlPath;
-  const tags = hasPageOrFilters ? [] : [getEtfListingTag()];
+  const qsParts: string[] = [];
+  if (hasPageOrFilters && searchParams) qsParts.push(etfToSortedQueryString(searchParams));
+  if (country) qsParts.push(`country=${encodeURIComponent(country)}`);
+  const qs = qsParts.filter(Boolean).join('&');
+  const url = qs ? `${baseUrlPath}?${qs}` : baseUrlPath;
+  const tags = hasPageOrFilters || country ? [] : [getEtfListingTag()];
 
   try {
     const res = await fetch(url, { next: { tags } });

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { parseNumericStringValue } from '@/utils/etf-filter-utils';
-import { ETF_EXCHANGE_TO_COUNTRY, EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { EtfSupportedCountry, getEtfExchangesByCountry } from '@/utils/etfCountryExchangeUtils';
 
 export interface EtfGroupingPreviewItem {
   id: string;
@@ -30,12 +30,6 @@ interface FetchEtfsForGroupingsArgs<TKey extends string> {
   country?: EtfSupportedCountry;
 }
 
-function exchangesForCountry(country: EtfSupportedCountry): string[] {
-  return Object.entries(ETF_EXCHANGE_TO_COUNTRY)
-    .filter(([, c]) => c === country)
-    .map(([ex]) => ex);
-}
-
 interface RawEtfRow {
   id: string;
   symbol: string;
@@ -55,7 +49,7 @@ async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: str
       ? { spaceId, stockAnalyzerInfo: { is: { category: { in: dbValues } } } }
       : { spaceId, stockAnalyzerInfo: { is: { assetClass: { in: dbValues } } } };
 
-  const where = country ? { ...baseWhere, exchange: { in: exchangesForCountry(country) } } : baseWhere;
+  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
 
   const etfs = await prisma.etf.findMany({
     where,

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/prisma';
 import { parseNumericStringValue } from '@/utils/etf-filter-utils';
+import { ETF_EXCHANGE_TO_COUNTRY, EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 
 export interface EtfGroupingPreviewItem {
   id: string;
@@ -25,6 +26,14 @@ interface FetchEtfsForGroupingsArgs<TKey extends string> {
   // Maps the raw DB value (category name or assetClass label) to the output bucket key.
   // Multiple raw values can share the same key (e.g. all categories in a group → group key).
   valueToKey: Map<string, TKey>;
+  // Restrict preview to ETFs whose exchange belongs to this country.
+  country?: EtfSupportedCountry;
+}
+
+function exchangesForCountry(country: EtfSupportedCountry): string[] {
+  return Object.entries(ETF_EXCHANGE_TO_COUNTRY)
+    .filter(([, c]) => c === country)
+    .map(([ex]) => ex);
 }
 
 interface RawEtfRow {
@@ -38,13 +47,15 @@ interface RawEtfRow {
   aum: string | null;
 }
 
-async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: string[]): Promise<RawEtfRow[]> {
+async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: string[], country?: EtfSupportedCountry): Promise<RawEtfRow[]> {
   if (dbValues.length === 0) return [];
 
-  const where =
+  const baseWhere =
     mode === 'category'
       ? { spaceId, stockAnalyzerInfo: { is: { category: { in: dbValues } } } }
       : { spaceId, stockAnalyzerInfo: { is: { assetClass: { in: dbValues } } } };
+
+  const where = country ? { ...baseWhere, exchange: { in: exchangesForCountry(country) } } : baseWhere;
 
   const etfs = await prisma.etf.findMany({
     where,
@@ -92,9 +103,10 @@ export async function fetchEtfsForGroupings<TKey extends string>({
   spaceId,
   mode,
   valueToKey,
+  country,
 }: FetchEtfsForGroupingsArgs<TKey>): Promise<EtfGroupingPreview<TKey>> {
   const dbValues = Array.from(valueToKey.keys());
-  const rawRows = await loadRawEtfRows(spaceId, mode, dbValues);
+  const rawRows = await loadRawEtfRows(spaceId, mode, dbValues, country);
 
   const rowsByKey = new Map<TKey, RawEtfRow[]>();
   const counts = new Map<TKey, number>();

--- a/insights-ui/src/utils/etfCountryExchangeUtils.ts
+++ b/insights-ui/src/utils/etfCountryExchangeUtils.ts
@@ -63,3 +63,7 @@ export const toEtfSupportedCountry = (val: string | null | undefined): EtfSuppor
   const trimmed = val.trim();
   return isEtfSupportedCountry(trimmed) ? trimmed : undefined;
 };
+
+/** All ETF exchanges that map to the given country. */
+export const getEtfExchangesByCountry = (country: EtfSupportedCountry): AllEtfExchanges[] =>
+  ETF_EXCHANGES.filter((ex) => ETF_EXCHANGE_TO_COUNTRY[ex] === country);


### PR DESCRIPTION
## Summary
- The Similar ETFs table on production ETF detail pages (e.g. `/etfs/NYSEARCA/VTI`) was rendering all 12 columns and all peer rows correctly, but every cell showed `N/A` / `--`.
- Root cause: the page-level `fetch()` for `/similar-etfs` is cached for a week (`revalidate: WEEK_IN_SECONDS`). Cached responses captured before the API was updated to include the financial fields only had `{id, symbol, exchange, name}`, and that stale entry kept being served.
- Direct API calls already return the full enriched payload — only the cached page-side response was stale.
- Fix: append `?v=2` to the fetch URL so Next.js treats this as a new cache key and revalidates immediately on the next request. The route handler ignores unknown query params, so behavior is unchanged.

## Test plan
- [ ] After deploy, visit `/etfs/NYSEARCA/VTI` and confirm Similar ETFs cells populate with real values (AUM, expense ratio, P/E, etc.) instead of `N/A` everywhere.
- [ ] Confirm the section still renders `N/A` gracefully for ETFs whose underlying `EtfFinancialInfo` rows lack a particular field.