### PR TITLE
Route ETF detail badges to country-scoped pages, color-code them

### DIFF
--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -311,7 +311,7 @@ function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Eleme
         </div>
       </div>
 
-      <EtfMetadataBadges assetClass={d.stockAnalyzerInfo?.assetClass} category={d.stockAnalyzerInfo?.category} className="mb-4" />
+      <EtfMetadataBadges exchange={d.exchange} assetClass={d.stockAnalyzerInfo?.assetClass} category={d.stockAnalyzerInfo?.category} className="mb-4" />
 
       {/* Summary (if available) */}
       {d.summary && d.summary.trim() && (

--- a/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
 import { getEtfGroupName, getEtfGroupKey } from '@/utils/etf-categorization-utils';
+import { getCountryByExchange, SupportedCountries, toExchange } from '@/utils/countryExchangeUtils';
 
 export interface EtfMetadataBadgesProps {
+  exchange?: string | null;
   assetClass?: string | null;
   category?: string | null;
   className?: string;
@@ -11,32 +13,51 @@ interface BadgeItem {
   label: string;
   value: string;
   href: string;
+  colorClasses: string;
 }
 
-export default function EtfMetadataBadges({ assetClass, category, className }: EtfMetadataBadgesProps): JSX.Element | null {
+const ASSET_CLASS_COLORS = 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800';
+const CATEGORY_COLORS = 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800';
+const GROUP_COLORS = 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300 hover:bg-cyan-200 dark:hover:bg-cyan-800';
+
+function getCountryPathPrefix(exchange: string | null | undefined): string {
+  if (!exchange) return '/etfs';
+  try {
+    const country = getCountryByExchange(toExchange(exchange));
+    return country === SupportedCountries.US ? '/etfs' : `/etfs/countries/${encodeURIComponent(country)}`;
+  } catch {
+    return '/etfs';
+  }
+}
+
+export default function EtfMetadataBadges({ exchange, assetClass, category, className }: EtfMetadataBadgesProps): JSX.Element | null {
   const groupName = getEtfGroupName(category);
   const groupKey = getEtfGroupKey(category);
+  const prefix = getCountryPathPrefix(exchange);
 
   const items: BadgeItem[] = [];
   if (assetClass) {
     items.push({
       label: 'Asset Class',
       value: assetClass,
-      href: `/etfs/asset-classes/${encodeURIComponent(assetClass)}`,
+      href: `${prefix}/asset-classes/${encodeURIComponent(assetClass)}`,
+      colorClasses: ASSET_CLASS_COLORS,
     });
   }
   if (category) {
     items.push({
       label: 'Category',
       value: category,
-      href: `/etfs/categories/${encodeURIComponent(category)}`,
+      href: `${prefix}/categories/${encodeURIComponent(category)}`,
+      colorClasses: CATEGORY_COLORS,
     });
   }
   if (groupName && groupKey) {
     items.push({
       label: 'Group',
       value: groupName,
-      href: `/etfs/groups/${encodeURIComponent(groupKey)}`,
+      href: `${prefix}/groups/${encodeURIComponent(groupKey)}`,
+      colorClasses: GROUP_COLORS,
     });
   }
 
@@ -48,10 +69,10 @@ export default function EtfMetadataBadges({ assetClass, category, className }: E
         <Link
           key={item.label}
           href={item.href}
-          className="inline-flex items-center gap-1 rounded-full border border-color bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-color hover:border-[#F59E0B] hover:bg-gray-700 transition-colors"
+          className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${item.colorClasses}`}
           aria-label={`View all ETFs in ${item.label}: ${item.value}`}
         >
-          <span className="text-muted-foreground">{item.label}:</span>
+          <span className="opacity-80">{item.label}:</span>
           <span>{item.value}</span>
         </Link>
       ))}

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -72,7 +72,7 @@ export default function EtfCategoryReport({
                   {formattedModifiedDate}
                 </time>
               </div>
-              <EtfMetadataBadges assetClass={assetClass} category={fundCategory} className="mt-3" />
+              <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} className="mt-3" />
             </div>
             <Link href={`/etfs/${exchange}/${symbol}`} className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1">
               View Full Report →


### PR DESCRIPTION
## Summary
- On the ETF detail page (e.g. `/etfs/TSX/HXS`), the **Asset Class**, **Category**, and **Group** badges now derive the ETF's country from its exchange and link into the country-scoped routes (`/etfs/countries/<country>/asset-classes/...`, `/etfs/countries/<country>/categories/...`, `/etfs/countries/<country>/groups/...`), matching the breadcrumb logic already in place.
- US-listed ETFs continue to link to the existing top-level routes (`/etfs/asset-classes/...`, etc.), mirroring the breadcrumb behavior.
- Each badge picks up a distinct existing color scheme (blue / purple / cyan, reusing the rounded-pill pattern already used elsewhere on the page) so the clickable nature is visually obvious.
- Both call sites of `EtfMetadataBadges` (the main detail header and the per-category analysis report card) now pass `exchange` through; if no exchange is provided the component falls back to the top-level US routes.

Previously, a Canadian ETF's badges (e.g. on `koalagains.com/etfs/TSX/HXS`) all sent users to the US-only pages, which didn't include that ETF.

## Test plan
- [ ] On Vercel preview, open `/etfs/TSX/HXS` and confirm the three badges are colored (Asset Class blue, Category purple, Group cyan), clickable, and link to `/etfs/countries/Canada/...` URLs that list the relevant Canadian ETFs.
- [ ] Open a US ETF detail page (e.g. `/etfs/NYSEARCA/SPY`) and confirm the badges still link to the top-level `/etfs/asset-classes/...`, `/etfs/categories/...`, `/etfs/groups/...` routes.
- [ ] Open a per-category analysis page (rendered via `EtfCategoryReport`) for a Canadian ETF and confirm the embedded badges also point at the country-scoped routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)