### PR TITLE
insights-ui: cache tariff URLs at CloudFront + manual flush workflow

### DIFF
--- a/.github/workflows/flush-cloudfront-cache.yml
+++ b/.github/workflows/flush-cloudfront-cache.yml
@@ -1,0 +1,81 @@
+name: Flush CloudFront cache
+
+# Manually-triggered: purges cached pages on the koalagains CloudFront
+# distribution. Tick whichever cache groups you want flushed — the workflow
+# combines them into a single CreateInvalidation call (1 quota path per
+# wildcard pattern, against the 1,000-path/month free tier).
+#
+# Cache groups:
+#   - stocks   → /stocks/*
+#   - etfs     → /etfs/*
+#   - tariffs  → /industry-tariff-report/*, /tariff-reports*
+#
+# /tariff-calculator/* and /hts-codes/* are force-dynamic and live outside
+# the CloudFront cache behaviors, so they're not invalidated here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      flush_stocks:
+        description: 'Flush /stocks/* cache'
+        type: boolean
+        default: false
+      flush_etfs:
+        description: 'Flush /etfs/* cache'
+        type: boolean
+        default: false
+      flush_tariffs:
+        description: 'Flush /industry-tariff-report/* and /tariff-reports* cache'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flush-cloudfront-cache
+  cancel-in-progress: false
+
+env:
+  CLOUDFRONT_DISTRIBUTION_ID: EZI5H8FKNE9R1
+  AWS_ACCESS_KEY_ID: ${{ secrets.KOALA_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.KOALA_AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+
+jobs:
+  flush:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Temporary debug step so we can confirm which IAM identity the
+      # KOALA_AWS_* secrets correspond to. Once verified, remove this step.
+      - name: Show AWS caller identity
+        run: aws sts get-caller-identity
+
+      - name: Build path list from selected cache groups
+        id: paths
+        run: |
+          paths=()
+          if [ "${{ github.event.inputs.flush_stocks }}" = "true" ]; then
+            paths+=("/stocks/*")
+          fi
+          if [ "${{ github.event.inputs.flush_etfs }}" = "true" ]; then
+            paths+=("/etfs/*")
+          fi
+          if [ "${{ github.event.inputs.flush_tariffs }}" = "true" ]; then
+            paths+=("/industry-tariff-report/*" "/tariff-reports*")
+          fi
+          if [ ${#paths[@]} -eq 0 ]; then
+            echo "::error::No cache group selected. Tick at least one of flush_stocks / flush_etfs / flush_tariffs."
+            exit 1
+          fi
+          echo "Selected paths: ${paths[*]}"
+          # Space-separated for the aws CLI invocation in the next step.
+          printf 'aws_paths=%s\n' "${paths[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Create CloudFront invalidation
+        run: |
+          # shellcheck disable=SC2086
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths ${{ steps.paths.outputs.aws_paths }}

--- a/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
+++ b/insights-ui/src/scripts/industry-tariff-reports/tariff-report-repository.ts
@@ -15,7 +15,7 @@ import type {
 } from '@/scripts/industry-tariff-reports/tariff-types';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 
-import { revalidateTariffReport, revalidateTariffReportsListing } from '@/utils/tariff-report-cache-utils';
+import { revalidateTariffReportChapter, revalidateTariffReportIndustry, revalidateTariffReportsListing } from '@/utils/tariff-report-cache-utils';
 
 /**
  * Prisma JSON columns accept "JSON-ish" values, but Prisma's generated TS types
@@ -199,9 +199,9 @@ async function writeSection(slug: string, data: Prisma.TariffChapterReportUpdate
   // Chapter routes (`/industry-tariff-report/chapters/<slug>`) cache their
   // fetches under a slug-keyed tag; legacy industry routes (when oldUrl is
   // set) cache under the oldUrl. Bust both so neither URL serves stale data.
-  revalidateTariffReport(slug);
+  revalidateTariffReportChapter(slug);
   if (row.oldUrl && row.oldUrl !== slug) {
-    revalidateTariffReport(row.oldUrl);
+    revalidateTariffReportIndustry(row.oldUrl);
   }
   // The /tariff-reports listing is cached via unstable_cache and shows the
   // updatedAt for every chapter; bust it on every write so the homepage card

--- a/insights-ui/src/utils/cloudfront-cache-utils.ts
+++ b/insights-ui/src/utils/cloudfront-cache-utils.ts
@@ -12,9 +12,10 @@ import { waitUntil } from '@vercel/functions';
  * keeps the old HTML at the edge for up to its TTL (currently 6 days), so
  * users can see stale pages even after a successful save.
  *
- * Only paths under `/stocks/*` or `/etfs/*` are cached at CloudFront today
- * (see `dodao-api-v2-deployment/cloudfront.tf`). Calls for any other path
- * are filtered out before reaching the AWS API — they would not have a cache
+ * Only paths under `/stocks/*`, `/etfs/*`, `/industry-tariff-report/*`, or
+ * `/tariff-reports*` are cached at CloudFront today (see
+ * `dodao-api-v2-deployment/cloudfront.tf`). Calls for any other path are
+ * filtered out before reaching the AWS API — they would not have a cache
  * entry to purge and would just consume the monthly invalidation quota.
  *
  * Configuration:
@@ -26,7 +27,7 @@ import { waitUntil } from '@vercel/functions';
 
 const DISTRIBUTION_ID = process.env.CLOUDFRONT_DISTRIBUTION_ID;
 
-const CACHED_PATH_PATTERNS = [/^\/stocks(\/|$)/, /^\/etfs(\/|$)/];
+const CACHED_PATH_PATTERNS = [/^\/stocks(\/|$)/, /^\/etfs(\/|$)/, /^\/industry-tariff-report(\/|$)/, /^\/tariff-reports(\/|\*|$)/];
 
 let client: CloudFrontClient | null = null;
 

--- a/insights-ui/src/utils/tariff-report-cache-utils.ts
+++ b/insights-ui/src/utils/tariff-report-cache-utils.ts
@@ -1,11 +1,46 @@
 import 'server-only';
 import { revalidateTag } from 'next/cache';
+import { invalidateCloudFrontPaths } from './cloudfront-cache-utils';
 import { tariffReportTag, TARIFF_REPORTS_LISTING_TAG } from './tariff-report-tags';
 
-/** Server-only revalidation helper */
-export const revalidateTariffReport = (industryId: string) => revalidateTag(tariffReportTag(industryId));
+/**
+ * Cache-tag helpers for per-tariff-report revalidation.
+ *
+ * The same `tariffReportTag(id)` function is used for two different URL
+ * topologies:
+ *
+ *   - Legacy industry routes: `/industry-tariff-report/<industryId>` and its
+ *     subpages — tagged by the industry slug.
+ *   - Chapter routes: `/industry-tariff-report/chapters/<chapterSlug>` and its
+ *     subpages — tagged by the chapter slug.
+ *
+ * The Vercel-side `revalidateTag` call is identical for both (it just clears
+ * the tag), but the CloudFront URL to purge differs. That's why this module
+ * exposes two helpers — `revalidateTariffReportIndustry` and
+ * `revalidateTariffReportChapter` — instead of one ambiguous helper. Callers
+ * know which topology they're invalidating.
+ *
+ * Each helper also purges the CloudFront edge cache for the corresponding
+ * URL — see `cloudfront-cache-utils.ts`.
+ */
 
-export const revalidateTariffReportsListing = () => revalidateTag(TARIFF_REPORTS_LISTING_TAG);
+/** Invalidate the cache for a legacy industry route: `/industry-tariff-report/<industryId>` + subpages. */
+export const revalidateTariffReportIndustry = (industryId: string) => {
+  revalidateTag(tariffReportTag(industryId));
+  invalidateCloudFrontPaths([`/industry-tariff-report/${industryId}*`]);
+};
+
+/** Invalidate the cache for a chapter route: `/industry-tariff-report/chapters/<chapterSlug>` + subpages. */
+export const revalidateTariffReportChapter = (chapterSlug: string) => {
+  revalidateTag(tariffReportTag(chapterSlug));
+  invalidateCloudFrontPaths([`/industry-tariff-report/chapters/${chapterSlug}*`]);
+};
+
+/** Invalidate the `/tariff-reports` listing page. */
+export const revalidateTariffReportsListing = () => {
+  revalidateTag(TARIFF_REPORTS_LISTING_TAG);
+  invalidateCloudFrontPaths(['/tariff-reports*']);
+};
 
 // Re-export tag builder for server usage when convenient
 export { tariffReportTag, TARIFF_REPORTS_LISTING_TAG };


### PR DESCRIPTION
## Summary

Two coordinated changes that bring the tariff report pages under CloudFront caching (matching the topology already used for `/stocks/*` and `/etfs/*`) and add a manually-triggered GitHub workflow to flush any combination of cache groups on demand.

Pairs with [dodao-api-v2-deployment commit 1c39f45](https://github.com/RobinNagpal/dodao-api-v2-deployment/commit/1c39f45) which adds two new `ordered_cache_behavior` blocks (`/industry-tariff-report/*` and `/tariff-reports*`) to the koalagains CloudFront distribution using the existing 6-day cache policy. Already applied to prod.

## Why

`/industry-tariff-report/*` is a deep tree (industry covers, 7 subpages per industry, plus chapters with their own subpages) — currently every request hits Vercel. Mirrors the cost/freshness pattern we already established for stocks and ETFs:
- CloudFront caches HTML at the edge for 6 days
- Saves invalidate the specific path (`invalidateCloudFrontPaths`)
- Manual flush available via GH Actions for bulk cases

`/tariff-calculator/*` and `/hts-codes/*` stay outside CloudFront — both are `force-dynamic` and would break under HTML caching.

## insights-ui changes

- **`cloudfront-cache-utils.ts`** — extend `CACHED_PATH_PATTERNS` so `/industry-tariff-report/*` and `/tariff-reports*` reach AWS instead of being filtered out as "uncached".

- **`tariff-report-cache-utils.ts`** — split the ambiguous `revalidateTariffReport` helper:
  - `revalidateTariffReportIndustry(industryId)` → invalidates `/industry-tariff-report/${industryId}*`
  - `revalidateTariffReportChapter(chapterSlug)` → invalidates `/industry-tariff-report/chapters/${chapterSlug}*`
  - `revalidateTariffReportsListing()` → also invalidates `/tariff-reports*`

  The same `tariffReportTag(id)` function is used for two different URL topologies (legacy industry routes and chapter routes), so the caller has to disambiguate. Splitting the helper avoids over-invalidation.

- **`tariff-report-repository.ts`** — update the only caller. Chapter slug → Chapter helper; `oldUrl` (legacy industry) → Industry helper.

## New workflow

**`.github/workflows/flush-cloudfront-cache.yml`** — `workflow_dispatch` with three boolean inputs:
- `flush_stocks` → `/stocks/*`
- `flush_etfs` → `/etfs/*`
- `flush_tariffs` → `/industry-tariff-report/*` + `/tariff-reports*`

Whichever boxes are ticked get combined into a single `aws cloudfront create-invalidation` call. Errors out if none ticked.

### One temporary thing

The workflow includes an `aws sts get-caller-identity` step at the top so we can identify which IAM user the `KOALA_AWS_*` secrets correspond to. After the first run, the `insights-ui-project-policy` ([already created in terraform](https://github.com/RobinNagpal/dodao-api-v2-deployment/commit/9bb2838)) needs to be attached to that user so the workflow has `cloudfront:CreateInvalidation` permission. The debug step can be removed in a follow-up PR once verified.

## Test plan

- [ ] `pnpm lint && pnpm prettier-check && pnpm compile` (all pass locally)
- [ ] Vercel preview builds cleanly
- [ ] After merge: trigger `Flush CloudFront cache` once with `flush_stocks=true` and read the ARN from the `Show AWS caller identity` step — share the user name so the IAM policy can be attached
- [ ] Re-run with the policy attached and confirm an invalidation appears in CloudFront Console