### PR TITLE
refactor(etfs): trim FuturePerformanceOutlook prompt input

### DIFF
--- a/docs/insights-ui/etf-prompts/future-performance-outlook.md
+++ b/docs/insights-ui/etf-prompts/future-performance-outlook.md
@@ -30,11 +30,11 @@ This category often cannot be completed using ETF snapshot data alone. You are e
 
 Use these blocks in this order when overlapping fields exist:
 
-- `etfMorPortfolioInfo` → asset allocation, sector exposure, credit quality, fixed-income style (duration/maturity/yield-to-maturity), holdings summary.
-- `etfMorAnalyzerInfo` → Mor overview (SEC/TTM yield, turnover, category/style box), holdings.topHoldings, `strategyText`, and any available analysis sections.
-- `etfStockAnalyzerInfo` → price/technicals (MA20/50/150/200, RSI daily/weekly/monthly, 52w/ATH/ATL distances), liquidity (avgVolume, dollarVol), flags (options/leverage).
-- `etfMorRiskInfo` → drawdown/capture/risk tables that inform regime + volatility fit.
-- `etfFinancialInfo` → AUM, expense ratio, P/E, dividend yield, volume, beta.
+- `etfMorPortfolioInfo` → asset allocation, sector exposure (vs category + vs index), credit quality, fixed-income style (duration / yield-to-maturity / average maturity), top-10 holdings, holdings summary (equity/bond/other split, % of assets in top 10).
+- `etfMorAnalyzerInfo` → `strategyText`, `overviewCategory`, `overviewStyleBox`, `overviewSecYield`, `overviewTtmYield`, and the fund-vs-category-vs-index `returnsAnnual` / `returnsTrailing` tables.
+- `etfStockAnalyzerInfo` → full price/technicals (MA20/50/150/200, RSI daily/weekly/monthly, ATH/ATL + 52w distances), multi-period returns 1m → 20y + CAGRs, beta windows, sortino / sharpe / atr, liquidity (avgVolume / dollarVol / relVolume), dividend growth (`divGrowth*`, `divYears`, `divGrYears`), leverage / options / region flags.
+- `etfMorRiskInfo` → drawdown / capture / risk-and-volatility tables for the 3-Yr and 5-Yr windows that inform regime + volatility fit.
+- `etfFinancialInfo` → `aum`, `pe`, `dividendYield`, `beta`, `holdings` (count).
 
 If you cite “the benchmark”, name it explicitly (index name from holdings/strategy blocks when present).
 
@@ -149,5 +149,4 @@ If a factor’s core metric is missing, use the lookup rule first; otherwise jud
 - etfStockAnalyzerInfo: {{etfStockAnalyzerInfo}}
 - etfMorAnalyzerInfo: {{etfMorAnalyzerInfo}}
 - etfMorRiskInfo: {{etfMorRiskInfo}}
-- etfMorPeopleInfo: {{etfMorPeopleInfo}}
 - etfMorPortfolioInfo: {{etfMorPortfolioInfo}}

--- a/insights-ui/schemas/etf-analysis/inputs/future-performance-outlook-input.schema.yaml
+++ b/insights-ui/schemas/etf-analysis/inputs/future-performance-outlook-input.schema.yaml
@@ -71,35 +71,40 @@ properties:
     type: ['string', 'null']
     description: 'The benchmark index this ETF tracks (e.g., "S&P 500", "MSCI EAFE"). May be null when not provided by upstream data.'
 
-  # From EtfFinancialInfo — baseline fund stats (cost, size, simple valuation/yield, liquidity)
+  # From EtfFinancialInfo — trimmed to forward-relevant fields only: aum, pe, dividendYield, beta, holdings count.
+  # Cost/payout fields (expenseRatio, dividendTtm, payoutFrequency, payoutRatio, sharesOut, volume,
+  # yearHigh, yearLow) belong to Cost & Team and are excluded.
   etfFinancialInfo:
     type: ['string', 'null']
-    description: 'JSON string from EtfFinancialInfo (aum, expenseRatio, pe, sharesOut, dividendTtm, dividendYield, payoutFrequency, payoutRatio, volume, yearHigh/yearLow, beta, holdings).'
+    description: 'JSON string with aum, pe, dividendYield, beta, holdings (count). Cost/payout/intraday fields are excluded — those belong to Cost & Team.'
 
