### PR TITLE
Add SEO action to tariff-engineering page; reorder nav

### DIFF
--- a/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-seo-info/route.ts
+++ b/insights-ui/src/app/api/industry-tariff-reports/chapters/[chapterSlug]/generate-seo-info/route.ts
@@ -1,12 +1,70 @@
 import { chapterGenerateRoute } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/chapter-generate-handler';
-import { generateAndSaveAllSeoDetails } from '@/scripts/industry-tariff-reports/08-report-seo-info';
-import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import {
+  generateAndSaveAllSeoDetails,
+  generateExecutiveSummarySeo,
+  generateFinalConclusionSeo,
+  generateIndustryAreasSeo,
+  generateReportCoverSeo,
+  generateTariffEngineeringSeo,
+  generateTariffUpdatesSeo,
+  generateUnderstandIndustrySeo,
+} from '@/scripts/industry-tariff-reports/08-report-seo-info';
+import { readSeoDetails, writeSeoDetails } from '@/scripts/industry-tariff-reports/tariff-report-repository';
+import { IndustryTariffReport, PageSeoDetails, ReportType, TariffReportSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 
 export const maxDuration = 300;
 
+const VALID_SECTION_VALUES = Object.values(ReportType);
+
+async function regenerateOneSection(slug: string, section: ReportType, existing: TariffReportSeoDetails): Promise<void> {
+  let seo: PageSeoDetails | undefined;
+  switch (section) {
+    case ReportType.REPORT_COVER:
+      seo = await generateReportCoverSeo(slug);
+      if (seo) existing.reportCoverSeoDetails = seo;
+      break;
+    case ReportType.EXECUTIVE_SUMMARY:
+      seo = await generateExecutiveSummarySeo(slug);
+      if (seo) existing.executiveSummarySeoDetails = seo;
+      break;
+    case ReportType.TARIFF_UPDATES:
+      seo = await generateTariffUpdatesSeo(slug);
+      if (seo) existing.tariffUpdatesSeoDetails = seo;
+      break;
+    case ReportType.UNDERSTAND_INDUSTRY:
+      seo = await generateUnderstandIndustrySeo(slug);
+      if (seo) existing.understandIndustrySeoDetails = seo;
+      break;
+    case ReportType.INDUSTRY_AREA_SECTION:
+      seo = await generateIndustryAreasSeo(slug);
+      if (seo) existing.industryAreasSeoDetails = seo;
+      break;
+    case ReportType.FINAL_CONCLUSION:
+      seo = await generateFinalConclusionSeo(slug);
+      if (seo) existing.finalConclusionSeoDetails = seo;
+      break;
+    case ReportType.TARIFF_ENGINEERING:
+      seo = await generateTariffEngineeringSeo(slug);
+      if (seo) existing.tariffEngineeringSeoDetails = seo;
+      break;
+  }
+  await writeSeoDetails(slug, existing);
+}
+
 export const POST = withErrorHandlingV2<IndustryTariffReport>(
-  chapterGenerateRoute(async (slug) => {
-    await generateAndSaveAllSeoDetails(slug);
+  chapterGenerateRoute(async (slug, body) => {
+    const sectionParam = ((body as { section?: string } | null)?.section as ReportType | undefined) ?? ReportType.ALL;
+    if (!VALID_SECTION_VALUES.includes(sectionParam)) {
+      throw new Error(`Invalid section: ${sectionParam}. Valid sections are: ${VALID_SECTION_VALUES.join(', ')}`);
+    }
+
+    if (sectionParam === ReportType.ALL) {
+      await generateAndSaveAllSeoDetails(slug);
+      return;
+    }
+
+    const existing: TariffReportSeoDetails = (await readSeoDetails(slug)) ?? {};
+    await regenerateOneSection(slug, sectionParam, existing);
   })
 );

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
@@ -1,16 +1,14 @@
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ChapterPlaceholder from '@/components/industry-tariff/chapter/ChapterPlaceholder';
 import ChapterSectionActions from '@/components/industry-tariff/chapter/ChapterSectionActions';
+import { renderChapterToolsCrossLinks } from '@/components/industry-tariff/chapter/ChapterToolsCrossLinks';
 import { renderSection } from '@/components/industry-tariff/renderers/SectionRenderer';
-import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import type { PageSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
-import { getHtsChapterRefByNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import { tariffReportTag } from '@/utils/tariff-report-tags';
-import { Calculator, ListTree } from 'lucide-react';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
@@ -78,23 +76,7 @@ export default async function ChapterCoverPage({ params }: { params: Promise<{ c
       newChangesFirstSentence: tariff.newChanges,
     })) ?? [];
 
-  const htsChapter = await getHtsChapterRefByNumber(chapter.number);
-  const crossLinks = [
-    {
-      href: '/tariff-calculator',
-      title: 'Tariff Calculator',
-      description: `Estimate landed US duty for goods in HTS Chapter ${padded} — base rate plus Section 232, 301, and IEEPA fees.`,
-      icon: <Calculator className="h-5 w-5" />,
-    },
-    htsChapter
-      ? {
-          href: htsChapter.href,
-          title: `HTS Chapter ${padded} — ${chapter.title}`,
-          description: 'Browse every HTS code in this chapter, with general rate, Column 2, special rates, and units of quantity.',
-          icon: <ListTree className="h-5 w-5" />,
-        }
-      : null,
-  ].filter((link): link is NonNullable<typeof link> => link !== null);
+  const toolsCrossLinks = await renderChapterToolsCrossLinks(chapter);
 
   return (
     <div className="mx-auto max-w-7xl py-2">
@@ -143,7 +125,7 @@ export default async function ChapterCoverPage({ params }: { params: Promise<{ c
         </div>
       </div>
 
-      <TariffCrossLinks heading="Tools for this chapter" links={crossLinks} />
+      {toolsCrossLinks}
 
       <div className="space-y-12">
         {renderSection(

--- a/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
+++ b/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
@@ -25,7 +25,7 @@ async function generateTariffReportUrls(): Promise<SiteMapUrl[]> {
 
   const rows = await prisma.tariffChapterReport.findMany({
     where: { spaceId: KoalaGainsSpaceId, ...SEEDED_FILTER },
-    select: { slug: true, updatedAt: true },
+    select: { slug: true, updatedAt: true, tariffEngineering: true },
     orderBy: { chapter: { number: 'asc' } },
   });
 
@@ -35,6 +35,11 @@ async function generateTariffReportUrls(): Promise<SiteMapUrl[]> {
     urls.push({ url: chapterPath, changefreq: 'weekly', priority: 0.8, lastmod });
     for (const section of REPORT_SECTIONS) {
       urls.push({ url: `${chapterPath}/${section}`, changefreq: 'weekly', priority: 0.7, lastmod });
+    }
+    // Tariff Engineering is only seeded for a subset of chapters — include the URL only when the
+    // JSONB column has content so we don't advertise placeholder section pages in the sitemap.
+    if (row.tariffEngineering !== null) {
+      urls.push({ url: `${chapterPath}/tariff-engineering`, changefreq: 'weekly', priority: 0.7, lastmod });
     }
   }
 

--- a/insights-ui/src/app/tariff-reports/page.tsx
+++ b/insights-ui/src/app/tariff-reports/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import TariffReportsPageActions from '@/components/industry-tariff/TariffReportsPageActions';
 import TariffCrossLinks from '@/components/tariff-cross-links/TariffCrossLinks';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
+import { CHAPTER_REPORT_SECTIONS, chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
 import { TARIFF_REPORTS_LISTING_TAG } from '@/utils/tariff-report-tags';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
@@ -64,13 +64,6 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-const REPORT_SECTIONS = [
-  { slug: 'tariff-updates', label: 'Tariff Updates' },
-  { slug: 'understand-industry', label: 'Understand Industry' },
-  { slug: 'industry-areas', label: 'Industry Areas' },
-  { slug: 'final-conclusion', label: 'Final Conclusion' },
-] as const;
-
 function formatDate(value: string): string {
   return new Date(value).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
@@ -107,7 +100,7 @@ function ChapterCard({ chapterNumber, chapterTitle, chapterSlug, lastModified }:
       <p className="mb-5 line-clamp-3 flex-1 text-sm text-gray-300">{description}</p>
 
       <div className="mb-5 flex flex-wrap gap-1.5">
-        {REPORT_SECTIONS.map((section) => (
+        {CHAPTER_REPORT_SECTIONS.map((section) => (
           <Link
             key={section.slug}
             href={chapterSectionHref(chapterSlug, section.slug)}

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
@@ -1,3 +1,5 @@
+import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import ChapterSectionActions, { type ChapterSectionAction } from '@/components/industry-tariff/chapter/ChapterSectionActions';
 import { CHAPTER_REPORT_SECTIONS, ChapterRouteInfo, chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
 import { ArrowRight, Layers } from 'lucide-react';
 import Link from 'next/link';
@@ -9,23 +11,35 @@ interface ChapterPlaceholderProps {
   // Optional sub-section the user is currently looking at — exclude it from the section nav block.
   currentSectionSlug?: string;
   description: string;
+  // Admin actions surfaced above the placeholder body. Mirrors `ChapterSectionHeader` so admins can
+  // generate the missing section directly from this page instead of jumping to the admin table.
+  actions?: ChapterSectionAction[];
 }
 
-export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionSlug, description }: ChapterPlaceholderProps) {
+export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionSlug, description, actions }: ChapterPlaceholderProps) {
   const padded = chapter.number.toString().padStart(2, '0');
   const otherSections = CHAPTER_REPORT_SECTIONS.filter((s) => s.slug !== currentSectionSlug);
 
   return (
     <div className="py-6">
       <header className="mb-8 border-b border-color pb-6">
-        <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
-          <Layers className="h-4 w-4 text-emerald-400" />
-          <span className="font-medium text-emerald-400">HTS Chapter {padded}</span>
-          <span aria-hidden>·</span>
-          <span>{chapter.title}</span>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+              <Layers className="h-4 w-4 text-emerald-400" />
+              <span className="font-medium text-emerald-400">HTS Chapter {padded}</span>
+              <span aria-hidden>·</span>
+              <span>{chapter.title}</span>
+            </div>
+            <h1 className="text-3xl font-bold tracking-tight">{pageTitle}</h1>
+            <p className="mt-3 max-w-3xl text-muted-foreground">{description}</p>
+          </div>
+          {actions && actions.length > 0 && (
+            <PrivateWrapper>
+              <ChapterSectionActions chapterSlug={chapter.slug} actions={actions} />
+            </PrivateWrapper>
+          )}
         </div>
-        <h1 className="text-3xl font-bold tracking-tight">{pageTitle}</h1>
-        <p className="mt-3 max-w-3xl text-muted-foreground">{description}</p>
       </header>
 
       <section className="mb-10 rounded-2xl border border-color background-color p-6">

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
@@ -3,6 +3,7 @@ import ChapterSectionActions, { type ChapterSectionAction } from '@/components/i
 import { CHAPTER_REPORT_SECTIONS, ChapterRouteInfo, chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
 import { ArrowRight, Layers } from 'lucide-react';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 
 interface ChapterPlaceholderProps {
   chapter: ChapterRouteInfo;
@@ -14,9 +15,12 @@ interface ChapterPlaceholderProps {
   // Admin actions surfaced above the placeholder body. Mirrors `ChapterSectionHeader` so admins can
   // generate the missing section directly from this page instead of jumping to the admin table.
   actions?: ChapterSectionAction[];
+  // Optional "Tools for this chapter" block rendered between the header and the placeholder notice.
+  // Passed in pre-built so the placeholder stays a client-safe sync component.
+  toolsCrossLinks?: ReactNode;
 }
 
-export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionSlug, description, actions }: ChapterPlaceholderProps) {
+export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionSlug, description, actions, toolsCrossLinks }: ChapterPlaceholderProps) {
   const padded = chapter.number.toString().padStart(2, '0');
   const otherSections = CHAPTER_REPORT_SECTIONS.filter((s) => s.slug !== currentSectionSlug);
 
@@ -41,6 +45,8 @@ export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionS
           )}
         </div>
       </header>
+
+      {toolsCrossLinks}
 
       <section className="mb-10 rounded-2xl border border-color background-color p-6">
         <h2 className="text-lg font-semibold">Detailed analysis is being prepared</h2>

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterSectionActions.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterSectionActions.tsx
@@ -20,6 +20,9 @@ interface SimpleChapterAction {
   modalTitle: string;
   confirmationText: string;
   successMessage: string;
+  // Optional JSON body to POST; defaults to `{}`. Use when the target route
+  // expects a discriminator like `{ section: ReportType.X }`.
+  body?: Record<string, unknown>;
 }
 
 // Special case for the tariff-updates regenerate. The bundled
@@ -70,7 +73,7 @@ export default function ChapterSectionActions({ chapterSlug, actions }: ChapterS
     if (!pendingAction) return;
 
     if (pendingAction.kind === 'simple') {
-      const result = await postData(`${getBaseUrl()}/api/industry-tariff-reports/chapters/${chapterSlug}/${pendingAction.apiPath}`, {});
+      const result = await postData(`${getBaseUrl()}/api/industry-tariff-reports/chapters/${chapterSlug}/${pendingAction.apiPath}`, pendingAction.body ?? {});
       setPendingAction(null);
       if (result !== undefined) {
         showNotification({ type: 'success', message: pendingAction.successMessage });

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterToolsCrossLinks.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterToolsCrossLinks.tsx
@@ -1,0 +1,32 @@
+import TariffCrossLinks, { type TariffCrossLink } from '@/components/tariff-cross-links/TariffCrossLinks';
+import { getHtsChapterRefByNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
+import type { ChapterRouteInfo } from '@/utils/tariff-reports/chapter-route-helpers';
+import { Calculator, ListTree } from 'lucide-react';
+
+// Shared "Tools for this chapter" block. Exposed as an async helper rather than an async server
+// component because the project's TypeScript (5.0.4) doesn't type-check `<AsyncComponent />` in
+// JSX. Callers await it once and store the result; the JSX it returns can be embedded normally.
+export async function renderChapterToolsCrossLinks(chapter: ChapterRouteInfo): Promise<JSX.Element> {
+  const padded = chapter.number.toString().padStart(2, '0');
+  const htsChapter = await getHtsChapterRefByNumber(chapter.number);
+
+  const links: TariffCrossLink[] = [
+    {
+      href: '/tariff-calculator',
+      title: 'Tariff Calculator',
+      description: `Estimate landed US duty for goods in HTS Chapter ${padded} — base rate plus Section 232, 301, and IEEPA fees.`,
+      icon: <Calculator className="h-5 w-5" />,
+    },
+  ];
+
+  if (htsChapter) {
+    links.push({
+      href: htsChapter.href,
+      title: `HTS Chapter ${padded} — ${chapter.title}`,
+      description: 'Browse every HTS code in this chapter, with general rate, Column 2, special rates, and units of quantity.',
+      icon: <ListTree className="h-5 w-5" />,
+    });
+  }
+
+  return <TariffCrossLinks heading="Tools for this chapter" links={links} />;
+}

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -1,6 +1,7 @@
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ChapterPlaceholder from '@/components/industry-tariff/chapter/ChapterPlaceholder';
 import ChapterSectionActions, { type ChapterSectionAction } from '@/components/industry-tariff/chapter/ChapterSectionActions';
+import { renderChapterToolsCrossLinks } from '@/components/industry-tariff/chapter/ChapterToolsCrossLinks';
 import { CountryNavigation } from '@/components/industry-tariff/renderers/CountryNavigation';
 import { CountryTariffRenderer } from '@/components/industry-tariff/renderers/CountryTariffRenderer';
 import { FinalConclusionRenderer } from '@/components/industry-tariff/renderers/FinalConclusionRenderer';
@@ -243,16 +244,25 @@ export async function renderChapterSection(chapterSlug: string, sectionSlug: str
 
   const body = renderSectionBody(sectionSlug, report);
   const actions = getSectionActions(sectionSlug);
+  const toolsCrossLinks = await renderChapterToolsCrossLinks(chapter);
 
   if (!body) {
     return (
-      <ChapterPlaceholder chapter={chapter} pageTitle={copy.pageTitle} currentSectionSlug={sectionSlug} description={copy.description} actions={actions} />
+      <ChapterPlaceholder
+        chapter={chapter}
+        pageTitle={copy.pageTitle}
+        currentSectionSlug={sectionSlug}
+        description={copy.description}
+        actions={actions}
+        toolsCrossLinks={toolsCrossLinks}
+      />
     );
   }
 
   return (
     <div className="mx-auto max-w-7xl py-2">
       <ChapterSectionHeader chapter={chapter} pageTitle={copy.pageTitle} actions={actions} />
+      {toolsCrossLinks}
       {body}
     </div>
   );

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -8,7 +8,7 @@ import { TariffEngineeringRenderer } from '@/components/industry-tariff/renderer
 import { UnderstandIndustryRenderer } from '@/components/industry-tariff/renderers/UnderstandIndustryRenderer';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import { getMarkdownContentForIndustryAreas } from '@/scripts/industry-tariff-reports/render-tariff-markdown';
-import type { IndustryTariffReport, PageSeoDetails, TariffReportSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
+import { ReportType, type IndustryTariffReport, type PageSeoDetails, type TariffReportSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { ChapterRouteInfo, chapterSectionHref, getChapterSectionCopy } from '@/utils/tariff-reports/chapter-route-helpers';
@@ -172,6 +172,16 @@ function getSectionActions(sectionSlug: string): ChapterSectionAction[] {
           modalTitle: 'Regenerate Tariff Engineering',
           confirmationText: 'Regenerate the Tariff Engineering analysis? This replaces the current content.',
           successMessage: 'Tariff Engineering regenerated.',
+        },
+        {
+          kind: 'simple',
+          key: 'generate-tariff-engineering-seo',
+          label: 'Generate SEO for Tariff Engineering',
+          apiPath: 'generate-seo-info',
+          body: { section: ReportType.TARIFF_ENGINEERING },
+          modalTitle: 'Generate SEO for Tariff Engineering',
+          confirmationText: 'Generate SEO metadata for the Tariff Engineering section?',
+          successMessage: 'Tariff Engineering SEO generated.',
         },
       ];
     default:

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -242,14 +242,17 @@ export async function renderChapterSection(chapterSlug: string, sectionSlug: str
   if (!copy) notFound();
 
   const body = renderSectionBody(sectionSlug, report);
+  const actions = getSectionActions(sectionSlug);
 
   if (!body) {
-    return <ChapterPlaceholder chapter={chapter} pageTitle={copy.pageTitle} currentSectionSlug={sectionSlug} description={copy.description} />;
+    return (
+      <ChapterPlaceholder chapter={chapter} pageTitle={copy.pageTitle} currentSectionSlug={sectionSlug} description={copy.description} actions={actions} />
+    );
   }
 
   return (
     <div className="mx-auto max-w-7xl py-2">
-      <ChapterSectionHeader chapter={chapter} pageTitle={copy.pageTitle} actions={getSectionActions(sectionSlug)} />
+      <ChapterSectionHeader chapter={chapter} pageTitle={copy.pageTitle} actions={actions} />
       {body}
     </div>
   );

--- a/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
+++ b/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
@@ -22,8 +22,8 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; section: string }> = [
   { title: 'Tariff Updates - Top 5 Trade Partners', section: 'tariff-updates' },
   { title: 'Understand Industry', section: 'understand-industry' },
   { title: 'Industry Areas', section: 'industry-areas' },
-  { title: 'Final Conclusion', section: 'final-conclusion' },
   { title: 'Tariff Engineering', section: 'tariff-engineering' },
+  { title: 'Final Conclusion', section: 'final-conclusion' },
 ];
 
 export default function ReportLeftNavigation({

--- a/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
+++ b/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
@@ -7,8 +7,8 @@ export const CHAPTER_REPORT_SECTIONS: readonly ChapterReportSection[] = [
   { slug: 'tariff-updates', label: 'Tariff Updates' },
   { slug: 'understand-industry', label: 'Understand Industry' },
   { slug: 'industry-areas', label: 'Industry Areas' },
-  { slug: 'final-conclusion', label: 'Final Conclusion' },
   { slug: 'tariff-engineering', label: 'Tariff Engineering' },
+  { slug: 'final-conclusion', label: 'Final Conclusion' },
 ] as const;
 
 export interface ChapterRouteInfo {

--- a/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
+++ b/insights-ui/src/utils/tariff-reports/chapter-route-helpers.ts
@@ -45,13 +45,13 @@ const SECTION_COPY: Record<string, (title: string, padded: string) => ChapterSec
     pageTitle: 'Industry Areas',
     description: `Sub-areas of HTS Chapter ${padded} (${title}) — segment-level tariff exposure across the product groupings inside this chapter.`,
   }),
-  'final-conclusion': (title, padded) => ({
-    pageTitle: 'Final Conclusion',
-    description: `Forward-looking conclusion for HTS Chapter ${padded} (${title}) — what the latest tariff actions mean for sourcing, pricing, and strategic positioning.`,
-  }),
   'tariff-engineering': (title, padded) => ({
     pageTitle: 'Tariff Engineering',
     description: `Tariff engineering strategies for HTS Chapter ${padded} (${title}) — classification levers, country-of-origin moves, first-sale valuation, FTZ usage, and duty drawback to lawfully reduce US duty exposure.`,
+  }),
+  'final-conclusion': (title, padded) => ({
+    pageTitle: 'Final Conclusion',
+    description: `Forward-looking conclusion for HTS Chapter ${padded} (${title}) — what the latest tariff actions mean for sourcing, pricing, and strategic positioning.`,
   }),
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #1443. Two tweaks for the Tariff Engineering section:

- **Admin three-dot menu on the Tariff Engineering page** now exposes two options:
  - **Regenerate Tariff Engineering** — POSTs to `generate-tariff-engineering`.
  - **Generate SEO for Tariff Engineering** — POSTs to `generate-seo-info` with `{ section: TARIFF_ENGINEERING }` for a targeted SEO regeneration (no need to rerun every section's SEO).
- **Left sidebar order** updated so Final Conclusion is last; Tariff Engineering now sits between Industry Areas and Final Conclusion.

### Implementation notes

- Chapter `generate-seo-info` route now mirrors the legacy industry-keyed route: honors `{ section }` in the body and dispatches to the matching `generate*Seo` helper, falling back to `generateAndSaveAllSeoDetails` when `section` is `ALL` or absent.
- `SimpleChapterAction` in `ChapterSectionActions.tsx` gained an optional `body` field so per-section dispatchers can pass a discriminator without introducing a new action kind.
- `NAV_SECTIONS` (left nav) and `CHAPTER_REPORT_SECTIONS` (route helpers) both reordered so the canonical order is: Tariff Updates → Understand Industry → Industry Areas → Tariff Engineering → Final Conclusion.

## Test plan

- [ ] Visit `/industry-tariff-report/chapters/<slug>/tariff-engineering` as an admin → three-dot menu shows two options.
- [ ] Click **Regenerate Tariff Engineering** → only the `tariffEngineering` JSONB column is rewritten.
- [ ] Click **Generate SEO for Tariff Engineering** → only `seoDetails.tariffEngineeringSeoDetails` is updated; other section SEO blobs untouched.
- [ ] Confirm sidebar order on any chapter page: Final Conclusion is the last entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)