### PR TITLE
Reduce per-ticker ISR write count

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/route.ts
@@ -9,6 +9,7 @@ import { Prisma, TickerV1Industry, TickerV1SubIndustry, TickerV1 } from '@prisma
 import { NextRequest } from 'next/server';
 import { generateExpectedStockAnalyzeUrl, validateStockAnalyzeUrl } from '@/utils/stockAnalyzeUrlValidation';
 import { AllExchanges, isExchange } from '@/utils/countryExchangeUtils';
+import { revalidateAllTickerTags } from '@/utils/ticker-v1-cache-utils';
 
 async function getHandler(
   req: NextRequest,
@@ -161,6 +162,14 @@ async function putHandler(
       }
     }
   }
+
+  // Admin edits to movedExchange/movedSymbol/isDeleted change what
+  // enforceMovedRedirect / enforceDeletedTicker do at the top of every
+  // per-ticker page, so all subpage caches need to drop their stale snapshot —
+  // not just the main aggregate page. The narrow per-subpage tags only get
+  // touched by their respective savers; an admin PUT here doesn't go through
+  // any saver, so we explicitly bust every per-ticker cache slice.
+  revalidateAllTickerTags(updatedTicker.symbol, updatedTicker.exchange);
 
   return updatedTicker;
 }

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/fetch-financial-data/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/fetch-financial-data/route.ts
@@ -1,6 +1,7 @@
 import { withLoggedInAdmin } from '@/app/api/helpers/withLoggedInAdmin';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { fetchAndUpdateStockAnalyzerData } from '@/utils/stock-analyzer-scraper-utils';
+import { revalidateAllTickerTags } from '@/utils/ticker-v1-cache-utils';
 import { prisma } from '@/prisma';
 import { NextRequest } from 'next/server';
 
@@ -53,6 +54,11 @@ const postHandler = async (
       }
 
       await fetchAndUpdateStockAnalyzerData(ticker);
