### PR TITLE
fix(etfs): meta tags + breadcrumb JSON-LD on every ETF listing page

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -119,6 +119,15 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] SEO/metadata review after new sections — titles/descriptions cover comparison + competition keywords; JSON-LD remains valid and updated.
 - [ ] Daily generation + sitemap updates — generate 5–10 ETFs daily; push generated URLs to sitemap (or sitemap index) automatically.
 
+### Meta tags audit across all ETF pages
+
+- [ ] **Inventory every ETF page route** and confirm each one exports either `generateMetadata` or a `metadata` constant — listing index (`/etfs`), listing sub-pages (`/etfs/categories[/...]`, `/etfs/countries[/...]` and its nested `groups` / `asset-classes` / `providers` subtrees, `/etfs/asset-classes[/...]`, `/etfs/groups[/...]` and its `categories` subtree, `/etfs/providers[/...]`), and ETF detail pages (`/etfs/[exchange]/[etf]` + its `performance-returns`, `risk-analysis`, `financial-data`, `holdings`, `cost-efficiency-team`, `future-performance-outlook`, `competition` sub-routes). Today `app/etfs/[exchange]/[etf]/financial-data/page.tsx` has no metadata export at all and inherits whatever the parent layout sets — fix as part of this audit.
+- [ ] **Verify each page emits a complete tag set**: unique `<title>`, `description`, `keywords` (where used elsewhere), canonical, `openGraph` (title / description / url / siteName / type / image), `twitter` (card / title / description / image), and `robots` (especially for partial-data ETFs gated by the upcoming `isComplete` filter — they should not be indexable while incomplete). Centralize anything still inline through `src/utils/etf-metadata-generators.ts` instead of duplicating per-page.
+- [ ] **Check uniqueness at scale**: pull the rendered `<title>` + `<meta name="description">` for a representative slice (top listing pages + ~50 ETF detail pages across exchanges/groups) and confirm no duplicates and no truncation against the standard 60-char title / 155-char description limits. Spot-check sub-page titles (e.g. `risk-analysis`) include the ETF symbol + section so they don't collide with the root detail page.
+- [ ] **JSON-LD parity** — every page that ships JSON-LD via `headSlot` (listing index, ETF detail) validates against schema.org and matches what the visible page actually shows; pages currently missing structured data (most sub-listing variants, ETF detail sub-routes) get a decision: add `ItemList` / `Article` schema or explicitly skip with a one-line rationale in `etf-metadata-generators.ts`.
+- [ ] **Crawler + social preview sanity**: render each page type with `curl` + a headless fetch, confirm meta tags appear in the SSR'd HTML (not injected client-side), then run the URL through the LinkedIn Post Inspector and Twitter card validator for one example of each page type and capture the screenshots in the PR.
+- [ ] Output of the audit: a short table (page type → status: ok / missing tag X / duplicate / truncated) in the PR description plus code fixes for every non-ok row in the same PR.
+
 ### Suggestion — Connect ETFs to the home page + categorization
 
 > ETF category pages and country pages exist (see closed-tasks). Remaining:

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -119,15 +119,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] SEO/metadata review after new sections — titles/descriptions cover comparison + competition keywords; JSON-LD remains valid and updated.
 - [ ] Daily generation + sitemap updates — generate 5–10 ETFs daily; push generated URLs to sitemap (or sitemap index) automatically.
 
-### Meta tags audit across all ETF pages
-
-- [ ] **Inventory every ETF page route** and confirm each one exports either `generateMetadata` or a `metadata` constant — listing index (`/etfs`), listing sub-pages (`/etfs/categories[/...]`, `/etfs/countries[/...]` and its nested `groups` / `asset-classes` / `providers` subtrees, `/etfs/asset-classes[/...]`, `/etfs/groups[/...]` and its `categories` subtree, `/etfs/providers[/...]`), and ETF detail pages (`/etfs/[exchange]/[etf]` + its `performance-returns`, `risk-analysis`, `financial-data`, `holdings`, `cost-efficiency-team`, `future-performance-outlook`, `competition` sub-routes). Today `app/etfs/[exchange]/[etf]/financial-data/page.tsx` has no metadata export at all and inherits whatever the parent layout sets — fix as part of this audit.
-- [ ] **Verify each page emits a complete tag set**: unique `<title>`, `description`, `keywords` (where used elsewhere), canonical, `openGraph` (title / description / url / siteName / type / image), `twitter` (card / title / description / image), and `robots` (especially for partial-data ETFs gated by the upcoming `isComplete` filter — they should not be indexable while incomplete). Centralize anything still inline through `src/utils/etf-metadata-generators.ts` instead of duplicating per-page.
-- [ ] **Check uniqueness at scale**: pull the rendered `<title>` + `<meta name="description">` for a representative slice (top listing pages + ~50 ETF detail pages across exchanges/groups) and confirm no duplicates and no truncation against the standard 60-char title / 155-char description limits. Spot-check sub-page titles (e.g. `risk-analysis`) include the ETF symbol + section so they don't collide with the root detail page.
-- [ ] **JSON-LD parity** — every page that ships JSON-LD via `headSlot` (listing index, ETF detail) validates against schema.org and matches what the visible page actually shows; pages currently missing structured data (most sub-listing variants, ETF detail sub-routes) get a decision: add `ItemList` / `Article` schema or explicitly skip with a one-line rationale in `etf-metadata-generators.ts`.
-- [ ] **Crawler + social preview sanity**: render each page type with `curl` + a headless fetch, confirm meta tags appear in the SSR'd HTML (not injected client-side), then run the URL through the LinkedIn Post Inspector and Twitter card validator for one example of each page type and capture the screenshots in the PR.
-- [ ] Output of the audit: a short table (page type → status: ok / missing tag X / duplicate / truncated) in the PR description plus code fixes for every non-ok row in the same PR.
-
 ### Suggestion — Connect ETFs to the home page + categorization
 
 > ETF category pages and country pages exist (see closed-tasks). Remaining:

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -7,7 +7,7 @@ import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
 import { etfCompetitionTag } from '@/utils/etf-cache-utils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { buildEtfReportSubpageBreadcrumbs } from '@/utils/etf-breadcrumbs-utils';
-import { generateBreadcrumbJsonLdFromCrumbs } from '@/utils/etf-metadata-generators';
+import { generateBreadcrumbJsonLdFromCrumbs, generateEtfCompetitionArticleJsonLd, generateEtfCompetitionMetadata } from '@/utils/etf-metadata-generators';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -39,49 +39,24 @@ async function fetchEtfFast(exchange: string, etf: string): Promise<EtfFastRespo
   }
 }
 
-function truncateForMeta(text: string, maxLength: number = 155): string {
-  if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength).replace(/\s+\S*$/, '') + '…';
-}
-
 export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
   const { exchange, etf } = await params;
   const exchangeUpper = exchange.toUpperCase();
   const etfUpper = etf.toUpperCase();
 
   let etfName = etfUpper;
