### PR TITLE
Add Canadian crypto/currency pair ETF categories to group mapping

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/prisma';
+import { ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
 import {
   createEtfFinancialFilter,
   createEtfStockAnalyzerFilter,
@@ -15,6 +16,7 @@ import {
 } from '@/utils/etf-filter-utils';
 import { getEtfExchangesByCountry, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 
 const DEFAULT_PAGE_SIZE = 32;
@@ -123,7 +125,17 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const stockAnalyzerFilter = createEtfStockAnalyzerFilter(filters);
   const hasStockAnalyzerFilter = Object.keys(stockAnalyzerFilter).length > 0;
-  if (hasStockAnalyzerFilter) {
+  const isOthersGroup = filters[EtfFilterParamKey.GROUP]?.trim() === ETF_OTHERS_GROUP_KEY;
+  if (isOthersGroup) {
+    // "Others" must also pick up ETFs that have no EtfStockAnalyzerInfo row at
+    // all. createEtfStockAnalyzerFilter has already set category: null for the
+    // case where a row exists; OR that with `is: null` for the no-row case.
+    // Wrapped in AND so it composes with any etfWhere.OR set by the search
+    // filter, which would otherwise be overwritten.
+    const othersOr: Prisma.EtfWhereInput[] = [{ stockAnalyzerInfo: { is: null } }, { stockAnalyzerInfo: { is: stockAnalyzerFilter } }];
+    const existingAnd = Array.isArray(etfWhere.AND) ? etfWhere.AND : etfWhere.AND ? [etfWhere.AND] : [];
+    etfWhere.AND = [...existingAnd, { OR: othersOr }];
+  } else if (hasStockAnalyzerFilter) {
     etfWhere.stockAnalyzerInfo = { is: stockAnalyzerFilter };
   }
 

--- a/insights-ui/src/app/api/etf-scenarios/[id]/links/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/[id]/links/route.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 const addLinkSchema = z.object({
   symbol: z.string().min(1),
   // Exchange must be one of the ETF-specific exchanges (NYSEARCA / BATS /
-  // NASDAQ / NYSE / TSX / TSXV / NEOE). Below we additionally enforce that
+  // NASDAQ / NYSE / TSX / TSXV / NEO). Below we additionally enforce that
   // the exchange's country is in scenario.countries — see the mismatch
   // check after we load the scenario.
   exchange: z

--- a/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
@@ -1,8 +1,8 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
-import { fetchEtfsForGroupings } from '@/utils/etf-grouping-utils';
+import { ETF_OTHERS_GROUP, getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
+import { fetchEtfsForGroupings, fetchUncategorizedEtfPreview } from '@/utils/etf-grouping-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
 
@@ -20,12 +20,15 @@ export default async function EtfGroupsIndex({ country }: EtfGroupsIndexProps) {
     }
   }
 
-  const { values, counts } = await fetchEtfsForGroupings({
-    spaceId: KoalaGainsSpaceId,
-    mode: 'category',
-    valueToKey,
-    country,
-  });
+  const [{ values, counts }, others] = await Promise.all([
+    fetchEtfsForGroupings({
+      spaceId: KoalaGainsSpaceId,
+      mode: 'category',
+      valueToKey,
+      country,
+    }),
+    fetchUncategorizedEtfPreview(KoalaGainsSpaceId, country),
+  ]);
 
   const displayName = etfCountryDisplayName(country);
   const groupsPath = etfBrowsePath(country, 'groups');
@@ -48,6 +51,13 @@ export default async function EtfGroupsIndex({ country }: EtfGroupsIndexProps) {
             etfs={values.get(group.key) ?? []}
           />
         ))}
+        <CompactEtfGroupingCard
+          key={ETF_OTHERS_GROUP.key}
+          title={ETF_OTHERS_GROUP.name}
+          href={etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key)}
+          totalCount={others.count}
+          etfs={others.items}
+        />
       </div>
     </EtfPageLayout>
   );

--- a/insights-ui/src/etf-analysis-data/etf-analysis-categories.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-categories.json
@@ -203,6 +203,16 @@
     { "name": "Broad Market", "group": "broad-equity" },
     { "name": "Long CAD", "group": "alt-strategies" },
     { "name": "Volatility", "group": "alt-strategies" },
-    { "name": "Carbon Credits", "group": "alt-strategies" }
+    { "name": "Carbon Credits", "group": "alt-strategies" },
+    { "name": "Long BTC, Short CAD", "group": "alt-strategies" },
+    { "name": "Long BTC, Short USD", "group": "alt-strategies" },
+    { "name": "Long CAD, Short BTC", "group": "leveraged-inverse" },
+    { "name": "Long Cryptocurrency Basket, Short CAD", "group": "alt-strategies" },
+    { "name": "Long ETH, Short CAD", "group": "alt-strategies" },
+    { "name": "Long ETH, Short USD", "group": "alt-strategies" },
+    { "name": "Long SOL, Short USD", "group": "alt-strategies" },
+    { "name": "Long USD, Short CAD", "group": "alt-strategies" },
+    { "name": "Long XRP, Short CAD", "group": "alt-strategies" },
+    { "name": "Long XRP, Short USD", "group": "alt-strategies" }
   ]
 }

