### PR TITLE
Narrow per-step cache invalidation; time-based revalidate on financial fetches

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/fetch-financial-data/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/fetch-financial-data/route.ts
@@ -1,7 +1,7 @@
 import { withLoggedInAdmin } from '@/app/api/helpers/withLoggedInAdmin';
 import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { fetchAndUpdateStockAnalyzerData } from '@/utils/stock-analyzer-scraper-utils';
-import { revalidateAllTickerTags } from '@/utils/ticker-v1-cache-utils';
+import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
 import { prisma } from '@/prisma';
 import { NextRequest } from 'next/server';
 
@@ -57,8 +57,11 @@ const postHandler = async (
       // fetchAndUpdateStockAnalyzerData no longer revalidates on its own (it
       // runs in the read path of several API routes where revalidating would
       // double the ISR write count). This admin endpoint is an explicit
-      // write-path refresh, so we invalidate every per-ticker tag here.
-      revalidateAllTickerTags(ticker.symbol, ticker.exchange);
+      // write-path refresh, so we invalidate the umbrella tag here — the
+      // scraper data feeds the main /stocks/[exchange]/[ticker] page only
+      // (financial-info + quarterly-chart), so per-subpage tags (category,
+      // competition, management-team) don't need invalidation.
+      revalidateTickerAndExchangeTag(ticker.symbol, ticker.exchange);
       processed++;
     } catch (error: any) {
       errors.push({

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -131,13 +131,21 @@ async function getTickerOrRedirect(params: RouteParams): Promise<TickerV1FastRes
  * Refresh window for time-driven scraper / market-data fetches. These hit
  * external services (Stock Analyzer Lambda, Yahoo Finance) whose underlying
  * upserts use a 7-day staleness threshold (`yahoo-price-history.ts` /
- * `stock-analyzer-scraper-utils.ts` FETCH_CONFIGS). Setting `revalidate` on
- * those specific fetches lets the page-level fetch cache expire on the same
- * cadence — so the freshness check has a chance to run on dormant tickers
- * without us blasting a `revalidateTag` call that would invalidate every
- * unrelated fetch tagged on the same page.
+ * `stock-analyzer-scraper-utils.ts` FETCH_CONFIGS).
+ *
+ * We deliberately pick 8 days — one full day beyond the staleness threshold —
+ * so that when this fetch's cache does expire and the API route runs, the DB
+ * row's `lastUpdatedAt*` is guaranteed to be older than 7 days, which makes
+ * the freshness check fire and the upstream Lambda/Yahoo call actually
+ * happen. At exactly 7 days the comparison (`ageInDays > 7`) can fall on the
+ * wrong side and skip the refresh.
+ *
+ * Only the 3 fetches that depend on external freshness (price-history,
+ * financial-info, quarterly-chart) carry this revalidate. The umbrella tag
+ * is invalidated independently by savers/admin actions; the time-based
+ * revalidate is purely a backstop for dormant tickers.
  */
-const SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60;
+const EIGHT_DAYS_IN_SECONDS = 8 * 24 * 60 * 60;
 
 /** Similar + financial fetchers (promise-based for Suspense) */
 async function fetchSimilar(exchange: string, ticker: string): Promise<SimilarTicker[]> {
@@ -154,7 +162,7 @@ async function fetchFinancialInfo(exchange: string, ticker: string): Promise<Fin
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/financial-info`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: EIGHT_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchFinancialInfo failed (${res.status}): ${url}`);
       return null;
@@ -172,7 +180,7 @@ async function fetchQuarterlyChartData(exchange: string, ticker: string): Promis
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/quarterly-chart-data`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: EIGHT_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchQuarterlyChartData failed (${res.status}): ${url}`);
       return null;
@@ -190,7 +198,7 @@ async function fetchPriceHistory(exchange: string, ticker: string): Promise<Pric
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/price-history`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: EIGHT_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchPriceHistory failed (${res.status}): ${url}`);
       return null;

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -127,6 +127,18 @@ async function getTickerOrRedirect(params: RouteParams): Promise<TickerV1FastRes
   return tickerAnyExchange;
 }
 