+  let createdTime: string | undefined;
+  let updatedTime: string | undefined;
   try {
-    const data = await fetchEtfCompetition(exchangeUpper, etfUpper);
-    etfName = data?.etf?.name ?? etfName;
+    const [competition, fast] = await Promise.all([fetchEtfCompetition(exchangeUpper, etfUpper), fetchEtfFast(exchangeUpper, etfUpper)]);
+    etfName = competition?.etf?.name ?? fast?.name ?? etfName;
+    createdTime = fast?.createdAt?.toISOString();
+    updatedTime = fast?.updatedAt?.toISOString();
   } catch {
     /* keep generic */
   }
 
-  const year = new Date().getFullYear();
-  const shortDesc = truncateForMeta(
-    `Peer-vs-peer competitive analysis of ${etfName} (${etfUpper}). Compare against its closest peer ETFs on past returns, future outlook, cost efficiency, and risk.`
-  );
-  const canonicalUrl = `https://koalagains.com/etfs/${exchangeUpper}/${etfUpper}/competition`;
-
-  return {
-    title: `${etfName} (${etfUpper}) Competitive Analysis & Peer Comparison (${year})`,
-    description: shortDesc,
-    alternates: { canonical: canonicalUrl },
-    openGraph: {
-      title: `${etfName} (${etfUpper}) Competitive Analysis | KoalaGains`,
-      description: shortDesc,
-      url: canonicalUrl,
-      siteName: 'KoalaGains',
-      type: 'article',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: `${etfName} (${etfUpper}) Competitive Analysis | KoalaGains`,
-      description: shortDesc,
-      site: '@koalagains',
-      creator: '@koalagains',
-    },
-  };
+  return generateEtfCompetitionMetadata({ etfName, symbol: etfUpper, exchange: exchangeUpper, createdTime, updatedTime });
 }
 
 export default async function EtfCompetitionPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
@@ -107,9 +82,27 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
   });
   const breadcrumbJsonLd = generateBreadcrumbJsonLdFromCrumbs(breadcrumbs);
 
+  const safeDate = (val: unknown): Date => {
+    if (val instanceof Date && !isNaN(val.getTime())) return val;
+    if (typeof val === 'string' && val.trim()) {
+      const parsed = new Date(val);
+      if (!isNaN(parsed.getTime())) return parsed;
+    }
+    return new Date();
+  };
+  const publishedDate = safeDate(data.vsCompetition?.createdAt ?? etfFast?.createdAt).toISOString();
+  const modifiedDate = safeDate(data.vsCompetition?.updatedAt ?? etfFast?.updatedAt).toISOString();
+  const articleJsonLd = generateEtfCompetitionArticleJsonLd({
+    etfName: data.etf.name,
+    symbol: etfUpper,
+    exchange: exchangeUpper,
+    publishedDate,
+    modifiedDate,
+  });
+
   return (
     <PageWrapper>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleJsonLd, breadcrumbJsonLd]) }} />
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
       <EtfCompetitionFullView data={data} availableSlugs={availableSlugs} />
     </PageWrapper>

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -7,7 +7,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { etfHoldingsTag } from '@/utils/etf-cache-utils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { buildEtfReportSubpageBreadcrumbs } from '@/utils/etf-breadcrumbs-utils';
-import { generateBreadcrumbJsonLdFromCrumbs } from '@/utils/etf-metadata-generators';
+import { generateBreadcrumbJsonLdFromCrumbs, generateEtfHoldingsMetadata } from '@/utils/etf-metadata-generators';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -44,19 +44,20 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   const symbol = rawEtf.toUpperCase();
 
   let etfName = symbol;
+  let createdTime: string | undefined;
+  let updatedTime: string | undefined;
   try {
     const data = await fetchEtf(exchange, symbol);
-    if (data) etfName = data.name ?? etfName;
+    if (data) {
+      etfName = data.name ?? etfName;
+      createdTime = data.createdAt?.toISOString();
+      updatedTime = data.updatedAt?.toISOString();
+    }
   } catch {
     /* keep generic */
   }
 
-  const title = `${etfName} (${symbol}) Holdings`;
-  return {
-    title,
-    description: `Top reported holdings for ${etfName} (${symbol}) ETF, including portfolio weights and sector exposure.`,
-    alternates: { canonical: `/etfs/${exchange}/${symbol}/holdings` },
-  };
+  return generateEtfHoldingsMetadata({ etfName, symbol, exchange, createdTime, updatedTime });
 }
 
 export default async function EtfHoldingsPage({ params }: { params: RouteParams }): Promise<JSX.Element> {
@@ -91,9 +92,13 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
     <footer className="mt-8 pt-6 border-t border-color">
       <div className="text-sm text-muted-foreground">
         <span>Last updated by </span>
-        <span>KoalaGains</span>
+        <span itemProp="author" itemScope itemType="https://schema.org/Organization">
+          <span itemProp="name">KoalaGains</span>
+        </span>
         <span> on </span>
-        <time dateTime={lastUpdatedDate.toISOString()}>{formattedLastUpdated}</time>
+        <time dateTime={lastUpdatedDate.toISOString()} itemProp="dateModified">
+          {formattedLastUpdated}
+        </time>
       </div>
     </footer>
   );
@@ -110,12 +115,15 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
 
-      <div className="py-4">
+      <article className="py-4" itemScope itemType="https://schema.org/Article">
+        <meta itemProp="datePublished" content={lastUpdatedDate.toISOString()} />
         <header className="mb-4 mt-2">
-          <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl">
+          <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl" itemProp="headline">
             {etfData.name} ({symbol}) &mdash; Holdings
           </h1>
-          <p className="text-sm text-gray-400 mt-1">Top holdings reported by this ETF.</p>
+          <p className="text-sm text-gray-400 mt-1" itemProp="description">
+            Top holdings reported by this ETF.
+          </p>
         </header>
 
         {totalHoldings > 0 ? (
@@ -126,7 +134,7 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
             {relatedSections}
           </section>
         )}