+      // fetchAndUpdateStockAnalyzerData no longer revalidates on its own (it
+      // runs in the read path of several API routes where revalidating would
+      // double the ISR write count). This admin endpoint is an explicit
+      // write-path refresh, so we invalidate every per-ticker tag here.
+      revalidateAllTickerTags(ticker.symbol, ticker.exchange);
       processed++;
     } catch (error: any) {
       errors.push({

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/CompetitionAnalysisButton.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/CompetitionAnalysisButton.tsx
@@ -11,6 +11,7 @@ export default function CompetitionAnalysisButton({ exchange, ticker }: Competit
     <div className="flex-shrink-0 relative">
       <Link
         href={`/stocks/${exchange}/${ticker}/competition`}
+        prefetch={false}
         className="inline-flex items-center px-4 py-2 text-sm font-medium text-black bg-gradient-to-r from-[#38BDF8] to-[#818CF8] hover:from-[#0EA5E9] hover:to-[#6366F1] border border-transparent rounded-lg shadow-md"
         title="View competition analysis"
       >

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -1,5 +1,6 @@
 import BusinessAndMoat from '@/components/ticker-reportsv1/BusinessAndMoat';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { generateBusinessAndMoatArticleSchema, generateBusinessAndMoatBreadcrumbSchema } from '@/utils/metadata-generators';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
 import {
@@ -16,6 +17,7 @@ import { notFound } from 'next/navigation';
 
 const DATA_SLUG = 'business-and-moat-data';
 const PAGE_SLUG = 'business-and-moat';
+const CATEGORY = TickerAnalysisCategory.BusinessAndMoat;
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -38,7 +40,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let updatedTime: string;
 
   try {
-    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG, CATEGORY);
     companyName = data.ticker?.name ?? companyName;
     industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
     const timestamps = extractPerformanceTimestamps(data);
@@ -98,7 +100,7 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
   const routeParams = await params;
   const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
 
-  const bmData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const bmData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG, CATEGORY);
   const tickerData = bmData.ticker;
   if (!tickerData) {
     notFound();

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -4,7 +4,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { CompetitionResponse } from '@/types/ticker-typesv1';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import { tickerCompetitionTag } from '@/utils/ticker-v1-cache-utils';
 import { enforceMovedRedirect } from '@/utils/ticker-moved-redirect';
 import { enforceDeletedTicker } from '@/utils/ticker-deleted-handler';
 import { generateCompetitionArticleSchema, generateCompetitionBreadcrumbSchema } from '@/utils/metadata-generators';
@@ -33,7 +33,7 @@ function truncateForMeta(text: string, maxLength: number = 155): string {
 /** Fetch competition data for a specific exchange+ticker (cached). Returns null ticker if exchange mismatch. */
 async function fetchCompetitionByExchange(exchange: string, ticker: string): Promise<CompetitionResponse> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/competition-tickers`;
-  const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { tags: [tickerCompetitionTag(ticker, exchange)] } });
   if (!res.ok) {
     throw new Error(`fetchCompetitionByExchange failed (${res.status}): ${url}`);
   }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -1,5 +1,6 @@
 import FairValue from '@/components/ticker-reportsv1/FairValue';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { generateFairValueArticleSchema, generateFairValueBreadcrumbSchema } from '@/utils/metadata-generators';
 import {
   buildPerformanceBreadcrumbs,
@@ -15,6 +16,7 @@ import { notFound } from 'next/navigation';
 
 const DATA_SLUG = 'fair-value-data';
 const PAGE_SLUG = 'fair-value';
+const CATEGORY = TickerAnalysisCategory.FairValue;
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -37,7 +39,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let updatedTime: string;
 
   try {
-    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG, CATEGORY);
     companyName = data.ticker?.name ?? companyName;
     industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
     const timestamps = extractPerformanceTimestamps(data);
@@ -102,7 +104,7 @@ export default async function FairValuePage({ params }: { params: RouteParams })
   const routeParams = await params;
   const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
 
-  const fairValueData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const fairValueData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG, CATEGORY);
   const tickerData = fairValueData.ticker;
   if (!tickerData) {
     notFound();

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -1,5 +1,6 @@
 import FinancialStatementAnalysis from '@/components/ticker-reportsv1/FinancialStatementAnalysis';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { generateFinancialStatementAnalysisArticleSchema, generateFinancialStatementAnalysisBreadcrumbSchema } from '@/utils/metadata-generators';
 import {
   buildPerformanceBreadcrumbs,
@@ -15,6 +16,7 @@ import { notFound } from 'next/navigation';
 
 const DATA_SLUG = 'financial-statement-analysis-data';
 const PAGE_SLUG = 'financial-statement-analysis';
+const CATEGORY = TickerAnalysisCategory.FinancialStatementAnalysis;
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -37,7 +39,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let updatedTime: string;
 
   try {
-    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG, CATEGORY);
     companyName = data.ticker?.name ?? companyName;
     industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
     const timestamps = extractPerformanceTimestamps(data);
@@ -103,7 +105,7 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
   const routeParams = await params;
   const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
 
-  const financialStatementData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const financialStatementData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG, CATEGORY);
   const tickerData = financialStatementData.ticker;
   if (!tickerData) {
     notFound();

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -1,5 +1,6 @@
 import FuturePerformance from '@/components/ticker-reportsv1/FuturePerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { generateFuturePerformanceArticleSchema, generateFuturePerformanceBreadcrumbSchema } from '@/utils/metadata-generators';
 import {
   buildPerformanceBreadcrumbs,
@@ -15,6 +16,7 @@ import { notFound } from 'next/navigation';
 
 const DATA_SLUG = 'future-performance-data';
 const PAGE_SLUG = 'future-performance';
+const CATEGORY = TickerAnalysisCategory.FutureGrowth;
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -37,7 +39,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let updatedTime: string;
 
   try {
-    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG, CATEGORY);
     companyName = data.ticker?.name ?? companyName;
     industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
     const timestamps = extractPerformanceTimestamps(data);
@@ -102,7 +104,7 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
   const routeParams = await params;
   const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
 
-  const futurePerformanceData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const futurePerformanceData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG, CATEGORY);
   const tickerData = futurePerformanceData.ticker;
   if (!tickerData) {
     notFound();

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -5,7 +5,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { MANAGEMENT_TEAM_ALIGNMENT_VERDICT_LABELS, ManagementTeamAlignmentVerdict } from '@/types/ticker-typesv1';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import { tickerManagementTeamTag } from '@/utils/ticker-v1-cache-utils';
 import { enforceMovedRedirect } from '@/utils/ticker-moved-redirect';
 import { enforceDeletedTicker } from '@/utils/ticker-deleted-handler';
 import { generateManagementTeamArticleSchema, generateManagementTeamBreadcrumbSchema } from '@/utils/metadata-generators';
@@ -34,7 +34,7 @@ function truncateForMeta(text: string, maxLength: number = 155): string {
 
 async function fetchTickerByExchange(exchange: string, ticker: string): Promise<TickerV1FastResponse | null> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}?allowNull=true`;
-  const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  const res: Response = await fetch(url, { next: { tags: [tickerManagementTeamTag(ticker, exchange)] } });
   if (!res.ok) {
     throw new Error(`fetchTickerByExchange failed (${res.status}): ${url}`);
   }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -584,6 +584,7 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
         </div>
         <Link
           href={link.href(d.exchange.toUpperCase(), d.symbol.toUpperCase())}
+          prefetch={false}
           className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
           style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
         >
@@ -637,6 +638,7 @@ function TickerAnalysisInfo({
               </div>
               <Link
                 href={`/stocks/${d.exchange.toUpperCase()}/${d.symbol.toUpperCase()}/management-team`}
+                prefetch={false}
                 className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
                 style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
               >

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -1,5 +1,6 @@
 import PastPerformance from '@/components/ticker-reportsv1/PastPerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { generatePastPerformanceArticleSchema, generatePastPerformanceBreadcrumbSchema } from '@/utils/metadata-generators';
 import {
   buildPerformanceBreadcrumbs,
@@ -15,6 +16,7 @@ import { notFound } from 'next/navigation';
 
 const DATA_SLUG = 'past-performance-data';
 const PAGE_SLUG = 'past-performance';
+const CATEGORY = TickerAnalysisCategory.PastPerformance;
 
 /**
  * Static-by-default with on-demand invalidation.
@@ -37,7 +39,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let updatedTime: string;
 
   try {
-    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG);
+    const data = await fetchPerformanceByExchange(exchange, ticker, DATA_SLUG, CATEGORY);
     companyName = data.ticker?.name ?? companyName;
     industryName = data.ticker?.industry?.name || data.ticker?.industryKey || '';
     const timestamps = extractPerformanceTimestamps(data);
@@ -102,7 +104,7 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
   const routeParams = await params;
   const { exchange, ticker } = { exchange: routeParams.exchange.toUpperCase(), ticker: routeParams.ticker.toUpperCase() };
 
-  const pastPerformanceData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG);
+  const pastPerformanceData = await getPerformanceOrRedirect(exchange, ticker, DATA_SLUG, PAGE_SLUG, CATEGORY);
   const tickerData = pastPerformanceData.ticker;
   if (!tickerData) {
     notFound();

--- a/insights-ui/src/components/competition/CompetitorCard.tsx
+++ b/insights-ui/src/components/competition/CompetitorCard.tsx
@@ -31,7 +31,7 @@ export interface CompetitorCardProps {
  */
 export default function CompetitorCard({ competitor, href, actionSlot }: CompetitorCardProps): JSX.Element {
   const nameNode = href ? (
-    <Link href={href} title="View detailed report" className="flex gap-x-2 items-center text-[#F59E0B] hover:text-[#F97316] transition-colors">
+    <Link href={href} prefetch={false} title="View detailed report" className="flex gap-x-2 items-center text-[#F59E0B] hover:text-[#F97316] transition-colors">
       <h3 className="font-semibold">{competitor.companyName}</h3>
       <ArrowTopRightOnSquareIcon className="size-4 text-primary-text" />
     </Link>

--- a/insights-ui/src/components/daily-stock-movers/StockMoverDetails.tsx
+++ b/insights-ui/src/components/daily-stock-movers/StockMoverDetails.tsx
@@ -48,6 +48,7 @@ export default function StockMoverDetails({ mover, type }: StockMoverDetailsProp
 
             <Link
               href={`/stocks/${toExchange(mover.ticker.exchange)}/${mover.ticker.symbol}`}
+              prefetch={false}
               className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1"
             >
               View Full Report →

--- a/insights-ui/src/components/daily-stock-movers/StockMoversTable.tsx
+++ b/insights-ui/src/components/daily-stock-movers/StockMoversTable.tsx
@@ -102,6 +102,7 @@ export default function StockMoversTable({ movers, type, country, availableDates
                     <td className="px-6 py-4 whitespace-nowrap">
                       <Link
                         href={`/stocks/${mover.ticker.exchange}/${mover.ticker.symbol}`}
+                        prefetch={false}
                         className="group inline-flex items-center gap-1 text-sm font-semibold"
                       >
                         <span className="text-color group-hover:text-[#a09bff] group-hover:underline">{mover.ticker.symbol}</span>

--- a/insights-ui/src/components/favourites/FavouriteItem.tsx
+++ b/insights-ui/src/components/favourites/FavouriteItem.tsx
@@ -58,6 +58,7 @@ export default function FavouriteItem({
           )}
           <Link
             href={`/stocks/${favourite.ticker.exchange}/${favourite.ticker.symbol}`}
+            prefetch={false}
             className="hover:text-blue-400"
             target="_blank"
             rel="noopener noreferrer"

--- a/insights-ui/src/components/favourites/TickerBadge.tsx
+++ b/insights-ui/src/components/favourites/TickerBadge.tsx
@@ -37,7 +37,11 @@ export default function TickerBadge({ ticker, showScore = false, showName = fals
   );
 
   if (linkToStock) {
-    return <Link href={`/stocks/${ticker.exchange}/${ticker.symbol}`}>{content}</Link>;
+    return (
+      <Link href={`/stocks/${ticker.exchange}/${ticker.symbol}`} prefetch={false}>
+        {content}
+      </Link>
+    );
   }
 
   return content;

--- a/insights-ui/src/components/portfolios/PortfolioHoldings.tsx
+++ b/insights-ui/src/components/portfolios/PortfolioHoldings.tsx
@@ -25,7 +25,7 @@ export default function PortfolioHoldings({ portfolioTickers, listsWithTickers, 
         <div className="flex-1">
           {/* Header with Name, Symbol, and Score */}
           <div className="flex items-center gap-3 flex-wrap mb-3">
-            <Link href={`/stocks/${ticker.ticker?.exchange}/${ticker.ticker?.symbol}`} className="hover:text-blue-400 transition-colors">
+            <Link href={`/stocks/${ticker.ticker?.exchange}/${ticker.ticker?.symbol}`} prefetch={false} className="hover:text-blue-400 transition-colors">
               <h4 className="text-lg font-bold text-white hover:text-blue-400">
                 {ticker.ticker?.name} <span>({ticker.ticker?.symbol})</span>
               </h4>

--- a/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
+++ b/insights-ui/src/components/stock-scenarios/StockScenarioLinkColumns.tsx
@@ -46,7 +46,7 @@ function LinkPill({ link }: { link: StockScenarioLinkDto }): JSX.Element {
   }
 
   return (
-    <Link href={`/stocks/${link.exchange}/${link.symbol}`} className="hover:opacity-80">
+    <Link href={`/stocks/${link.exchange}/${link.symbol}`} prefetch={false} className="hover:opacity-80">
       <PillVisual link={link} />
     </Link>
   );
@@ -151,6 +151,7 @@ function LinkCard({ link }: { link: StockScenarioLinkDto }): JSX.Element {
     return (
       <Link
         href={`/stocks/${link.exchange}/${link.symbol}`}
+        prefetch={false}
         className="block bg-[#111827] border border-[#374151] rounded-md p-2.5 hover:border-blue-500 hover:bg-[#0f1623] transition-colors"
       >
         {body}

--- a/insights-ui/src/components/stocks/CompactIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactIndustryCard.tsx
@@ -35,6 +35,7 @@ export default function CompactIndustryCard({ industryKey, industryName, topTick
                 <li key={ticker.symbol}>
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
+                    prefetch={false}
                     className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>

--- a/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
@@ -31,6 +31,7 @@ export default function CompactSubIndustryCard({ industryKey, subIndustryName, t
                 <li key={ticker.id}>
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
+                    prefetch={false}
                     className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>

--- a/insights-ui/src/components/stocks/StockTickerItem.tsx
+++ b/insights-ui/src/components/stocks/StockTickerItem.tsx
@@ -41,7 +41,7 @@ export default function StockTickerItem({ symbol, name, exchange, score, display
 
   return (
     <>
-      <Link href={`/stocks/${exchange}/${symbol}`} className="w-full" aria-label={`View ${name}`} title={`View ${name}`}>
+      <Link href={`/stocks/${exchange}/${symbol}`} prefetch={false} className="w-full" aria-label={`View ${name}`} title={`View ${name}`}>
         <div className="flex gap-1.5 items-center min-w-0">
           <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[45px] text-right shrink-0`}>
             <span className="font-mono tabular-nums text-right text-xs">{score}/25</span>

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -178,7 +178,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
                       );
 
                       return tickerLink ? (
-                        <Link key={dp.ticker} href={tickerLink} className="flex items-start gap-2.5 text-sm group">
+                        <Link key={dp.ticker} href={tickerLink} prefetch={false} className="flex items-start gap-2.5 text-sm group">
                           {content}
                         </Link>
                       ) : (

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -119,6 +119,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
 
             <Link
               href={`/stocks/${tickerData.exchange}/${tickerData.symbol}`}
+              prefetch={false}
               className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1"
             >
               View Full Report →

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -64,6 +64,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
           <h2 className="text-xl font-bold">Competition</h2>
           <Link
             href={`/stocks/${exchange}/${ticker}/competition`}
+            prefetch={false}
             className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
             style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
           >

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
@@ -28,6 +28,7 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
             <Link
               key={similarTicker.id}
               href={`/stocks/${similarTicker.exchange.toUpperCase()}/${similarTicker.symbol.toUpperCase()}`}
+              prefetch={false}
               className="block bg-gray-800 p-3 sm:p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
             >
               <div className="flex flex-col gap-y-2">

--- a/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerCategoryReport.tsx
@@ -105,6 +105,7 @@ export default function TickerCategoryReport({
 
             <Link
               href={`/stocks/${tickerData.exchange}/${tickerData.symbol}`}
+              prefetch={false}
               className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1"
             >
               View Full Report →

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -97,6 +97,7 @@ export default function TickerRelatedSections({
           <li key={s.slug} className="h-full">
             <Link
               href={`/stocks/${ex}/${tk}/${s.slug}`}
+              prefetch={false}
               className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
             >
               {s.label} &rarr;

--- a/insights-ui/src/utils/analysis-reports/save-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@/types/public-equity/analysis-factors-types';
 import { CATEGORY_MAPPINGS, InvestorTypes, ManagementTeamAlignmentVerdict, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { fetchAnalysisFactors, fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
-import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import { revalidateAllTickerTags } from '@/utils/ticker-v1-cache-utils';
 import { bumpUpdatedAtAndInvalidateCache, TickerCacheSlice, updateTickerCachedScore } from '@/utils/ticker-v1-model-utils';
 import { TickerV1 } from '@prisma/client';
 
@@ -316,7 +316,14 @@ export async function saveFinalSummaryResponse(
   });
 
   if (!options?.skipRevalidation) {
-    revalidateTickerAndExchangeTag(tickerRecord.symbol, tickerRecord.exchange);
+    // saveFinalSummaryResponse is the final step of the full generation
+    // pipeline. Every earlier step in `save-report-callback` passes
+    // `skipRevalidation: true`, so this is the only place an end-to-end run
+    // gets to invalidate caches. The pipeline touched every slice (categories,
+    // competition, management-team, ticker core), so we need to invalidate all
+    // per-ticker tags here — not just the umbrella — otherwise the per-subpage
+    // caches would keep serving stale data after a regeneration.
+    revalidateAllTickerTags(tickerRecord.symbol, tickerRecord.exchange);
   }
 }
 

--- a/insights-ui/src/utils/analysis-reports/save-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-utils.ts
@@ -9,7 +9,7 @@ import {
 import { CATEGORY_MAPPINGS, InvestorTypes, ManagementTeamAlignmentVerdict, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { fetchAnalysisFactors, fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
 import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
-import { bumpUpdatedAtAndInvalidateCache, updateTickerCachedScore } from '@/utils/ticker-v1-model-utils';
+import { bumpUpdatedAtAndInvalidateCache, TickerCacheSlice, updateTickerCachedScore } from '@/utils/ticker-v1-model-utils';
 import { TickerV1 } from '@prisma/client';
 
 /**
@@ -92,7 +92,8 @@ export async function saveFactorAnalysisResponse(
   // Update cached score using the utility function
   await updateTickerCachedScore(tickerRecord, tickerAnalysisCategory, score);
 
-  await bumpUpdatedAtAndInvalidateCache(tickerRecord, options);
+  const slice: TickerCacheSlice = { kind: 'category', category: tickerAnalysisCategory };
+  await bumpUpdatedAtAndInvalidateCache(tickerRecord, slice, options);
 }
 
 // Category-specific functions that use the generic saveFactorAnalysisResponse function
@@ -188,7 +189,10 @@ export async function saveInvestorAnalysisResponse(
     },
   });
 
-  await bumpUpdatedAtAndInvalidateCache(tickerRecord);
+  // Investor analysis has no dedicated subpage today — only the main ticker
+  // page surfaces it (indirectly via the summary). Invalidate the umbrella tag
+  // through the 'core' slice so the main page picks it up.
+  await bumpUpdatedAtAndInvalidateCache(tickerRecord, { kind: 'core' });
 }
 
 /**
@@ -238,7 +242,7 @@ export async function saveCompetitionAnalysisResponse(
     },
   });
 
-  await bumpUpdatedAtAndInvalidateCache(tickerRecord, options);
+  await bumpUpdatedAtAndInvalidateCache(tickerRecord, { kind: 'competition' }, options);
 }
 
 /**
@@ -282,7 +286,7 @@ export async function saveManagementTeamResponse(
     },
   });
 
-  await bumpUpdatedAtAndInvalidateCache(tickerRecord, options);
+  await bumpUpdatedAtAndInvalidateCache(tickerRecord, { kind: 'managementTeam' }, options);
 }
 
 /**

--- a/insights-ui/src/utils/cache-actions.ts
+++ b/insights-ui/src/utils/cache-actions.ts
@@ -1,11 +1,11 @@
 'use server';
 
 import {
+  revalidateAllTickerTags,
   revalidateStocksPageTag,
   revalidateIndustryPageTag,
   revalidatePortfolioManagersByTypeTag,
   revalidatePortfolioProfileTag,
-  revalidateTickerAndExchangeTag,
 } from '@/utils/ticker-v1-cache-utils';
 import { revalidateEtfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
@@ -49,7 +49,9 @@ export async function revalidatePortfolioProfileCache(portfolioManagerId: string
 }
 
 export async function revalidateTickerCache(ticker: string, exchange: string) {
-  revalidateTickerAndExchangeTag(ticker, exchange);
+  // The admin-facing "Revalidate" action is meant to clear *everything* for a
+  // ticker — main page plus every per-subpage cache slice.
+  revalidateAllTickerTags(ticker, exchange);
   return { success: true, message: `Cache invalidated for ${exchange.toUpperCase()}:${ticker.toUpperCase()}` };
 }
 

--- a/insights-ui/src/utils/performance-page-utils.ts
+++ b/insights-ui/src/utils/performance-page-utils.ts
@@ -1,8 +1,8 @@
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { PerformanceResponse } from '@/types/ticker-typesv1';
+import { PerformanceResponse, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import { tickerCategoryReportTag } from '@/utils/ticker-v1-cache-utils';
 import { enforceMovedRedirect } from '@/utils/ticker-moved-redirect';
 import { enforceDeletedTicker } from '@/utils/ticker-deleted-handler';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
@@ -17,10 +17,19 @@ export function truncateForMeta(text: string, maxLength: number = 155): string {
 }
 
 /** Fetch performance data for a specific exchange+ticker (cached). */
-export async function fetchPerformanceByExchange(exchange: string, ticker: string, dataSlug: string): Promise<PerformanceResponse> {
+export async function fetchPerformanceByExchange(
+  exchange: string,
+  ticker: string,
+  dataSlug: string,
+  category: TickerAnalysisCategory
+): Promise<PerformanceResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/${dataSlug}`;
   try {
-    const res = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    // Subscribe to the narrow per-category tag only. The umbrella tag would
+    // pull this page into every unrelated ticker-data invalidation (price
+    // history, scraper refresh, competition save, ...) and explode ISR
+    // writes — see knowledge/cache-invalidation.md if added.
+    const res = await fetch(url, { next: { tags: [tickerCategoryReportTag(ticker, exchange, category)] } });
     if (!res.ok) {
       console.warn(`fetchPerformanceByExchange failed (${res.status}): ${url}`);
       return EMPTY_RESPONSE;
@@ -52,9 +61,16 @@ export async function fetchPerformanceAnyExchange(ticker: string, dataSlug: stri
  * Exchange-aware fetch with uncached fallback + canonical redirect.
  * @param dataSlug  API data segment, e.g. "past-performance-data" or "future-performance-data"
  * @param pageSlug  Page segment for the redirect URL, e.g. "past-performance" or "future-performance"
+ * @param category  TickerAnalysisCategory for cache-tag scoping (one tag per subpage, not the umbrella)
  */
-export async function getPerformanceOrRedirect(exchange: string, ticker: string, dataSlug: string, pageSlug: string): Promise<PerformanceResponse> {
-  const data = await fetchPerformanceByExchange(exchange, ticker, dataSlug);
+export async function getPerformanceOrRedirect(
+  exchange: string,
+  ticker: string,
+  dataSlug: string,
+  pageSlug: string,
+  category: TickerAnalysisCategory
+): Promise<PerformanceResponse> {
+  const data = await fetchPerformanceByExchange(exchange, ticker, dataSlug, category);
 
   if (data.ticker) {
     enforceDeletedTicker(data.ticker);

--- a/insights-ui/src/utils/price-history-utils.ts
+++ b/insights-ui/src/utils/price-history-utils.ts
@@ -1,7 +1,6 @@
 import { prisma } from '@/prisma';
 import { TickerV1, TickerV1PriceHistory } from '@prisma/client';
 import { PriceHistoryPoint } from '@/types/prismaTypes';
-import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
 import { convertToYahooFinanceSymbol } from '@/utils/yahoo-finance-symbol-utils';
 import {
   DAILY_LOOKBACK_DAYS,
@@ -67,7 +66,13 @@ export async function ensurePriceHistoryIsFresh(ticker: TickerV1): Promise<Ticke
       },
     });
 
-    revalidateTickerAndExchangeTag(ticker.symbol, ticker.exchange);
+    // Intentionally do NOT revalidate any cache tag here. This function runs in
+    // the read path (called from the price-history API route which the ticker
+    // page itself fetches), so a revalidate here would evict the very cache
+    // entry we're about to fill — causing the page to be rebuilt twice and
+    // counting as an extra ISR write each time. The freshly-returned data is
+    // already what the caller's fetch will cache. Stale data will be picked up
+    // on the next external invalidation (admin refresh, scraper save, etc.).
     return saved;
   } catch (error) {
     console.error(`Failed to refresh price history for ${ticker.symbol} (${ticker.exchange}):`, error);

--- a/insights-ui/src/utils/stock-analyzer-scraper-utils.ts
+++ b/insights-ui/src/utils/stock-analyzer-scraper-utils.ts
@@ -1,6 +1,5 @@
 import { prisma } from '@/prisma';
 import { TickerV1, TickerV1StockAnalyzerScrapperInfo, Prisma } from '@prisma/client';
-import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
 import {
   IncomeAnnualData,
   IncomeQuarterlyData,
@@ -320,7 +319,13 @@ export async function fetchAndUpdateStockAnalyzerData(ticker: TickerV1): Promise
   });
 
   console.log(`Updated scraper info for ticker ${ticker.symbol}`);
-  revalidateTickerAndExchangeTag(ticker.symbol, ticker.exchange);
+  // Intentionally do NOT revalidate the ticker tag here. This function runs in
+  // the read path of several API routes (financial-info, quarterly-chart-data,
+  // business-and-moat, etc.) that the static ticker pages fetch during render,
+  // so a revalidate here would evict the very cache entry we just filled and
+  // force an immediate re-render — double-counting ISR writes. The freshly
+  // upserted data is already in the response we're returning, which the
+  // caller's fetch will cache.
   return scraperInfo;
 }
 
@@ -383,7 +388,10 @@ export async function refreshMarketSummaryForFairValue(ticker: TickerV1): Promis
   });
 
   console.log(`Refreshed market summary only for ticker ${ticker.symbol} (fair value)`);
-  revalidateTickerAndExchangeTag(ticker.symbol, ticker.exchange);
+  // Intentionally do NOT revalidate here — see the note on
+  // fetchAndUpdateStockAnalyzerData above. This is called from the fair-value
+  // report-generation pipeline; the subsequent saveFactorAnalysisResponse call
+  // for the FairValue category will invalidate the right narrow tag.
   return scraperInfo;
 }
 

--- a/insights-ui/src/utils/ticker-v1-cache-utils.ts
+++ b/insights-ui/src/utils/ticker-v1-cache-utils.ts
@@ -1,14 +1,54 @@
 import { revalidateTag } from 'next/cache';
 import { SupportedCountries } from './countryExchangeUtils';
 import { DailyMoverType } from '@/types/daily-mover-constants';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 
-/** Cache tag helpers for per-ticker revalidation */
+/**
+ * Cache-tag helpers for per-ticker revalidation.
+ *
+ * The main ticker page (`/stocks/[exchange]/[ticker]`) renders an aggregate
+ * view of everything for one ticker, so it subscribes to the umbrella
+ * `tickerAndExchangeTag`. Per-subpage routes (e.g. `/fair-value`,
+ * `/competition`, `/management-team`) only need to rebuild when *their* slice
+ * of data changes, so each subscribes to a narrow tag. Savers invalidate the
+ * narrow tag for the data they touched and the umbrella tag for the main
+ * page — that way one category save invalidates two pages (main + the one
+ * subpage) instead of all seven.
+ */
 const TICKER_EXCHANGE_TAG_PREFIX = 'ticker_exchange:' as const;
 
 export const tickerAndExchangeTag = (t: string, exchange: string): `${typeof TICKER_EXCHANGE_TAG_PREFIX}${string}` =>
   `${TICKER_EXCHANGE_TAG_PREFIX}_${t.toUpperCase()}_${exchange.toUpperCase()}`;
 
 export const revalidateTickerAndExchangeTag = (ticker: string, exchange: string) => revalidateTag(tickerAndExchangeTag(ticker, exchange));
+
+/** Per-category report tag — used by `/business-and-moat`, `/financial-statement-analysis`, `/past-performance`, `/future-performance`, `/fair-value` subpages. */
+export const tickerCategoryReportTag = (ticker: string, exchange: string, category: TickerAnalysisCategory): string =>
+  `ticker_category_report:_${ticker.toUpperCase()}_${exchange.toUpperCase()}_${category}`;
+
+export const revalidateTickerCategoryReportTag = (ticker: string, exchange: string, category: TickerAnalysisCategory) =>
+  revalidateTag(tickerCategoryReportTag(ticker, exchange, category));
+
+/** Competition subpage tag — used by `/competition`. */
+export const tickerCompetitionTag = (ticker: string, exchange: string): string => `ticker_competition:_${ticker.toUpperCase()}_${exchange.toUpperCase()}`;
+
+export const revalidateTickerCompetitionTag = (ticker: string, exchange: string) => revalidateTag(tickerCompetitionTag(ticker, exchange));
+
+/** Management-team subpage tag — used by `/management-team`. */
+export const tickerManagementTeamTag = (ticker: string, exchange: string): string =>
+  `ticker_management_team:_${ticker.toUpperCase()}_${exchange.toUpperCase()}`;
+
+export const revalidateTickerManagementTeamTag = (ticker: string, exchange: string) => revalidateTag(tickerManagementTeamTag(ticker, exchange));
+
+/** Invalidate every per-ticker cache. Used by the admin "Revalidate" button so it behaves like the old umbrella-only flow. */
+export const revalidateAllTickerTags = (ticker: string, exchange: string) => {
+  revalidateTickerAndExchangeTag(ticker, exchange);
+  revalidateTickerCompetitionTag(ticker, exchange);
+  revalidateTickerManagementTeamTag(ticker, exchange);
+  for (const category of Object.values(TickerAnalysisCategory)) {
+    revalidateTickerCategoryReportTag(ticker, exchange, category);
+  }
+};
 
 export const getStocksPageTag = (country: SupportedCountries) => `koalagains:${country}:stocks`;
 

--- a/insights-ui/src/utils/ticker-v1-model-utils.ts
+++ b/insights-ui/src/utils/ticker-v1-model-utils.ts
@@ -4,7 +4,12 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { TickerWithMissingReportInfo } from '@/utils/analysis-reports/report-steps-statuses';
 import { getMissingReportsForTicker } from '@/utils/missing-reports-utils';
-import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import {
+  revalidateTickerAndExchangeTag,
+  revalidateTickerCategoryReportTag,
+  revalidateTickerCompetitionTag,
+  revalidateTickerManagementTeamTag,
+} from '@/utils/ticker-v1-cache-utils';
 import {
   Prisma,
   TickerV1,
@@ -319,9 +324,38 @@ export const updateTickerCachedScore = async (tickerRecord: TickerV1, categoryTy
   });
 };
 
-export const bumpUpdatedAtAndInvalidateCache = async (tickerRecord: TickerV1, options?: { skipRevalidation?: boolean }) => {
+/**
+ * Discriminator for which narrow per-subpage tag to invalidate alongside the
+ * umbrella `tickerAndExchangeTag` (which the main `/stocks/[exchange]/[ticker]`
+ * page subscribes to). Pass the right one so only the affected subpage's cache
+ * is invalidated, not all seven.
+ */
+export type TickerCacheSlice = { kind: 'category'; category: TickerAnalysisCategory } | { kind: 'competition' } | { kind: 'managementTeam' } | { kind: 'core' };
+
+const invalidateNarrowTag = (tickerRecord: TickerV1, slice: TickerCacheSlice): void => {
+  switch (slice.kind) {
+    case 'category':
+      revalidateTickerCategoryReportTag(tickerRecord.symbol, tickerRecord.exchange, slice.category);
+      return;
+    case 'competition':
+      revalidateTickerCompetitionTag(tickerRecord.symbol, tickerRecord.exchange);
+      return;
+    case 'managementTeam':
+      revalidateTickerManagementTeamTag(tickerRecord.symbol, tickerRecord.exchange);
+      return;
+    case 'core':
+      // Ticker-core changes (summary/aboutReport) only need the umbrella tag —
+      // the subpage caches still hold valid data for their own slice.
+      return;
+  }
+};
+
+export const bumpUpdatedAtAndInvalidateCache = async (tickerRecord: TickerV1, slice: TickerCacheSlice, options?: { skipRevalidation?: boolean }) => {
   if (!options?.skipRevalidation) {
+    // Always bump the umbrella so the aggregate main page rebuilds...
     revalidateTickerAndExchangeTag(tickerRecord.symbol, tickerRecord.exchange);
+    // ...plus the one narrow tag for the subpage whose data actually changed.
+    invalidateNarrowTag(tickerRecord, slice);
   }
   await prisma.tickerV1.update({
     where: {


### PR DESCRIPTION
## Summary

Three coordinated fixes to stop one ticker update from invalidating every per-ticker static page (`/stocks/[exchange]/[ticker]` plus its 6 subpages).

### 1. Stop calling `revalidateTag` from the read path

`ensurePriceHistoryIsFresh` (`utils/price-history-utils.ts`) and `fetchAndUpdateStockAnalyzerData` / `refreshMarketSummaryForFairValue` (`utils/stock-analyzer-scraper-utils.ts`) used to call `revalidateTickerAndExchangeTag` while serving an API request. The static ticker page itself fetches those APIs during its render, so each revalidate evicted the very cache entry that was about to be filled — forcing the next request to rebuild and counting as a duplicate ISR write each time.

### 2. Split the umbrella tag into per-subpage slice tags

The main `/stocks/[exchange]/[ticker]` page still uses the umbrella `tickerAndExchangeTag`. The per-category subpages now subscribe to a narrow `tickerCategoryReportTag(t, e, category)`; the competition and management-team subpages use their own narrow tags. Savers (`bumpUpdatedAtAndInvalidateCache`) invalidate the umbrella plus the one narrow tag that matches the data they touched, so a category save now invalidates two pages (main + that one subpage) instead of all seven.

The admin "Revalidate" action (`cache-actions.ts` → `revalidateAllTickerTags`) keeps the previous "blow away everything for this ticker" behavior.

### 3. `prefetch={false}` on every ticker-bound `<Link>`

Listing pages render 50–100 ticker cards each. The App Router was prefetching every one when they entered the viewport, converting any tag invalidation into an ISR rebuild as soon as the next listing-page view fired. With `prefetch={false}` the rebuild only happens on actual navigation.

Files: 28 changed, 175 insertions, 40 deletions.

## Test plan

- [ ] `yarn lint` passes (verified locally).
- [ ] `yarn prettier-check` passes (verified locally).
- [ ] `yarn compile` — 6 pre-existing image-module errors remain unrelated to this branch; no new errors introduced.
- [ ] Smoke-test the main ticker page and at least one subpage of each kind (fair-value, competition, management-team) — visible data still renders.
- [ ] Trigger an admin "Revalidate" on a ticker and confirm all per-ticker pages refresh.
- [ ] After deploy, watch ISR write counts for `/stocks/[exchange]/[ticker]` and `/stocks/[exchange]/[ticker]/fair-value` — they should drop substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)