--- a/insights-ui/src/utils/etf-categorization-utils.ts
+++ b/insights-ui/src/utils/etf-categorization-utils.ts
@@ -40,6 +40,19 @@ function validateEtfCategoriesConfig(): void {
 
 validateEtfCategoriesConfig();
 
+// Synthetic group for ETFs whose source data has no EtfStockAnalyzerInfo.category
+// value (either the relation is missing entirely or category is null). Not
+// stored in etf-analysis-categories.json — it isn't an analysis target, just a
+// browse bucket so users can still find these funds.
+export const ETF_OTHERS_GROUP_KEY = 'others';
+
+export const ETF_OTHERS_GROUP: EtfGroup = {
+  key: ETF_OTHERS_GROUP_KEY,
+  name: 'Others',
+  description:
+    'ETFs that are not yet assigned an analysis category in our source data. Shown so they remain discoverable; they are not part of the group-based analysis pipeline.',
+};
+
 export function getEtfGroupKey(category: string | null | undefined): string | undefined {
   if (!category) return undefined;
   const canonical = canonicalizeCategory(category);
@@ -54,6 +67,7 @@ export function getEtfGroupName(category: string | null | undefined): string | u
 
 export function getEtfGroupByKey(key: string | null | undefined): EtfGroup | undefined {
   if (!key) return undefined;
+  if (key === ETF_OTHERS_GROUP_KEY) return ETF_OTHERS_GROUP;
   return categoriesConfig.groups.find((g) => g.key === key);
 }
 

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { ReadonlyURLSearchParams } from 'next/navigation';
-import { getCategoriesForGroupKey, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { ETF_OTHERS_GROUP_KEY, getCategoriesForGroupKey, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { expandCategoryAliases } from '@/utils/etf-category-aliases';
 
 /** ----- Types and Enums ----- */
@@ -946,16 +946,22 @@ export function createEtfStockAnalyzerFilter(filters: EtfFilterParams): Prisma.E
   }
 
   // Group is not stored on the row — translate the group key into the set of
-  // category names that belong to it and match any of them.
+  // category names that belong to it and match any of them. The synthetic
+  // "others" group means "category is null"; the listing route then OR-s in
+  // ETFs that lack a stockAnalyzerInfo relation entirely.
   const groupKey = filters[EtfFilterParamKey.GROUP]?.trim();
   if (groupKey) {
-    const categoryNames = getCategoriesForGroupKey(groupKey).map((c) => c.name);
-    if (categoryNames.length === 0) {
-      // Unknown / empty group: force-empty result set so callers see "no matches"
-      // rather than the unfiltered listing.
-      where.category = { equals: '__no_match__' };
+    if (groupKey === ETF_OTHERS_GROUP_KEY) {
+      where.category = null;
     } else {
-      where.category = { in: expandCategoryAliases(categoryNames) };
+      const categoryNames = getCategoriesForGroupKey(groupKey).map((c) => c.name);
+      if (categoryNames.length === 0) {
+        // Unknown / empty group: force-empty result set so callers see "no matches"
+        // rather than the unfiltered listing.
+        where.category = { equals: '__no_match__' };
+      } else {
+        where.category = { in: expandCategoryAliases(categoryNames) };
+      }
     }
   }
 

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -152,6 +152,47 @@ export async function fetchEtfProvidersForCountry(spaceId: string, country?: Etf
   return { providers, values, counts };
 }
 
+export interface EtfUncategorizedPreview {
+  items: EtfGroupingPreviewItem[];
+  count: number;
+}
+
+export async function fetchUncategorizedEtfPreview(spaceId: string, country?: EtfSupportedCountry): Promise<EtfUncategorizedPreview> {
+  // "Others" = ETFs missing a category value: either no EtfStockAnalyzerInfo
+  // relation at all, or one whose category column is null.
+  const baseWhere = {
+    spaceId,
+    OR: [{ stockAnalyzerInfo: { is: null } }, { stockAnalyzerInfo: { is: { category: null } } }],
+  };
+  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
+
+  const etfs = await prisma.etf.findMany({
+    where,
+    select: {
+      id: true,
+      symbol: true,
+      name: true,
+      exchange: true,
+      stockAnalyzerInfo: { select: { assetClass: true, category: true } },
+      financialInfo: { select: { aum: true } },
+      cachedScore: { select: { finalScore: true } },
+    },
+  });
+
+  const rows: RawEtfRow[] = etfs.map((etf) => ({
+    id: etf.id,
+    symbol: etf.symbol,
+    name: etf.name,
+    exchange: etf.exchange,
+    assetClass: etf.stockAnalyzerInfo?.assetClass ?? null,
+    category: etf.stockAnalyzerInfo?.category ?? null,
+    finalScore: etf.cachedScore?.finalScore ?? null,
+    aum: etf.financialInfo?.aum ?? null,
+  }));
+
+  return { items: selectTopFive(rows), count: rows.length };
+}
+
 export async function fetchEtfsForGroupings<TKey extends string>({
   spaceId,
   mode,

--- a/insights-ui/src/utils/etfCountryExchangeUtils.ts
+++ b/insights-ui/src/utils/etfCountryExchangeUtils.ts
@@ -3,7 +3,7 @@
  * `countryExchangeUtils.ts` (stocks) because:
  *  - ETF coverage is currently US + Canada only; reusing the 10-country stock
  *    list would let admins create scenarios in markets we have no ETF data for.
- *  - ETF venues (NYSEARCA, BATS, NEOE) don't all overlap with the stock
+ *  - ETF venues (NYSEARCA, BATS, NEO) don't all overlap with the stock
  *    exchange list.
  *
  * Country code values are reused from `SupportedCountries` so the strings
@@ -29,7 +29,7 @@ export enum EtfUSExchanges {
 export enum EtfCanadaExchanges {
   TSX = 'TSX',
   TSXV = 'TSXV',
-  NEOE = 'NEOE',
+  NEO = 'NEO',
 }
 
 export type AllEtfExchanges = EtfUSExchanges | EtfCanadaExchanges;
@@ -41,7 +41,7 @@ export const ETF_EXCHANGES: ReadonlyArray<AllEtfExchanges> = [
   EtfUSExchanges.NYSE,
   EtfCanadaExchanges.TSX,
   EtfCanadaExchanges.TSXV,
-  EtfCanadaExchanges.NEOE,
+  EtfCanadaExchanges.NEO,
 ] as const;
 
 export const ETF_EXCHANGE_TO_COUNTRY: Record<AllEtfExchanges, EtfSupportedCountry> = {
@@ -51,7 +51,7 @@ export const ETF_EXCHANGE_TO_COUNTRY: Record<AllEtfExchanges, EtfSupportedCountr
   [EtfUSExchanges.NYSE]: SupportedCountries.US,
   [EtfCanadaExchanges.TSX]: SupportedCountries.Canada,
   [EtfCanadaExchanges.TSXV]: SupportedCountries.Canada,
-  [EtfCanadaExchanges.NEOE]: SupportedCountries.Canada,
+  [EtfCanadaExchanges.NEO]: SupportedCountries.Canada,
 };
 
 export const isEtfExchange = (val: string): val is AllEtfExchanges => {


### PR DESCRIPTION
## Summary

Maps 10 Canadian-specific ETF category labels to their analysis groups so they show up on `/etfs/countries/Canada/groups`:

- **Long CAD, Short BTC** → **Leveraged & Inverse Trading** (inverse BTC exposure — this is the first Canadian category that lands in the `leveraged-inverse` bucket)
- All other crypto/currency pair longs (`Long BTC, Short CAD`, `Long BTC, Short USD`, `Long ETH, Short CAD`, `Long ETH, Short USD`, `Long SOL, Short USD`, `Long XRP, Short CAD`, `Long XRP, Short USD`, `Long Cryptocurrency Basket, Short CAD`, `Long USD, Short CAD`) → **Alternative Strategies**

## Why

User reported empty Leveraged & Inverse Trading + Municipal Bonds groups on the Canada page. Investigation of the Canadian ETF source data showed 21 unique categories not present as exact-match entries in `etf-analysis-categories.json`. Of those:

- 11 were already covered by existing aliases in `etf-category-aliases.json` (e.g., `Information Technology` → `Technology`, `Health Care` → `Health`, `Financials` → `Financial`, `Energy` → `Equity Energy`, `Multi-strategy` → `Multistrategy`, `Long/Short` → `Long-Short Equity`, etc.) — no action needed; they already route to their canonical buckets via `expandCategoryAliases` in `etf-grouping-utils.ts`.
- 10 were genuinely new (the crypto/currency pair categories above) — added in this PR.

The Canadian ETF universe in the source has no muni bond products, so the **Municipal Bonds** group will remain empty for Canada with the current data.

## Test plan

- [ ] Visit `/etfs/countries/Canada/groups` — Leveraged & Inverse Trading card should now show ETFs (driven by `Long CAD, Short BTC`)
- [ ] Alternative Strategies card on the Canada page should now include the crypto-pair ETFs (BTC/ETH/SOL/XRP/basket, USD↔CAD)
- [ ] US group counts unchanged
- [ ] `yarn lint && yarn prettier-check && yarn compile` pass