### PR TITLE
Restyle tariff chapter pages around stock-style single article card

### DIFF
--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
@@ -34,7 +34,7 @@ export default async function ChapterReportLayout({ children, params }: { childr
   return (
     <PageWrapper>
       <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
-      <div className="mx-auto max-w-5xl text-color">{children}</div>
+      <div className="text-color">{children}</div>
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/layout.tsx
@@ -1,5 +1,3 @@
-import CollapsibleLayout from '@/components/industry-tariff/collapsible-layout';
-import MobileNavToggle from '@/components/industry-tariff/mobile-nav-toggle';
 import BreadcrumbsWithJsonLd from '@/components/ui/BreadcrumbsWithJsonLd';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
@@ -20,15 +18,12 @@ export default async function ChapterReportLayout({ children, params }: { childr
   const { chapterSlug } = await params;
   const data = await fetchChapterTariffReport(chapterSlug);
 
-  // Without a resolved chapter the leaf page will 404 — render bare so the chapter-specific
-  // breadcrumb/nav chrome doesn't try to read undefined chapter data.
   if (!data) {
     return <PageWrapper>{children}</PageWrapper>;
   }
 
   const { chapter } = data;
   const padded = chapter.number.toString().padStart(2, '0');
-  const navTitle = `HTS Chapter ${padded} ${chapter.title}`;
   const basePath = chapterCoverHref(chapter.slug);
 
   const breadcrumbs: BreadcrumbsOjbect[] = [
@@ -39,33 +34,7 @@ export default async function ChapterReportLayout({ children, params }: { childr
   return (
     <PageWrapper>
       <BreadcrumbsWithJsonLd breadcrumbs={breadcrumbs} />
-
-      <div className="mx-auto text-color">
-        <div className="mx-auto">
-          <div className="block lg:hidden fixed bottom-6 left-6 z-50">
-            <MobileNavToggle basePath={basePath} navTitle={navTitle} />
-          </div>
-
-          <div className="hidden lg:block">
-            <CollapsibleLayout basePath={basePath}>{children}</CollapsibleLayout>
-          </div>
-
-          <div className="block lg:hidden">
-            <div className="flex min-h-[calc(100vh-10rem)] overflow-hidden rounded-lg border border-color background-color shadow-lg">
-              <div className="flex-1 bg-background p-2 sm:p-3">
-                <div className="mx-auto max-w-4xl">
-                  <div className="relative min-h-[calc(100vh-10rem)] rounded-lg block-bg-color p-2 sm:p-2 shadow-md">
-                    <div className="absolute right-0 top-0 h-12 w-12 bg-muted/20">
-                      <div className="absolute right-0 top-0 h-0 w-0 border-l-[48px] border-b-[48px] border-l-transparent border-b-[var(--block-bg)]"></div>
-                    </div>
-                    <div className="prose max-w-none">{children}</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div className="mx-auto max-w-5xl text-color">{children}</div>
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/chapters/[chapterSlug]/page.tsx
@@ -1,8 +1,6 @@
-import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import { ChapterArticle } from '@/components/industry-tariff/chapter/chapter-section-page';
 import ChapterPlaceholder from '@/components/industry-tariff/chapter/ChapterPlaceholder';
-import ChapterSectionActions from '@/components/industry-tariff/chapter/ChapterSectionActions';
 import { renderChapterToolsCrossLinks } from '@/components/industry-tariff/chapter/ChapterToolsCrossLinks';
-import { renderSection } from '@/components/industry-tariff/renderers/SectionRenderer';
 import type { ChapterTariffReportResponse } from '@/app/api/industry-tariff-reports/chapters/[chapterSlug]/route';
 import type { PageSeoDetails } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
@@ -78,97 +76,82 @@ export default async function ChapterCoverPage({ params }: { params: Promise<{ c
 
   const toolsCrossLinks = await renderChapterToolsCrossLinks(chapter);
 
+  const pageTitle = report.reportCover?.title || fallbackPageTitle;
+
+  const actions = [
+    {
+      kind: 'simple' as const,
+      key: 'regenerate-cover',
+      label: 'Regenerate Cover',
+      apiPath: 'generate-report-cover',
+      modalTitle: 'Regenerate Cover',
+      confirmationText: 'Regenerate the cover for this chapter? This replaces the current content.',
+      successMessage: 'Cover regenerated.',
+    },
+    {
+      kind: 'simple' as const,
+      key: 'regenerate-executive-summary',
+      label: 'Regenerate Executive Summary',
+      apiPath: 'generate-executive-summary',
+      modalTitle: 'Regenerate Executive Summary',
+      confirmationText: 'Regenerate the executive summary? This replaces the current content.',
+      successMessage: 'Executive summary regenerated.',
+    },
+    {
+      kind: 'simple' as const,
+      key: 'regenerate-seo',
+      label: 'Regenerate SEO',
+      apiPath: 'generate-seo-info',
+      modalTitle: 'Regenerate SEO',
+      confirmationText: 'Regenerate SEO metadata for every section of this chapter?',
+      successMessage: 'SEO metadata regenerated.',
+    },
+  ];
+
   return (
-    <div className="mx-auto max-w-7xl py-2">
-      <div className="mb-8 pb-4 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <div className="text-sm text-muted-foreground mb-1">
-              HTS Chapter {padded} — {chapter.title}
-            </div>
-            <h1 className="text-3xl font-bold heading-color">{report.reportCover?.title || fallbackPageTitle}</h1>
-          </div>
-          <PrivateWrapper>
-            <ChapterSectionActions
-              chapterSlug={chapter.slug}
-              actions={[
-                {
-                  kind: 'simple',
-                  key: 'regenerate-cover',
-                  label: 'Regenerate Cover',
-                  apiPath: 'generate-report-cover',
-                  modalTitle: 'Regenerate Cover',
-                  confirmationText: 'Regenerate the cover for this chapter? This replaces the current content.',
-                  successMessage: 'Cover regenerated.',
-                },
-                {
-                  kind: 'simple',
-                  key: 'regenerate-executive-summary',
-                  label: 'Regenerate Executive Summary',
-                  apiPath: 'generate-executive-summary',
-                  modalTitle: 'Regenerate Executive Summary',
-                  confirmationText: 'Regenerate the executive summary? This replaces the current content.',
-                  successMessage: 'Executive summary regenerated.',
-                },
-                {
-                  kind: 'simple',
-                  key: 'regenerate-seo',
-                  label: 'Regenerate SEO',
-                  apiPath: 'generate-seo-info',
-                  modalTitle: 'Regenerate SEO',
-                  confirmationText: 'Regenerate SEO metadata for every section of this chapter?',
-                  successMessage: 'SEO metadata regenerated.',
-                },
-              ]}
-            />
-          </PrivateWrapper>
-        </div>
-      </div>
-
-      {toolsCrossLinks}
-
-      <div className="space-y-12">
-        {renderSection(
-          'Overview',
-          report.reportCover ? (
+    <ChapterArticle chapter={chapter} pageTitle={pageTitle} actions={actions} toolsCrossLinks={toolsCrossLinks} currentSlug="overview">
+      <div className="space-y-10">
+        <section>
+          <h2 className="text-xl font-semibold heading-color mb-3">Overview</h2>
+          {report.reportCover ? (
             <div
               className="prose max-w-none markdown markdown-body"
               dangerouslySetInnerHTML={{ __html: parseMarkdown(report.reportCover.reportCoverContent) }}
             />
           ) : (
             <p className="text-gray-500 italic">No content available</p>
-          )
+          )}
+        </section>
+
+        {tariffUpdatesSummary.length > 0 && (
+          <section>
+            <h2 className="text-xl font-semibold heading-color mb-3">Latest HTS Chapter {padded} Tariff Actions</h2>
+            <div className="space-y-4 mb-4">
+              {tariffUpdatesSummary.map((tariff, index) => (
+                <div key={index} className="bg-gray-800 rounded-md p-4">
+                  <h3 className="font-bold text-lg mb-2">{tariff.countryName}</h3>
+                  <div dangerouslySetInnerHTML={{ __html: parseMarkdown(tariff.newChangesFirstSentence) }} className="markdown markdown-body" />
+                </div>
+              ))}
+            </div>
+            <div>
+              <a href={chapterSectionHref(chapter.slug, 'tariff-updates')} className="link-color underline font-medium">
+                See full country breakdown
+              </a>
+            </div>
+          </section>
         )}
 
-        {tariffUpdatesSummary.length > 0 &&
-          renderSection(
-            `Latest HTS Chapter ${padded} Tariff Actions`,
-            <div>
-              <div className="space-y-4 mb-4">
-                {tariffUpdatesSummary.map((tariff, index) => (
-                  <div key={index} className="mb-6">
-                    <h3 className="font-bold text-lg mb-2">{tariff.countryName}</h3>
-                    <div dangerouslySetInnerHTML={{ __html: parseMarkdown(tariff.newChangesFirstSentence) }} className="markdown markdown-body" />
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4">
-                <a href={chapterSectionHref(chapter.slug, 'tariff-updates')} className="link-color underline font-medium">
-                  See full country breakdown
-                </a>
-              </div>
-            </div>
-          )}
-
-        {report.executiveSummary &&
-          renderSection(
-            'Executive Summary',
+        {report.executiveSummary && (
+          <section>
+            <h2 className="text-xl font-semibold heading-color mb-3">Executive Summary</h2>
             <div
               className="prose max-w-none markdown markdown-body"
               dangerouslySetInnerHTML={{ __html: parseMarkdown(report.executiveSummary.executiveSummary) }}
             />
-          )}
+          </section>
+        )}
       </div>
-    </div>
+    </ChapterArticle>
   );
 }

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
@@ -2,7 +2,6 @@ import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ChapterRelatedSections from '@/components/industry-tariff/chapter/ChapterRelatedSections';
 import ChapterSectionActions, { type ChapterSectionAction } from '@/components/industry-tariff/chapter/ChapterSectionActions';
 import { ChapterRouteInfo } from '@/utils/tariff-reports/chapter-route-helpers';
-import { Layers } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface ChapterPlaceholderProps {
@@ -32,12 +31,6 @@ export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionS
         <header className="mb-6 pb-4 border-b border-color">
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div className="flex-1">
-              <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
-                <Layers className="h-4 w-4 text-emerald-400" />
-                <span className="font-medium text-emerald-400">HTS Chapter {padded}</span>
-                <span aria-hidden>·</span>
-                <span>{chapter.title}</span>
-              </div>
               <h1 className="text-2xl md:text-3xl font-bold tracking-tight heading-color">{pageTitle}</h1>
               <p className="mt-3 max-w-3xl text-muted-foreground">{description}</p>
             </div>

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterPlaceholder.tsx
@@ -1,8 +1,8 @@
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
+import ChapterRelatedSections from '@/components/industry-tariff/chapter/ChapterRelatedSections';
 import ChapterSectionActions, { type ChapterSectionAction } from '@/components/industry-tariff/chapter/ChapterSectionActions';
-import { CHAPTER_REPORT_SECTIONS, ChapterRouteInfo, chapterCoverHref, chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
-import { ArrowRight, Layers } from 'lucide-react';
-import Link from 'next/link';
+import { ChapterRouteInfo } from '@/utils/tariff-reports/chapter-route-helpers';
+import { Layers } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface ChapterPlaceholderProps {
@@ -22,65 +22,43 @@ interface ChapterPlaceholderProps {
 
 export default function ChapterPlaceholder({ chapter, pageTitle, currentSectionSlug, description, actions, toolsCrossLinks }: ChapterPlaceholderProps) {
   const padded = chapter.number.toString().padStart(2, '0');
-  const otherSections = CHAPTER_REPORT_SECTIONS.filter((s) => s.slug !== currentSectionSlug);
+  const currentSlug = currentSectionSlug ?? 'overview';
 
   return (
-    <div className="py-6">
-      <header className="mb-8 border-b border-color pb-6">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
-              <Layers className="h-4 w-4 text-emerald-400" />
-              <span className="font-medium text-emerald-400">HTS Chapter {padded}</span>
-              <span aria-hidden>·</span>
-              <span>{chapter.title}</span>
+    <div className="py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8">
+        {toolsCrossLinks}
+
+        <header className="mb-6 pb-4 border-b border-color">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="flex-1">
+              <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+                <Layers className="h-4 w-4 text-emerald-400" />
+                <span className="font-medium text-emerald-400">HTS Chapter {padded}</span>
+                <span aria-hidden>·</span>
+                <span>{chapter.title}</span>
+              </div>
+              <h1 className="text-2xl md:text-3xl font-bold tracking-tight heading-color">{pageTitle}</h1>
+              <p className="mt-3 max-w-3xl text-muted-foreground">{description}</p>
             </div>
-            <h1 className="text-3xl font-bold tracking-tight">{pageTitle}</h1>
-            <p className="mt-3 max-w-3xl text-muted-foreground">{description}</p>
+            {actions && actions.length > 0 && (
+              <PrivateWrapper>
+                <ChapterSectionActions chapterSlug={chapter.slug} actions={actions} />
+              </PrivateWrapper>
+            )}
           </div>
-          {actions && actions.length > 0 && (
-            <PrivateWrapper>
-              <ChapterSectionActions chapterSlug={chapter.slug} actions={actions} />
-            </PrivateWrapper>
-          )}
-        </div>
-      </header>
+        </header>
 
-      {toolsCrossLinks}
+        <section className="rounded-lg border border-gray-700/60 bg-gray-800/40 p-5">
+          <h2 className="text-lg font-semibold">Detailed analysis is being prepared</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            We&apos;re building out the full tariff analysis for HTS Chapter {padded} ({chapter.title}). Use the navigation below to explore the sections of
+            this chapter as content rolls out.
+          </p>
+        </section>
 
-      <section className="mb-10 rounded-2xl border border-color background-color p-6">
-        <h2 className="text-lg font-semibold">Detailed analysis is being prepared</h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          We&apos;re building out the full tariff analysis for HTS Chapter {padded} ({chapter.title}). Use the navigation below to explore the sections of this
-          chapter as content rolls out.
-        </p>
-      </section>
-
-      <section className="mb-10">
-        <h2 className="mb-4 text-lg font-semibold">Sections in this chapter</h2>
-        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <li>
-            <Link
-              href={chapterCoverHref(chapter.slug)}
-              className="group flex items-center justify-between rounded-lg border border-color background-color px-4 py-3 transition hover:border-emerald-500/60 hover:bg-emerald-500/5"
-            >
-              <span className="font-medium">Chapter overview</span>
-              <ArrowRight className="h-4 w-4 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-emerald-400" />
-            </Link>
-          </li>
-          {otherSections.map((section) => (
-            <li key={section.slug}>
-              <Link
-                href={chapterSectionHref(chapter.slug, section.slug)}
-                className="group flex items-center justify-between rounded-lg border border-color background-color px-4 py-3 transition hover:border-emerald-500/60 hover:bg-emerald-500/5"
-              >
-                <span className="font-medium">{section.label}</span>
-                <ArrowRight className="h-4 w-4 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-emerald-400" />
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </section>
+        <ChapterRelatedSections chapter={chapter} currentSlug={currentSlug} />
+      </article>
     </div>
   );
 }

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterRelatedSections.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterRelatedSections.tsx
@@ -1,0 +1,48 @@
+import { CHAPTER_REPORT_SECTIONS, chapterCoverHref, chapterSectionHref, type ChapterRouteInfo } from '@/utils/tariff-reports/chapter-route-helpers';
+import Link from 'next/link';
+
+interface ChapterRelatedSectionsProps {
+  chapter: ChapterRouteInfo;
+  // Slug of the current sub-section, or 'overview' on the chapter cover page. The matching link is
+  // excluded from the related grid so the user only sees pages they aren't already on.
+  currentSlug: string;
+}
+
+// Bottom-of-card "More HTS Chapter X sections" navigation. Replaces the left sidebar from the
+// previous layout — same set of links, just moved to the end of the article in the stock-page
+// style (cf. TickerRelatedSections / "More OMC analyses").
+export default function ChapterRelatedSections({ chapter, currentSlug }: ChapterRelatedSectionsProps): JSX.Element | null {
+  const padded = chapter.number.toString().padStart(2, '0');
+  const chapterLabel = `HTS Chapter ${padded} — ${chapter.title}`;
+
+  const items: Array<{ href: string; label: string }> = [];
+
+  if (currentSlug !== 'overview') {
+    items.push({ href: chapterCoverHref(chapter.slug), label: 'Overview' });
+  }
+
+  for (const section of CHAPTER_REPORT_SECTIONS) {
+    if (section.slug === currentSlug) continue;
+    items.push({ href: chapterSectionHref(chapter.slug, section.slug), label: section.label });
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <nav aria-label={`More ${chapterLabel} sections`} className="mt-10 pt-6 border-t border-color">
+      <h2 className="text-lg font-semibold mb-3">More {chapterLabel} sections</h2>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {items.map((item) => (
+          <li key={item.href} className="h-full">
+            <Link
+              href={item.href}
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
+            >
+              {chapterLabel} {item.label} &rarr;
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterRelatedSections.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterRelatedSections.tsx
@@ -8,13 +8,13 @@ interface ChapterRelatedSectionsProps {
   currentSlug: string;
 }
 
-// Bottom-of-card "More HTS Chapter X sections" navigation. Replaces the left sidebar from the
-// previous layout — same set of links, just moved to the end of the article in the stock-page
-// style (cf. TickerRelatedSections / "More OMC analyses").
+// Bottom-of-card "More Related Reports" navigation. Replaces the left sidebar from the previous
+// layout — same set of links, just moved to the end of the article in the stock-page style
+// (cf. TickerRelatedSections / "More OMC analyses"). Card labels intentionally omit the chapter
+// title because the HTS chapter titles ("Dairy produce; birds eggs; natural honey; edible
+// products of animal origin, not elsewhere specified or included") are long enough to drown out
+// the per-section labels.
 export default function ChapterRelatedSections({ chapter, currentSlug }: ChapterRelatedSectionsProps): JSX.Element | null {
-  const padded = chapter.number.toString().padStart(2, '0');
-  const chapterLabel = `HTS Chapter ${padded} — ${chapter.title}`;
-
   const items: Array<{ href: string; label: string }> = [];
 
   if (currentSlug !== 'overview') {
@@ -29,8 +29,8 @@ export default function ChapterRelatedSections({ chapter, currentSlug }: Chapter
   if (items.length === 0) return null;
 
   return (
-    <nav aria-label={`More ${chapterLabel} sections`} className="mt-10 pt-6 border-t border-color">
-      <h2 className="text-lg font-semibold mb-3">More {chapterLabel} sections</h2>
+    <nav aria-label="More related reports" className="mt-10 pt-6 border-t border-color">
+      <h2 className="text-lg font-semibold mb-3">More Related Reports</h2>
       <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
         {items.map((item) => (
           <li key={item.href} className="h-full">
@@ -38,7 +38,7 @@ export default function ChapterRelatedSections({ chapter, currentSlug }: Chapter
               href={item.href}
               className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
             >
-              {chapterLabel} {item.label} &rarr;
+              {item.label} &rarr;
             </Link>
           </li>
         ))}

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterToolsBar.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterToolsBar.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+export interface ChapterToolLink {
+  href: string;
+  label: string;
+  description: string;
+  icon: ReactNode;
+  // Tailwind color stem (e.g. "indigo", "emerald"). Used for chip tinting so multiple tools
+  // get a subtle visual distinction without going off-palette.
+  tone?: 'indigo' | 'emerald';
+}
+
+interface ChapterToolsBarProps {
+  links: ChapterToolLink[];
+}
+
+const TONE_CLASSES: Record<NonNullable<ChapterToolLink['tone']>, string> = {
+  indigo: 'bg-indigo-500/10 text-indigo-300 ring-indigo-500/30 hover:bg-indigo-500/20 hover:text-indigo-200',
+  emerald: 'bg-emerald-500/10 text-emerald-300 ring-emerald-500/30 hover:bg-emerald-500/20 hover:text-emerald-200',
+};
+
+// Compact in-card "Tools for this chapter" bar. Renders as a horizontal pill row at the top of the
+// chapter article card — lighter than the full TariffCrossLinks grid so it doesn't compete with
+// the article body for attention while still giving quick access to the Tariff Calculator and the
+// HTS chapter browser.
+export default function ChapterToolsBar({ links }: ChapterToolsBarProps): JSX.Element | null {
+  if (links.length === 0) return null;
+  return (
+    <div className="mb-6 flex flex-wrap items-center gap-2 rounded-lg border border-gray-700/60 bg-gray-800/40 px-3 py-2">
+      <span className="text-xs font-semibold uppercase tracking-wider text-gray-400">Tools for this chapter</span>
+      <span aria-hidden className="text-gray-600">
+        ·
+      </span>
+      {links.map((link) => {
+        const tone = link.tone ?? 'indigo';
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            title={link.description}
+            className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset transition-colors sm:text-sm ${TONE_CLASSES[tone]}`}
+          >
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center">{link.icon}</span>
+            <span>{link.label}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/insights-ui/src/components/industry-tariff/chapter/ChapterToolsCrossLinks.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/ChapterToolsCrossLinks.tsx
@@ -1,4 +1,4 @@
-import TariffCrossLinks, { type TariffCrossLink } from '@/components/tariff-cross-links/TariffCrossLinks';
+import ChapterToolsBar, { type ChapterToolLink } from '@/components/industry-tariff/chapter/ChapterToolsBar';
 import { getHtsChapterRefByNumber } from '@/utils/tariff-cross-links/hts-chapter-ref';
 import type { ChapterRouteInfo } from '@/utils/tariff-reports/chapter-route-helpers';
 import { Calculator, ListTree } from 'lucide-react';
@@ -10,23 +10,25 @@ export async function renderChapterToolsCrossLinks(chapter: ChapterRouteInfo): P
   const padded = chapter.number.toString().padStart(2, '0');
   const htsChapter = await getHtsChapterRefByNumber(chapter.number);
 
-  const links: TariffCrossLink[] = [
+  const links: ChapterToolLink[] = [
     {
       href: '/tariff-calculator',
-      title: 'Tariff Calculator',
+      label: 'Tariff Calculator',
       description: `Estimate landed US duty for goods in HTS Chapter ${padded} — base rate plus Section 232, 301, and IEEPA fees.`,
-      icon: <Calculator className="h-5 w-5" />,
+      icon: <Calculator className="h-4 w-4" />,
+      tone: 'indigo',
     },
   ];
 
   if (htsChapter) {
     links.push({
       href: htsChapter.href,
-      title: `HTS Chapter ${padded} — ${chapter.title}`,
+      label: `HTS Chapter ${padded} Codes`,
       description: 'Browse every HTS code in this chapter, with general rate, Column 2, special rates, and units of quantity.',
-      icon: <ListTree className="h-5 w-5" />,
+      icon: <ListTree className="h-4 w-4" />,
+      tone: 'emerald',
     });
   }
 
-  return <TariffCrossLinks heading="Tools for this chapter" links={links} />;
+  return <ChapterToolsBar links={links} />;
 }

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -89,14 +89,10 @@ interface ChapterArticleHeaderProps {
 }
 
 function ChapterArticleHeader({ chapter, pageTitle, actions }: ChapterArticleHeaderProps): JSX.Element {
-  const padded = chapter.number.toString().padStart(2, '0');
   return (
     <header className="mb-6 pb-4 border-b border-color">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="flex-1">
-          <div className="text-sm text-muted-foreground mb-1">
-            HTS Chapter {padded} — {chapter.title}
-          </div>
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight heading-color">{pageTitle}</h1>
         </div>
         {actions.length > 0 && (

--- a/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
+++ b/insights-ui/src/components/industry-tariff/chapter/chapter-section-page.tsx
@@ -1,5 +1,6 @@
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import ChapterPlaceholder from '@/components/industry-tariff/chapter/ChapterPlaceholder';
+import ChapterRelatedSections from '@/components/industry-tariff/chapter/ChapterRelatedSections';
 import ChapterSectionActions, { type ChapterSectionAction } from '@/components/industry-tariff/chapter/ChapterSectionActions';
 import { renderChapterToolsCrossLinks } from '@/components/industry-tariff/chapter/ChapterToolsCrossLinks';
 import { CountryNavigation } from '@/components/industry-tariff/renderers/CountryNavigation';
@@ -16,6 +17,7 @@ import { ChapterRouteInfo, chapterSectionHref, getChapterSectionCopy } from '@/u
 import { tariffReportTag } from '@/utils/tariff-report-tags';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import type { ReactNode } from 'react';
 
 // Small wrappers used by every chapter section page (`tariff-updates`, `understand-industry`, ...).
 // Keeps the per-route page.tsx files to a few lines each — same fetch/redirect/render flow, only
@@ -80,22 +82,22 @@ export async function buildChapterSectionMetadata(chapterSlug: string, sectionSl
   };
 }
 
-interface ChapterSectionHeaderProps {
+interface ChapterArticleHeaderProps {
   chapter: ChapterRouteInfo;
   pageTitle: string;
   actions: ChapterSectionAction[];
 }
 
-function ChapterSectionHeader({ chapter, pageTitle, actions }: ChapterSectionHeaderProps): JSX.Element {
+function ChapterArticleHeader({ chapter, pageTitle, actions }: ChapterArticleHeaderProps): JSX.Element {
   const padded = chapter.number.toString().padStart(2, '0');
   return (
-    <div className="mb-8 pb-4 border-b border-gray-200">
-      <div className="flex items-start justify-between gap-3">
-        <div>
+    <header className="mb-6 pb-4 border-b border-color">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="flex-1">
           <div className="text-sm text-muted-foreground mb-1">
             HTS Chapter {padded} — {chapter.title}
           </div>
-          <h1 className="text-3xl font-bold heading-color">{pageTitle}</h1>
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight heading-color">{pageTitle}</h1>
         </div>
         {actions.length > 0 && (
           <PrivateWrapper>
@@ -103,6 +105,35 @@ function ChapterSectionHeader({ chapter, pageTitle, actions }: ChapterSectionHea
           </PrivateWrapper>
         )}
       </div>
+    </header>
+  );
+}
+
+// Outer article wrapper shared by the chapter cover and every chapter section page. Mirrors the
+// stock-detail card on /stocks/<EX>/<TK>/<section> — single `bg-gray-900` card with header at
+// the top, the section body in the middle, and related-section navigation + footer at the bottom.
+interface ChapterArticleProps {
+  chapter: ChapterRouteInfo;
+  pageTitle: string;
+  actions?: ChapterSectionAction[];
+  // Pre-rendered tools bar from renderChapterToolsCrossLinks().
+  toolsCrossLinks: ReactNode;
+  // The section's main content (cover overview, tariff-updates, etc.).
+  children: ReactNode;
+  // Slug used by ChapterRelatedSections to omit the current page from the related grid.
+  // Pass 'overview' on the chapter cover.
+  currentSlug: string;
+}
+
+export function ChapterArticle({ chapter, pageTitle, actions = [], toolsCrossLinks, children, currentSlug }: ChapterArticleProps): JSX.Element {
+  return (
+    <div className="py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8">
+        {toolsCrossLinks}
+        <ChapterArticleHeader chapter={chapter} pageTitle={pageTitle} actions={actions} />
+        {children}
+        <ChapterRelatedSections chapter={chapter} currentSlug={currentSlug} />
+      </article>
     </div>
   );
 }
@@ -202,33 +233,31 @@ function renderSectionBody(sectionSlug: string, report: IndustryTariffReport): J
           {tariffUpdates.countryNames?.length ? <CountryNavigation countries={tariffUpdates.countryNames} /> : null}
           {tariffUpdates.countrySpecificTariffs.map((countryTariff, index) => {
             const sectionId = `country-${countryTariff.countryName.toLowerCase().replace(/\s+/g, '-')}`;
-            return <CountryTariffRenderer key={index} countryTariff={countryTariff} sectionId={sectionId} />;
+            return <CountryTariffRenderer key={index} countryTariff={countryTariff} sectionId={sectionId} flat />;
           })}
         </div>
       );
     }
     case 'understand-industry': {
       if (!report.understandIndustry) return null;
-      return <UnderstandIndustryRenderer understandIndustry={report.understandIndustry} />;
+      return <UnderstandIndustryRenderer understandIndustry={report.understandIndustry} flat />;
     }
     case 'industry-areas': {
       if (!report.industryAreasSections) return null;
       const html = parseMarkdown(getMarkdownContentForIndustryAreas(report.industryAreasSections));
       return (
-        <div className="bg-gray-900 rounded-lg p-2 shadow-sm">
-          <div className="markdown-body prose max-w-none px-2">
-            <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
-          </div>
+        <div className="markdown-body prose max-w-none">
+          <div className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
         </div>
       );
     }
     case 'final-conclusion': {
       if (!report.finalConclusion) return null;
-      return <FinalConclusionRenderer finalConclusion={report.finalConclusion} />;
+      return <FinalConclusionRenderer finalConclusion={report.finalConclusion} flat />;
     }
     case 'tariff-engineering': {
       if (!report.tariffEngineering) return null;
-      return <TariffEngineeringRenderer tariffEngineering={report.tariffEngineering} />;
+      return <TariffEngineeringRenderer tariffEngineering={report.tariffEngineering} flat />;
     }
     default:
       return null;
@@ -260,10 +289,8 @@ export async function renderChapterSection(chapterSlug: string, sectionSlug: str
   }
 
   return (
-    <div className="mx-auto max-w-7xl py-2">
-      <ChapterSectionHeader chapter={chapter} pageTitle={copy.pageTitle} actions={actions} />
-      {toolsCrossLinks}
+    <ChapterArticle chapter={chapter} pageTitle={copy.pageTitle} actions={actions} toolsCrossLinks={toolsCrossLinks} currentSlug={sectionSlug}>
       {body}
-    </div>
+    </ChapterArticle>
   );
 }

--- a/insights-ui/src/components/industry-tariff/renderers/CountryTariffRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/CountryTariffRenderer.tsx
@@ -5,13 +5,67 @@ import { parseMarkdown } from '@/util/parse-markdown';
 interface CountryTariffRendererProps {
   countryTariff: CountrySpecificTariff;
   sectionId?: string;
+  // When true, render as a bg-gray-800 inner card (factor-analysis style) instead of a
+  // standalone bg-gray-900 card — designed to sit inside a single outer article card on the
+  // chapter pages.
+  flat?: boolean;
 }
 
 /**
  * Renders a CountrySpecificTariff object with styled components
  * This replaces the markdown generation logic from render-tariff-markdown.ts
  */
-export const CountryTariffRenderer: React.FC<CountryTariffRendererProps> = ({ countryTariff, sectionId }) => {
+export const CountryTariffRenderer: React.FC<CountryTariffRendererProps> = ({ countryTariff, sectionId, flat = false }) => {
+  if (flat) {
+    return (
+      <div id={sectionId} className="bg-gray-800 rounded-md p-4 sm:p-5">
+        <h3 className="text-lg font-bold heading-color mb-3">{countryTariff.countryName}</h3>
+
+        <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(countryTariff.tariffDetails) }} />
+
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-1">Existing Trade Agreements</h4>
+          <div
+            className="prose max-w-none markdown markdown-body"
+            dangerouslySetInnerHTML={{ __html: parseMarkdown(countryTariff.existingTradeAmountAndAgreement) }}
+          />
+        </div>
+
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-1">New Tariff Changes</h4>
+          <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(countryTariff.newChanges) }} />
+        </div>
+
+        {countryTariff.tariffChangesForIndustrySubArea && countryTariff.tariffChangesForIndustrySubArea.length > 0 && (
+          <div className="mt-4">
+            <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-1">Impact on Industry Sub-Areas</h4>
+            <ul className="list-disc pl-5 space-y-2">
+              {countryTariff.tariffChangesForIndustrySubArea.map((change, index) => (
+                <li key={index} className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(change) }} />
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-1">Trade Impacted by New Tariff</h4>
+          <div
+            className="prose max-w-none markdown markdown-body"
+            dangerouslySetInnerHTML={{ __html: parseMarkdown(countryTariff.tradeImpactedByNewTariff) }}
+          />
+        </div>
+
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-1">Trade Exempted by New Tariff</h4>
+          <div
+            className="prose max-w-none markdown markdown-body"
+            dangerouslySetInnerHTML={{ __html: parseMarkdown(countryTariff.tradeExemptedByNewTariff) }}
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div id={sectionId} className="bg-gray-900 rounded-lg shadow-sm overflow-hidden">
       {/* Country Name Header */}

--- a/insights-ui/src/components/industry-tariff/renderers/FinalConclusionRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/FinalConclusionRenderer.tsx
@@ -4,13 +4,16 @@ import { parseMarkdown } from '@/util/parse-markdown';
 
 interface FinalConclusionRendererProps {
   finalConclusion: FinalConclusion;
+  // When true, render without nested gray-900 cards — sections become H2 headings + content,
+  // designed to sit inside a single outer article card (chapter pages).
+  flat?: boolean;
 }
 
 /**
  * Renders a FinalConclusion object with styled components
  * This replaces the markdown generation logic from render-tariff-markdown.ts
  */
-export const FinalConclusionRenderer: React.FC<FinalConclusionRendererProps> = ({ finalConclusion }) => {
+export const FinalConclusionRenderer: React.FC<FinalConclusionRendererProps> = ({ finalConclusion, flat = false }) => {
   const title = typeof finalConclusion?.title === 'string' ? finalConclusion.title : '';
   const conclusionBrief = typeof finalConclusion?.conclusionBrief === 'string' ? finalConclusion.conclusionBrief : '';
   const positive = finalConclusion?.positiveImpacts;
@@ -25,9 +28,48 @@ export const FinalConclusionRenderer: React.FC<FinalConclusionRendererProps> = (
   const hasAnyContent = title || conclusionBrief || positiveTitle || positiveBody || negativeTitle || negativeBody || finalStatements;
 
   if (!hasAnyContent) {
+    if (flat) {
+      return <p className="text-gray-500 italic">No content available</p>;
+    }
     return (
       <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
         <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
+  if (flat) {
+    return (
+      <div className="space-y-8">
+        {(title || conclusionBrief) && (
+          <section>
+            {title && <h2 className="text-2xl font-bold heading-color mb-3">{title}</h2>}
+            {conclusionBrief && (
+              <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(conclusionBrief) }} />
+            )}
+          </section>
+        )}
+
+        {(positiveTitle || positiveBody) && (
+          <section>
+            {positiveTitle && <h2 className="text-xl font-semibold heading-color mb-3">{positiveTitle}</h2>}
+            {positiveBody && <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(positiveBody) }} />}
+          </section>
+        )}
+
+        {(negativeTitle || negativeBody) && (
+          <section>
+            {negativeTitle && <h2 className="text-xl font-semibold heading-color mb-3">{negativeTitle}</h2>}
+            {negativeBody && <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(negativeBody) }} />}
+          </section>
+        )}
+
+        {finalStatements && (
+          <section>
+            <h2 className="text-xl font-semibold heading-color mb-3">Final Statements</h2>
+            <div className="prose max-w-none markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(finalStatements) }} />
+          </section>
+        )}
       </div>
     );
   }

--- a/insights-ui/src/components/industry-tariff/renderers/TariffEngineeringRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/TariffEngineeringRenderer.tsx
@@ -4,6 +4,10 @@ import { parseMarkdown } from '@/util/parse-markdown';
 
 interface TariffEngineeringRendererProps {
   tariffEngineering: TariffEngineering;
+  // When true, render without nested gray-900 cards — sections become H2 headings + content
+  // and per-strategy items become bg-gray-800 inner cards (factor-analysis style), designed to
+  // sit inside a single outer article card on chapter pages.
+  flat?: boolean;
 }
 
 function MarkdownBlock({ markdown }: { markdown: string }): JSX.Element {
@@ -21,7 +25,138 @@ function SectionCard({ heading, children }: { heading: string; children: React.R
   );
 }
 
-export const TariffEngineeringRenderer: React.FC<TariffEngineeringRendererProps> = ({ tariffEngineering }) => {
+function FlatSection({ heading, children }: { heading: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <section>
+      <h2 className="text-xl font-semibold heading-color mb-3">{heading}</h2>
+      {children}
+    </section>
+  );
+}
+
+interface ClassificationLever {
+  leverTitle?: string;
+  currentClassification?: string;
+  engineeredClassification?: string;
+  basisForReclassification?: string;
+  dutyDelta?: string;
+}
+
+function ClassificationLeversTable({ levers }: { levers: ClassificationLever[] }): JSX.Element {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-700 text-sm">
+        <thead className="bg-gray-800/60">
+          <tr>
+            <th className="px-3 py-2 text-left font-semibold">Lever</th>
+            <th className="px-3 py-2 text-left font-semibold">Current Classification</th>
+            <th className="px-3 py-2 text-left font-semibold">Engineered Classification</th>
+            <th className="px-3 py-2 text-left font-semibold">Basis</th>
+            <th className="px-3 py-2 text-left font-semibold">Duty Delta</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-700">
+          {levers.map((lever, idx) => {
+            const leverTitle = typeof lever?.leverTitle === 'string' ? lever.leverTitle : '';
+            const currentClassification = typeof lever?.currentClassification === 'string' ? lever.currentClassification : '';
+            const engineeredClassification = typeof lever?.engineeredClassification === 'string' ? lever.engineeredClassification : '';
+            const basisForReclassification = typeof lever?.basisForReclassification === 'string' ? lever.basisForReclassification : '';
+            const dutyDelta = typeof lever?.dutyDelta === 'string' ? lever.dutyDelta : '';
+            return (
+              <tr key={idx} className="align-top">
+                <td className="px-3 py-3 font-medium">{leverTitle}</td>
+                <td className="px-3 py-3">
+                  <MarkdownBlock markdown={currentClassification} />
+                </td>
+                <td className="px-3 py-3">
+                  <MarkdownBlock markdown={engineeredClassification} />
+                </td>
+                <td className="px-3 py-3">
+                  <MarkdownBlock markdown={basisForReclassification} />
+                </td>
+                <td className="px-3 py-3">
+                  <MarkdownBlock markdown={dutyDelta} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface Strategy {
+  title?: string;
+  technique?: string;
+  applicabilityToChapter?: string;
+  potentialDutyImpact?: string;
+  implementationSteps?: string[];
+  risksAndCaveats?: string;
+  precedent?: string;
+}
+
+function StrategyCard({ strategy, flat }: { strategy: Strategy; flat: boolean }): JSX.Element {
+  const stTitle = typeof strategy?.title === 'string' ? strategy.title : '';
+  const technique = typeof strategy?.technique === 'string' ? strategy.technique : '';
+  const applicability = typeof strategy?.applicabilityToChapter === 'string' ? strategy.applicabilityToChapter : '';
+  const dutyImpact = typeof strategy?.potentialDutyImpact === 'string' ? strategy.potentialDutyImpact : '';
+  const steps = Array.isArray(strategy?.implementationSteps) ? strategy.implementationSteps : [];
+  const risks = typeof strategy?.risksAndCaveats === 'string' ? strategy.risksAndCaveats : '';
+  const precedent = typeof strategy?.precedent === 'string' ? strategy.precedent : '';
+
+  // Flat variant uses bg-gray-800 inner card (factor-analysis style); legacy uses border + bg-gray-900/40.
+  const cardClass = flat ? 'rounded-md bg-gray-800 p-4' : 'rounded-lg border border-gray-700 bg-gray-900/40 p-4';
+
+  return (
+    <div className={cardClass}>
+      {stTitle && <h3 className="text-lg font-semibold heading-color mb-2">{stTitle}</h3>}
+      {technique && (
+        <div className="mb-3">
+          <MarkdownBlock markdown={technique} />
+        </div>
+      )}
+      {applicability && (
+        <div className="mb-3">
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Applicability to chapter</div>
+          <MarkdownBlock markdown={applicability} />
+        </div>
+      )}
+      {dutyImpact && (
+        <div className="mb-3">
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Potential duty impact</div>
+          <MarkdownBlock markdown={dutyImpact} />
+        </div>
+      )}
+      {steps.length > 0 && (
+        <div className="mb-3">
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Implementation steps</div>
+          <ol className="list-decimal list-inside space-y-1">
+            {steps.map((step, sIdx) => (
+              <li key={sIdx}>
+                <span className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(step) }} />
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {risks && (
+        <div className="mb-3">
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Risks &amp; caveats</div>
+          <MarkdownBlock markdown={risks} />
+        </div>
+      )}
+      {precedent && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Precedent</div>
+          <MarkdownBlock markdown={precedent} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TariffEngineeringRenderer: React.FC<TariffEngineeringRendererProps> = ({ tariffEngineering, flat = false }) => {
   const title = typeof tariffEngineering?.title === 'string' ? tariffEngineering.title : '';
   const overview = typeof tariffEngineering?.overview === 'string' ? tariffEngineering.overview : '';
   const classificationLevers = Array.isArray(tariffEngineering?.classificationLevers) ? tariffEngineering.classificationLevers : [];
@@ -44,9 +179,64 @@ export const TariffEngineeringRenderer: React.FC<TariffEngineeringRendererProps>
     bottomLine;
 
   if (!hasAnyContent) {
+    if (flat) {
+      return <p className="text-gray-500 italic">No content available</p>;
+    }
     return (
       <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
         <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
+  if (flat) {
+    return (
+      <div className="space-y-8">
+        {(title || overview) && (
+          <section>
+            {title && <h2 className="text-2xl font-bold heading-color mb-3">{title}</h2>}
+            {overview && <MarkdownBlock markdown={overview} />}
+          </section>
+        )}
+        {classificationLevers.length > 0 && (
+          <FlatSection heading="Classification Levers">
+            <ClassificationLeversTable levers={classificationLevers} />
+          </FlatSection>
+        )}
+        {strategies.length > 0 && (
+          <FlatSection heading="Tariff Engineering Strategies">
+            <div className="space-y-4">
+              {strategies.map((strategy, idx) => (
+                <StrategyCard key={idx} strategy={strategy} flat />
+              ))}
+            </div>
+          </FlatSection>
+        )}
+        {countryOfOriginPlaybook && (
+          <FlatSection heading="Country-of-Origin Playbook">
+            <MarkdownBlock markdown={countryOfOriginPlaybook} />
+          </FlatSection>
+        )}
+        {valuationOpportunities && (
+          <FlatSection heading="Valuation Opportunities">
+            <MarkdownBlock markdown={valuationOpportunities} />
+          </FlatSection>
+        )}
+        {ftzAndDrawback && (
+          <FlatSection heading="Foreign Trade Zones & Duty Drawback">
+            <MarkdownBlock markdown={ftzAndDrawback} />
+          </FlatSection>
+        )}
+        {complianceGuardrails && (
+          <FlatSection heading="Compliance Guardrails">
+            <MarkdownBlock markdown={complianceGuardrails} />
+          </FlatSection>
+        )}
+        {bottomLine && (
+          <FlatSection heading="Bottom Line">
+            <MarkdownBlock markdown={bottomLine} />
+          </FlatSection>
+        )}
       </div>
     );
   }
@@ -70,106 +260,16 @@ export const TariffEngineeringRenderer: React.FC<TariffEngineeringRendererProps>
 
       {classificationLevers.length > 0 && (
         <SectionCard heading="Classification Levers">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-700 text-sm">
-              <thead className="bg-gray-800/60">
-                <tr>
-                  <th className="px-3 py-2 text-left font-semibold">Lever</th>
-                  <th className="px-3 py-2 text-left font-semibold">Current Classification</th>
-                  <th className="px-3 py-2 text-left font-semibold">Engineered Classification</th>
-                  <th className="px-3 py-2 text-left font-semibold">Basis</th>
-                  <th className="px-3 py-2 text-left font-semibold">Duty Delta</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-700">
-                {classificationLevers.map((lever, idx) => {
-                  const leverTitle = typeof lever?.leverTitle === 'string' ? lever.leverTitle : '';
-                  const currentClassification = typeof lever?.currentClassification === 'string' ? lever.currentClassification : '';
-                  const engineeredClassification = typeof lever?.engineeredClassification === 'string' ? lever.engineeredClassification : '';
-                  const basisForReclassification = typeof lever?.basisForReclassification === 'string' ? lever.basisForReclassification : '';
-                  const dutyDelta = typeof lever?.dutyDelta === 'string' ? lever.dutyDelta : '';
-                  return (
-                    <tr key={idx} className="align-top">
-                      <td className="px-3 py-3 font-medium">{leverTitle}</td>
-                      <td className="px-3 py-3">
-                        <MarkdownBlock markdown={currentClassification} />
-                      </td>
-                      <td className="px-3 py-3">
-                        <MarkdownBlock markdown={engineeredClassification} />
-                      </td>
-                      <td className="px-3 py-3">
-                        <MarkdownBlock markdown={basisForReclassification} />
-                      </td>
-                      <td className="px-3 py-3">
-                        <MarkdownBlock markdown={dutyDelta} />
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          <ClassificationLeversTable levers={classificationLevers} />
         </SectionCard>
       )}
 
       {strategies.length > 0 && (
         <SectionCard heading="Tariff Engineering Strategies">
           <div className="space-y-6">
-            {strategies.map((strategy, idx) => {
-              const stTitle = typeof strategy?.title === 'string' ? strategy.title : '';
-              const technique = typeof strategy?.technique === 'string' ? strategy.technique : '';
-              const applicability = typeof strategy?.applicabilityToChapter === 'string' ? strategy.applicabilityToChapter : '';
-              const dutyImpact = typeof strategy?.potentialDutyImpact === 'string' ? strategy.potentialDutyImpact : '';
-              const steps = Array.isArray(strategy?.implementationSteps) ? strategy.implementationSteps : [];
-              const risks = typeof strategy?.risksAndCaveats === 'string' ? strategy.risksAndCaveats : '';
-              const precedent = typeof strategy?.precedent === 'string' ? strategy.precedent : '';
-              return (
-                <div key={idx} className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
-                  {stTitle && <h3 className="text-lg font-semibold heading-color mb-2">{stTitle}</h3>}
-                  {technique && (
-                    <div className="mb-3">
-                      <MarkdownBlock markdown={technique} />
-                    </div>
-                  )}
-                  {applicability && (
-                    <div className="mb-3">
-                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Applicability to chapter</div>
-                      <MarkdownBlock markdown={applicability} />
-                    </div>
-                  )}
-                  {dutyImpact && (
-                    <div className="mb-3">
-                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Potential duty impact</div>
-                      <MarkdownBlock markdown={dutyImpact} />
-                    </div>
-                  )}
-                  {steps.length > 0 && (
-                    <div className="mb-3">
-                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Implementation steps</div>
-                      <ol className="list-decimal list-inside space-y-1">
-                        {steps.map((step, sIdx) => (
-                          <li key={sIdx}>
-                            <span className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(step) }} />
-                          </li>
-                        ))}
-                      </ol>
-                    </div>
-                  )}
-                  {risks && (
-                    <div className="mb-3">
-                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Risks &amp; caveats</div>
-                      <MarkdownBlock markdown={risks} />
-                    </div>
-                  )}
-                  {precedent && (
-                    <div>
-                      <div className="text-xs uppercase tracking-wider text-gray-400 mb-1">Precedent</div>
-                      <MarkdownBlock markdown={precedent} />
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+            {strategies.map((strategy, idx) => (
+              <StrategyCard key={idx} strategy={strategy} flat={false} />
+            ))}
           </div>
         </SectionCard>
       )}

--- a/insights-ui/src/components/industry-tariff/renderers/UnderstandIndustryRenderer.tsx
+++ b/insights-ui/src/components/industry-tariff/renderers/UnderstandIndustryRenderer.tsx
@@ -4,20 +4,49 @@ import { parseMarkdown } from '@/util/parse-markdown';
 
 interface UnderstandIndustryRendererProps {
   understandIndustry: UnderstandIndustry;
+  // When true, render without nested gray-900 cards — sections are H2/H3 headings + content,
+  // designed to sit inside a single outer article card (chapter pages).
+  flat?: boolean;
 }
 
 /**
  * Renders an UnderstandIndustry object with styled components
  * This replaces the markdown generation logic from render-tariff-markdown.ts
  */
-export const UnderstandIndustryRenderer: React.FC<UnderstandIndustryRendererProps> = ({ understandIndustry }) => {
+export const UnderstandIndustryRenderer: React.FC<UnderstandIndustryRendererProps> = ({ understandIndustry, flat = false }) => {
   const sections = Array.isArray(understandIndustry?.sections) ? understandIndustry.sections : [];
   const title = typeof understandIndustry?.title === 'string' ? understandIndustry.title : '';
 
   if (!title && sections.length === 0) {
+    if (flat) {
+      return <p className="text-gray-500 italic">No content available</p>;
+    }
     return (
       <div className="bg-gray-900 rounded-lg p-6 shadow-sm">
         <p className="text-gray-500 italic">No content available</p>
+      </div>
+    );
+  }
+
+  if (flat) {
+    return (
+      <div className="space-y-8">
+        {title && <h2 className="text-2xl font-bold heading-color">{title}</h2>}
+        {sections.map((section, index) => {
+          const paragraphs = Array.isArray(section?.paragraphs) ? section.paragraphs : [];
+          const sectionTitle = typeof section?.title === 'string' ? section.title : '';
+          if (!sectionTitle && paragraphs.length === 0) return null;
+          return (
+            <section key={index}>
+              {sectionTitle && <h3 className="text-xl font-semibold heading-color mb-3">{sectionTitle}</h3>}
+              <div className="prose max-w-none space-y-4">
+                {paragraphs.map((paragraph, pIndex) => (
+                  <div key={pIndex} className="markdown markdown-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(paragraph) }} />
+                ))}
+              </div>
+            </section>
+          );
+        })}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Strip the left sidebar from `/industry-tariff-report/chapters/*` pages; the chapters layout now renders just a `PageWrapper` + breadcrumbs.
- Wrap the chapter cover and every chapter section in one outer `bg-gray-900` article card (mirrors `/stocks/<EX>/<TK>/<section>` — see `TickerCategoryReport`). Tools bar at the top, content in the middle, related-sections nav + footer at the bottom.
- New `ChapterToolsBar` compact pill row replaces the heavy `TariffCrossLinks` grid for the "Tools for this chapter" block. Tinted chips (indigo for Tariff Calculator, emerald for HTS chapter codes); descriptions kept as `title` tooltips.
- New `ChapterRelatedSections` renders "More HTS Chapter NN — Title sections" at the bottom of the article (mirrors `TickerRelatedSections` "More OMC analyses"), restoring the navigation the left sidebar previously provided.
- Added a `flat={true}` variant to `UnderstandIndustryRenderer`, `CountryTariffRenderer`, `FinalConclusionRenderer`, and `TariffEngineeringRenderer`. In flat mode they emit `H2/H3 + content` (and `bg-gray-800` inner cards for grouped items like per-country tariff blocks and per-strategy engineering items, matching the stock factor-analysis style) instead of nested `bg-gray-900` cards.
- `ChapterPlaceholder` reshaped to the same single-card layout so the "content being prepared" state stays visually consistent.

The legacy `/industry-tariff-report/[industryId]/` routes still use the sidebar layout and the non-flat renderer variants — unchanged.

## Test plan

- [ ] Visit `/industry-tariff-report/chapters/4-dairy-eggs-honey` — single dark card, compact tools bar, related-sections list at the bottom.
- [ ] Visit each sub-page (`/tariff-updates`, `/understand-industry`, `/industry-areas`, `/tariff-engineering`, `/final-conclusion`) — same layout, body content rendered flat (no nested gray-900 cards), per-country / per-strategy items rendered as `bg-gray-800` inner cards.
- [ ] Confirm "More HTS Chapter 04 — Dairy, Eggs, Honey sections" navigation excludes the current page.
- [ ] Confirm the legacy `/industry-tariff-report/<industryId>/` routes are unaffected and still show the sidebar.
- [ ] Mobile (~375px wide): article card scales, tools bar wraps, related-sections grid collapses to one column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)