-      </div>
+      </article>
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-uti
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { etfBrowseDetailPath } from '@/utils/etf-country-route-utils';
+import { generateEtfAssetClassDetailBreadcrumbJsonLd, generateEtfAssetClassDetailMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -26,11 +27,13 @@ function resolveAssetClass(rawParam: string): { canonical: string; slug: string 
 export async function generateMetadata(props: { params: Promise<{ assetClass: string }> }): Promise<Metadata> {
   const { assetClass } = await props.params;
   const resolved = resolveAssetClass(assetClass);
-  const display = resolved?.canonical ?? decodeURIComponent(assetClass);
-  return {
-    title: `${display} ETFs | KoalaGains`,
-    description: `Browse US ETFs in the ${display} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const canonical = resolved?.canonical ?? decodeURIComponent(assetClass);
+  const slug = resolved?.slug ?? slugifyEtfTag(canonical);
+  return generateEtfAssetClassDetailMetadata({
+    country: SupportedCountries.US,
+    assetClass: canonical,
+    assetClassSlug: slug,
+  });
 }
 
 export default async function EtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -43,5 +46,15 @@ export default async function EtfsByAssetClassPage({ params, searchParams: searc
   }
 
   const searchParams = await searchParamsPromise;
-  return EtfAssetClassDetail({ country: SupportedCountries.US, assetClass: resolved.canonical, searchParams });
+  const breadcrumb = generateEtfAssetClassDetailBreadcrumbJsonLd({
+    country: SupportedCountries.US,
+    assetClass: resolved.canonical,
+    assetClassSlug: resolved.slug,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfAssetClassDetail({ country: SupportedCountries.US, assetClass: resolved.canonical, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/page.tsx
@@ -3,17 +3,13 @@ import EtfAssetClassesIndex from '@/components/etfs/EtfAssetClassesIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfAssetClassesIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import type { Metadata } from 'next';
 
 export const dynamic = 'force-static';
 export const revalidate = 1209600; // 14 days — must be a literal for Next.js segment config
 
-export const metadata: Metadata = {
-  title: 'US ETFs by Asset Class | KoalaGains',
-  description:
-    'Browse US ETFs by asset class — Equity, Fixed Income, Commodity, Alternatives, and more. Each card highlights the top-rated ETFs in that class.',
-};
+export const metadata = generateEtfAssetClassesIndexMetadata(SupportedCountries.US);
 
 const EMPTY_ASSET_CLASSES: EtfAssetClassesIndexResponse = { values: {}, counts: {} };
 
@@ -37,5 +33,13 @@ async function fetchAssetClassesIndex(country: SupportedCountries): Promise<EtfA
 
 export default async function EtfsAssetClassesIndexPage() {
   const data = await fetchAssetClassesIndex(SupportedCountries.US);
-  return <EtfAssetClassesIndex country={SupportedCountries.US} data={data} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfAssetClassesIndexBreadcrumbJsonLd(SupportedCountries.US)) }}
+      />
+      <EtfAssetClassesIndex country={SupportedCountries.US} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-uti
 import { etfBrowseDetailPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { generateEtfAssetClassDetailBreadcrumbJsonLd, generateEtfAssetClassDetailMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -25,13 +26,15 @@ function resolveAssetClass(rawParam: string): { canonical: string; slug: string 
 
 export async function generateMetadata(props: { params: Promise<{ country: string; assetClass: string }> }): Promise<Metadata> {
   const { country, assetClass } = await props.params;
-  const decodedCountry = decodeURIComponent(country);
   const resolved = resolveAssetClass(assetClass);
-  const display = resolved?.canonical ?? decodeURIComponent(assetClass);
-  return {
-    title: `${display} ${decodedCountry} ETFs | KoalaGains`,
-    description: `Browse ${decodedCountry} ETFs in the ${display} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const canonical = resolved?.canonical ?? decodeURIComponent(assetClass);
+  const slug = resolved?.slug ?? slugifyEtfTag(canonical);
+  const decodedCountry = resolveEtfCountryParam(country, etfBrowseDetailPath(SupportedCountries.US, 'asset-classes', slug));
+  return generateEtfAssetClassDetailMetadata({
+    country: decodedCountry,
+    assetClass: canonical,
+    assetClassSlug: slug,
+  });
 }
 
 export default async function CountryEtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -46,5 +49,15 @@ export default async function CountryEtfsByAssetClassPage({ params, searchParams
   }
 
   const searchParams = await searchParamsPromise;
-  return EtfAssetClassDetail({ country: decodedCountry, assetClass: resolved.canonical, searchParams });
+  const breadcrumb = generateEtfAssetClassDetailBreadcrumbJsonLd({
+    country: decodedCountry,
+    assetClass: resolved.canonical,
+    assetClassSlug: resolved.slug,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfAssetClassDetail({ country: decodedCountry, assetClass: resolved.canonical, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
@@ -4,6 +4,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getEtfAssetClassesIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
@@ -37,16 +38,18 @@ async function fetchAssetClassesIndex(country: EtfSupportedCountry): Promise<Etf
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { country } = await props.params;
-  const decoded = decodeURIComponent(country);
-  return {
-    title: `${decoded} ETFs by Asset Class | KoalaGains`,
-    description: `Browse ${decoded} ETFs by asset class — Equity, Fixed Income, Commodity, Alternatives, and more. Each card highlights the top-rated ETFs in that class.`,
-  };
+  const decoded = resolveEtfCountryParam(country, '/etfs/asset-classes');
+  return generateEtfAssetClassesIndexMetadata(decoded);
 }
 
 export default async function CountryEtfsAssetClassesIndexPage({ params }: PageProps) {
   const { country } = await params;
   const decoded = resolveEtfCountryParam(country, '/etfs/asset-classes');
   const data = await fetchAssetClassesIndex(decoded);
-  return <EtfAssetClassesIndex country={decoded} data={data} />;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfAssetClassesIndexBreadcrumbJsonLd(decoded)) }} />
+      <EtfAssetClassesIndex country={decoded} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfCategoryByName, getEtfCategoryBySlug, getEtfGroupByKey, slugifyEtfCategory } from '@/utils/etf-categorization-utils';
 import { etfGroupCategoryPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { generateEtfGroupCategoryListingBreadcrumbJsonLd, generateEtfGroupCategoryListingMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -15,17 +16,17 @@ type PageProps = {
 
 export async function generateMetadata(props: { params: Promise<{ country: string; group: string; category: string }> }): Promise<Metadata> {
   const { country, group, category } = await props.params;
-  const decodedCountry = decodeURIComponent(country);
   const decodedGroup = decodeURIComponent(group);
   const decodedCategory = decodeURIComponent(category);
-  const groupObj = getEtfGroupByKey(decodedGroup);
   const cat = getEtfCategoryBySlug(decodedCategory) ?? getEtfCategoryByName(decodedCategory);
-  const categoryName = cat?.name ?? decodedCategory;
-  const groupName = groupObj?.name ?? decodedGroup;
-  return {
-    title: `${categoryName} ${decodedCountry} ETFs | KoalaGains`,
-    description: `Browse ${decodedCountry} ETFs in the ${categoryName} category (part of ${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const decodedCountry = resolveEtfCountryParam(country, etfGroupCategoryPath(SupportedCountries.US, cat?.group ?? decodedGroup, cat?.name ?? decodedCategory));
+  const groupObj = getEtfGroupByKey(decodedGroup);
+  return generateEtfGroupCategoryListingMetadata({
+    country: decodedCountry,
+    groupKey: cat?.group ?? decodedGroup,
+    groupName: groupObj?.name ?? decodedGroup,
+    categoryName: cat?.name ?? decodedCategory,
+  });
 }
 
 export default async function CountryEtfsByGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -42,10 +43,17 @@ export default async function CountryEtfsByGroupCategoryPage({ params, searchPar
   }
 
   const searchParams = await searchParamsPromise;
-  return EtfGroupCategoryDetail({
+  const groupObj = getEtfGroupByKey(decodedGroupKey);
+  const breadcrumb = generateEtfGroupCategoryListingBreadcrumbJsonLd({
     country: decodedCountry,
     groupKey: decodedGroupKey,
-    category: resolved.name,
-    searchParams,
+    groupName: groupObj?.name ?? decodedGroupKey,
+    categoryName: resolved.name,
   });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfGroupCategoryDetail({ country: decodedCountry, groupKey: decodedGroupKey, category: resolved.name, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -5,6 +5,7 @@ import { getEtfGroupDetailTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-ut
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
@@ -40,14 +41,14 @@ async function fetchGroupDetail(country: EtfSupportedCountry, groupKey: string):
 
 export async function generateMetadata(props: { params: Promise<{ country: string; group: string }> }): Promise<Metadata> {
   const { country, group } = await props.params;
-  const decodedCountry = decodeURIComponent(country);
   const decodedGroup = decodeURIComponent(group);
+  const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroup)}`);
   const groupObj = getEtfGroupByKey(decodedGroup);
-  const displayName = groupObj?.name ?? decodedGroup;
-  return {
-    title: `${displayName} ${decodedCountry} ETFs | KoalaGains`,
-    description: `Browse ${decodedCountry} ETFs in the ${displayName} group organised by analysis category, with top-rated ETFs in each category.`,
-  };
+  return generateEtfGroupDetailMetadata({
+    country: decodedCountry,
+    groupKey: decodedGroup,
+    groupName: groupObj?.name ?? decodedGroup,
+  });
 }
 
 export default async function CountryEtfsByGroupPage({ params }: PageProps) {
@@ -55,5 +56,16 @@ export default async function CountryEtfsByGroupPage({ params }: PageProps) {
   const decodedGroupKey = decodeURIComponent(group);
   const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
   const data = await fetchGroupDetail(decodedCountry, decodedGroupKey);
-  return <EtfGroupDetail country={decodedCountry} groupKey={decodedGroupKey} data={data} />;
+  const groupObj = getEtfGroupByKey(decodedGroupKey);
+  const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
+    country: decodedCountry,
+    groupKey: decodedGroupKey,
+    groupName: groupObj?.name ?? decodedGroupKey,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <EtfGroupDetail country={decodedCountry} groupKey={decodedGroupKey} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/page.tsx
@@ -4,6 +4,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getEtfGroupsIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
 import { etfBrowsePath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { generateEtfGroupsIndexBreadcrumbJsonLd, generateEtfGroupsIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
@@ -42,11 +43,8 @@ async function fetchGroupsIndex(country: EtfSupportedCountry): Promise<EtfGroups
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { country } = await props.params;
-  const decoded = decodeURIComponent(country);
-  return {
-    title: `${decoded} ETFs by Group | KoalaGains`,
-    description: `Browse ${decoded} ETFs organized by analysis group. Each group highlights top-rated ETFs by report score and AUM.`,
-  };
+  const decoded = resolveEtfCountryParam(country, '/etfs');
+  return generateEtfGroupsIndexMetadata(decoded);
 }
 
 export default async function CountryEtfsGroupsIndexPage({ params }: PageProps) {
@@ -59,6 +57,7 @@ export default async function CountryEtfsGroupsIndexPage({ params }: PageProps) 
       data={data}
       switcherSection="groups"
       extraBreadcrumbs={[{ name: 'Groups', href: etfBrowsePath(decoded, 'groups'), current: true }]}
+      headSlot={<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfGroupsIndexBreadcrumbJsonLd(decoded)) }} />}
     />
   );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/page.tsx
@@ -3,6 +3,7 @@ import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListing
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
 import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
+import { generateEtfCountryListingBreadcrumbJsonLd, generateEtfCountryListingMetadata } from '@/utils/etf-metadata-generators';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -14,11 +15,8 @@ type PageProps = {
 
 export async function generateMetadata(props: { params: Promise<{ country: string }> }): Promise<Metadata> {
   const { country } = await props.params;
-  const decoded = decodeURIComponent(country);
-  return {
-    title: `${decoded} ETFs | KoalaGains`,
-    description: `Browse ${decoded} exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const decoded = resolveEtfCountryParam(country, '/etfs');
+  return generateEtfCountryListingMetadata(decoded);
 }
 
 export default async function CountryEtfsPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -29,12 +27,15 @@ export default async function CountryEtfsPage({ params, searchParams: searchPara
   const dataPromise = fetchEtfListingData(searchParams, decoded);
 
   return (
-    <EtfPageLayout
-      title={`${decoded} ETFs`}
-      description={`Explore ${decoded} exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
-      currentCountry={decoded}
-    >
-      <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
-    </EtfPageLayout>
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfCountryListingBreadcrumbJsonLd(decoded)) }} />
+      <EtfPageLayout
+        title={`${decoded} ETFs`}
+        description={`Explore ${decoded} exchange-traded funds with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
+        currentCountry={decoded}
+      >
+        <WithSuspenseEtfListingGrid dataPromise={dataPromise} />
+      </EtfPageLayout>
+    </>
   );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { etfBrowseDetailPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { getEtfProviderBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { generateEtfProviderDetailBreadcrumbJsonLd, generateEtfProviderDetailMetadata } from '@/utils/etf-metadata-generators';
 import { permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -15,13 +16,13 @@ type PageProps = {
 
 export async function generateMetadata(props: { params: Promise<{ country: string; provider: string }> }): Promise<Metadata> {
   const { country, provider } = await props.params;
-  const decodedCountry = decodeURIComponent(country);
-  const decoded = decodeURIComponent(provider);
-  const display = getEtfProviderBySlug(slugifyEtfTag(decoded));
-  return {
-    title: `${display} ${decodedCountry} ETFs | KoalaGains`,
-    description: `Browse ${decodedCountry} ETFs issued by ${display} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const slug = slugifyEtfTag(decodeURIComponent(provider));
+  const decodedCountry = resolveEtfCountryParam(country, etfBrowseDetailPath(SupportedCountries.US, 'providers', slug));
+  return generateEtfProviderDetailMetadata({
+    country: decodedCountry,
+    providerCanonical: getEtfProviderBySlug(slug),
+    providerSlug: slug,
+  });
 }
 
 export default async function CountryEtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -37,5 +38,15 @@ export default async function CountryEtfsByProviderPage({ params, searchParams: 
 
   const canonical = getEtfProviderBySlug(slug);
   const searchParams = await searchParamsPromise;
-  return EtfProviderDetail({ country: decodedCountry, provider: canonical, searchParams });
+  const breadcrumb = generateEtfProviderDetailBreadcrumbJsonLd({
+    country: decodedCountry,
+    providerCanonical: canonical,
+    providerSlug: slug,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfProviderDetail({ country: decodedCountry, provider: canonical, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
@@ -4,6 +4,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getEtfProvidersIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
@@ -37,16 +38,18 @@ async function fetchProvidersIndex(country: EtfSupportedCountry): Promise<EtfPro
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { country } = await props.params;
-  const decoded = decodeURIComponent(country);
-  return {
-    title: `${decoded} ETFs by Provider | KoalaGains`,
-    description: `Browse ${decoded} ETFs grouped by issuer. Each card highlights the top-rated ETFs from that provider.`,
-  };
+  const decoded = resolveEtfCountryParam(country, '/etfs/providers');
+  return generateEtfProvidersIndexMetadata(decoded);
 }
 
 export default async function CountryEtfsProvidersIndexPage({ params }: PageProps) {
   const { country } = await params;
   const decoded = resolveEtfCountryParam(country, '/etfs/providers');
   const data = await fetchProvidersIndex(decoded);
-  return <EtfProvidersIndex country={decoded} data={data} />;
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfProvidersIndexBreadcrumbJsonLd(decoded)) }} />
+      <EtfProvidersIndex country={decoded} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfCategoryByName, getEtfCategoryBySlug, getEtfGroupByKey, slugifyEtfCategory } from '@/utils/etf-categorization-utils';
 import { etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { generateEtfGroupCategoryListingBreadcrumbJsonLd, generateEtfGroupCategoryListingMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -19,12 +20,12 @@ export async function generateMetadata(props: { params: Promise<{ group: string;
   const decodedCategory = decodeURIComponent(category);
   const groupObj = getEtfGroupByKey(decodedGroup);
   const cat = getEtfCategoryBySlug(decodedCategory) ?? getEtfCategoryByName(decodedCategory);
-  const categoryName = cat?.name ?? decodedCategory;
-  const groupName = groupObj?.name ?? decodedGroup;
-  return {
-    title: `${categoryName} ETFs | KoalaGains`,
-    description: `Browse US ETFs in the ${categoryName} category (part of ${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  return generateEtfGroupCategoryListingMetadata({
+    country: SupportedCountries.US,
+    groupKey: cat?.group ?? decodedGroup,
+    groupName: groupObj?.name ?? decodedGroup,
+    categoryName: cat?.name ?? decodedCategory,
+  });
 }
 
 export default async function EtfGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -39,10 +40,17 @@ export default async function EtfGroupCategoryPage({ params, searchParams: searc
   }
 
   const searchParams = await searchParamsPromise;
-  return EtfGroupCategoryDetail({
+  const groupObj = getEtfGroupByKey(decodedGroup);
+  const breadcrumb = generateEtfGroupCategoryListingBreadcrumbJsonLd({
     country: SupportedCountries.US,
     groupKey: decodedGroup,
-    category: resolved.name,
-    searchParams,
+    groupName: groupObj?.name ?? decodedGroup,
+    categoryName: resolved.name,
   });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfGroupCategoryDetail({ country: SupportedCountries.US, groupKey: decodedGroup, category: resolved.name, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -4,6 +4,7 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfGroupDetailTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
@@ -39,18 +40,29 @@ async function fetchGroupDetail(country: SupportedCountries, groupKey: string): 
 
 export async function generateMetadata(props: { params: Promise<{ group: string }> }): Promise<Metadata> {
   const { group } = await props.params;
-  const decoded = decodeURIComponent(group);
-  const groupObj = getEtfGroupByKey(decoded);
-  const displayName = groupObj?.name ?? decoded;
-  return {
-    title: `${displayName} ETFs | KoalaGains`,
-    description: `Browse US ETFs in the ${displayName} group organised by analysis category, with top-rated ETFs in each category.`,
-  };
+  const groupKey = decodeURIComponent(group);
+  const groupObj = getEtfGroupByKey(groupKey);
+  return generateEtfGroupDetailMetadata({
+    country: SupportedCountries.US,
+    groupKey,
+    groupName: groupObj?.name ?? groupKey,
+  });
 }
 
 export default async function EtfsByGroupPage({ params }: PageProps) {
   const { group } = await params;
   const groupKey = decodeURIComponent(group);
   const data = await fetchGroupDetail(SupportedCountries.US, groupKey);
-  return <EtfGroupDetail country={SupportedCountries.US} groupKey={groupKey} data={data} />;
+  const groupObj = getEtfGroupByKey(groupKey);
+  const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
+    country: SupportedCountries.US,
+    groupKey,
+    groupName: groupObj?.name ?? groupKey,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <EtfGroupDetail country={SupportedCountries.US} groupKey={groupKey} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -3,7 +3,7 @@ import EtfGroupsIndex from '@/components/etfs/EtfGroupsIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfGroupsIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
-import { generateEtfListingMetadata, generateEtfListingJsonLd } from '@/utils/etf-metadata-generators';
+import { generateEtfListingBreadcrumbJsonLd, generateEtfListingJsonLd, generateEtfListingMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
 export const dynamic = 'force-static';
@@ -43,7 +43,12 @@ export default async function EtfsPage() {
       country={SupportedCountries.US}
       data={data}
       title="US ETFs"
-      headSlot={<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfListingJsonLd()) }} />}
+      headSlot={
+        <>
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfListingJsonLd()) }} />
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfListingBreadcrumbJsonLd()) }} />
+        </>
+      }
     />
   );
 }

--- a/insights-ui/src/app/etfs/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/providers/[provider]/page.tsx
@@ -3,6 +3,7 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfProviderBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { etfBrowseDetailPath } from '@/utils/etf-country-route-utils';
+import { generateEtfProviderDetailBreadcrumbJsonLd, generateEtfProviderDetailMetadata } from '@/utils/etf-metadata-generators';
 import { permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
@@ -15,12 +16,12 @@ type PageProps = {
 
 export async function generateMetadata(props: { params: Promise<{ provider: string }> }): Promise<Metadata> {
   const { provider } = await props.params;
-  const decoded = decodeURIComponent(provider);
-  const display = getEtfProviderBySlug(slugifyEtfTag(decoded));
-  return {
-    title: `${display} ETFs | KoalaGains`,
-    description: `Browse US ETFs issued by ${display} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
-  };
+  const slug = slugifyEtfTag(decodeURIComponent(provider));
+  return generateEtfProviderDetailMetadata({
+    country: SupportedCountries.US,
+    providerCanonical: getEtfProviderBySlug(slug),
+    providerSlug: slug,
+  });
 }
 
 export default async function EtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {
@@ -33,5 +34,15 @@ export default async function EtfsByProviderPage({ params, searchParams: searchP
 
   const canonical = getEtfProviderBySlug(slug);
   const searchParams = await searchParamsPromise;
-  return EtfProviderDetail({ country: SupportedCountries.US, provider: canonical, searchParams });
+  const breadcrumb = generateEtfProviderDetailBreadcrumbJsonLd({
+    country: SupportedCountries.US,
+    providerCanonical: canonical,
+    providerSlug: slug,
+  });
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      {await EtfProviderDetail({ country: SupportedCountries.US, provider: canonical, searchParams })}
+    </>
+  );
 }

--- a/insights-ui/src/app/etfs/providers/page.tsx
+++ b/insights-ui/src/app/etfs/providers/page.tsx
@@ -3,16 +3,13 @@ import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfProvidersIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
-import type { Metadata } from 'next';
 
 export const dynamic = 'force-static';
 export const revalidate = 1209600; // 14 days — must be a literal for Next.js segment config
 
-export const metadata: Metadata = {
-  title: 'US ETFs by Provider | KoalaGains',
-  description: 'Browse US ETFs grouped by issuer. Each card highlights the top-rated ETFs from that provider.',
-};
+export const metadata = generateEtfProvidersIndexMetadata(SupportedCountries.US);
 
 const EMPTY_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {} };
 
@@ -36,5 +33,13 @@ async function fetchProvidersIndex(country: SupportedCountries): Promise<EtfProv
 
 export default async function EtfsProvidersIndexPage() {
   const data = await fetchProvidersIndex(SupportedCountries.US);
-  return <EtfProvidersIndex country={SupportedCountries.US} data={data} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfProvidersIndexBreadcrumbJsonLd(SupportedCountries.US)) }}
+      />
+      <EtfProvidersIndex country={SupportedCountries.US} data={data} />
+    </>
+  );
 }

--- a/insights-ui/src/app/layout.tsx
+++ b/insights-ui/src/app/layout.tsx
@@ -9,6 +9,7 @@ import Providers from './providers/Providers';
 import ClarityComponent from './ClarityComponent';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://koalagains.com'),
   title: 'KoalaGains',
   description:
     'KoalaGains gives retail investors access to institutional-level reports—helping you understand a business, its financials, and the competition from first principles so you can make the best decisions when investing in a stock.',

--- a/insights-ui/src/utils/etf-metadata-generators.ts
+++ b/insights-ui/src/utils/etf-metadata-generators.ts
@@ -203,11 +203,13 @@ export function generateEtfDetailMetadata({ etfName, symbol, exchange, createdTi
       type: 'article',
       publishedTime: createdTime ?? updatedTime,
       modifiedTime: updatedTime ?? createdTime,
+      images: [LOGO_URL],
     },
     twitter: {
       card: 'summary_large_image',
       title: `${etfName} (${symbol}) ETF Analysis & Key Metrics | ${SITE_NAME}`,
       description,
+      images: [LOGO_URL],
     },
   };
 }
@@ -328,11 +330,13 @@ export function generateEtfCategoryMetadata(input: EtfCategoryMetadataInput): Me
       type: 'article',
       publishedTime: createdTime,
       modifiedTime: updatedTime,
+      images: [LOGO_URL],
     },
     twitter: {
       card: 'summary_large_image',
       title: `${etfName} (${symbol}) ${categoryName} Analysis | ${SITE_NAME}`,
       description: shortDesc,
+      images: [LOGO_URL],
     },
   };
 }
@@ -550,4 +554,151 @@ export function generateEtfProviderDetailBreadcrumbJsonLd({ country, providerCan
     { name: 'Providers', href: etfBrowsePath(country, 'providers') },
     { name: providerCanonical, href: etfBrowseDetailPath(country, 'providers', providerSlug) },
   ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ETF Holdings Sub-page (/etfs/[exchange]/[etf]/holdings)
+// ────────────────────────────────────────────────────────────────────────────────
+
+interface EtfHoldingsMetadataInput {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  createdTime?: string;
+  updatedTime?: string;
+}
+
+export function generateEtfHoldingsMetadata({ etfName, symbol, exchange, createdTime, updatedTime }: EtfHoldingsMetadataInput): Metadata {
+  const year = new Date().getFullYear();
+  const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}/holdings`;
+  const description = truncateForMeta(
+    `Top reported holdings for ${etfName} (${symbol}) ETF — portfolio weights, sector exposure, and underlying positions on ${exchange}.`
+  );
+  const title = `${etfName} (${symbol}) Holdings — Portfolio & Top Positions (${year}) | ${SITE_NAME}`;
+  const ogTitle = `${etfName} (${symbol}) Holdings & Portfolio Weights | ${SITE_NAME}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
+    keywords: [
+      `${etfName} holdings`,
+      `${symbol} ETF holdings`,
+      `${symbol} portfolio`,
+      `${symbol} top holdings`,
+      `${symbol} sector exposure`,
+      `${etfName} portfolio weights`,
+      `${exchange} ETFs`,
+      'ETF holdings',
+      'ETF portfolio composition',
+      'exchange-traded funds',
+      SITE_NAME,
+    ],
+    openGraph: {
+      title: ogTitle,
+      description,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      type: 'article',
+      publishedTime: createdTime,
+      modifiedTime: updatedTime ?? createdTime,
+      images: [LOGO_URL],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: ogTitle,
+      description,
+      images: [LOGO_URL],
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ETF Competition Sub-page (/etfs/[exchange]/[etf]/competition)
+// ────────────────────────────────────────────────────────────────────────────────
+
+interface EtfCompetitionMetadataInput {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  createdTime?: string;
+  updatedTime?: string;
+}
+
+export function generateEtfCompetitionMetadata({ etfName, symbol, exchange, createdTime, updatedTime }: EtfCompetitionMetadataInput): Metadata {
+  const year = new Date().getFullYear();
+  const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}/competition`;
+  const description = truncateForMeta(
+    `Peer-vs-peer competitive analysis of ${etfName} (${symbol}). Compare against its closest peer ETFs on past returns, future outlook, cost efficiency, and risk.`
+  );
+  const title = `${etfName} (${symbol}) Competitive Analysis & Peer Comparison (${year}) | ${SITE_NAME}`;
+  const ogTitle = `${etfName} (${symbol}) Competitive Analysis | ${SITE_NAME}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
+    keywords: [
+      `${etfName} competition`,
+      `${symbol} ETF peers`,
+      `${symbol} vs peer ETFs`,
+      `${symbol} competitor comparison`,
+      `${etfName} peer comparison`,
+      `${exchange} ETFs`,
+      'ETF competitive analysis',
+      'ETF peer comparison',
+      'exchange-traded funds',
+      SITE_NAME,
+    ],
+    openGraph: {
+      title: ogTitle,
+      description,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      type: 'article',
+      publishedTime: createdTime,
+      modifiedTime: updatedTime ?? createdTime,
+      images: [LOGO_URL],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: ogTitle,
+      description,
+      images: [LOGO_URL],
+    },
+  };
+}
+
+export function generateEtfCompetitionArticleJsonLd({
+  etfName,
+  symbol,
+  exchange,
+  publishedDate,
+  modifiedDate,
+}: {
+  etfName: string;
+  symbol: string;
+  exchange: string;
+  publishedDate: string;
+  modifiedDate: string;
+}) {
+  const canonicalUrl = `${BASE_URL}/etfs/${exchange}/${symbol}/competition`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${etfName} (${symbol}) Competitive Analysis & Peer Comparison`,
+    description: `Peer-vs-peer competitive analysis of ${etfName} (${symbol}) on ${exchange} — past returns, future outlook, cost efficiency, and risk vs closest peer ETFs.`,
+    image: [LOGO_URL],
+    datePublished: publishedDate,
+    dateModified: modifiedDate,
+    author: { '@type': 'Organization', name: SITE_NAME, url: BASE_URL },
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: BASE_URL,
+      logo: { '@type': 'ImageObject', url: LOGO_URL, width: 600, height: 60 },
+    },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
+    articleSection: 'ETF Competitive Analysis',
+  };
 }

--- a/insights-ui/src/utils/etf-metadata-generators.ts
+++ b/insights-ui/src/utils/etf-metadata-generators.ts
@@ -1,10 +1,60 @@
 import { Metadata } from 'next';
 import type { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import type { EtfFundCategoryHierarchy } from '@/utils/etf-categorization-utils';
+import { etfBasePath, etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName, etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
+import type { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 
 const SITE_NAME = 'KoalaGains';
 const BASE_URL = 'https://koalagains.com';
 const LOGO_URL = `${BASE_URL}/koalagain_logo.png`;
+
+const DEFAULT_LISTING_KEYWORDS = [
+  'ETFs',
+  'ETF analysis',
+  'ETF comparison',
+  'exchange-traded funds',
+  'ETF performance',
+  'ETF expense ratio',
+  'ETF risk analysis',
+  SITE_NAME,
+];
+
+interface ListingMetadataInput {
+  title: string;
+  description: string;
+  path: string;
+  keywords?: string[];
+}
+
+function buildListingMetadata({ title, description, path, keywords }: ListingMetadataInput): Metadata {
+  const fullTitle = `${title} | ${SITE_NAME}`;
+  const desc = truncateForMeta(description);
+  const url = `${BASE_URL}${path}`;
+  return {
+    title: fullTitle,
+    description: desc,
+    alternates: { canonical: url },
+    keywords: keywords ?? DEFAULT_LISTING_KEYWORDS,
+    openGraph: {
+      title: fullTitle,
+      description: desc,
+      url,
+      siteName: SITE_NAME,
+      type: 'website',
+      images: [LOGO_URL],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: fullTitle,
+      description: desc,
+      images: [LOGO_URL],
+    },
+  };
+}
+
+function listingBaseCrumb(country: EtfSupportedCountry): { name: string; href: string } {
+  return { name: `${etfCountryDisplayName(country)} ETFs`, href: etfBasePath(country) };
+}
 
 function toAbsoluteUrl(href: string): string {
   return href.startsWith('http') ? href : `${BASE_URL}${href.startsWith('/') ? '' : '/'}${href}`;
@@ -66,11 +116,13 @@ export function generateEtfListingMetadata(): Metadata {
       url,
       siteName: SITE_NAME,
       type: 'website',
+      images: [LOGO_URL],
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
+      images: [LOGO_URL],
     },
   };
 }
@@ -348,4 +400,154 @@ export function generateEtfCategoryBreadcrumbJsonLd(
     '@type': 'BreadcrumbList',
     itemListElement: items,
   };
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ETF Listing Sub-Pages (countries, groups, asset-classes, providers)
+// ────────────────────────────────────────────────────────────────────────────────
+
+export function generateEtfCountryListingMetadata(country: EtfSupportedCountry): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${countryName} ETFs — Exchange Traded Funds Analysis & Insights`,
+    description: `Browse ${countryName} exchange-traded funds with AI-driven analysis on performance, risk, cost efficiency, expense ratios, dividends, and portfolio holdings.`,
+    path: etfBasePath(country),
+  });
+}
+
+export function generateEtfCountryListingBreadcrumbJsonLd(country: EtfSupportedCountry) {
+  return generateBreadcrumbJsonLdFromCrumbs([listingBaseCrumb(country)]);
+}
+
+export function generateEtfGroupsIndexMetadata(country: EtfSupportedCountry): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${countryName} ETFs by Group`,
+    description: `Browse ${countryName} ETFs organised by analysis group. Each group highlights the top-rated ETFs by report score and AUM.`,
+    path: etfBrowsePath(country, 'groups'),
+  });
+}
+
+export function generateEtfGroupsIndexBreadcrumbJsonLd(country: EtfSupportedCountry) {
+  return generateBreadcrumbJsonLdFromCrumbs([listingBaseCrumb(country), { name: 'Groups', href: etfBrowsePath(country, 'groups') }]);
+}
+
+interface EtfGroupDetailMetadataInput {
+  country: EtfSupportedCountry;
+  groupKey: string;
+  groupName: string;
+}
+
+export function generateEtfGroupDetailMetadata({ country, groupKey, groupName }: EtfGroupDetailMetadataInput): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${groupName} ${countryName} ETFs`,
+    description: `Browse ${countryName} ETFs in the ${groupName} group organised by analysis category, with the top-rated ETFs in each category.`,
+    path: etfBrowseDetailPath(country, 'groups', groupKey),
+  });
+}
+
+export function generateEtfGroupDetailBreadcrumbJsonLd({ country, groupKey, groupName }: EtfGroupDetailMetadataInput) {
+  return generateBreadcrumbJsonLdFromCrumbs([
+    listingBaseCrumb(country),
+    { name: 'Groups', href: etfBrowsePath(country, 'groups') },
+    { name: groupName, href: etfBrowseDetailPath(country, 'groups', groupKey) },
+  ]);
+}
+
+interface EtfGroupCategoryListingMetadataInput {
+  country: EtfSupportedCountry;
+  groupKey: string;
+  groupName: string;
+  categoryName: string;
+}
+
+export function generateEtfGroupCategoryListingMetadata({ country, groupKey, groupName, categoryName }: EtfGroupCategoryListingMetadataInput): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${categoryName} ${countryName} ETFs`,
+    description: `Browse ${countryName} ETFs in the ${categoryName} category (part of ${groupName}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+    path: etfGroupCategoryPath(country, groupKey, categoryName),
+  });
+}
+
+export function generateEtfGroupCategoryListingBreadcrumbJsonLd({ country, groupKey, groupName, categoryName }: EtfGroupCategoryListingMetadataInput) {
+  return generateBreadcrumbJsonLdFromCrumbs([
+    listingBaseCrumb(country),
+    { name: 'Groups', href: etfBrowsePath(country, 'groups') },
+    { name: groupName, href: etfBrowseDetailPath(country, 'groups', groupKey) },
+    { name: categoryName, href: etfGroupCategoryPath(country, groupKey, categoryName) },
+  ]);
+}
+
+export function generateEtfAssetClassesIndexMetadata(country: EtfSupportedCountry): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${countryName} ETFs by Asset Class`,
+    description: `Browse ${countryName} ETFs by asset class — Equity, Fixed Income, Commodity, Alternatives, and more. Each card highlights the top-rated ETFs in that class.`,
+    path: etfBrowsePath(country, 'asset-classes'),
+  });
+}
+
+export function generateEtfAssetClassesIndexBreadcrumbJsonLd(country: EtfSupportedCountry) {
+  return generateBreadcrumbJsonLdFromCrumbs([listingBaseCrumb(country), { name: 'Asset Classes', href: etfBrowsePath(country, 'asset-classes') }]);
+}
+
+interface EtfAssetClassDetailMetadataInput {
+  country: EtfSupportedCountry;
+  assetClass: string;
+  assetClassSlug: string;
+}
+
+export function generateEtfAssetClassDetailMetadata({ country, assetClass, assetClassSlug }: EtfAssetClassDetailMetadataInput): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${assetClass} ${countryName} ETFs`,
+    description: `Browse ${countryName} ETFs in the ${assetClass} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+    path: etfBrowseDetailPath(country, 'asset-classes', assetClassSlug),
+  });
+}
+
+export function generateEtfAssetClassDetailBreadcrumbJsonLd({ country, assetClass, assetClassSlug }: EtfAssetClassDetailMetadataInput) {
+  return generateBreadcrumbJsonLdFromCrumbs([
+    listingBaseCrumb(country),
+    { name: 'Asset Classes', href: etfBrowsePath(country, 'asset-classes') },
+    { name: assetClass, href: etfBrowseDetailPath(country, 'asset-classes', assetClassSlug) },
+  ]);
+}
+
+export function generateEtfProvidersIndexMetadata(country: EtfSupportedCountry): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${countryName} ETFs by Provider`,
+    description: `Browse ${countryName} ETFs grouped by issuer. Each card highlights the top-rated ETFs from that provider.`,
+    path: etfBrowsePath(country, 'providers'),
+  });
+}
+
+export function generateEtfProvidersIndexBreadcrumbJsonLd(country: EtfSupportedCountry) {
+  return generateBreadcrumbJsonLdFromCrumbs([listingBaseCrumb(country), { name: 'Providers', href: etfBrowsePath(country, 'providers') }]);
+}
+
+interface EtfProviderDetailMetadataInput {
+  country: EtfSupportedCountry;
+  providerCanonical: string;
+  providerSlug: string;
+}
+
+export function generateEtfProviderDetailMetadata({ country, providerCanonical, providerSlug }: EtfProviderDetailMetadataInput): Metadata {
+  const countryName = etfCountryDisplayName(country);
+  return buildListingMetadata({
+    title: `${providerCanonical} ${countryName} ETFs`,
+    description: `Browse ${countryName} ETFs issued by ${providerCanonical} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`,
+    path: etfBrowseDetailPath(country, 'providers', providerSlug),
+  });
+}
+
+export function generateEtfProviderDetailBreadcrumbJsonLd({ country, providerCanonical, providerSlug }: EtfProviderDetailMetadataInput) {
+  return generateBreadcrumbJsonLdFromCrumbs([
+    listingBaseCrumb(country),
+    { name: 'Providers', href: etfBrowsePath(country, 'providers') },
+    { name: providerCanonical, href: etfBrowseDetailPath(country, 'providers', providerSlug) },
+  ]);
 }