-  # From EtfStockAnalyzerInfo — price, technicals, momentum, liquidity, issuer/category tags
+  # Full EtfStockAnalyzerInfo row passed through as-is. The forward outlook benefits from the
+  # full multi-period view (returns 1m → 20y, CAGRs, full MA stack, RSI daily/weekly/monthly,
+  # ATH/ATL + 52w distances, beta windows, risk-adjusted ratios, liquidity, dividend growth,
+  # categorical flags).
   etfStockAnalyzerInfo:
     type: ['string', 'null']
-    description: 'JSON string from EtfStockAnalyzerInfo (stockPrice, MAs, RSI, ATR, beta windows, 52w/ATH/ATL distances & dates, issuer/category, avgVolume/relVolume/dollarVol, options/leverage/region/country, etc.).'
+    description: 'JSON string with the full EtfStockAnalyzerInfo row (all returns/CAGRs, MA stack, RSI, ATH/ATL, 52w distances, beta windows, sortino/sharpe/atr, liquidity, dividend growth fields, leverage/options/region flags).'
 
-  # From EtfMorAnalyzerInfo — overview, returns, holdings snapshot, and Mornstar analysis sections (when available)
+  # From EtfMorAnalyzerInfo — narrow slice. Only fields that are reliably populated by the
+  # upstream Mor scrape AND directly inform the forward read. The `analysis` block
+  # (medalistRating, headline, sections) is intentionally omitted because the scrape does
+  # not consistently populate it.
   etfMorAnalyzerInfo:
     type: ['string', 'null']
-    description: 'JSON string from EtfMorAnalyzerInfo (overview metrics like SEC/TTM yield, turnover, style box; annual/trailing returns; holdings.topHoldings; strategyText; analysis sections if available).'
+    description: 'JSON string with strategyText, overviewCategory, overviewStyleBox, overviewSecYield, overviewTtmYield, returnsAnnual, returnsTrailing. The Mor `analysis` block (sections / medalistRating / headline) is omitted because it is unreliable in the upstream scrape.'
 
-  # From EtfMorRiskInfo — risk tables useful for volatility regime + drawdown context
+  # From EtfMorRiskInfo — only the 3-Yr and 5-Yr risk periods. The 10-Yr window belongs to
+  # the Risk Analysis report.
   etfMorRiskInfo:
     type: ['string', 'null']
-    description: 'JSON string from EtfMorRiskInfo (riskPeriods for 3/5/10-yr: risk score/level, risk vs category, capture ratios, drawdowns/dates, risk & volatility measures).'
+    description: 'JSON string with riskPeriods limited to 3-Yr and 5-Yr (each carrying portfolioRiskScore, morAnalyzerRiskReturn, riskAndVolatilityMeasures, marketVolatilityMeasures with captureRatios + drawdown + drawdownDates). The 10-Yr period is excluded.'
 
-  # From EtfMorPeopleInfo — used for catalyst risk and process/people stability context
-  etfMorPeopleInfo:
-    type: ['string', 'null']
-    description: 'JSON string from EtfMorPeopleInfo (inception date, managers, tenure, advisors, current managers list).'
-
-  # From EtfMorPortfolioInfo — the richest source for holdings mix + style/sector/credit positioning
+  # From EtfMorPortfolioInfo — the richest source for holdings mix + style/sector/credit positioning.
+  # Holdings tail is capped at top 10; ESG and turnover fields on the summary are excluded.
   etfMorPortfolioInfo:
     type: ['string', 'null']