+/**
+ * Refresh window for time-driven scraper / market-data fetches. These hit
+ * external services (Stock Analyzer Lambda, Yahoo Finance) whose underlying
+ * upserts use a 7-day staleness threshold (`yahoo-price-history.ts` /
+ * `stock-analyzer-scraper-utils.ts` FETCH_CONFIGS). Setting `revalidate` on
+ * those specific fetches lets the page-level fetch cache expire on the same
+ * cadence — so the freshness check has a chance to run on dormant tickers
+ * without us blasting a `revalidateTag` call that would invalidate every
+ * unrelated fetch tagged on the same page.
+ */
+const SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60;
+
 /** Similar + financial fetchers (promise-based for Suspense) */
 async function fetchSimilar(exchange: string, ticker: string): Promise<SimilarTicker[]> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/similar-tickers`;
@@ -142,7 +154,7 @@ async function fetchFinancialInfo(exchange: string, ticker: string): Promise<Fin
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/financial-info`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchFinancialInfo failed (${res.status}): ${url}`);
       return null;
@@ -160,7 +172,7 @@ async function fetchQuarterlyChartData(exchange: string, ticker: string): Promis
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/quarterly-chart-data`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchQuarterlyChartData failed (${res.status}): ${url}`);
       return null;
@@ -178,7 +190,7 @@ async function fetchPriceHistory(exchange: string, ticker: string): Promise<Pric
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/price-history`;
 
   try {
-    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+    const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)], revalidate: SEVEN_DAYS_IN_SECONDS } });
     if (!res.ok) {
       console.error(`fetchPriceHistory failed (${res.status}): ${url}`);
       return null;

--- a/insights-ui/src/utils/analysis-reports/save-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@/types/public-equity/analysis-factors-types';
 import { CATEGORY_MAPPINGS, InvestorTypes, ManagementTeamAlignmentVerdict, TickerAnalysisCategory } from '@/types/ticker-typesv1';
 import { fetchAnalysisFactors, fetchTickerRecordBySymbolAndExchangeWithIndustryAndSubIndustry } from '@/utils/analysis-reports/get-report-data-utils';
-import { revalidateAllTickerTags } from '@/utils/ticker-v1-cache-utils';
+import { revalidateTickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
 import { bumpUpdatedAtAndInvalidateCache, TickerCacheSlice, updateTickerCachedScore } from '@/utils/ticker-v1-model-utils';
 import { TickerV1 } from '@prisma/client';
 
@@ -316,14 +316,14 @@ export async function saveFinalSummaryResponse(
   });
 
   if (!options?.skipRevalidation) {
-    // saveFinalSummaryResponse is the final step of the full generation
-    // pipeline. Every earlier step in `save-report-callback` passes
-    // `skipRevalidation: true`, so this is the only place an end-to-end run
-    // gets to invalidate caches. The pipeline touched every slice (categories,
-    // competition, management-team, ticker core), so we need to invalidate all
-    // per-ticker tags here — not just the umbrella — otherwise the per-subpage
-    // caches would keep serving stale data after a regeneration.
-    revalidateAllTickerTags(tickerRecord.symbol, tickerRecord.exchange);
+    // Final summary updates ticker.summary / metaDescription / aboutReport —
+    // all surfaced only on the main aggregate page, not on any subpage. Each
+    // step that DID run during this regen already invalidated its own narrow
+    // tag (per the new bumpUpdatedAtAndInvalidateCache semantics), so all we
+    // need to bump here is the umbrella. For a partial regen that includes
+    // only Final Summary, only the main page rebuilds — no false-positive
+    // subpage rebuilds.
+    revalidateTickerAndExchangeTag(tickerRecord.symbol, tickerRecord.exchange);
   }
 }
 