### PR DESCRIPTION
## Summary

Until this PR, only `/etfs` declared its own `alternates.canonical`, `openGraph`, and `twitter` tags. The 14 other ETF listing routes (providers, groups, asset-classes, all the country variants) set only `title` + `description`, so Next.js's metadata merge inherited the root layout's homepage values — meaning every sub-listing page served `canonical: https://koalagains.com/`, `og:url: https://koalagains.com/`, `og:title: KoalaGains`, and `twitter:title: KoalaGains`. Social previews on every sub-listing looked like the homepage and Google saw 14 duplicates of `/`.

This PR fixes that, plus adds a `BreadcrumbList` JSON-LD payload to all 15 listing pages.

### What changed
- `metadataBase` added to the root layout so relative image paths resolve cleanly.
- `images: [LOGO_URL]` added to `openGraph` + `twitter` on the existing `generateEtfListingMetadata()` (since it fully replaces the parent og, it was dropping the homepage image).
- 9 new helpers in `src/utils/etf-metadata-generators.ts` — one per listing variant. Each returns a complete `Metadata` (title, truncated description, canonical, keywords, `openGraph` with images, `twitter` with images), built from a single shared `buildListingMetadata()` builder.
- 9 matching `BreadcrumbList` JSON-LD generators, emitted via the existing `EtfGroupsIndex.headSlot` slot where available and via an inline `<script type="application/ld+json">` otherwise. `/etfs` itself now ships both its existing `CollectionPage` JSON-LD and the breadcrumb list.
- Country / group / category / asset-class / provider display names in titles now come from the same resolvers the page body uses (`etfCountryDisplayName`, `getEtfGroupByKey`, `getEtfCategoryBySlug`), so the title matches the visible H1 instead of rendering raw URL slugs like `"us ETFs"` or `"fixed-income-core ETFs"`.
- Async detail components are now called as functions and awaited inside a Fragment (`{await Foo({...})}`), since TS rejects `<AsyncComponent .../>` even though React/Next supports it at runtime.

### Routes touched (15)
- `/etfs`
- `/etfs/providers`, `/etfs/providers/[provider]`
- `/etfs/groups/[group]`, `/etfs/groups/[group]/categories/[category]`
- `/etfs/asset-classes`, `/etfs/asset-classes/[assetClass]`
- `/etfs/countries/[country]` + its `groups`, `groups/[group]`, `groups/[group]/categories/[category]`, `asset-classes`, `asset-classes/[assetClass]`, `providers`, `providers/[provider]`

## Test plan

- [ ] `yarn lint && yarn prettier-check && yarn compile` all pass locally (verified)
- [ ] Spot-check one US listing and one Canada listing in preview: `view-source:` confirms a unique `<link rel="canonical">`, `<meta property="og:url">`, `<meta property="og:title">`, and a `<script type="application/ld+json">` with a `BreadcrumbList` payload
- [ ] Run a representative URL through the LinkedIn Post Inspector / Twitter card validator and confirm the preview matches the page (not the KoalaGains homepage)
- [ ] Validate one `BreadcrumbList` JSON-LD payload via Google's Rich Results test
- [ ] Sitemap / search-console check after deploy: previously broken sub-listing URLs should start surfacing as their own canonicals rather than as homepage duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)