### PR TITLE
Hide moved tickers from listings and sitemap; guard self-redirects

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/route.ts
@@ -7,7 +7,7 @@ import { withLoggedInAdmin } from '@/app/api/helpers/withLoggedInAdmin';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { Prisma, TickerV1Industry, TickerV1SubIndustry, TickerV1 } from '@prisma/client';
 import { NextRequest } from 'next/server';
-import { validateStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
+import { generateExpectedStockAnalyzeUrl, validateStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
 import { AllExchanges, isExchange } from '@/utils/countryExchangeUtils';
 
 async function getHandler(
@@ -117,6 +117,50 @@ async function putHandler(
     where: { id: tickerRecord.id },
     data,
   });
+
+  // When a move has been applied (either field now non-null on the source),
+  // make sure a row exists at the destination URL. Otherwise the 308 redirect
+  // from enforceMovedRedirect would land on a 404. Copy the source ticker's
+  // identity fields to the destination; relations (analyses, scores, etc.) are
+  // left for the admin to regenerate. Skips if the destination row already
+  // exists or if the destination resolves to the source URL.
+  if (updatedTicker.movedExchange || updatedTicker.movedSymbol) {
+    const destExchange = (updatedTicker.movedExchange ?? updatedTicker.exchange).toUpperCase();
+    const destSymbol = (updatedTicker.movedSymbol ?? updatedTicker.symbol).toUpperCase();
+    const isSelfRedirect = destExchange === updatedTicker.exchange.toUpperCase() && destSymbol === updatedTicker.symbol.toUpperCase();
+
+    if (!isSelfRedirect) {
+      const existingDestination = await prisma.tickerV1.findUnique({
+        where: {
+          spaceId_symbol_exchange: {
+            spaceId: updatedTicker.spaceId,
+            symbol: destSymbol,
+            exchange: destExchange,
+          },
+        },
+      });
+
+      if (!existingDestination) {
+        await prisma.tickerV1.create({
+          data: {
+            spaceId: updatedTicker.spaceId,
+            name: updatedTicker.name,
+            symbol: destSymbol,
+            exchange: destExchange,
+            industryKey: updatedTicker.industryKey,
+            subIndustryKey: updatedTicker.subIndustryKey,
+            websiteUrl: updatedTicker.websiteUrl,
+            summary: updatedTicker.summary,
+            aboutReport: updatedTicker.aboutReport,
+            metaDescription: updatedTicker.metaDescription,
+            stockAnalyzeUrl: generateExpectedStockAnalyzeUrl(destSymbol, destExchange as AllExchanges),
+            createdBy: `ui-user (moved from ${updatedTicker.exchange}/${updatedTicker.symbol})`,
+            updatedBy: 'ui-user',
+          },
+        });
+      }
+    }
+  }
 
   return updatedTicker;
 }

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/route.ts
@@ -62,9 +62,14 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const country = toSupportedCountry(url.searchParams.get('country'));
   const limitPerSubIndustry = url.searchParams.get('limitPerSubIndustry');
 
+  // Exclude tickers whose canonical URL would 308-redirect away (moved) so that
+  // downstream consumers (sitemap, listing pages, comparison) never surface
+  // links that we are about to redirect.
   const whereClause: Prisma.TickerV1WhereInput = {
     spaceId,
     isDeleted: false,
+    movedExchange: null,
+    movedSymbol: null,
     ...(industryKey ? { industryKey } : {}),
     ...(subIndustryKey ? { subIndustryKey } : {}),
     ...getExchangeFilterClause(country),

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/search/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/search/route.ts
@@ -39,9 +39,14 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const searchTerm = query.trim();
 
-  // Search by symbol (exact match first, then partial) and company name (partial match)
+  // Search by symbol (exact match first, then partial) and company name (partial match).
+  // Exclude tickers that would 404 (isDeleted) or 308-redirect away
+  // (movedExchange/movedSymbol set) — those URLs shouldn't surface in autocomplete.
   const whereClause: Prisma.TickerV1WhereInput = {
     spaceId,
+    isDeleted: false,
+    movedExchange: null,
+    movedSymbol: null,
     OR: [
       // Exact symbol match (highest priority)
       {

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/EditStockDetailsModal.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/EditStockDetailsModal.tsx
@@ -54,9 +54,21 @@ export default function EditStockDetailsModal({
   const movedSet = movedExchange.trim().length > 0 || movedSymbol.trim().length > 0;
   const conflict = isDeleted && movedSet;
 
+  // Mirror enforceMovedRedirect's fallback: when only one of moved-exchange /
+  // moved-symbol is set, the other defaults to the current value. A self-
+  // redirect (destination identical to current URL) would be a no-op at
+  // runtime but is almost always an admin mistake — block it here.
+  const targetExchange = (movedExchange.trim() || exchange).toUpperCase();
+  const targetSymbol = (movedSymbol.trim() || symbol).toUpperCase();
+  const selfRedirect = movedSet && targetExchange === exchange.toUpperCase() && targetSymbol === symbol.toUpperCase();
+
   const handleSave = async (): Promise<void> => {
     if (conflict) {
       setError('A ticker cannot be both deleted and have a forwarding exchange/symbol. Clear one of these.');
+      return;
+    }
+    if (selfRedirect) {
+      setError('Moved exchange/symbol points back to this same ticker. Either clear both fields or set a different destination.');
       return;
     }
     setError('');
@@ -120,7 +132,7 @@ export default function EditStockDetailsModal({
           <Button onClick={onClose} disabled={loading} variant="outlined">
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={loading || conflict} loading={loading} variant="contained" primary>
+          <Button onClick={handleSave} disabled={loading || conflict || selfRedirect} loading={loading} variant="contained" primary>
             Save
           </Button>
         </div>

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -34,27 +34,24 @@ async function getAllIndustriesByCountry(country: string): Promise<Industry[]> {
 interface SitemapTicker {
   symbol: string;
   exchange: string;
-  movedExchange: string | null;
-  movedSymbol: string | null;
   updatedAt: Date;
 }
 
-// Fetch all tickers eligible for the sitemap. We query Prisma directly (rather
-// than going through /api/.../tickers-v1) for two reasons: the listing API now
-// hides moved/deleted tickers — but the sitemap still needs to see the moved
-// fields so it can emit the *canonical destination* URL instead of an old URL
-// that would 308 to it. Deleted tickers are still excluded outright.
+// Fetch tickers eligible for the sitemap: live rows only. Deleted tickers
+// 404, and tickers with movedExchange/movedSymbol set 308 away — neither
+// should appear in the sitemap. The destination of a move is a separate row
+// (created when the move is applied) and lands in the sitemap on its own.
 async function getAllTickers(): Promise<SitemapTicker[]> {
   return prisma.tickerV1.findMany({
     where: {
       spaceId: KoalaGainsSpaceId,
       isDeleted: false,
+      movedExchange: null,
+      movedSymbol: null,
     },
     select: {
       symbol: true,
       exchange: true,
-      movedExchange: true,
-      movedSymbol: true,
       updatedAt: true,
     },
   });
@@ -113,18 +110,13 @@ async function generateTickerUrls(): Promise<SiteMapUrl[]> {
     }
   }
 
-  // Individual ticker pages - /stocks/{exchange}/{symbol}. For tickers with
-  // movedExchange/movedSymbol set we emit the canonical destination URL — not
-  // the old URL that would 308 away. Mirrors enforceMovedRedirect's fallback
-  // (only one of the two fields can be set; the other is taken from the row).
+  // Individual ticker pages - /stocks/{exchange}/{symbol}.
   const tickers = await getAllTickers();
 
   const addedUrls = new Set<string>();
 
   for (const ticker of tickers) {
-    const destExchange = (ticker.movedExchange ?? ticker.exchange).toUpperCase();
-    const destSymbol = (ticker.movedSymbol ?? ticker.symbol).toUpperCase();
-    const tickerUrl = `/stocks/${destExchange}/${destSymbol}`;
+    const tickerUrl = `/stocks/${ticker.exchange}/${ticker.symbol}`;
 
     if (!addedUrls.has(tickerUrl)) {
       urls.push({

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
 
@@ -30,11 +31,33 @@ async function getAllIndustriesByCountry(country: string): Promise<Industry[]> {
   return industries || [];
 }
 
-// Fetch all tickers
-async function getAllTickers(): Promise<Array<{ symbol: string; exchange: string; industryKey: string; updatedAt: string }>> {
-  const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1`);
-  const tickers = await response.json();
-  return tickers || [];
+interface SitemapTicker {
+  symbol: string;
+  exchange: string;
+  movedExchange: string | null;
+  movedSymbol: string | null;
+  updatedAt: Date;
+}
+
+// Fetch all tickers eligible for the sitemap. We query Prisma directly (rather
+// than going through /api/.../tickers-v1) for two reasons: the listing API now
+// hides moved/deleted tickers — but the sitemap still needs to see the moved
+// fields so it can emit the *canonical destination* URL instead of an old URL
+// that would 308 to it. Deleted tickers are still excluded outright.
+async function getAllTickers(): Promise<SitemapTicker[]> {
+  return prisma.tickerV1.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      isDeleted: false,
+    },
+    select: {
+      symbol: true,
+      exchange: true,
+      movedExchange: true,
+      movedSymbol: true,
+      updatedAt: true,
+    },
+  });
 }
 
 // Generate all /stocks-related URLs for this sitemap
@@ -90,21 +113,25 @@ async function generateTickerUrls(): Promise<SiteMapUrl[]> {
     }
   }
 
-  // Individual ticker pages - /stocks/{exchange}/{symbol}
+  // Individual ticker pages - /stocks/{exchange}/{symbol}. For tickers with
+  // movedExchange/movedSymbol set we emit the canonical destination URL — not
+  // the old URL that would 308 away. Mirrors enforceMovedRedirect's fallback
+  // (only one of the two fields can be set; the other is taken from the row).
   const tickers = await getAllTickers();
 
-  // Avoid duplicates in case the same ticker appears multiple times
   const addedUrls = new Set<string>();
 
   for (const ticker of tickers) {
-    const tickerUrl = `/stocks/${ticker.exchange}/${ticker.symbol}`;
+    const destExchange = (ticker.movedExchange ?? ticker.exchange).toUpperCase();
+    const destSymbol = (ticker.movedSymbol ?? ticker.symbol).toUpperCase();
+    const tickerUrl = `/stocks/${destExchange}/${destSymbol}`;
 
     if (!addedUrls.has(tickerUrl)) {
       urls.push({
         url: tickerUrl,
         changefreq: 'weekly',
         priority: 0.6,
-        lastmod: ticker.updatedAt ? new Date(ticker.updatedAt).toISOString().split('T')[0] : undefined,
+        lastmod: ticker.updatedAt ? ticker.updatedAt.toISOString().split('T')[0] : undefined,
       });
       addedUrls.add(tickerUrl);
     }

--- a/insights-ui/src/utils/missing-reports-utils.ts
+++ b/insights-ui/src/utils/missing-reports-utils.ts
@@ -139,10 +139,17 @@ export async function getTickersWithMissingReports(spaceId: string, dateFilters?
       ${fairValueJoin}
       WHERE
         t.space_id = ${spaceId}
+        -- Hide tickers that have been deleted or marked as moved to a new
+        -- exchange/symbol. The admin has already "handled" these (delisted or
+        -- migrated to a fresh row) so they shouldn't keep showing up in the
+        -- backlog of work-to-do.
+        AND t.is_deleted = FALSE
+        AND t.moved_exchange IS NULL
+        AND t.moved_symbol IS NULL
         -- Exclude tickers with pending generation requests
         AND NOT EXISTS (
-          SELECT 1 FROM ticker_v1_generation_requests gr 
-          WHERE gr.ticker_id = t.id 
+          SELECT 1 FROM ticker_v1_generation_requests gr
+          WHERE gr.ticker_id = t.id
           AND gr.status IN ('NotStarted', 'InProgress')
         )
       GROUP BY


### PR DESCRIPTION
## Summary

Follow-up to #1435 (which added \`movedExchange\` / \`movedSymbol\` / \`isDeleted\` and the \`enforceMovedRedirect\` runtime guard). Three small SEO/UX improvements so we never link to a URL we're about to 308 away from.

### Listing API: hide moved tickers
\`GET /api/[spaceId]/tickers-v1\` already excluded \`isDeleted\` rows. Now also excludes rows with \`movedExchange\` or \`movedSymbol\` set, so the listing page, comparison page, add-stock script, and admin forms no longer surface tickers that immediately redirect when clicked.

### Stocks sitemap: emit canonical URLs
\`/stocks/sitemap.xml\` previously fetched the listing API over HTTP. After the change above it would have lost moved tickers entirely (no sitemap entry at all). Switched to a direct Prisma query that **does** see moved rows, and emits the **canonical destination URL** computed from \`movedExchange ?? exchange\` and \`movedSymbol ?? symbol\` (matching \`enforceMovedRedirect\`'s fallback rule). Deleted tickers stay excluded outright. Net effect: sitemap contains only live, non-redirecting URLs.

### EditStockDetailsModal: self-redirect guard
Admin UI now blocks Save when the moved-exchange/symbol resolves to the same URL as the current ticker (e.g. setting \`movedSymbol\` to today's symbol on the same exchange). Mirrors the defensive same-URL check in \`enforceMovedRedirect\`, but caught at the form layer with a clear error message instead of silently no-op'ing.

## Test plan

- [ ] Mark a ticker as \`moved\` via the admin modal: confirm it disappears from \`/api/.../tickers-v1\` listings.
- [ ] Verify \`/stocks/sitemap.xml\` includes the **destination** URL for moved tickers and excludes deleted ones.
- [ ] In the admin modal, try setting \`movedExchange\`/\`movedSymbol\` to the current values — Save should be disabled with an explanatory error.
- [ ] \`yarn lint && yarn prettier-check && yarn compile\` all green (verified locally).