### PR TITLE
Add ETF provider pages and detail-page Provider badge

### DIFF
--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -129,6 +129,7 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
         updatedAt={modifiedDate}
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
+        issuer={etfData.stockAnalyzerInfo?.issuer}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
@@ -129,6 +129,7 @@ export default async function FuturePerformanceOutlookPage({ params }: { params:
         updatedAt={modifiedDate}
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
+        issuer={etfData.stockAnalyzerInfo?.issuer}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -311,7 +311,13 @@ function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Eleme
         </div>
       </div>
 
-      <EtfMetadataBadges exchange={d.exchange} assetClass={d.stockAnalyzerInfo?.assetClass} category={d.stockAnalyzerInfo?.category} className="mb-4" />
+      <EtfMetadataBadges
+        exchange={d.exchange}
+        assetClass={d.stockAnalyzerInfo?.assetClass}
+        category={d.stockAnalyzerInfo?.category}
+        issuer={d.stockAnalyzerInfo?.issuer}
+        className="mb-4"
+      />
 
       {/* Summary (if available) */}
       {d.summary && d.summary.trim() && (

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -129,6 +129,7 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
         updatedAt={modifiedDate}
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
+        issuer={etfData.stockAnalyzerInfo?.issuer}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -129,6 +129,7 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
         updatedAt={modifiedDate}
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
+        issuer={etfData.stockAnalyzerInfo?.issuer}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
@@ -1,0 +1,30 @@
+import EtfProviderDetail from '@/components/etfs/EtfProviderDetail';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string; provider: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string; provider: string }> }): Promise<Metadata> {
+  const { country, provider } = await props.params;
+  const decodedCountry = decodeURIComponent(country);
+  const decoded = decodeURIComponent(provider);
+  return {
+    title: `${decoded} ${decodedCountry} ETFs | KoalaGains`,
+    description: `Browse ${decodedCountry} ETFs issued by ${decoded} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country, provider } = await params;
+  const decodedProvider = decodeURIComponent(provider);
+  const decodedCountry = resolveEtfCountryParam(country, `/etfs/providers/${encodeURIComponent(decodedProvider)}`);
+
+  const searchParams = await searchParamsPromise;
+  return EtfProviderDetail({ country: decodedCountry, provider: decodedProvider, searchParams });
+}

--- a/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
@@ -1,0 +1,24 @@
+import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
+import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string }>;
+};
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { country } = await props.params;
+  const decoded = decodeURIComponent(country);
+  return {
+    title: `${decoded} ETFs by Provider | KoalaGains`,
+    description: `Browse ${decoded} ETFs grouped by issuer. Each card highlights the top-rated ETFs from that provider.`,
+  };
+}
+
+export default async function CountryEtfsProvidersIndexPage({ params }: PageProps) {
+  const { country } = await params;
+  const decoded = resolveEtfCountryParam(country, '/etfs/providers');
+  return EtfProvidersIndex({ country: decoded });
+}

--- a/insights-ui/src/app/etfs/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/providers/[provider]/page.tsx
@@ -1,0 +1,26 @@
+import EtfProviderDetail from '@/components/etfs/EtfProviderDetail';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ provider: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ provider: string }> }): Promise<Metadata> {
+  const { provider } = await props.params;
+  const decoded = decodeURIComponent(provider);
+  return {
+    title: `${decoded} ETFs | KoalaGains`,
+    description: `Browse US ETFs issued by ${decoded} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function EtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { provider } = await params;
+  const searchParams = await searchParamsPromise;
+  return EtfProviderDetail({ country: SupportedCountries.US, provider: decodeURIComponent(provider), searchParams });
+}

--- a/insights-ui/src/app/etfs/providers/page.tsx
+++ b/insights-ui/src/app/etfs/providers/page.tsx
@@ -1,0 +1,14 @@
+import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'US ETFs by Provider | KoalaGains',
+  description: 'Browse US ETFs grouped by issuer. Each card highlights the top-rated ETFs from that provider.',
+};
+
+export default async function EtfsProvidersIndexPage() {
+  return EtfProvidersIndex({ country: SupportedCountries.US });
+}

--- a/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
@@ -6,6 +6,7 @@ export interface EtfMetadataBadgesProps {
   exchange?: string | null;
   assetClass?: string | null;
   category?: string | null;
+  issuer?: string | null;
   className?: string;
 }
 
@@ -19,6 +20,7 @@ interface BadgeItem {
 const ASSET_CLASS_COLORS = 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800';
 const CATEGORY_COLORS = 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800';
 const GROUP_COLORS = 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300 hover:bg-cyan-200 dark:hover:bg-cyan-800';
+const PROVIDER_COLORS = 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800';
 
 function getCountryPathPrefix(exchange: string | null | undefined): string {
   if (!exchange) return '/etfs';
@@ -30,10 +32,11 @@ function getCountryPathPrefix(exchange: string | null | undefined): string {
   }
 }
 
-export default function EtfMetadataBadges({ exchange, assetClass, category, className }: EtfMetadataBadgesProps): JSX.Element | null {
+export default function EtfMetadataBadges({ exchange, assetClass, category, issuer, className }: EtfMetadataBadgesProps): JSX.Element | null {
   const groupName = getEtfGroupName(category);
   const groupKey = getEtfGroupKey(category);
   const prefix = getCountryPathPrefix(exchange);
+  const trimmedIssuer = issuer?.trim();
 
   const items: BadgeItem[] = [];
   if (assetClass) {
@@ -58,6 +61,14 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, clas
       value: groupName,
       href: `${prefix}/groups/${encodeURIComponent(groupKey)}`,
       colorClasses: GROUP_COLORS,
+    });
+  }
+  if (trimmedIssuer) {
+    items.push({
+      label: 'Provider',
+      value: trimmedIssuer,
+      href: `${prefix}/providers/${encodeURIComponent(trimmedIssuer)}`,
+      colorClasses: PROVIDER_COLORS,
     });
   }
 

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -25,6 +25,7 @@ export interface EtfCategoryReportProps {
   updatedAt?: string;
   assetClass?: string | null;
   fundCategory?: string | null;
+  issuer?: string | null;
 }
 
 export default function EtfCategoryReport({
@@ -38,6 +39,7 @@ export default function EtfCategoryReport({
   updatedAt,
   assetClass,
   fundCategory,
+  issuer,
 }: EtfCategoryReportProps): JSX.Element | null {
   if (!categoryResult) return null;
 
@@ -72,7 +74,7 @@ export default function EtfCategoryReport({
                   {formattedModifiedDate}
                 </time>
               </div>
-              <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} className="mt-3" />
+              <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} issuer={issuer} className="mt-3" />
             </div>
             <Link href={`/etfs/${exchange}/${symbol}`} className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1">
               View Full Report →

--- a/insights-ui/src/components/etfs/EtfProviderDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfProviderDetail.tsx
@@ -1,0 +1,39 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
+
+interface EtfProviderDetailProps {
+  country: EtfSupportedCountry;
+  provider: string;
+  searchParams: EtfSearchParams;
+}
+
+export default async function EtfProviderDetail({ country, provider, searchParams }: EtfProviderDetailProps) {
+  const displayCountry = etfCountryDisplayName(country);
+
+  const dataPromise = fetchEtfListingData(
+    {
+      ...searchParams,
+      [EtfFilterParamKey.ISSUER]: provider,
+    },
+    country
+  );
+
+  return (
+    <EtfPageLayout
+      title={`${provider} ${displayCountry} ETFs`}
+      description={`Explore ${displayCountry} ETFs issued by ${provider} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+      currentCountry={country}
+      switcherSection="providers"
+      extraBreadcrumbs={[
+        { name: 'All Providers', href: etfBrowsePath(country, 'providers'), current: false },
+        { name: provider, href: etfBrowseDetailPath(country, 'providers', provider), current: true },
+      ]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
@@ -1,0 +1,43 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { fetchEtfProvidersForCountry } from '@/utils/etf-grouping-utils';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
+
+interface EtfProvidersIndexProps {
+  country: EtfSupportedCountry;
+}
+
+export default async function EtfProvidersIndex({ country }: EtfProvidersIndexProps) {
+  const { providers, values, counts } = await fetchEtfProvidersForCountry(KoalaGainsSpaceId, country);
+
+  const displayName = etfCountryDisplayName(country);
+  const providersPath = etfBrowsePath(country, 'providers');
+
+  return (
+    <EtfPageLayout
+      title={`${displayName} ETFs by Provider`}
+      description={`Browse ${displayName} ETFs grouped by issuer. Each card shows the top-rated ETFs from that provider.`}
+      currentCountry={country}
+      switcherSection="providers"
+      extraBreadcrumbs={[{ name: 'Providers', href: providersPath, current: true }]}
+    >
+      {providers.length === 0 ? (
+        <p className="text-[#E5E7EB] text-md">No providers available for {displayName} ETFs.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
+          {providers.map((provider) => (
+            <CompactEtfGroupingCard
+              key={provider}
+              title={provider}
+              href={etfBrowseDetailPath(country, 'providers', provider)}
+              totalCount={counts.get(provider) ?? 0}
+              etfs={values.get(provider) ?? []}
+            />
+          ))}
+        </div>
+      )}
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/utils/etf-country-route-utils.ts
+++ b/insights-ui/src/utils/etf-country-route-utils.ts
@@ -2,7 +2,7 @@ import { notFound, redirect } from 'next/navigation';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { EtfSupportedCountry, ETF_SUPPORTED_COUNTRIES, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 
-export type EtfBrowseSection = 'groups' | 'categories' | 'asset-classes';
+export type EtfBrowseSection = 'groups' | 'categories' | 'asset-classes' | 'providers';
 
 const COUNTRY_DISPLAY_NAME: Record<EtfSupportedCountry, string> = {
   [SupportedCountries.US]: 'US',

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -94,6 +94,64 @@ function selectTopFive(rows: RawEtfRow[]): EtfGroupingPreviewItem[] {
   }));
 }
 
+export interface EtfProvidersPreview {
+  providers: string[];
+  values: Map<string, EtfGroupingPreviewItem[]>;
+  counts: Map<string, number>;
+}
+
+export async function fetchEtfProvidersForCountry(spaceId: string, country?: EtfSupportedCountry): Promise<EtfProvidersPreview> {
+  const baseWhere = { spaceId, stockAnalyzerInfo: { is: { issuer: { not: null } } } };
+  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
+
+  const etfs = await prisma.etf.findMany({
+    where,
+    select: {
+      id: true,
+      symbol: true,
+      name: true,
+      exchange: true,
+      stockAnalyzerInfo: { select: { issuer: true } },
+      financialInfo: { select: { aum: true } },
+      cachedScore: { select: { finalScore: true } },
+    },
+  });
+
+  const rowsByIssuer = new Map<string, RawEtfRow[]>();
+  const counts = new Map<string, number>();
+
+  for (const etf of etfs) {
+    const issuer = etf.stockAnalyzerInfo?.issuer?.trim();
+    if (!issuer) continue;
+    const row: RawEtfRow = {
+      id: etf.id,
+      symbol: etf.symbol,
+      name: etf.name,
+      exchange: etf.exchange,
+      assetClass: null,
+      category: null,
+      finalScore: etf.cachedScore?.finalScore ?? null,
+      aum: etf.financialInfo?.aum ?? null,
+    };
+    const bucket = rowsByIssuer.get(issuer) ?? [];
+    bucket.push(row);
+    rowsByIssuer.set(issuer, bucket);
+    counts.set(issuer, (counts.get(issuer) ?? 0) + 1);
+  }
+
+  const values = new Map<string, EtfGroupingPreviewItem[]>();
+  for (const [issuer, rows] of rowsByIssuer.entries()) {
+    values.set(issuer, selectTopFive(rows));
+  }
+
+  const providers = Array.from(counts.keys()).sort((a, b) => {
+    const diff = (counts.get(b) ?? 0) - (counts.get(a) ?? 0);
+    return diff !== 0 ? diff : a.localeCompare(b);
+  });
+
+  return { providers, values, counts };
+}
+
 export async function fetchEtfsForGroupings<TKey extends string>({
   spaceId,
   mode,


### PR DESCRIPTION
## Summary
- Surface the ETF issuer on the detail page as a clickable green **Provider** badge that links to `/etfs/{country?}/providers/<issuer>`.
- Add country-scoped provider index and detail pages mirroring the existing groups / categories / asset-classes flow.
- Added a `fetchEtfProvidersForCountry` helper that buckets ETFs by issuer per country with top-5 previews.

## Test plan
- [ ] Visit `/etfs/NASDAQ/VXUS` and confirm the green **Provider: Vanguard** badge appears and links to the US providers page.
- [ ] Visit `/etfs/providers` (US) — providers grid renders, each card lists top-5 ETFs and total count.
- [ ] Click into a provider card — detail page lists ETFs filtered by issuer with breadcrumbs `US ETFs > All Providers > <provider>`.
- [ ] Visit `/etfs/countries/Canada/providers` and a Canadian provider detail page — same flow, country-scoped.
- [ ] Confirm the "Also view" switcher on a provider page links to the other country's provider section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)