--- a/insights-ui/src/utils/ticker-v1-model-utils.ts
+++ b/insights-ui/src/utils/ticker-v1-model-utils.ts
@@ -351,11 +351,19 @@ const invalidateNarrowTag = (tickerRecord: TickerV1, slice: TickerCacheSlice): v
 };
 
 export const bumpUpdatedAtAndInvalidateCache = async (tickerRecord: TickerV1, slice: TickerCacheSlice, options?: { skipRevalidation?: boolean }) => {
+  // Each saver writes one specific slice of data; the only page that actually
+  // renders that slice is the matching subpage. Invalidate its narrow tag
+  // unconditionally so the subpage rebuilds the next time it's hit, regardless
+  // of whether more pipeline steps are queued.
+  invalidateNarrowTag(tickerRecord, slice);
+
+  // The umbrella (main aggregate page) is the one we defer during a multi-step
+  // generation. The page renders every slice at once, so rebuilding it after
+  // each step would re-render the same shell with one section's update — we'd
+  // rather invalidate once when the pipeline finishes. `skipRevalidation: true`
+  // skips ONLY the umbrella for this reason.
   if (!options?.skipRevalidation) {
-    // Always bump the umbrella so the aggregate main page rebuilds...
     revalidateTickerAndExchangeTag(tickerRecord.symbol, tickerRecord.exchange);
-    // ...plus the one narrow tag for the subpage whose data actually changed.
-    invalidateNarrowTag(tickerRecord, slice);
   }
   await prisma.tickerV1.update({
     where: {


### PR DESCRIPTION
Follow-up to #1472. Three refinements driven by re-reading `save-report-callback` and walking through what each subpage actually queries from Prisma.

## Summary

### 1. `bumpUpdatedAtAndInvalidateCache` — narrow tag always fires; `skipRevalidation` defers only the umbrella

Before: when a step ran with `skipRevalidation: true` (any intermediate step of a multi-step generation), the saver invalidated nothing. The last step then invalidated only its own narrow tag + umbrella, leaving every other step's subpage stale until something else fired.

After: every step invalidates its own narrow tag immediately. `skipRevalidation` only defers the umbrella (main aggregate page). Result: a partial regen that touches only business-and-moat invalidates only the business-and-moat subpage + the main page — never competition, never management-team, never the other 4 category subpages.

### 2. `saveFinalSummaryResponse` — back to umbrella-only

It used to call `revalidateAllTickerTags` to compensate for the gap above. With (1) fixed, that's now over-invalidating in a partial regen that happens to include `FINAL_SUMMARY`. Reverted to `revalidateTickerAndExchangeTag`. Final-summary fields are only rendered on the main page.

### 3. `fetch-financial-data` admin endpoint — also umbrella-only

Audited what each subpage's data route actually reads:

| Page | API route | Prisma tables read |
|---|---|---|
| Main `/stocks/[exchange]/[ticker]` | `/financial-info`, `/quarterly-chart-data` | `TickerV1StockAnalyzerScrapperInfo` ✓ |
| 5 category subpages | `/{slug}-data` | `TickerV1` + `TickerV1CategoryAnalysisResult` |
| `/competition` | `/competition-tickers` | `TickerV1VsCompetition` |
| `/management-team` | `/exchange/[exchange]/[ticker]` | `TickerV1` + `TickerV1ManagementTeamReport` |

Only the main page reads scraper data. So the admin "refresh financial data" endpoint just needs the umbrella tag — invalidating category/competition/management-team tags after a scraper refresh is wasted ISR writes.

### 4. `revalidate: 7d` on price-history / financial-info / quarterly-chart fetches

The underlying `ensurePriceHistoryIsFresh` / `ensureStockAnalyzerDataIsFresh` utilities have 7-day staleness thresholds, but with #1472's read-path-revalidate removal, dormant tickers (no saves, no admin activity) would never have their freshness check fire. Adding `next: { revalidate: 7d }` to those three specific fetches lets only those fetch caches expire on a 7-day cadence — no need for a periodic `revalidateTag` call that would invalidate every unrelated tag on the page.

## Test plan

- [x] `yarn lint`
- [x] `yarn prettier-check`
- [x] `yarn compile`
- [ ] After deploy: kick off a partial regen (e.g. just business-and-moat) and confirm only that subpage's cache invalidates (other subpages keep serving their cached version)
- [ ] After deploy: kick off a full regen and confirm all 7 subpages + main page rebuild
- [ ] Confirm main ticker page rebuilds at most once / 7 days from time-based revalidate alone, without other invalidations

🤖 Generated with [Claude Code](https://claude.com/claude-code)