### PR TITLE
perf(etfs): tag-cache /financial-data page like other ETF detail subpages

### DIFF
--- a/insights-ui/src/app/etfs/[exchange]/[etf]/financial-data/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/financial-data/page.tsx
@@ -4,16 +4,23 @@ import EtfMorInfo from '@/components/etf-reportsv1/EtfMorInfo';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { buildEtfReportSubpageBreadcrumbs } from '@/utils/etf-breadcrumbs-utils';
+import { etfAndExchangeTag } from '@/utils/etf-cache-utils';
 import { generateBreadcrumbJsonLdFromCrumbs } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { notFound } from 'next/navigation';
 
+export const dynamic = 'force-static';
+export const dynamicParams = true;
+export const revalidate = false;
+
 type RouteParams = Promise<Readonly<{ exchange: string; etf: string }>>;
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
 
 async function fetchEtfData(exchange: string, etf: string): Promise<EtfFastResponse | null> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}?allowNull=true`;
-  const res = await fetch(url);
+  const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
   if (!res.ok) return null;
   return (await res.json()) as EtfFastResponse | null;
 }
@@ -21,7 +28,7 @@ async function fetchEtfData(exchange: string, etf: string): Promise<EtfFastRespo
 async function fetchMorInfo(exchange: string, etf: string): Promise<EtfMorInfoOptionalWrapper> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange}/${etf}/mor-info`;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { next: { revalidate: WEEK_IN_SECONDS, tags: [etfAndExchangeTag(etf, exchange)] } });
     if (!res.ok) return { morAnalyzerInfo: null, morRiskInfo: null, morPeopleInfo: null, morPortfolioInfo: null };
     return (await res.json()) as EtfMorInfoOptionalWrapper;
   } catch {


### PR DESCRIPTION
## Summary

- The \`/etfs/[exchange]/[etf]/financial-data\` subpage was the only ETF detail route rendering fresh on every request (no \`force-static\`, no fetch cache config, no tags).
- Add the same caching pattern used by all other ETF detail subpages: \`force-static\` + \`revalidate = false\` + per-ETF tag (\`etfAndExchangeTag\`) on both fetches.
- This brings the page under the existing \`revalidateEtfAndExchangeTag(symbol, exchange)\` invalidation path that ETF report saves, mor-info callbacks, \`fetch-financial-info\`, and the admin cache-invalidate button already fire — so the page now refreshes alongside the others.

## Test plan

- [x] \`yarn lint\` — clean
- [x] \`yarn prettier-check\` — clean
- [x] \`yarn compile\` — clean
- [ ] Visit \`/etfs/<exchange>/<etf>/financial-data\` after a save that invalidates \`etfAndExchangeTag\` and confirm the rendered data refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)