### PR TITLE
Add Canadian ETF browse pages and switch listing card to Dividend Yield

### DIFF
--- a/insights-ui/src/components/etfs/EtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfListingGrid.tsx
@@ -1,5 +1,6 @@
 import { EtfListingResponse, EtfListingItem } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { formatPercentageDecimal } from '@/components/reportsv1/financialFormatters';
 import Link from 'next/link';
 import React, { use } from 'react';
 import EtfPagination from './EtfPagination';
@@ -86,8 +87,8 @@ function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
           <p className="text-white font-medium">{formatNumber(etf.pe)}</p>
         </div>
         <div>
-          <span className="text-gray-400">Dividend TTM</span>
-          <p className="text-white font-medium">{etf.dividendTtm !== null && etf.dividendTtm !== 0 ? `$${formatNumber(etf.dividendTtm)}` : '--'}</p>
+          <span className="text-gray-400">Dividend Yield</span>
+          <p className="text-white font-medium">{etf.dividendYield !== null && etf.dividendYield !== 0 ? formatPercentageDecimal(etf.dividendYield) : '--'}</p>
         </div>
       </div>
     </Link>


### PR DESCRIPTION
## Summary
- Mirror the stocks `/stocks/countries/Canada` pattern for ETFs: new `/etfs/countries/[country]/...` routes for the listing, groups, categories, and asset-class index + detail pages, plus a US/Canada switcher rendered on each ETF browse page.
- Extract two reusable helpers — `getEtfExchangesByCountry` (used by the listing API and groupings util) and `resolveEtfCountryParam` (used by all 7 country routes to dedupe decode + US-redirect + 404 boilerplate).
- ETF listing card now shows `Dividend Yield` (a comparable cross-fund metric) instead of `Dividend TTM`.

## Test plan
- [ ] Visit `/etfs` and verify the "Also view: Canadian ETFs" link appears and routes to `/etfs/countries/Canada`.
- [ ] Visit `/etfs/countries/Canada` and confirm only TSX/TSXV/NEOE-listed ETFs render.
- [ ] Verify the All Groups / All Categories / All Asset Classes pages each carry the Canadian switcher and link to the corresponding `/etfs/countries/Canada/<section>` index page.
- [ ] Confirm `/etfs/countries/US/...` redirects back to the canonical `/etfs/...` path.
- [ ] On any ETF listing card, confirm the bottom-right stat reads `Dividend Yield` formatted as a percentage (e.g. `1.85%`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)