-    description: 'JSON string from EtfMorPortfolioInfo (asset allocation, style measures, sector exposure, fixed income style, bond breakdown/credit quality, holdings summary and detail, turnover/ESG fields when present).'
+    description: 'JSON string with assetAllocation, styleMeasures, fixedIncomeStyle, sectorExposure, bondBreakdown, plus the holdings block with the holdings array capped at the top 10 by weight and ESG / turnover fields stripped from the summary.'
 
 required:
   - name

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -102,27 +102,51 @@ function prepareFactorAnalysisArray(factors: EtfAnalysisFactorDefinition[]) {
 
 const PORTFOLIO_HOLDINGS_TOP_N = 10;
 
+// Summary fields on EtfMorPortfolioInfo.holdings.summary that belong to other reports
+// (turnover → Cost & Team; women director / executive percentages → ESG, not forward outlook)
+// and should be stripped before passing the bundle to the future-outlook prompt.
+const OUTLOOK_PORTFOLIO_SUMMARY_DROPPED_KEYS = new Set(['reportedTurnoverPct', 'turnoverAsOfDate', 'womenDirectorsPct', 'womenExecutivesPct']);
+
 /**
- * Returns a shallow clone of `morPortfolioInfo` with the inner holdings list capped
- * at the top N entries. The raw holdings array for a broad-index ETF can contain
- * hundreds of rows and blow the prompt size past `60KB`, even though only the
- * largest positions drive the analysis. Everything else on the record is kept intact.
+ * Trim `morPortfolioInfo` for the future-performance-outlook prompt: cap the holdings
+ * list at the top 10 by weight AND strip ESG + turnover fields from the holdings
+ * summary block. Asset allocation, style measures, fixed-income style, sector exposure,
+ * and bond breakdown are kept intact.
  */
-function trimPortfolioHoldings(portfolio: EtfWithAllData['morPortfolioInfo']): EtfWithAllData['morPortfolioInfo'] {
+function trimPortfolioForOutlook(portfolio: EtfWithAllData['morPortfolioInfo']): EtfWithAllData['morPortfolioInfo'] {
   if (!portfolio) return portfolio;
 
-  const holdingsJson = portfolio.holdings as { summary?: unknown; columns?: unknown; holdings?: unknown } | null;
-  if (!holdingsJson || !Array.isArray(holdingsJson.holdings) || holdingsJson.holdings.length <= PORTFOLIO_HOLDINGS_TOP_N) {
-    return portfolio;
-  }
+  const holdingsJson = portfolio.holdings as { summary?: Record<string, unknown> | null; columns?: unknown; holdings?: unknown[] } | null;
+  if (!holdingsJson) return portfolio;
+
+  const trimmedSummary = holdingsJson.summary
+    ? Object.fromEntries(Object.entries(holdingsJson.summary).filter(([k]) => !OUTLOOK_PORTFOLIO_SUMMARY_DROPPED_KEYS.has(k)))
+    : holdingsJson.summary;
+
+  const trimmedHoldings = Array.isArray(holdingsJson.holdings) ? holdingsJson.holdings.slice(0, PORTFOLIO_HOLDINGS_TOP_N) : holdingsJson.holdings;
 
   return {
     ...portfolio,
     holdings: {
       ...holdingsJson,
-      holdings: holdingsJson.holdings.slice(0, PORTFOLIO_HOLDINGS_TOP_N),
+      summary: trimmedSummary,
+      holdings: trimmedHoldings,
     } as typeof portfolio.holdings,
   };
+}
+
+// Risk periods we surface to the future-outlook prompt. The 10-Yr window belongs to
+// the Risk Analysis report and is not referenced by any outlook factor.
+const OUTLOOK_RISK_PERIOD_KEYS: ReadonlyArray<'3-Yr' | '5-Yr'> = ['3-Yr', '5-Yr'];
+
+function pickOutlookRiskPeriods(riskPeriods: unknown): Record<string, unknown> | null {
+  if (!riskPeriods || typeof riskPeriods !== 'object') return null;
+  const source = riskPeriods as Record<string, unknown>;
+  const picked: Record<string, unknown> = {};
+  for (const key of OUTLOOK_RISK_PERIOD_KEYS) {
+    if (source[key] != null) picked[key] = source[key];
+  }
+  return Object.keys(picked).length > 0 ? picked : null;
 }
 
 export function preparePerformanceAndReturnsInputJson(etf: EtfWithAllData) {
@@ -366,15 +390,45 @@ export function prepareFuturePerformanceOutlookInputJson(etf: EtfWithAllData) {
   const mor = etf.morAnalyzerInfo;
   const fin = etf.financialInfo;
   const risk = etf.morRiskInfo;
-  const people = etf.morPeopleInfo;
-  // The raw holdings list can run to hundreds of rows; trim to the top positions so
-  // the resulting prompt stays within a reasonable size budget for downstream LLMs.
-  const portfolio = trimPortfolioHoldings(etf.morPortfolioInfo);
+  const portfolio = trimPortfolioForOutlook(etf.morPortfolioInfo);
 
   const assetClass = sa?.assetClass || 'Equity';
   const fundCategory = sa?.category || null;
   const groupKey = getEtfGroupKeyForCategory(fundCategory) || DEFAULT_GROUP_KEY;
   const factors = getEtfAnalysisFactorsForCategory(EtfAnalysisCategory.FuturePerformanceOutlook, { fundCategory: fundCategory ?? undefined });
+
+  // EtfFinancialInfo — keep only forward-relevant fields. Cost/payout/intraday columns
+  // (expenseRatio, dividendTtm, payoutFrequency, payoutRatio, sharesOut, volume,
+  // yearHigh, yearLow) belong to Cost & Team and are excluded.
+  const financialBundle = fin
+    ? {
+        aum: fin.aum,
+        pe: fin.pe,
+        dividendYield: fin.dividendYield,
+        beta: fin.beta,
+        holdings: fin.holdings,
+      }
+    : null;
+
+  // EtfMorAnalyzerInfo — narrow slice. The Mor `analysis` block (sections / medalistRating
+  // / headline) is intentionally omitted: the upstream scrape does not consistently
+  // populate it, and including it in the schema trains the LLM to expect data that
+  // typically won't be there. Market data + cost-related overview fields are also dropped.
+  const morAnalyzerBundle = mor
+    ? {
+        strategyText: mor.strategyText,
+        overviewCategory: mor.overviewCategory,
+        overviewStyleBox: mor.overviewStyleBox,
+        overviewSecYield: mor.overviewSecYield,
+        overviewTtmYield: mor.overviewTtmYield,
+        returnsAnnual: mor.returnsAnnual,
+        returnsTrailing: mor.returnsTrailing,
+      }
+    : null;
+
+  // EtfMorRiskInfo — keep only 3-Yr + 5-Yr periods. 10-Yr is Risk Analysis territory.
+  const riskPeriodsBundle = pickOutlookRiskPeriods(risk?.riskPeriods);
+  const morRiskBundle = riskPeriodsBundle ? { riskPeriods: riskPeriodsBundle } : null;
 
   return {
     name: etf.name,
@@ -389,15 +443,16 @@ export function prepareFuturePerformanceOutlookInputJson(etf: EtfWithAllData) {
     indexName: sa?.indexName ?? null,
     factorAnalysisArray: prepareFactorAnalysisArray(factors),
 
-    // Broad blocks: the forward-looking category is explicitly synthesis-heavy,
-    // and upstream data availability varies a lot by ETF type. Route through
-    // serializeBigIntFields so BigInt columns (stockAnalyzerInfo.avgVolume,
-    // dollarVol, preVolume) don't break JSON.stringify.
-    etfFinancialInfo: fin ? JSON.stringify(serializeBigIntFields(fin)) : null,
+    etfFinancialInfo: financialBundle ? JSON.stringify(financialBundle) : null,
+    // Full EtfStockAnalyzerInfo row passes through — slicing it loses too many useful
+    // signals for the forward read (full multi-period returns + CAGRs, complete MA stack,
+    // RSI daily/weekly/monthly, ATH/ATL + 52w distances, beta windows, risk-adjusted
+    // ratios, liquidity, dividend growth, leverage/options/region flags). Routed through
+    // serializeBigIntFields so BigInt columns (avgVolume, dollarVol, preVolume) don't
+    // break JSON.stringify.
     etfStockAnalyzerInfo: sa ? JSON.stringify(serializeBigIntFields(sa)) : null,
-    etfMorAnalyzerInfo: mor ? JSON.stringify(serializeBigIntFields(mor)) : null,
-    etfMorRiskInfo: risk ? JSON.stringify(serializeBigIntFields(risk)) : null,
-    etfMorPeopleInfo: people ? JSON.stringify(serializeBigIntFields(people)) : null,
+    etfMorAnalyzerInfo: morAnalyzerBundle ? JSON.stringify(serializeBigIntFields(morAnalyzerBundle)) : null,
+    etfMorRiskInfo: morRiskBundle ? JSON.stringify(serializeBigIntFields(morRiskBundle)) : null,
     etfMorPortfolioInfo: portfolio ? JSON.stringify(serializeBigIntFields(portfolio)) : null,
   };
 }


### PR DESCRIPTION
## Summary

Replaces the six dump-everything JSON blobs that today get sent to the FuturePerformanceOutlook prompt with five narrower bundles sized to what the prompt + factor logic actually use.

- **etfFinancialInfo**: only `aum`, `pe`, `dividendYield`, `beta`, `holdings` (count). Drop cost / payout / volume / 52w-range columns (those are Cost & Team or already covered by StockAnalyzer 52w fields).
- **etfStockAnalyzerInfo**: pass the full row through — slicing it loses too many signals for the forward read (multi-period returns + CAGRs, full MA stack, RSI daily/weekly/monthly, ATH/ATL + 52w distances, beta windows, sortino / sharpe / atr, liquidity, dividend growth, leverage / options / region flags).
- **etfMorAnalyzerInfo**: only `strategyText`, `overviewCategory`, `overviewStyleBox`, `overviewSecYield`, `overviewTtmYield`, `returnsAnnual`, `returnsTrailing`. Drop the `analysis` block (`medalistRating`, `headline`, `sections`) — unreliable in the upstream Mor scrape, so including it trains the LLM to expect data that typically won't be there. Also drop all `marketData.*` and the cost-related overview fields.
- **etfMorRiskInfo**: keep only 3-Yr and 5-Yr risk periods. 10-Yr belongs to the Risk Analysis report.
- **etfMorPortfolioInfo**: keep `assetAllocation`, `styleMeasures`, `fixedIncomeStyle`, `sectorExposure`, `bondBreakdown`, plus the holdings block with the holdings array capped at top 10 and the summary stripped of ESG (`womenDirectorsPct`, `womenExecutivesPct`) + turnover (`reportedTurnoverPct`, `turnoverAsOfDate`) fields.
- **etfMorPeopleInfo**: removed entirely. No outlook factor reads from it.

Schema YAML, builder (\`prepareFuturePerformanceOutlookInputJson\` in \`etf-report-input-json-utils.ts\`), and reference prompt doc (\`docs/insights-ui/etf-prompts/future-performance-outlook.md\`) updated in lockstep. The DB-stored prompt template needs to be re-seeded from the updated doc.

Dead helper \`trimPortfolioHoldings\` removed; the new \`trimPortfolioForOutlook\` is a strict superset (caps holdings at top 10 AND strips summary ESG + turnover fields).

## Files

- \`insights-ui/schemas/etf-analysis/inputs/future-performance-outlook-input.schema.yaml\`
- \`insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts\`
- \`docs/insights-ui/etf-prompts/future-performance-outlook.md\`

## Test plan

- [x] \`yarn lint\` — clean.
- [x] \`yarn prettier-check\` — clean.
- [x] \`yarn compile\` (prisma generate + tsc) — clean.
- [ ] Re-seed the DB-stored \`future-performance-outlook\` prompt template from the updated reference doc (the \`### Data\` block now omits the \`etfMorPeopleInfo\` line; \"Data source priority\" section updated to match the new field contents).
- [ ] Regenerate the FuturePerformanceOutlook report for **HODL** (single-asset crypto — exercises the commodities-and-digital-assets path with mostly-empty portfolio decomposition) and **AVMV** (US value equity — exercises sector breakdown + style measures + dividend yield). Diff verdicts (Favorable / Mixed / Unfavorable) per factor against the prior pre-change generation; verdict labels should not regress.
- [ ] Spot-check the resulting input JSON byte size — the trim should drop noticeably for AVMV (entire EtfMorPeopleInfo gone, ~12 unused Mor overview fields gone, ~7 EtfFinancialInfo cost/payout fields gone, 10-Yr risk period gone, holdings tail beyond top 10 gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)