### PR TITLE
Add ETF search bar on ETF pages, reusing the stock SearchBar UI

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/search/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/search/route.ts
@@ -1,0 +1,119 @@
+import { prisma } from '@/prisma';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { Prisma } from '@prisma/client';
+import { NextRequest } from 'next/server';
+
+export interface EtfSearchResult {
+  id: string;
+  name: string;
+  symbol: string;
+  exchange: string;
+  cachedScoreEntry: {
+    finalScore: number;
+  } | null;
+}
+
+export interface EtfSearchResponse {
+  results: EtfSearchResult[];
+  totalCount: number;
+  query: string;
+}
+
+async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<EtfSearchResponse> {
+  const { spaceId } = await context.params;
+  const url = new URL(req.url);
+  const query = url.searchParams.get('q');
+  const limit = parseInt(url.searchParams.get('limit') || '10');
+
+  if (!query || query.trim().length < 1) {
+    return { results: [], totalCount: 0, query: query || '' };
+  }
+
+  const searchTerm = query.trim();
+
+  const whereClause: Prisma.EtfWhereInput = {
+    spaceId,
+    OR: [
+      { symbol: { equals: searchTerm.toUpperCase(), mode: 'insensitive' } },
+      { symbol: { startsWith: searchTerm.toUpperCase(), mode: 'insensitive' } },
+      { name: { startsWith: searchTerm, mode: 'insensitive' } },
+      { symbol: { contains: searchTerm, mode: 'insensitive' } },
+      { name: { contains: searchTerm, mode: 'insensitive' } },
+    ],
+  };
+
+  // For short queries, fetch more rows so the priority sort has room to surface
+  // the best matches before slicing to `limit`.
+  const fetchLimit = searchTerm.length <= 2 ? Math.min(limit * 4, 200) : Math.min(limit * 2, 100);
+
+  const etfs = await prisma.etf.findMany({
+    where: whereClause,
+    select: {
+      id: true,
+      name: true,
+      symbol: true,
+      exchange: true,
+      cachedScore: {
+        select: { finalScore: true },
+      },
+    },
+    take: fetchLimit,
+  });
+
+  const results: EtfSearchResult[] = etfs
+    .sort((a, b) => {
+      const searchUpper = searchTerm.toUpperCase();
+      const searchLower = searchTerm.toLowerCase();
+
+      const aSymbolExact = a.symbol.toUpperCase() === searchUpper;
+      const bSymbolExact = b.symbol.toUpperCase() === searchUpper;
+      if (aSymbolExact && !bSymbolExact) return -1;
+      if (!aSymbolExact && bSymbolExact) return 1;
+
+      const aSymbolStarts = a.symbol.toUpperCase().startsWith(searchUpper);
+      const bSymbolStarts = b.symbol.toUpperCase().startsWith(searchUpper);
+      if (aSymbolStarts && !bSymbolStarts) return -1;
+      if (!aSymbolStarts && bSymbolStarts) return 1;
+      if (aSymbolStarts && bSymbolStarts && a.symbol.length !== b.symbol.length) {
+        return a.symbol.length - b.symbol.length;
+      }
+
+      const aSymbolContains = a.symbol.toUpperCase().includes(searchUpper);
+      const bSymbolContains = b.symbol.toUpperCase().includes(searchUpper);
+      if (aSymbolContains && !bSymbolContains) return -1;
+      if (!aSymbolContains && bSymbolContains) return 1;
+      if (aSymbolContains && bSymbolContains) {
+        const aSymbolIndex = a.symbol.toUpperCase().indexOf(searchUpper);
+        const bSymbolIndex = b.symbol.toUpperCase().indexOf(searchUpper);
+        if (aSymbolIndex !== bSymbolIndex) return aSymbolIndex - bSymbolIndex;
+      }
+
+      const aNameStarts = a.name.toLowerCase().startsWith(searchLower);
+      const bNameStarts = b.name.toLowerCase().startsWith(searchLower);
+      if (aNameStarts && !bNameStarts) return -1;
+      if (!aNameStarts && bNameStarts) return 1;
+
+      const aNameContains = a.name.toLowerCase().includes(searchLower);
+      const bNameContains = b.name.toLowerCase().includes(searchLower);
+      if (aNameContains && !bNameContains) return -1;
+      if (!aNameContains && bNameContains) return 1;
+
+      const aScore = a.cachedScore?.finalScore ?? 0;
+      const bScore = b.cachedScore?.finalScore ?? 0;
+      if (bScore !== aScore) return bScore - aScore;
+
+      return a.symbol.localeCompare(b.symbol);
+    })
+    .slice(0, limit)
+    .map((etf) => ({
+      id: etf.id,
+      name: etf.name,
+      symbol: etf.symbol,
+      exchange: etf.exchange,
+      cachedScoreEntry: etf.cachedScore ? { finalScore: etf.cachedScore.finalScore } : null,
+    }));
+
+  return { results, totalCount: results.length, query: searchTerm };
+}
+
+export const GET = withErrorHandlingV2<EtfSearchResponse>(getHandler);

