### PR TITLE
feat(etfs): add bid-ask-spread / trading-cost factor to Cost & Team

### DIFF
--- a/insights-ui/src/etf-analysis-data/etf-analysis-factors-cost-efficiency-and-team.json
+++ b/insights-ui/src/etf-analysis-data/etf-analysis-factors-cost-efficiency-and-team.json
@@ -1,7 +1,7 @@
 {
   "categoryKey": "CostEfficiencyAndTeam",
   "categoryName": "Cost, Efficiency & Team",
-  "categoryDescription": "Looks at the slow-leak factors that quietly decide whether long-term returns reach the investor or get eaten up by costs: fees, what you actually earn for those fees, the people running the fund, and tax drag. Four factors apply to every ETF group. `factorDescription` carries the generic measurement principle and Pass/Fail rule. `groupInstructions` carries the group-specific perspective. When the two seem to conflict, follow `groupInstructions`.",
+  "categoryDescription": "Looks at the slow-leak factors that quietly decide whether long-term returns reach the investor or get eaten up by costs: fees, what you actually earn for those fees, the recurring spread cost of trading, the people running the fund, and tax drag. Five factors apply to every ETF group. `factorDescription` carries the generic measurement principle and Pass/Fail rule. `groupInstructions` carries the group-specific perspective. When the two seem to conflict, follow `groupInstructions`.",
   "factors": [
     {
       "factorKey": "expense_ratio_vs_competition",
@@ -35,6 +35,23 @@
         "allocation-target-date": "Compare net return to a simple cheap blend (e.g. broad equity + core bond at near-zero fee) over multi-year windows. The value-add is automatic rebalancing — if the fund doesn't beat the DIY mix, the extra fee is hard to justify. Verdict band: Strong = net return ≥2 pp above the cheap DIY blend; In Line = within ±2 pp; Weak / Fail = ≥2 pp below.",
         "fixed-income-investment-grade": "Compare net total return to a cheap passive sibling of the same duration. A fee gap should be paid for by yield or active alpha — otherwise the cheap passive option wins. Verdict band uses narrow thresholds for bonds: Strong = net return ≥0.5 pp above the cheap passive sibling; In Line = within ±0.5 pp; Weak / Fail = ≥0.5 pp below.",
         "fixed-income-credit-and-income": "Compare net total return to a cheap passive credit sibling of the same tier. Active credit should show documented manager alpha after fees — otherwise the cheap passive option wins. Verdict band uses narrow thresholds for credit: Strong = net return ≥0.5 pp above the cheap passive sibling; In Line = within ±0.5 pp; Weak / Fail = ≥0.5 pp below."
+      }
+    },
+    {
+      "factorKey": "bid_ask_spread_and_trading_cost",
+      "factorTitle": "Bid-Ask Spread & Implicit Trading Cost",
+      "factorDescription": "Measures the cost retail pays every time they enter or exit the fund — a recurring drag that sits outside the expense ratio and compounds with every rebalance, dividend reinvestment, or dollar-cost-averaging contribution. The 30-day median bid-ask spread (in basis points) is the headline measure. A 2 bps spread on a fund traded once a year is trivial; a persistent 30 bps spread on a fund a retail investor DCAs into monthly costs more than the expense ratio every year. Spread quality is downstream of underlying liquidity, AUM supporting tight market-maker quoting, and authorized-participant arbitrage health — but treated here purely as the recurring cost retail pays to transact, not as a stress-event risk. Pass when the median spread is at or below category norm for the fund's structure. Fail when the spread is persistently wide vs peers in normal market conditions, making the fund materially more expensive to own than the expense ratio suggests.",
+      "factorMetrics": "marketBidAskSpread, avgVolume, dollarVol, aum, overviewCategory",
+      "groups": "all",
+      "groupInstructions": {
+        "broad-equity": "Tightest bar — mega-cap passive ETFs (VOO, VTI, IVV, SPY) trade at 1-2 bps. Anything above 5 bps on a plain US large-cap tracker signals thin AP support or low volume. Small-cap and international broad trackers run 3-10 bps as normal.",
+        "sector-thematic-equity": "S&P sector ETFs (XL- series, VGT) trade at 1-3 bps. Thematic and niche ETFs commonly run 10-40 bps in normal conditions — material vs the headline fee for a retail investor making monthly contributions.",
+        "leveraged-inverse": "TQQQ, SOXL, UPRO trade at 1-3 bps because of massive volume. Smaller leveraged products can run 10-30 bps even in calm markets — a critical cost because the use case is rapid trading with multiple round-trips.",
+        "commodities-and-digital-assets": "GLD, IAU, SLV: 1-3 bps. Spot Bitcoin ETFs (IBIT, FBTC): 2-5 bps. Futures-based commodity funds: 5-20 bps. Smaller single-commodity wrappers can hit 30-100 bps in normal conditions — material vs the headline fee.",
+        "derivative-income": "JEPI, JEPQ: 2-4 bps. Smaller covered-call and defined-outcome ETFs run 10-40 bps. The spread is especially consequential because these funds attract income-seekers who reinvest distributions monthly.",
+        "allocation-target-date": "Vanguard / BlackRock / iShares allocation ETFs: 2-5 bps. Tactical allocation ETFs can run 15-40 bps. Matters most for retail using these as DCA buy-and-hold vehicles.",
+        "fixed-income-investment-grade": "AGG, BND, VGIT: 1-3 bps. Long-duration Treasury (TLT) similar. Muni ETFs (MUB, VTEB) at 2-5 bps. Single-state muni ETFs run wider (10-30 bps) — flag for retail rebalancing in taxable accounts.",
+        "fixed-income-credit-and-income": "HYG, JNK, LQD: 2-5 bps in normal conditions. EM debt (EMB) and bank-loan (BKLN): 5-15 bps. Preferred ETFs (PFF): 3-10 bps. Anything materially above these bands is a cost flag."
       }
     },
     {


### PR DESCRIPTION
New factor `bid_ask_spread_and_trading_cost` covers the recurring cost retail pays on every entry / exit / DCA contribution — a drag that sits outside the expense ratio and compounds across every monthly contribution and reinvestment. Headline measure is the 30-day median spread in bps; size + average-daily-volume context anchors why the spread is what it is.

Applies to all 8 ETF groups with group-specific bps bands:
- broad-equity: 1-2 bps mega-cap baseline, anything over 5 bps flags thin AP support
- sector-thematic-equity: 1-3 bps for S&P sector ETFs, 10-40 bps for thematic/niche
- leveraged-inverse: 1-3 bps for TQQQ/SOXL/UPRO, 10-30 bps for smaller products
- commodities-and-digital-assets: 1-3 bps for GLD/IAU/SLV, 2-5 bps for spot-BTC, up to 100 bps for smaller single-commodity wrappers
- derivative-income: 2-4 bps for JEPI/JEPQ, 10-40 bps for smaller covered-call / defined-outcome
- allocation-target-date: 2-5 bps for major-issuer allocation ETFs, 15-40 bps tactical
- fixed-income-investment-grade: 1-3 bps for AGG/BND/TLT, 10-30 bps for single-state muni
- fixed-income-credit-and-income: 2-5 bps for HYG/JNK/LQD, 5-15 bps for EM debt / bank-loan, 3-10 bps for preferred

Cross-checked metric names against the upstream data we actually surface to the Cost & Team prompt:
- `marketBidAskSpread` is already in the `morAnalysis` bundle.
- `avgVolume` and `dollarVol` are in `stockAnalyzerFundInfo`.
- `aum` is in `financialInfo`.
- `overviewCategory` is in `morAnalysis`. No schema or builder change needed — the data the new factor reads is already in the input.

Also bumps `categoryDescription` from "Four factors" → "Five factors".

# Pull Request Template

Before submitting this PR, please make sure you have completed the following checklist. This helps ensure that our codebase remains high quality and that our features work well across all supported devices and themes.

### Code Review
- [ ] I have carefully reviewed my code and believe it is final from my side.
- [ ] I have ensured there is no hardcoded color in my changes. Colors should be defined in theme files and reused.

### Theme Compatibility
- [ ] I have tested the new feature or updates in both light and dark themes.
- [ ] I confirm that the visual aspects of the feature are compatible and appealing in both themes.

### Device Compatibility
- [ ] I have tested my changes on mobile screen sizes.
- [ ] I have tested my changes on tablet screen sizes.
- [ ] I have tested my changes on laptop screen sizes.

### Functional Testing
- [ ] I have thoroughly tested the functionality of my changes.
- [ ] I am confident that my changes do not negatively impact existing features.

### Testing Documentation
Please provide a brief description of the tests you have performed to verify your changes. Include any relevant scenarios or edge cases.

- Example test 1: Tested feature X by uploading the image
- Example test 2: Tested feature X by doing these things.

# Demo Video
Please provide a demo video of your changes. This helps reviewers understand the changes and verify the functionality.

You can record the video using tools like Loom(https://www.loom.com/), Clip by ClickUp(https://clickup.com/features/clips), Sendspark(https://www.sendspark.com/), etc.

Include the link to the video below and make sure the video covers
- [ ] Explain the task/bug you are solving
- [ ] Show the changes in the UI
- [ ] Show the changes in the codebase
- [ ] Show the changes you tested to make sure it works
- [ ] Show the changes in various screen sizes
- [ ] Show the changes in both light and dark themes
