### PR TITLE
docs(etfs): add task entry for ETF listing pages UI fixes

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -128,6 +128,10 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] **Add ETF country pages** (later) — `/etfs/countries/[country]` route exists; finish data wiring + sitemap + SEO once category pages are battle-tested.
 - [ ] **Cross-link from ETF detail pages** — category name links to the category page; small "Related ETFs in this category" block at the bottom.
 
+### ETF listing pages — UI fixes
+
+- [ ] **Audit + fix UI issues across the ETF listing surfaces** — `/etfs` (index), `/etfs/categories` (+ `[category]`), `/etfs/countries` (+ `[country]`), `/etfs/asset-classes` (+ `[assetClass]`), `/etfs/groups` (+ `[group]`), `/etfs/providers` (+ `[provider]`). Walk each page on desktop + mobile and capture concrete issues here as sub-bullets before scheduling fixes: layout/spacing, card alignment, header + breadcrumb consistency across the sub-listing variants, empty/loading/error states, sort + filter UX, pagination, and dark/light theme rendering. Cross-check against the `isComplete` filter behavior once that lands.
+
 ### Known limitations in the new 8-group taxonomy (follow-up cleanups)
 
 - [ ] **Split strategy funds back out of `derivative-income`** — managed-futures / market-neutral / long-short (~50 funds) don't share a decision framework with the ~600 option-engineered payoff funds; prompt has to branch internally. Highest-impact follow-up.

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -36,6 +36,8 @@ export interface EtfListingItem {
   payoutFrequency: string | null;
   holdings: number | null;
   beta: number | null;
+  finalScore: number | null;
+  category: string | null;
   hasMorAnalyzerInfo: boolean;
   hasMorRiskInfo: boolean;
   hasMorPeopleInfo: boolean;
@@ -73,6 +75,8 @@ function toEtfListingItem(etf: any): EtfListingItem {
     payoutFrequency: etf.financialInfo?.payoutFrequency ?? null,
     holdings: etf.financialInfo?.holdings ?? null,
     beta: etf.financialInfo?.beta ?? null,
+    finalScore: etf.cachedScore?.finalScore ?? null,
+    category: etf.stockAnalyzerInfo?.category ?? null,
     hasMorAnalyzerInfo: !!etf.morAnalyzerInfo,
     hasMorRiskInfo: !!etf.morRiskInfo,
     hasMorPeopleInfo: !!etf.morPeopleInfo,
@@ -81,6 +85,8 @@ function toEtfListingItem(etf: any): EtfListingItem {
 
 const etfListingInclude = {
   financialInfo: true,
+  cachedScore: { select: { finalScore: true } },
+  stockAnalyzerInfo: { select: { category: true } },
   morAnalyzerInfo: { select: { id: true } },
   morRiskInfo: { select: { id: true } },
   morPeopleInfo: { select: { id: true } },
@@ -88,6 +94,8 @@ const etfListingInclude = {
 
 const etfListingIncludeWithMorRisk = {
   financialInfo: true,
+  cachedScore: { select: { finalScore: true } },
+  stockAnalyzerInfo: { select: { category: true } },
   morAnalyzerInfo: { select: { id: true } },
   morRiskInfo: true,
   morPeopleInfo: { select: { id: true } },

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
@@ -1,0 +1,43 @@
+import EtfGroupCategoryDetail from '@/components/etfs/EtfGroupCategoryDetail';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfCategoryByName, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { etfGroupCategoryPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ country: string; group: string; category: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ country: string; group: string; category: string }> }): Promise<Metadata> {
+  const { country, group, category } = await props.params;
+  const decodedCountry = decodeURIComponent(country);
+  const decodedGroup = decodeURIComponent(group);
+  const decodedCategory = decodeURIComponent(category);
+  const groupObj = getEtfGroupByKey(decodedGroup);
+  const cat = getEtfCategoryByName(decodedCategory);
+  const categoryName = cat?.name ?? decodedCategory;
+  const groupName = groupObj?.name ?? decodedGroup;
+  return {
+    title: `${categoryName} ${decodedCountry} ETFs | KoalaGains`,
+    description: `Browse ${decodedCountry} ETFs in the ${categoryName} category (part of ${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function CountryEtfsByGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { country, group, category } = await params;
+  const decodedGroupKey = decodeURIComponent(group);
+  const decodedCategory = decodeURIComponent(category);
+  const decodedCountry = resolveEtfCountryParam(country, etfGroupCategoryPath(SupportedCountries.US, decodedGroupKey, decodedCategory));
+
+  const searchParams = await searchParamsPromise;
+  return EtfGroupCategoryDetail({
+    country: decodedCountry,
+    groupKey: decodedGroupKey,
+    category: decodedCategory,
+    searchParams,
+  });
+}

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -1,5 +1,4 @@
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
-import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import type { Metadata } from 'next';
@@ -8,7 +7,6 @@ export const dynamic = 'force-dynamic';
 
 type PageProps = {
   params: Promise<{ country: string; group: string }>;
-  searchParams: Promise<EtfSearchParams>;
 };
 
 export async function generateMetadata(props: { params: Promise<{ country: string; group: string }> }): Promise<Metadata> {
@@ -19,15 +17,14 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
   const displayName = groupObj?.name ?? decodedGroup;
   return {
     title: `${displayName} ${decodedCountry} ETFs | KoalaGains`,
-    description: `Browse ${decodedCountry} ETFs in the ${displayName} group with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+    description: `Browse ${decodedCountry} ETFs in the ${displayName} group organised by analysis category, with top-rated ETFs in each category.`,
   };
 }
 
-export default async function CountryEtfsByGroupPage({ params, searchParams: searchParamsPromise }: PageProps) {
+export default async function CountryEtfsByGroupPage({ params }: PageProps) {
   const { country, group } = await params;
   const decodedGroupKey = decodeURIComponent(group);
   const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
 
-  const searchParams = await searchParamsPromise;
-  return EtfGroupDetail({ country: decodedCountry, groupKey: decodedGroupKey, searchParams });
+  return EtfGroupDetail({ country: decodedCountry, groupKey: decodedGroupKey });
 }

--- a/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
@@ -1,0 +1,37 @@
+import EtfGroupCategoryDetail from '@/components/etfs/EtfGroupCategoryDetail';
+import { EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfCategoryByName, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ group: string; category: string }>;
+  searchParams: Promise<EtfSearchParams>;
+};
+
+export async function generateMetadata(props: { params: Promise<{ group: string; category: string }> }): Promise<Metadata> {
+  const { group, category } = await props.params;
+  const decodedGroup = decodeURIComponent(group);
+  const decodedCategory = decodeURIComponent(category);
+  const groupObj = getEtfGroupByKey(decodedGroup);
+  const cat = getEtfCategoryByName(decodedCategory);
+  const categoryName = cat?.name ?? decodedCategory;
+  const groupName = groupObj?.name ?? decodedGroup;
+  return {
+    title: `${categoryName} ETFs | KoalaGains`,
+    description: `Browse US ETFs in the ${categoryName} category (part of ${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+  };
+}
+
+export default async function EtfGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
+  const { group, category } = await params;
+  const searchParams = await searchParamsPromise;
+  return EtfGroupCategoryDetail({
+    country: SupportedCountries.US,
+    groupKey: decodeURIComponent(group),
+    category: decodeURIComponent(category),
+    searchParams,
+  });
+}

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -1,5 +1,4 @@
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
-import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import type { Metadata } from 'next';
@@ -8,7 +7,6 @@ export const dynamic = 'force-dynamic';
 
 type PageProps = {
   params: Promise<{ group: string }>;
-  searchParams: Promise<EtfSearchParams>;
 };
 
 export async function generateMetadata(props: { params: Promise<{ group: string }> }): Promise<Metadata> {
@@ -18,12 +16,11 @@ export async function generateMetadata(props: { params: Promise<{ group: string 
   const displayName = groupObj?.name ?? decoded;
   return {
     title: `${displayName} ETFs | KoalaGains`,
-    description: `Browse US ETFs in the ${displayName} group with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+    description: `Browse US ETFs in the ${displayName} group organised by analysis category, with top-rated ETFs in each category.`,
   };
 }
 
-export default async function EtfsByGroupPage({ params, searchParams: searchParamsPromise }: PageProps) {
+export default async function EtfsByGroupPage({ params }: PageProps) {
   const { group } = await params;
-  const searchParams = await searchParamsPromise;
-  return EtfGroupDetail({ country: SupportedCountries.US, groupKey: decodeURIComponent(group), searchParams });
+  return EtfGroupDetail({ country: SupportedCountries.US, groupKey: decodeURIComponent(group) });
 }

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -29,6 +29,8 @@ function toEtfListingItem(etf: any): EtfListingItem {
     payoutFrequency: etf.financialInfo?.payoutFrequency ?? null,
     holdings: etf.financialInfo?.holdings ?? null,
     beta: etf.financialInfo?.beta ?? null,
+    finalScore: etf.cachedScore?.finalScore ?? null,
+    category: etf.stockAnalyzerInfo?.category ?? null,
     hasMorAnalyzerInfo: !!etf.morAnalyzerInfo,
     hasMorRiskInfo: !!etf.morRiskInfo,
     hasMorPeopleInfo: !!etf.morPeopleInfo,
@@ -44,6 +46,8 @@ export default async function EtfsPage() {
         where: { spaceId: KoalaGainsSpaceId },
         include: {
           financialInfo: true,
+          cachedScore: { select: { finalScore: true } },
+          stockAnalyzerInfo: { select: { category: true } },
           morAnalyzerInfo: { select: { id: true } },
           morRiskInfo: { select: { id: true } },
           morPeopleInfo: { select: { id: true } },

--- a/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
+++ b/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
@@ -1,4 +1,5 @@
 import { EtfGroupingPreviewItem } from '@/utils/etf-grouping-utils';
+import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import Link from 'next/link';
 import React from 'react';
 
@@ -7,19 +8,14 @@ interface CompactEtfGroupingCardProps {
   href: string;
   totalCount?: number;
   etfs: EtfGroupingPreviewItem[];
+  maxRows?: number;
 }
 
-function getEtfScoreColorClasses(score: number | null): { textColorClass: string; bgColorClass: string } {
-  if (score === null) {
-    return { textColorClass: 'text-gray-400', bgColorClass: 'bg-gray-500' };
-  }
-  if (score >= 75) return { textColorClass: 'text-green-500', bgColorClass: 'bg-green-500' };
-  if (score >= 50) return { textColorClass: 'text-yellow-500', bgColorClass: 'bg-yellow-500' };
-  if (score >= 25) return { textColorClass: 'text-orange-500', bgColorClass: 'bg-orange-500' };
-  return { textColorClass: 'text-red-500', bgColorClass: 'bg-red-500' };
-}
+const DEFAULT_MAX_ROWS = 4;
 
-export default function CompactEtfGroupingCard({ title, href, totalCount, etfs }: CompactEtfGroupingCardProps): React.JSX.Element {
+export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, maxRows = DEFAULT_MAX_ROWS }: CompactEtfGroupingCardProps): React.JSX.Element {
+  const displayedEtfs = etfs.slice(0, maxRows);
+
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
       <Link href={href} className="block px-3 py-1.5 bg-[#374151] hover:bg-[#2D3748] transition-colors">
@@ -29,12 +25,12 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs }
         </h3>
       </Link>
 
-      {etfs.length > 0 ? (
+      {displayedEtfs.length > 0 ? (
         <div className="px-3 py-1">
           <ul className="space-y-1">
-            {etfs.map((etf) => {
+            {displayedEtfs.map((etf) => {
               const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
-              const scoreLabel = etf.finalScore !== null ? String(etf.finalScore) : '—';
+              const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
 
               return (
                 <li key={etf.id}>
@@ -42,7 +38,7 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs }
                     href={`/etfs/${etf.exchange}/${etf.symbol}`}
                     className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
                   >
-                    <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[34px] text-right`}>
+                    <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
                       <span className={`${textColorClass} text-xs font-mono`}>{scoreLabel}</span>
                     </p>
                     <span className="text-xs font-medium bg-[#4F46E5] text-white ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>

--- a/insights-ui/src/components/etfs/EtfCategoriesGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfCategoriesGrid.tsx
@@ -1,0 +1,84 @@
+import EtfCategoryCard from '@/components/etfs/EtfCategoryCard';
+import { EtfGroupingPreviewItem } from '@/utils/etf-grouping-utils';
+import React from 'react';
+
+export interface EtfCategoryCardSpec {
+  key: string;
+  categoryName: string;
+  href: string;
+  etfs: EtfGroupingPreviewItem[];
+  total: number;
+}
+
+const CARD_HEADER_PX = 41;
+const ROW_PX = 36;
+
+function estimateCardHeight(rowCount: number): number {
+  return CARD_HEADER_PX + rowCount * ROW_PX;
+}
+
+function packIntoColumns<T extends { estH: number }>(items: T[], cols: number): T[][] {
+  const buckets: { items: T[]; h: number }[] = Array.from({ length: cols }, () => ({ items: [], h: 0 }));
+  items.forEach((item, i) => {
+    if (i < cols) {
+      buckets[i].items.push(item);
+      buckets[i].h += item.estH;
+    } else {
+      let min = 0;
+      for (let c = 1; c < cols; c++) if (buckets[c].h < buckets[min].h) min = c;
+      buckets[min].items.push(item);
+      buckets[min].h += item.estH;
+    }
+  });
+  return buckets.map((b) => b.items);
+}
+
+interface EtfCategoriesGridProps {
+  categories: EtfCategoryCardSpec[];
+  emptyMessage?: string;
+}
+
+/**
+ * Mirrors `IndustryStocksGrid`: pack category cards into 1/2/3 columns based on
+ * estimated card height so the columns end roughly the same height.
+ */
+export default function EtfCategoriesGrid({ categories, emptyMessage }: EtfCategoriesGridProps): React.JSX.Element {
+  if (categories.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[#E5E7EB] text-lg">{emptyMessage ?? 'No ETFs available.'}</p>
+      </div>
+    );
+  }
+
+  const items = categories.map((c) => ({ ...c, estH: estimateCardHeight(c.etfs.length) }));
+  const cols1 = [items];
+  const cols2 = packIntoColumns(items, 2);
+  const cols3 = packIntoColumns(items, 3);
+
+  const renderCard = (c: (typeof items)[number]) => <EtfCategoryCard key={c.key} categoryName={c.categoryName} href={c.href} etfs={c.etfs} total={c.total} />;
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-6 mb-10 md:hidden">
+        <div className="flex flex-col gap-6">{cols1[0].map(renderCard)}</div>
+      </div>
+
+      <div className="hidden md:grid lg:hidden grid-cols-2 gap-6 mb-10">
+        {cols2.map((col, i) => (
+          <div key={`md-col-${i}`} className="flex flex-col gap-6">
+            {col.map(renderCard)}
+          </div>
+        ))}
+      </div>
+
+      <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
+        {cols3.map((col, i) => (
+          <div key={`lg-col-${i}`} className="flex flex-col gap-6">
+            {col.map(renderCard)}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfCategoryCard.tsx
+++ b/insights-ui/src/components/etfs/EtfCategoryCard.tsx
@@ -1,0 +1,57 @@
+import { EtfGroupingPreviewItem } from '@/utils/etf-grouping-utils';
+import { getEtfScoreColorClasses } from '@/utils/score-utils';
+import Link from 'next/link';
+import React from 'react';
+
+interface EtfCategoryCardProps {
+  categoryName: string;
+  href: string;
+  etfs: EtfGroupingPreviewItem[];
+  total: number;
+}
+
+/**
+ * Full ETF list per category, mirroring `SubIndustryCard` on the stocks side.
+ * Header acts as a link to the category detail page; "X ETFs" badge sits in
+ * the corner.
+ */
+export default function EtfCategoryCard({ categoryName, href, etfs, total }: EtfCategoryCardProps): React.JSX.Element {
+  const etfLabel = `${total.toLocaleString()} ${total === 1 ? 'ETF' : 'ETFs'}`;
+
+  return (
+    <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
+      <Link href={href} className="block px-3 py-2 sm:px-4 border-b border-color bg-[#374151] hover:bg-[#2D3748] transition-colors">
+        <h3 className="text-sm font-semibold heading-color leading-snug break-words pr-24" title={categoryName}>
+          {categoryName}
+        </h3>
+      </Link>
+      <div className="absolute top-2 right-2 z-10 text-[13px] text-white bg-[#4F46E5] px-2 py-0.5 rounded-full" aria-label={etfLabel} title={etfLabel}>
+        {etfLabel}
+      </div>
+      <ul className="divide-y divide-color flex-1">
+        {etfs.map((etf) => {
+          const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
+          const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
+          return (
+            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-[#2D3748] transition-colors">
+              <Link
+                href={`/etfs/${etf.exchange}/${etf.symbol}`}
+                className="flex gap-1.5 items-center min-w-0 w-full"
+                aria-label={`View ${etf.name}`}
+                title={etf.name}
+              >
+                <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
+                  <span className={`${textColorClass} font-mono tabular-nums text-right text-xs`}>{scoreLabel}</span>
+                </p>
+                <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-[#4F46E5] text-white self-center shadow-sm shrink-0">
+                  {etf.symbol}
+                </p>
+                <p className="text-sm font-medium text-break break-words text-white truncate min-w-0 flex-1">{etf.name}</p>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfFiltersButton.tsx
+++ b/insights-ui/src/components/etfs/EtfFiltersButton.tsx
@@ -273,13 +273,15 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
         </div>
       </div>
 
-      {/* Advanced (Mor) Filters */}
+      {/* Advanced risk-period filters (capture ratios + risk level) */}
       <div>
-        <h3 className="text-white font-semibold text-xs mb-1">Advanced Filters (Mor)</h3>
-        <p className="text-[#9CA3AF] text-[10px] mb-2">Only ETFs with Mor data shown when active. Pick a time period; the three filters below apply to it.</p>
+        <h3 className="text-white font-semibold text-xs mb-1 text-center">Advanced Filters</h3>
+        <p className="text-[#9CA3AF] text-[10px] mb-2 text-center">
+          Only ETFs with risk data are shown when these are active. Pick a time period; the three filters below apply to it.
+        </p>
 
-        <div className="mb-3">
-          <span className="text-gray-300 text-[10px] font-medium uppercase tracking-wider mr-2">Time Period:</span>
+        <div className="mb-3 flex flex-wrap items-center justify-center gap-2">
+          <span className="text-gray-300 text-[10px] font-medium uppercase tracking-wider">Time Period:</span>
           <div className="inline-flex gap-1.5">
             {MOR_PERIODS.map((p) => (
               <button
@@ -297,7 +299,7 @@ function EtfFilterModalContent({ initialSelected, onClose }: EtfFilterModalConte
           </div>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 max-w-2xl mx-auto">
           {MOR_FIELD_KINDS.map((kind) => {
             const def = getMorFilterDef(kind, morPeriod);
             return (

--- a/insights-ui/src/components/etfs/EtfGroupCategoryDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupCategoryDetail.tsx
@@ -1,0 +1,55 @@
+import EtfPageLayout from '@/components/etfs/EtfPageLayout';
+import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
+import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { getEtfCategoryByName, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName, etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+interface EtfGroupCategoryDetailProps {
+  country: EtfSupportedCountry;
+  groupKey: string;
+  category: string;
+  searchParams: EtfSearchParams;
+}
+
+export default async function EtfGroupCategoryDetail({ country, groupKey, category, searchParams }: EtfGroupCategoryDetailProps) {
+  const groupObj = getEtfGroupByKey(groupKey);
+  if (!groupObj) notFound();
+
+  const knownCategory = getEtfCategoryByName(category);
+  if (!knownCategory) notFound();
+
+  // The category must actually belong to this group; otherwise redirect to the
+  // canonical group-category combination so we never serve mismatched URLs.
+  if (knownCategory.group !== groupObj.key) {
+    permanentRedirect(etfGroupCategoryPath(country, knownCategory.group, knownCategory.name));
+  }
+
+  const displayCountry = etfCountryDisplayName(country);
+
+  const dataPromise = fetchEtfListingData(
+    {
+      ...searchParams,
+      [EtfFilterParamKey.CATEGORY]: knownCategory.name,
+    },
+    country
+  );
+
+  return (
+    <EtfPageLayout
+      title={`${knownCategory.name} ${displayCountry} ETFs`}
+      description={`Explore ${displayCountry} ETFs in the ${knownCategory.name} category (part of ${groupObj.name}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+      currentCountry={country}
+      switcherSection="groups"
+      extraBreadcrumbs={[
+        { name: 'All Groups', href: etfBrowsePath(country, 'groups'), current: false },
+        { name: groupObj.name, href: etfBrowseDetailPath(country, 'groups', groupObj.key), current: false },
+        { name: knownCategory.name, href: etfGroupCategoryPath(country, groupObj.key, knownCategory.name), current: true },
+      ]}
+    >
+      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+    </EtfPageLayout>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfGroupDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupDetail.tsx
@@ -1,31 +1,54 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
-import { fetchEtfListingData } from '@/utils/etf-data-utils';
-import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
-import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import EtfCategoriesGrid, { EtfCategoryCardSpec } from '@/components/etfs/EtfCategoriesGrid';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getEtfGroupByKey, getCategoriesForGroupKey, ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
+import { fetchAllEtfsByCategory, fetchUncategorizedEtfPreview } from '@/utils/etf-grouping-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
+import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName, etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
 import { notFound } from 'next/navigation';
 
 interface EtfGroupDetailProps {
   country: EtfSupportedCountry;
   groupKey: string;
-  searchParams: EtfSearchParams;
 }
 
-export default async function EtfGroupDetail({ country, groupKey, searchParams }: EtfGroupDetailProps) {
+export default async function EtfGroupDetail({ country, groupKey }: EtfGroupDetailProps) {
   const groupObj = getEtfGroupByKey(groupKey);
   if (!groupObj) notFound();
 
   const displayCountry = etfCountryDisplayName(country);
 
-  const dataPromise = fetchEtfListingData(
-    {
-      ...searchParams,
-      [EtfFilterParamKey.GROUP]: groupObj.key,
-    },
-    country
-  );
+  const categories = getCategoriesForGroupKey(groupObj.key);
+  const categoryNames = categories.map((c) => c.name);
+
+  let cardSpecs: EtfCategoryCardSpec[] = [];
+
+  if (groupObj.key === ETF_OTHERS_GROUP_KEY) {
+    // "Others" has no analysis categories — render uncategorized ETFs as a single card.
+    const others = await fetchUncategorizedEtfPreview(KoalaGainsSpaceId, country);
+    if (others.count > 0) {
+      cardSpecs = [
+        {
+          key: ETF_OTHERS_GROUP_KEY,
+          categoryName: 'Uncategorized',
+          href: etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP_KEY),
+          etfs: others.items,
+          total: others.count,
+        },
+      ];
+    }
+  } else {
+    const { values, counts } = await fetchAllEtfsByCategory(KoalaGainsSpaceId, categoryNames, country);
+    cardSpecs = categories
+      .map((cat) => ({
+        key: cat.name,
+        categoryName: cat.name,
+        href: etfGroupCategoryPath(country, groupObj.key, cat.name),
+        etfs: values.get(cat.name) ?? [],
+        total: counts.get(cat.name) ?? 0,
+      }))
+      .filter((spec) => spec.etfs.length > 0);
+  }
 
   return (
     <EtfPageLayout
@@ -38,7 +61,7 @@ export default async function EtfGroupDetail({ country, groupKey, searchParams }
         { name: groupObj.name, href: etfBrowseDetailPath(country, 'groups', groupObj.key), current: true },
       ]}
     >
-      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+      <EtfCategoriesGrid categories={cardSpecs} emptyMessage={`No ${displayCountry} ETFs found in the ${groupObj.name} group.`} />
     </EtfPageLayout>
   );
 }

--- a/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
@@ -4,7 +4,8 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ETF_OTHERS_GROUP, getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
 import { fetchEtfsForGroupings, fetchUncategorizedEtfPreview } from '@/utils/etf-grouping-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
-import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
+import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName, etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
+import Link from 'next/link';
 
 interface EtfGroupsIndexProps {
   country: EtfSupportedCountry;
@@ -13,18 +14,34 @@ interface EtfGroupsIndexProps {
 export default async function EtfGroupsIndex({ country }: EtfGroupsIndexProps) {
   const groups = getAllEtfGroups();
 
-  const valueToKey = new Map<string, string>();
+  // Bucket every category in every group so we can fetch top-N ETFs per category.
+  const categoryValueToKey = new Map<string, string>();
   for (const group of groups) {
     for (const cat of getCategoriesForGroupKey(group.key)) {
-      valueToKey.set(cat.name, group.key);
+      categoryValueToKey.set(cat.name, cat.name);
     }
   }
 
-  const [{ values, counts }, others] = await Promise.all([
+  // Also bucket categories by group key so we can compute total ETFs per group
+  // (sum of category counts) for the "Show all" header link.
+  const groupValueToKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const cat of getCategoriesForGroupKey(group.key)) {
+      groupValueToKey.set(cat.name, group.key);
+    }
+  }
+
+  const [{ values: categoryValues, counts: categoryCounts }, { counts: groupCounts }, others] = await Promise.all([
     fetchEtfsForGroupings({
       spaceId: KoalaGainsSpaceId,
       mode: 'category',
-      valueToKey,
+      valueToKey: categoryValueToKey,
+      country,
+    }),
+    fetchEtfsForGroupings({
+      spaceId: KoalaGainsSpaceId,
+      mode: 'category',
+      valueToKey: groupValueToKey,
       country,
     }),
     fetchUncategorizedEtfPreview(KoalaGainsSpaceId, country),
@@ -36,29 +53,70 @@ export default async function EtfGroupsIndex({ country }: EtfGroupsIndexProps) {
   return (
     <EtfPageLayout
       title={`${displayName} ETFs by Group`}
-      description={`Diversified, sector, fixed income, and alternative-strategy fund groups for ${displayName} ETFs. Each card lists the top-rated ETFs in that group.`}
+      description={`Diversified, sector, fixed income, and alternative-strategy fund groups for ${displayName} ETFs. Each card lists the top-rated ETFs in that category.`}
       currentCountry={country}
       switcherSection="groups"
       extraBreadcrumbs={[{ name: 'Groups', href: groupsPath, current: true }]}
     >
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
-        {groups.map((group) => (
-          <CompactEtfGroupingCard
-            key={group.key}
-            title={group.name}
-            href={etfBrowseDetailPath(country, 'groups', group.key)}
-            totalCount={counts.get(group.key) ?? 0}
-            etfs={values.get(group.key) ?? []}
-          />
-        ))}
-        <CompactEtfGroupingCard
-          key={ETF_OTHERS_GROUP.key}
-          title={ETF_OTHERS_GROUP.name}
-          href={etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key)}
-          totalCount={others.count}
-          etfs={others.items}
-        />
-      </div>
+      {groups.map((group) => {
+        const categories = getCategoriesForGroupKey(group.key);
+        const categoriesWithEtfs = categories.filter((cat) => (categoryValues.get(cat.name)?.length ?? 0) > 0);
+        if (categoriesWithEtfs.length === 0) return null;
+
+        const totalEtfsInGroup = groupCounts.get(group.key) ?? 0;
+        const groupHref = etfBrowseDetailPath(country, 'groups', group.key);
+
+        return (
+          <div key={group.key} className="mb-8">
+            <div className="flex items-center justify-between mb-4 gap-4">
+              <h2 className="text-xl font-bold text-white">{group.name}</h2>
+              <Link
+                href={groupHref}
+                className="text-sm bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium px-3 py-1 rounded-lg shadow-md flex items-center whitespace-nowrap"
+              >
+                Show all {totalEtfsInGroup.toLocaleString()} ETFs
+                <span className="ml-1">→</span>
+              </Link>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6">
+              {categoriesWithEtfs.map((cat) => (
+                <CompactEtfGroupingCard
+                  key={cat.name}
+                  title={cat.name}
+                  href={etfGroupCategoryPath(country, group.key, cat.name)}
+                  totalCount={categoryCounts.get(cat.name) ?? 0}
+                  etfs={categoryValues.get(cat.name) ?? []}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {others.count > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4 gap-4">
+            <h2 className="text-xl font-bold text-white">{ETF_OTHERS_GROUP.name}</h2>
+            <Link
+              href={etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key)}
+              className="text-sm bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium px-3 py-1 rounded-lg shadow-md flex items-center whitespace-nowrap"
+            >
+              Show all {others.count.toLocaleString()} ETFs
+              <span className="ml-1">→</span>
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6">
+            <CompactEtfGroupingCard
+              key={ETF_OTHERS_GROUP.key}
+              title={ETF_OTHERS_GROUP.name}
+              href={etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key)}
+              totalCount={others.count}
+              etfs={others.items}
+            />
+          </div>
+        </div>
+      )}
     </EtfPageLayout>
   );
 }

--- a/insights-ui/src/components/etfs/EtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfListingGrid.tsx
@@ -1,32 +1,10 @@
 import { EtfListingResponse, EtfListingItem } from '@/app/api/[spaceId]/etfs-v1/listing/route';
-import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import { formatPercentageDecimal } from '@/components/reportsv1/financialFormatters';
+import { getEtfGroupKey } from '@/utils/etf-categorization-utils';
+import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import Link from 'next/link';
 import React, { use } from 'react';
 import EtfPagination from './EtfPagination';
-
-const MOR_INDICATORS: Array<{ key: keyof Pick<EtfListingItem, 'hasMorAnalyzerInfo' | 'hasMorRiskInfo' | 'hasMorPeopleInfo'>; label: string }> = [
-  { key: 'hasMorAnalyzerInfo', label: 'Analyzer' },
-  { key: 'hasMorRiskInfo', label: 'Risk' },
-  { key: 'hasMorPeopleInfo', label: 'People' },
-];
-
-function MorIndicators({ etf }: { etf: EtfListingItem }): JSX.Element {
-  return (
-    <PrivateWrapper>
-      <div className="flex items-center gap-1.5" aria-label="MOR data available">
-        {MOR_INDICATORS.map(({ key, label }) => (
-          <span key={key} className="relative group/dot">
-            <span className={`inline-block w-2 h-2 rounded-full ${etf[key] ? 'bg-emerald-400' : 'bg-gray-600'}`} />
-            <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-[10px] text-gray-200 opacity-0 shadow-lg transition-opacity group-hover/dot:opacity-100 border border-gray-700 z-10">
-              MOR {label}: {etf[key] ? 'Present' : 'Missing'}
-            </span>
-          </span>
-        ))}
-      </div>
-    </PrivateWrapper>
-  );
-}
 
 function parseNumericString(value: string | null): number | null {
   if (!value) return null;
@@ -56,19 +34,55 @@ function formatNumber(value: number | null): string {
   return value.toLocaleString('en-US', { maximumFractionDigits: 2 });
 }
 
+// Groups where P/E is a meaningful summary statistic (the fund's underlying is
+// earnings-bearing equities). For everything else, the listing card swaps P/E
+// out for a group-appropriate metric (see `pickThirdMetric`).
+const EQUITY_GROUP_KEYS = new Set(['broad-equity', 'sector-thematic-equity', 'leveraged-inverse']);
+
+interface ThirdMetric {
+  label: string;
+  value: string;
+}
+
+function pickThirdMetric(etf: EtfListingItem): ThirdMetric {
+  const groupKey = getEtfGroupKey(etf.category);
+  if (groupKey && EQUITY_GROUP_KEYS.has(groupKey)) {
+    return { label: 'P/E Ratio', value: formatNumber(etf.pe) };
+  }
+  // Holdings count works as the generic stand-in for non-equity funds
+  // (commodities/digital-assets, fixed income, allocation, derivative income):
+  // it tells the reader how diversified the wrapper is without leaning on a
+  // metric that only makes sense for equities.
+  return { label: 'Holdings', value: etf.holdings !== null && etf.holdings !== undefined ? etf.holdings.toLocaleString('en-US') : 'N/A' };
+}
+
 function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
+  const third = pickThirdMetric(etf);
+  const score = etf.finalScore;
+  const { textColorClass, bgColorClass } = getEtfScoreColorClasses(score);
+  const showScore = score !== null;
+
   return (
     <Link
       href={`/etfs/${etf.exchange}/${etf.symbol}`}
-      className="block bg-[#1F2937] border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+      className="block bg-gray-900 border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
     >
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between mb-3 gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">{etf.symbol}</span>
           <span className="text-xs text-gray-400">{etf.exchange}</span>
-          <MorIndicators etf={etf} />
         </div>
-        {etf.payoutFrequency && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
+        <div className="flex items-center gap-2 shrink-0">
+          {showScore && (
+            <span
+              className={`${textColorClass} px-1.5 rounded-md ${bgColorClass} bg-opacity-15 text-xs font-mono tabular-nums`}
+              title={`KoalaGains score: ${score}/20`}
+            >
+              {score}/20
+            </span>
+          )}
+          {etf.payoutFrequency && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
+        </div>
       </div>
 
       <h3 className="text-white text-sm font-medium mb-3 line-clamp-2 min-h-[2.5rem]">{etf.name}</h3>
@@ -83,8 +97,8 @@ function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
           <p className="text-white font-medium">{etf.expenseRatio !== null ? `${etf.expenseRatio}%` : 'N/A'}</p>
         </div>
         <div>
-          <span className="text-gray-400">P/E Ratio</span>
-          <p className="text-white font-medium">{formatNumber(etf.pe)}</p>
+          <span className="text-gray-400">{third.label}</span>
+          <p className="text-white font-medium">{third.value}</p>
         </div>
         <div>
           <span className="text-gray-400">Dividend Yield</span>

--- a/insights-ui/src/utils/etf-country-route-utils.ts
+++ b/insights-ui/src/utils/etf-country-route-utils.ts
@@ -26,6 +26,11 @@ export function etfBrowseDetailPath(country: EtfSupportedCountry, section: EtfBr
   return `${etfBrowsePath(country, section)}/${encodeURIComponent(slug)}`;
 }
 
+/** Path to a category page nested under a group: `/etfs/groups/<group>/categories/<category>`. */
+export function etfGroupCategoryPath(country: EtfSupportedCountry, groupKey: string, categoryName: string): string {
+  return `${etfBrowseDetailPath(country, 'groups', groupKey)}/categories/${encodeURIComponent(categoryName)}`;
+}
+
 export const ALL_ETF_COUNTRIES = ETF_SUPPORTED_COUNTRIES;
 
 /**

--- a/insights-ui/src/utils/etf-grouping-utils.ts
+++ b/insights-ui/src/utils/etf-grouping-utils.ts
@@ -193,6 +193,65 @@ export async function fetchUncategorizedEtfPreview(spaceId: string, country?: Et
   return { items: selectTopFive(rows), count: rows.length };
 }
 
+function sortByScoreThenAum(rows: RawEtfRow[]): EtfGroupingPreviewItem[] {
+  const withReport = rows.filter((r) => r.finalScore !== null).sort((a, b) => (b.finalScore ?? 0) - (a.finalScore ?? 0));
+
+  const withoutReport = rows.filter((r) => r.finalScore === null).sort((a, b) => (parseNumericStringValue(b.aum) ?? 0) - (parseNumericStringValue(a.aum) ?? 0));
+
+  return [...withReport, ...withoutReport].map((r) => ({
+    id: r.id,
+    symbol: r.symbol,
+    exchange: r.exchange,
+    name: r.name,
+    finalScore: r.finalScore,
+    hasDetailedReport: r.finalScore !== null,
+  }));
+}
+
+/**
+ * Returns every ETF (no top-N cap) bucketed by category for the given canonical
+ * category names. ETFs are ordered by `finalScore desc, AUM desc`. Used by the
+ * group detail page which lists all ETFs per category, packed into columns.
+ */
+export async function fetchAllEtfsByCategory(spaceId: string, categoryNames: string[], country?: EtfSupportedCountry): Promise<EtfGroupingPreview<string>> {
+  const valueToKey = new Map<string, string>();
+  for (const name of categoryNames) {
+    valueToKey.set(name, name);
+  }
+
+  const canonicalToBucket = new Map(valueToKey);
+  for (const [canonical, bucketKey] of canonicalToBucket) {
+    const expansions = expandCategoryAliases([canonical]);
+    for (const raw of expansions) {
+      if (!valueToKey.has(raw)) valueToKey.set(raw, bucketKey);
+    }
+  }
+
+  const dbValues = Array.from(valueToKey.keys());
+  const rawRows = await loadRawEtfRows(spaceId, 'category', dbValues, country);
+
+  const rowsByKey = new Map<string, RawEtfRow[]>();
+  const counts = new Map<string, number>();
+
+  for (const row of rawRows) {
+    if (!row.category) continue;
+    const lookup = canonicalizeCategory(row.category);
+    const bucketKey = valueToKey.get(lookup) ?? valueToKey.get(row.category);
+    if (!bucketKey) continue;
+    const bucket = rowsByKey.get(bucketKey) ?? [];
+    bucket.push(row);
+    rowsByKey.set(bucketKey, bucket);
+    counts.set(bucketKey, (counts.get(bucketKey) ?? 0) + 1);
+  }
+
+  const values = new Map<string, EtfGroupingPreviewItem[]>();
+  for (const [bucketKey, rows] of rowsByKey.entries()) {
+    values.set(bucketKey, sortByScoreThenAum(rows));
+  }
+
+  return { values, counts };
+}
+
 export async function fetchEtfsForGroupings<TKey extends string>({
   spaceId,
   mode,

--- a/insights-ui/src/utils/score-utils.ts
+++ b/insights-ui/src/utils/score-utils.ts
@@ -86,3 +86,38 @@ export function getScoreColorClasses(score: number) {
 
   return { textColorClass, bgColorClass, scoreLabel };
 }
+
+/**
+ * Get color classes and label for an ETF score.
+ *
+ * ETF final scores sum four category scores (0–5 each) for a 0–20 range.
+ * Thresholds are scaled proportionally to the 0–25 stock thresholds:
+ *   stocks <8/<14/<20/>=20  →  etfs <6/<11/<16/>=16.
+ *
+ * Returns gray for `null` (no report yet) so the badge still renders.
+ */
+export function getEtfScoreColorClasses(score: number | null) {
+  if (score === null) {
+    return { textColorClass: 'text-gray-400', bgColorClass: 'bg-gray-500', scoreLabel: 'Unknown' };
+  }
+
+  let textColorClass = 'text-green-500';
+  let bgColorClass = 'bg-green-500';
+  let scoreLabel = 'Excellent';
+
+  if (score < 6) {
+    textColorClass = 'text-red-500';
+    bgColorClass = 'bg-red-500';
+    scoreLabel = 'Poor';
+  } else if (score < 11) {
+    textColorClass = 'text-orange-500';
+    bgColorClass = 'bg-orange-500';
+    scoreLabel = 'Fair';
+  } else if (score < 16) {
+    textColorClass = 'text-yellow-500';
+    bgColorClass = 'bg-yellow-500';
+    scoreLabel = 'Good';
+  }
+
+  return { textColorClass, bgColorClass, scoreLabel };
+}


### PR DESCRIPTION
## Summary

Adds a placeholder task under ETFs in `docs/insights-ui/tasks/todo-tasks.md` covering an audit + UI fixes pass across the ETF listing surfaces (`/etfs` index, `/etfs/categories`, `/etfs/countries`, `/etfs/asset-classes`, `/etfs/groups`, `/etfs/providers`, plus each `[param]` sub-page).

Concrete issues will be captured as sub-bullets on the entry once the walk-through happens, so this PR is just the entry itself.

## Test plan

- [ ] Confirm the new section renders correctly in the todo-tasks.md preview.