--- a/insights-ui/src/components/core/SearchBar/SearchBar.tsx
+++ b/insights-ui/src/components/core/SearchBar/SearchBar.tsx
@@ -10,13 +10,15 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+export type SearchKind = 'stocks' | 'etfs';
+
 export interface SearchResult {
   id: string;
   name: string;
   symbol: string;
   exchange: string;
-  industryKey: string;
-  subIndustryKey: string;
+  industryKey?: string;
+  subIndustryKey?: string;
   websiteUrl?: string | null;
   summary?: string | null;
   cachedScoreEntry: {
@@ -27,6 +29,7 @@ export interface SearchResult {
 export interface SearchBarProps {
   placeholder?: string;
   variant?: 'hero' | 'navbar';
+  kind?: SearchKind;
   onResultClick?: (result: SearchResult) => void;
   className?: string;
 }
@@ -40,12 +43,42 @@ type VariantStyles = {
   searchButton: string;
 };
 
+interface KindConfig {
+  apiPath: string;
+  detailHref: (r: SearchResult) => string;
+  viewAllHref: (q: string) => string;
+  noResultsTitle: (q: string) => string;
+  noResultsHint: string;
+  ariaLabel: string;
+}
+
+const KIND_CONFIG: Record<SearchKind, KindConfig> = {
+  stocks: {
+    apiPath: 'tickers-v1/search',
+    detailHref: (r) => `/stocks/${r.exchange}/${r.symbol}`,
+    viewAllHref: (q) => `/stocks?search=${encodeURIComponent(q)}`,
+    noResultsTitle: (q) => `No stocks found for “${q}”`,
+    noResultsHint: 'Try searching by company name or stock symbol',
+    ariaLabel: 'Search stocks',
+  },
+  etfs: {
+    apiPath: 'etfs-v1/search',
+    detailHref: (r) => `/etfs/${r.exchange}/${r.symbol}`,
+    viewAllHref: (q) => `/etfs?search=${encodeURIComponent(q)}`,
+    noResultsTitle: (q) => `No ETFs found for “${q}”`,
+    noResultsHint: 'Try searching by ETF name or ticker symbol',
+    ariaLabel: 'Search ETFs',
+  },
+};
+
 export default function SearchBar({
   placeholder = 'Search stocks by symbol or company name...',
   variant = 'hero',
+  kind = 'stocks',
   onResultClick,
   className = '',
 }: SearchBarProps): JSX.Element {
+  const config = KIND_CONFIG[kind];
   const [query, setQuery] = useState<string>('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -70,36 +103,38 @@ export default function SearchBar({
   }, []);
 
   // Debounced search function
-  const searchTickers = useCallback(async (searchQuery: string): Promise<void> => {
-    if (!searchQuery.trim() || searchQuery.length < 1) {
-      setResults([]);
-      setIsOpen(false);
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/search?q=${encodeURIComponent(searchQuery)}&limit=8`);
-
-      if (response.ok) {
-        const data: { results?: SearchResult[] } = await response.json();
-        setResults(Array.isArray(data.results) ? data.results : []);
-        // Keep dropdown open if we have results OR if we searched but found nothing
-        setIsOpen(true);
-      } else {
+  const runSearch = useCallback(
+    async (searchQuery: string): Promise<void> => {
+      if (!searchQuery.trim() || searchQuery.length < 1) {
         setResults([]);
         setIsOpen(false);
+        return;
       }
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Search error:', error);
-      setResults([]);
-      setIsOpen(false);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+
+      setIsLoading(true);
+
+      try {
+        const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/${config.apiPath}?q=${encodeURIComponent(searchQuery)}&limit=8`);
+
+        if (response.ok) {
+          const data: { results?: SearchResult[] } = await response.json();
+          setResults(Array.isArray(data.results) ? data.results : []);
+          setIsOpen(true);
+        } else {
+          setResults([]);
+          setIsOpen(false);
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Search error:', error);
+        setResults([]);
+        setIsOpen(false);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [config.apiPath]
+  );
 
   // Handle input change with debouncing
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -110,7 +145,7 @@ export default function SearchBar({
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     debounceRef.current = setTimeout((): void => {
-      void searchTickers(value);
+      void runSearch(value);
     }, 300);
   };
 
@@ -156,8 +191,7 @@ export default function SearchBar({
     if (onResultClick) {
       onResultClick(result);
     } else if (typeof window !== 'undefined') {
-      // Default navigation
-      window.location.href = `/stocks/${result.exchange}/${result.symbol}`;
+      window.location.href = config.detailHref(result);
     }
   };
 
@@ -210,8 +244,10 @@ export default function SearchBar({
 
   const styles = getVariantStyles();
 
-  // Helper to render ticker item content without Link wrapper when onResultClick is provided
-  const renderTickerItem = (result: SearchResult): JSX.Element => {
+  // Inline renderer used when we can't (or don't want to) defer to a per-row Link
+  // component — i.e. when `onResultClick` is provided, or for ETF results where
+  // we don't have a stock-specific ticker item with notes/favourites.
+  const renderInlineRow = (result: SearchResult): JSX.Element => {
     const { textColorClass, bgColorClass } = getScoreColorClasses(result.cachedScoreEntry?.finalScore ?? 0);
 
     return (
@@ -241,7 +277,7 @@ export default function SearchBar({
           className={styles.input}
           autoComplete="off"
           autoFocus={variant === 'hero'}
-          aria-label="Search stocks"
+          aria-label={config.ariaLabel}
         />
 
         {query && (
@@ -253,7 +289,7 @@ export default function SearchBar({
         {variant === 'hero' && (
           <button
             onClick={(): void => {
-              if (query.trim()) void searchTickers(query);
+              if (query.trim()) void runSearch(query);
             }}
             className={`${styles.searchButton} focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2`}
             aria-label="Search"
@@ -287,8 +323,8 @@ export default function SearchBar({
                     aria-selected={index === highlightedIndex}
                   >
                     <div className="px-3 py-2">
-                      {onResultClick ? (
-                        renderTickerItem(result)
+                      {onResultClick || kind === 'etfs' ? (
+                        renderInlineRow(result)
                       ) : (
                         <StockTickerItem
                           symbol={result.symbol}
@@ -305,7 +341,7 @@ export default function SearchBar({
                 {results.length >= 8 && (
                   <div className="p-3 text-center border-t border-gray-700/50">
                     <Link
-                      href={`/stocks?search=${encodeURIComponent(query)}`}
+                      href={config.viewAllHref(query)}
                       className="text-indigo-400 hover:text-indigo-300 text-sm transition-colors duration-200"
                       onClick={(): void => setIsOpen(false)}
                     >
@@ -317,8 +353,8 @@ export default function SearchBar({
             </Tooltip.Provider>
           ) : query.trim() && !isLoading ? (
             <div className="p-4 text-center text-gray-400">
-              <div className="text-sm">No stocks found for &ldquo;{query}&rdquo;</div>
-              <div className="text-xs mt-1 opacity-75">Try searching by company name or stock symbol</div>
+              <div className="text-sm">{config.noResultsTitle(query)}</div>
+              <div className="text-xs mt-1 opacity-75">{config.noResultsHint}</div>
             </div>
           ) : null}
         </div>

--- a/insights-ui/src/components/core/SearchBar/index.ts
+++ b/insights-ui/src/components/core/SearchBar/index.ts
@@ -1,2 +1,2 @@
 export { default } from './SearchBar';
-export type { SearchBarProps, SearchResult } from './SearchBar';
+export type { SearchBarProps, SearchResult, SearchKind } from './SearchBar';

--- a/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
@@ -30,6 +30,7 @@ interface MobileTopNavProps {
 export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, reportsDropdown, genaiDropdown }: MobileTopNavProps) {
   const pathname = usePathname() ?? '';
   const isStocksRoute = pathname.startsWith('/stocks');
+  const isEtfsRoute = pathname.startsWith('/etfs');
 
   // Fetch industries data when on stocks page
   const { data: industries, loading } = useFetchData<IndustryWithSubIndustriesAndCounts[]>(`${getBaseUrl()}/api/industries`, {}, 'Failed to load industries');
@@ -52,7 +53,7 @@ export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, report
 
         <div className="mt-6 flow-root">
           <div className="mb-4">
-            <SearchBar placeholder="Search stocks..." variant="navbar" />
+            <SearchBar placeholder={isEtfsRoute ? 'Search ETFs...' : 'Search stocks...'} variant="navbar" kind={isEtfsRoute ? 'etfs' : 'stocks'} />
           </div>
 
           <div className="-my-6 divide-y divide-gray-500/10 dark:divide-white/10">

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -46,6 +46,7 @@ export default function TopNav() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pathname = usePathname() ?? ''; // <-- safe for null
   const isStocksRoute = pathname.startsWith('/stocks');
+  const isEtfsRoute = pathname.startsWith('/etfs');
   const isHomeRoute = pathname === '/';
 
   // Wrap the whole header in a parent with className="dark" to force dark mode here
@@ -64,7 +65,7 @@ export default function TopNav() {
             {!isHomeRoute && (
               <div className="hidden ml-4 lg:block lg:w-auto lg:min-w-[24rem]">
                 <div className="max-w-full lg:max-w-none">
-                  <SearchBar placeholder="Search stocks..." variant="navbar" />
+                  <SearchBar placeholder={isEtfsRoute ? 'Search ETFs...' : 'Search stocks...'} variant="navbar" kind={isEtfsRoute ? 'etfs' : 'stocks'} />
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Reuses the existing \`SearchBar\` UI for ETFs by adding a \`kind: 'stocks' | 'etfs'\` prop (default \`'stocks'\`). The same component now drives both flavors — only the API endpoint, default navigation target, view-all link, and a few aria-labels / empty-state strings change between kinds.
- \`TopNav\` and \`MobileTopNav\` now pick the kind based on \`pathname.startsWith('/etfs')\`, so every page under \`/etfs\` (listing, country pages, group/category/asset-class pages, individual ETF detail pages) gets the ETF search bar in the same slot that stock pages use today. No per-page wiring needed.
- Adds a new \`GET /api/<spaceId>/etfs-v1/search?q=&limit=\` endpoint mirroring the existing \`tickers-v1/search\` route: same priority-based sort (exact symbol > symbol startsWith > symbol contains > name startsWith > name contains > score > alphabetical), same response shape (minus the unused \`industryKey\`/\`subIndustryKey\` fields, which were never read by the SearchBar component anyway).
- \`SearchResult.industryKey\` / \`subIndustryKey\` were demoted to optional so the ETF result shape fits the same type without forcing empty strings.
- For ETF results, the dropdown renders rows inline (matching the existing \`onResultClick\` path) instead of routing through \`StockTickerItem\`, which is stock-specific (favourites/notes + hardcoded \`/stocks/...\` link). Stock results continue to use \`StockTickerItem\` exactly as before.

## Test plan
- [ ] On Vercel preview, visit \`/etfs\`, \`/etfs/TSX/HXS\`, \`/etfs/countries/Canada/asset-classes/Equity\`, and \`/etfs/countries/Canada/groups\` — confirm the search bar at the top reads \"Search ETFs...\", returns ETF matches, and clicking a result lands on the corresponding \`/etfs/<exchange>/<symbol>\` page.
- [ ] On the same preview, visit \`/stocks/NYSE/AIN\` and \`/stocks/industries/...\` — confirm the search bar still says \"Search stocks...\" and behaves exactly as before (including the rich \`StockTickerItem\` rendering).
- [ ] Verify the mobile menu's search bar swaps kinds the same way (open the mobile hamburger on an ETF page and on a stock page).
- [ ] Try a query with 8+ ETF matches and confirm the \"View all results for ...\" link goes to \`/etfs?search=...\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)