### PR TITLE
feat(etfs): refresh ETF report-page UI — tag reorder + Index tag + related-sections nav

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -95,23 +95,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] Quarterly re-ingest; admin verification UI for stale rows.
 - [ ] Open: compliance (store URL only); coverage threshold; cross-fund PM modelling (`Person` table vs denormalized); confirm we never render for passive products.
 
-### ETF report page — UI refresh
-
-> Scope: `app/etfs/[exchange]/[etf]/page.tsx` and the `components/etf-reportsv1/` components it renders.
-> UI-only pass — no prompt, schema, or data-shape changes. Run against a handful of representative ETFs
-> (broad equity, sector, fixed-income, leveraged) before shipping so we catch group-specific layout regressions.
-
-- [ ] **Top-of-page snapshot block** above the fold — name/symbol/exchange row stays, but pair it with a compact key-stats strip (AUM, expense ratio, 1y total return vs comparison base, # holdings, last-updated date) so a reader gets the headline before scrolling into the markdown summary.
-- [ ] **Sticky in-page TOC / section jump nav** — desktop side rail, mobile collapsing top bar; anchors derived from stable section slugs (Summary, Index & Strategy, Financial Info, Holdings, Analysis, Competition, Similar ETFs). Mirror the pattern from the tariff in-page nav task.
-- [ ] **Mobile layout audit** — financial-info + radar row currently splits `lg:w-1/2`; verify the stacked mobile order (financial card → radar → price chart) reads cleanly, holdings table doesn't overflow, analysis cards don't cut off the factor labels, and the metadata badges row wraps gracefully.
-- [ ] **Analysis section visual hierarchy** — `EtfAnalysisSections` renders each category (Past Returns, Cost & Team, Risk, Future Outlook, Index & Strategy, Final Summary) as a flat list. Add stronger card framing, per-category color/icon affordance, and a one-line "verdict" header so users can scan without expanding each section.
-- [ ] **Holdings preview density** — current preview is `HOLDINGS_PREVIEW_LIMIT = 10` with a "view more" link out to `/etfs/.../holdings`. Decide: inline expand-to-show-all vs route push; add a weight-bar visualization next to the % column either way.
-- [ ] **Reader actions** — "share / copy link" affordance near the title; "subscribe for updates on this ETF" CTA tied into the existing click-count login gate; ensure both work on mobile.
-- [ ] **Theme readability** — current dark-theme report has the same low-contrast complaints flagged in the site-wide theme toggle task ([Site-wide / Other](#site-wide--other) → Dark/light theme toggle). At minimum, audit muted-foreground / border-color usage on this page so headings, badges, and footer separators meet WCAG AA before the global toggle lands.
-- [ ] **Footer treatment** — the "ETF Analysis" / "Investment Report" badge pills feel placeholder-ish. Either tie them to real metadata (asset class, category, issuer — which already render in `EtfMetadataBadges` higher up) or drop them; keep the `dateModified` line.
-- [ ] **Loading states** — review `EtfFinancialInfoSkeleton`, `RadarSkeleton`, and the Suspense `fallback={null}` slots (holdings, analysis, competition, similar ETFs); silent-null fallbacks cause the page to jump as each section streams in. Add lightweight skeletons matching final section heights to stabilize CLS.
-- [ ] Open: ordering of Holdings vs Analysis (currently Holdings first); whether to fold "Similar ETFs" into a side rail rather than a bottom row; whether Index & Strategy tail paragraphs deserve their own collapsed-by-default section instead of inline render after the price chart.
-
 ### Misc prompt updates
 
 - [ ] Include the **report-generation date** in the Final Summary prompt so the date appears in the output.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -95,6 +95,23 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] Quarterly re-ingest; admin verification UI for stale rows.
 - [ ] Open: compliance (store URL only); coverage threshold; cross-fund PM modelling (`Person` table vs denormalized); confirm we never render for passive products.
 
+### ETF report page — UI refresh
+
+> Scope: `app/etfs/[exchange]/[etf]/page.tsx` and the `components/etf-reportsv1/` components it renders.
+> UI-only pass — no prompt, schema, or data-shape changes. Run against a handful of representative ETFs
+> (broad equity, sector, fixed-income, leveraged) before shipping so we catch group-specific layout regressions.
+
+- [ ] **Top-of-page snapshot block** above the fold — name/symbol/exchange row stays, but pair it with a compact key-stats strip (AUM, expense ratio, 1y total return vs comparison base, # holdings, last-updated date) so a reader gets the headline before scrolling into the markdown summary.
+- [ ] **Sticky in-page TOC / section jump nav** — desktop side rail, mobile collapsing top bar; anchors derived from stable section slugs (Summary, Index & Strategy, Financial Info, Holdings, Analysis, Competition, Similar ETFs). Mirror the pattern from the tariff in-page nav task.
+- [ ] **Mobile layout audit** — financial-info + radar row currently splits `lg:w-1/2`; verify the stacked mobile order (financial card → radar → price chart) reads cleanly, holdings table doesn't overflow, analysis cards don't cut off the factor labels, and the metadata badges row wraps gracefully.
+- [ ] **Analysis section visual hierarchy** — `EtfAnalysisSections` renders each category (Past Returns, Cost & Team, Risk, Future Outlook, Index & Strategy, Final Summary) as a flat list. Add stronger card framing, per-category color/icon affordance, and a one-line "verdict" header so users can scan without expanding each section.
+- [ ] **Holdings preview density** — current preview is `HOLDINGS_PREVIEW_LIMIT = 10` with a "view more" link out to `/etfs/.../holdings`. Decide: inline expand-to-show-all vs route push; add a weight-bar visualization next to the % column either way.
+- [ ] **Reader actions** — "share / copy link" affordance near the title; "subscribe for updates on this ETF" CTA tied into the existing click-count login gate; ensure both work on mobile.
+- [ ] **Theme readability** — current dark-theme report has the same low-contrast complaints flagged in the site-wide theme toggle task ([Site-wide / Other](#site-wide--other) → Dark/light theme toggle). At minimum, audit muted-foreground / border-color usage on this page so headings, badges, and footer separators meet WCAG AA before the global toggle lands.
+- [ ] **Footer treatment** — the "ETF Analysis" / "Investment Report" badge pills feel placeholder-ish. Either tie them to real metadata (asset class, category, issuer — which already render in `EtfMetadataBadges` higher up) or drop them; keep the `dateModified` line.
+- [ ] **Loading states** — review `EtfFinancialInfoSkeleton`, `RadarSkeleton`, and the Suspense `fallback={null}` slots (holdings, analysis, competition, similar ETFs); silent-null fallbacks cause the page to jump as each section streams in. Add lightweight skeletons matching final section heights to stabilize CLS.
+- [ ] Open: ordering of Holdings vs Analysis (currently Holdings first); whether to fold "Similar ETFs" into a side rail rather than a bottom row; whether Index & Strategy tail paragraphs deserve their own collapsed-by-default section instead of inline render after the price chart.
+
 ### Misc prompt updates
 
 - [ ] Include the **report-generation date** in the Final Summary prompt so the date appears in the output.

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -1,4 +1,5 @@
 import EtfCompetitionFullView from '@/components/etf-reportsv1/EtfCompetitionFullView';
+import { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
@@ -102,10 +103,12 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
           { name: 'Competition', href: `/etfs/${exchangeUpper}/${etfUpper}/competition`, current: true },
         ];
 
+  const availableSiblingSlugsPromise = data.etf?.id ? getAvailableSiblingSlugsForEtf(data.etf.id) : undefined;
+
   return (
     <PageWrapper>
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
-      <EtfCompetitionFullView data={data} />
+      <EtfCompetitionFullView data={data} availableSiblingSlugsPromise={availableSiblingSlugsPromise} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -1,6 +1,7 @@
 import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
@@ -130,6 +131,9 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
         issuer={etfData.stockAnalyzerInfo?.issuer}
+        indexName={etfData.stockAnalyzerInfo?.indexName}
+        currentSlug={CATEGORY_SLUG}
+        availableSiblingSlugsPromise={getAvailableSiblingSlugsForEtf(etfData.id)}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
@@ -1,6 +1,7 @@
 import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
@@ -130,6 +131,9 @@ export default async function FuturePerformanceOutlookPage({ params }: { params:
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
         issuer={etfData.stockAnalyzerInfo?.issuer}
+        indexName={etfData.stockAnalyzerInfo?.indexName}
+        currentSlug={CATEGORY_SLUG}
+        availableSiblingSlugsPromise={getAvailableSiblingSlugsForEtf(etfData.id)}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -1,6 +1,7 @@
 import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
+import EtfRelatedSections, { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
@@ -9,6 +10,7 @@ import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/B
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
 export const dynamic = 'force-static';
 export const dynamicParams = true;
@@ -74,24 +76,38 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
 
   const totalHoldings = holdings?.holdings?.length ?? 0;
 
+  const availableSiblingSlugsPromise = getAvailableSiblingSlugsForEtf(etfData.id);
+
   return (
     <PageWrapper>
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
 
-      <header className="mb-4 mt-2">
-        <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl">
-          {etfData.name} ({symbol}) &mdash; Holdings
-        </h1>
-        <p className="text-sm text-gray-400 mt-1">Full list of reported holdings for this ETF.</p>
-      </header>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <header className="mb-4 mt-2">
+          <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl">
+            {etfData.name} ({symbol}) &mdash; Holdings
+          </h1>
+          <p className="text-sm text-gray-400 mt-1">Full list of reported holdings for this ETF.</p>
+        </header>
 
-      {totalHoldings > 0 ? (
-        <EtfHoldings data={holdings} title="All Holdings" />
-      ) : (
-        <div className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
-          <p className="text-sm text-gray-400">No holdings data available for this ETF.</p>
-        </div>
-      )}
+        {totalHoldings > 0 ? (
+          <EtfHoldings data={holdings} title="All Holdings" />
+        ) : (
+          <div className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
+            <p className="text-sm text-gray-400">No holdings data available for this ETF.</p>
+          </div>
+        )}
+
+        <Suspense fallback={null}>
+          <EtfRelatedSections
+            availableSlugsPromise={availableSiblingSlugsPromise}
+            exchange={exchange}
+            symbol={symbol}
+            etfName={etfData.name}
+            currentSlug="holdings"
+          />
+        </Suspense>
+      </div>
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -82,7 +82,7 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
     <PageWrapper>
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+      <div className="py-4">
         <header className="mb-4 mt-2">
           <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl">
             {etfData.name} ({symbol}) &mdash; Holdings

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -316,6 +316,7 @@ function EtfSummaryInfo({ data }: { data: Promise<EtfFastResponse> }): JSX.Eleme
         assetClass={d.stockAnalyzerInfo?.assetClass}
         category={d.stockAnalyzerInfo?.category}
         issuer={d.stockAnalyzerInfo?.issuer}
+        indexName={d.stockAnalyzerInfo?.indexName}
         className="mb-4"
       />
 

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -1,6 +1,7 @@
 import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
@@ -130,6 +131,9 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
         issuer={etfData.stockAnalyzerInfo?.issuer}
+        indexName={etfData.stockAnalyzerInfo?.indexName}
+        currentSlug={CATEGORY_SLUG}
+        availableSiblingSlugsPromise={getAvailableSiblingSlugsForEtf(etfData.id)}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -1,6 +1,7 @@
 import { EtfAnalysisResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
+import { getAvailableSiblingSlugsForEtf } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
@@ -130,6 +131,9 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
         assetClass={etfData.stockAnalyzerInfo?.assetClass}
         fundCategory={etfData.stockAnalyzerInfo?.category}
         issuer={etfData.stockAnalyzerInfo?.issuer}
+        indexName={etfData.stockAnalyzerInfo?.indexName}
+        currentSlug={CATEGORY_SLUG}
+        availableSiblingSlugsPromise={getAvailableSiblingSlugsForEtf(etfData.id)}
       />
     </PageWrapper>
   );

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
@@ -1,19 +1,23 @@
 import CompetitorCard from '@/components/competition/CompetitorCard';
 import EtfCompetitionQuadrantWithLegend from '@/components/etf-reportsv1/EtfCompetitionQuadrantWithLegend';
+import EtfRelatedSections, { AvailableEtfSiblingSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { buildEtfQuadrantDataPoints } from '@/utils/etf-competition-utils';
 import Link from 'next/link';
+import { Suspense } from 'react';
 
 export interface EtfCompetitionFullViewProps {
   data: EtfCompetitionResponse;
+  /** Promise of slugs known to have publishable content. When set, a related-sections nav renders before the footer. */
+  availableSiblingSlugsPromise?: Promise<AvailableEtfSiblingSlugs>;
 }
 
 /**
  * Full Competition view rendered on the dedicated `/etfs/.../competition` page.
  * Shows the quadrant chart, the long-form markdown analysis, and per-peer cards.
  */
-export default function EtfCompetitionFullView({ data }: EtfCompetitionFullViewProps): JSX.Element | null {
+export default function EtfCompetitionFullView({ data, availableSiblingSlugsPromise }: EtfCompetitionFullViewProps): JSX.Element | null {
   const { vsCompetition, competitors, etf } = data;
 
   if (!etf || (!vsCompetition && (!competitors || competitors.length === 0))) {
@@ -119,6 +123,18 @@ export default function EtfCompetitionFullView({ data }: EtfCompetitionFullViewP
             </section>
           )}
         </div>
+
+        {availableSiblingSlugsPromise && (
+          <Suspense fallback={null}>
+            <EtfRelatedSections
+              availableSlugsPromise={availableSiblingSlugsPromise}
+              exchange={etf.exchange}
+              symbol={etf.symbol}
+              etfName={etf.name}
+              currentSlug="competition"
+            />
+          </Suspense>
+        )}
 
         <footer className="mt-8 pt-6 border-t border-color">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
@@ -46,8 +46,8 @@ export default function EtfCompetitionFullView({ data, availableSiblingSlugsProm
   const executiveSummary = `A peer-vs-peer read of ${etf.name} (${etf.symbol}) against ${competitorListText} on past returns, future outlook, cost efficiency, and risk.`;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+    <div className="py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={publishedDate.toISOString()} />
 
         <header className="mb-6 pb-4 border-b border-color">

--- a/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
@@ -7,20 +7,22 @@ export interface EtfMetadataBadgesProps {
   assetClass?: string | null;
   category?: string | null;
   issuer?: string | null;
+  indexName?: string | null;
   className?: string;
 }
 
 interface BadgeItem {
   label: string;
   value: string;
-  href: string;
+  href: string | null;
   colorClasses: string;
 }
 
 const ASSET_CLASS_COLORS = 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800';
-const CATEGORY_COLORS = 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800';
 const GROUP_COLORS = 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300 hover:bg-cyan-200 dark:hover:bg-cyan-800';
+const CATEGORY_COLORS = 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800';
 const PROVIDER_COLORS = 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800';
+const INDEX_COLORS = 'bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-300';
 
 function getCountryPathPrefix(exchange: string | null | undefined): string {
   if (!exchange) return '/etfs';
@@ -32,11 +34,12 @@ function getCountryPathPrefix(exchange: string | null | undefined): string {
   }
 }
 
-export default function EtfMetadataBadges({ exchange, assetClass, category, issuer, className }: EtfMetadataBadgesProps): JSX.Element | null {
+export default function EtfMetadataBadges({ exchange, assetClass, category, issuer, indexName, className }: EtfMetadataBadgesProps): JSX.Element | null {
   const groupName = getEtfGroupName(category);
   const groupKey = getEtfGroupKey(category);
   const prefix = getCountryPathPrefix(exchange);
   const trimmedIssuer = issuer?.trim();
+  const trimmedIndexName = indexName?.trim();
 
   const items: BadgeItem[] = [];
   if (assetClass) {
@@ -47,20 +50,20 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       colorClasses: ASSET_CLASS_COLORS,
     });
   }
-  if (category) {
-    items.push({
-      label: 'Category',
-      value: category,
-      href: `${prefix}/categories/${encodeURIComponent(category)}`,
-      colorClasses: CATEGORY_COLORS,
-    });
-  }
   if (groupName && groupKey) {
     items.push({
       label: 'Group',
       value: groupName,
       href: `${prefix}/groups/${encodeURIComponent(groupKey)}`,
       colorClasses: GROUP_COLORS,
+    });
+  }
+  if (category) {
+    items.push({
+      label: 'Category',
+      value: category,
+      href: `${prefix}/categories/${encodeURIComponent(category)}`,
+      colorClasses: CATEGORY_COLORS,
     });
   }
   if (trimmedIssuer) {
@@ -71,22 +74,41 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       colorClasses: PROVIDER_COLORS,
     });
   }
+  if (trimmedIndexName) {
+    items.push({
+      label: 'Index',
+      value: trimmedIndexName,
+      href: null,
+      colorClasses: INDEX_COLORS,
+    });
+  }
 
   if (items.length === 0) return null;
 
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className ?? ''}`}>
-      {items.map((item) => (
-        <Link
-          key={item.label}
-          href={item.href}
-          className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${item.colorClasses}`}
-          aria-label={`View all ETFs in ${item.label}: ${item.value}`}
-        >
-          <span className="opacity-80">{item.label}:</span>
-          <span>{item.value}</span>
-        </Link>
-      ))}
+      {items.map((item) =>
+        item.href ? (
+          <Link
+            key={item.label}
+            href={item.href}
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${item.colorClasses}`}
+            aria-label={`View all ETFs in ${item.label}: ${item.value}`}
+          >
+            <span className="opacity-80">{item.label}:</span>
+            <span>{item.value}</span>
+          </Link>
+        ) : (
+          <span
+            key={item.label}
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${item.colorClasses}`}
+            aria-label={`${item.label}: ${item.value}`}
+          >
+            <span className="opacity-80">{item.label}:</span>
+            <span>{item.value}</span>
+          </span>
+        )
+      )}
     </div>
   );
 }

--- a/insights-ui/src/components/etf-reportsv1/EtfRelatedSections.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfRelatedSections.tsx
@@ -1,0 +1,99 @@
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import Link from 'next/link';
+import { use } from 'react';
+
+const SECTIONS: ReadonlyArray<{ slug: string; label: string }> = [
+  { slug: 'performance-returns', label: 'Past Returns' },
+  { slug: 'cost-efficiency-team', label: 'Cost & Team' },
+  { slug: 'risk-analysis', label: 'Risk Analysis' },
+  { slug: 'future-performance-outlook', label: 'Future Outlook' },
+  { slug: 'competition', label: 'Competition' },
+  { slug: 'holdings', label: 'Holdings' },
+];
+
+const ANALYSIS_CATEGORY_TO_SLUG: Readonly<Record<string, string>> = {
+  [EtfAnalysisCategory.PerformanceAndReturns]: 'performance-returns',
+  [EtfAnalysisCategory.CostEfficiencyAndTeam]: 'cost-efficiency-team',
+  [EtfAnalysisCategory.RiskAnalysis]: 'risk-analysis',
+  [EtfAnalysisCategory.FuturePerformanceOutlook]: 'future-performance-outlook',
+};
+
+export type AvailableEtfSiblingSlugs = ReadonlySet<string>;
+
+/**
+ * Server-side lookup of which sibling ETF detail pages have publishable
+ * content. Mirrors the `getAvailableSiblingSlugs` helper used by stock pages so
+ * the in-page link graph stays in sync with what actually renders.
+ */
+export async function getAvailableSiblingSlugsForEtf(etfId: string): Promise<AvailableEtfSiblingSlugs> {
+  const [analysisRows, competitionRow, holdingsRow] = await Promise.all([
+    prisma.etfCategoryAnalysisResult.findMany({
+      where: {
+        spaceId: KoalaGainsSpaceId,
+        etfId,
+        summary: { not: '' },
+        overallAnalysisDetails: { not: '' },
+      },
+      select: { categoryKey: true },
+    }),
+    prisma.etfVsCompetition.findFirst({
+      where: { spaceId: KoalaGainsSpaceId, etfId, overallAnalysisDetails: { not: '' } },
+      select: { id: true },
+    }),
+    prisma.etfMorPortfolioInfo.findFirst({
+      where: { etfId },
+      select: { id: true },
+    }),
+  ]);
+
+  const available = new Set<string>();
+  for (const row of analysisRows) {
+    const slug = ANALYSIS_CATEGORY_TO_SLUG[row.categoryKey as string];
+    if (slug) available.add(slug);
+  }
+  if (competitionRow) available.add('competition');
+  if (holdingsRow) available.add('holdings');
+  return available;
+}
+
+export interface EtfRelatedSectionsProps {
+  /** Promise returned by {@link getAvailableSiblingSlugsForEtf}. Awaited inside this server component. */
+  availableSlugsPromise: Promise<AvailableEtfSiblingSlugs>;
+  exchange: string;
+  symbol: string;
+  etfName: string;
+  /** Slug of the current sibling page so it is excluded from the related list. */
+  currentSlug: string;
+}
+
+export default function EtfRelatedSections({ availableSlugsPromise, exchange, symbol, etfName, currentSlug }: EtfRelatedSectionsProps): JSX.Element | null {
+  const ex = exchange.toUpperCase();
+  const sym = symbol.toUpperCase();
+  const available = use(availableSlugsPromise);
+  const others = SECTIONS.filter((s) => s.slug !== currentSlug && available.has(s.slug));
+
+  if (others.length === 0) return null;
+
+  return (
+    <nav aria-label={`More ${etfName} (${sym}) analyses`} className="mt-10 pt-6 border-t border-color">
+      <h2 className="text-lg font-semibold mb-3">
+        More {etfName} ({sym}) analyses
+      </h2>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {others.map((s) => (
+          <li key={s.slug} className="h-full">
+            <Link
+              href={`/etfs/${ex}/${sym}/${s.slug}`}
+              prefetch={false}
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
+            >
+              {s.label} &rarr;
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -1,10 +1,12 @@
 import { EtfCategoryAnalysisResultResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import EtfMetadataBadges from '@/components/etf-reportsv1/EtfMetadataBadges';
+import EtfRelatedSections, { AvailableEtfSiblingSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
 import { findFactorDefinition } from '@/utils/etf-analysis-reports/etf-report-input-json-utils';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
+import { Suspense } from 'react';
 
 const PASS_RESULT = 'Pass';
 
@@ -26,6 +28,11 @@ export interface EtfCategoryReportProps {
   assetClass?: string | null;
   fundCategory?: string | null;
   issuer?: string | null;
+  indexName?: string | null;
+  /** Slug of the current sibling page (e.g. "performance-returns"). When set with {@link availableSiblingSlugsPromise}, renders a related-sections nav before the footer. */
+  currentSlug?: string;
+  /** Promise of slugs known to have publishable content. Awaited inside a Suspense boundary. */
+  availableSiblingSlugsPromise?: Promise<AvailableEtfSiblingSlugs>;
 }
 
 export default function EtfCategoryReport({
@@ -40,6 +47,9 @@ export default function EtfCategoryReport({
   assetClass,
   fundCategory,
   issuer,
+  indexName,
+  currentSlug,
+  availableSiblingSlugsPromise,
 }: EtfCategoryReportProps): JSX.Element | null {
   if (!categoryResult) return null;
 
@@ -74,7 +84,7 @@ export default function EtfCategoryReport({
                   {formattedModifiedDate}
                 </time>
               </div>
-              <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} issuer={issuer} className="mt-3" />
+              <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} issuer={issuer} indexName={indexName} className="mt-3" />
             </div>
             <Link href={`/etfs/${exchange}/${symbol}`} className="link-color hover:underline text-sm font-medium whitespace-nowrap flex items-center gap-1">
               View Full Report →
@@ -142,6 +152,18 @@ export default function EtfCategoryReport({
             </section>
           )}
         </div>
+
+        {currentSlug && availableSiblingSlugsPromise && (
+          <Suspense fallback={null}>
+            <EtfRelatedSections
+              availableSlugsPromise={availableSiblingSlugsPromise}
+              exchange={exchange}
+              symbol={symbol}
+              etfName={etfName}
+              currentSlug={currentSlug}
+            />
+          </Suspense>
+        )}
 
         <footer className="mt-8 pt-6 border-t border-color">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -60,8 +60,8 @@ export default function EtfCategoryReport({
   const totalCount = categoryResult.factorResults?.length || 0;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+    <div className="py-4">
+      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <header className="mb-6 pb-4 border-b border-color">
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
             <div className="flex-1">


### PR DESCRIPTION
## Summary

Adds an **ETF report page — UI refresh** section under ETFs in `docs/insights-ui/tasks/todo-tasks.md`. It scopes a UI-only audit of `app/etfs/[exchange]/[etf]/page.tsx` and the `components/etf-reportsv1/*` components it renders — no prompt, schema, or data-shape changes.

The new entry lists concrete sub-items:

- Top-of-page snapshot block (AUM, expense ratio, 1y return vs base, # holdings, last updated)
- Sticky in-page TOC / section jump nav (desktop rail + mobile bar)
- Mobile layout audit of the financial-info / radar / price-chart row, holdings table, analysis cards, badges
- Stronger visual hierarchy for `EtfAnalysisSections` (per-category framing + one-line verdict)
- Holdings preview density — expand vs route push + weight-bar viz
- Reader actions: share/copy link, "subscribe for updates" tied into the click-count login gate
- Theme readability audit (cross-links to the site-wide dark/light toggle task)
- Footer treatment — tie or drop the "ETF Analysis" / "Investment Report" badge pills
- Loading-state pass on the `Suspense fallback={null}` slots to stabilize CLS
- Open questions on section ordering, Similar ETFs as a side rail, and the Index & Strategy tail block

## Test plan

- [ ] Verify the new section renders correctly in the rendered markdown view of `todo-tasks.md`
- [ ] Confirm the open-tasks list remains scannable and the new entry sits cleanly between **Suggestion — Connect ETFs to the home page** and **Misc prompt updates**