### PR TITLE
Fix Target Outcome miscategorization for Canadian ETFs

### DIFF
--- a/insights-ui/src/etf-analysis-data/etf-analysis-categories.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-categories.json
@@ -190,6 +190,7 @@
     { "name": "Long ETH", "group": "alt-strategies" },
     { "name": "Mid Cap", "group": "broad-equity" },
     { "name": "Target Risk", "group": "allocation-target-date" },
+    { "name": "Target Outcome", "group": "allocation-target-date" },
     { "name": "Extended Market", "group": "broad-equity" },
     { "name": "Downside Hedge", "group": "alt-strategies" },
     { "name": "Silver", "group": "alt-strategies" },

--- a/insights-ui/src/etf-analysis-data/etf-category-aliases.json
+++ b/insights-ui/src/etf-analysis-data/etf-category-aliases.json
@@ -11,7 +11,6 @@
     "Multi-strategy": "Multistrategy",
     "Long/Short": "Long-Short Equity",
     "Global Macro": "Macro Trading",
-    "Target Outcome": "Defined Outcome",
     "High Yield": "High Yield Bond"
   }
 }


### PR DESCRIPTION
## Summary
- Remove the bad alias `"Target Outcome" -> "Defined Outcome"`.
- Add `Target Outcome` as a first-class category mapped to `allocation-target-date`.

## Why
The alias was semantically wrong. In the Canadian Stock-Analysis data, `Target Outcome` labels target-asset-allocation balanced portfolios (60/40, 80/20, etc. — VGRO, VBAL, XGRO, XBAL, FIE). In the Morningstar taxonomy we use as our canonical set, `Defined Outcome` labels buffered/structured outcome products (Innovator-style capped-upside ETFs). Aliasing the two sent ~70 Canadian balanced portfolios into the **Alternative Strategies** group alongside crypto / commodities / hedge-style funds, and left the **Allocation & Target-Date** group nearly empty for Canada.

## Effect on /etfs/countries/Canada/groups
- `alt-strategies`: ~133 -> ~62 (balanced portfolios removed)
- `allocation-target-date`: ~10 -> ~81 (balanced portfolios added)

## Test plan
- [x] `yarn prettier-check`
- [x] `yarn lint`
- [x] `yarn compile`
- [ ] Verify on Vercel preview that VGRO/VBAL/XGRO/XBAL appear under Allocation & Target-Date, not Alternative Strategies.