### PR TITLE
insights-ui: slim /full-render response (~215 KB JSON / ~800 KB HTML)

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -486,7 +486,7 @@ function TickerAnalysisInfo({
       <div className="space-y-4">
         <CategorySummaryCard categoryKey={TickerAnalysisCategory.BusinessAndMoat} d={d} />
 
-        <CompetitionChartSection dataPromise={Promise.resolve(competitionData)} exchange={exchange} ticker={ticker} />
+        <CompetitionChartSection dataPromise={Promise.resolve(competitionData)} tickerData={d} exchange={exchange} ticker={ticker} />
 
         {managementTeamReport && (
           <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -3,24 +3,29 @@
 import { computeQuadrantScores, classifyStock, QuadrantDataPoint } from '@/util/quadrant-chart-utils';
 import CompetitionQuadrantChart from '@/components/ticker-reportsv1/CompetitionQuadrantChart';
 import type { CompetitionResponse } from '@/types/ticker-typesv1';
+import type { TickerV1FastResponse } from '@/utils/ticker-v1-model-utils';
 import Link from 'next/link';
 import { use } from 'react';
 
 export interface CompetitionChartSectionProps {
   dataPromise: Promise<CompetitionResponse | null>;
+  // Source of truth for the main ticker's symbol/name/exchange/cachedScoreEntry.
+  // The consolidated `/full-render` endpoint no longer ships these in
+  // `competition.ticker` (they duplicated the top-level `ticker` field) so the
+  // parent passes the top-level ticker directly here.
+  tickerData: TickerV1FastResponse;
   exchange: string;
   ticker: string;
 }
 
-export default function CompetitionChartSection({ dataPromise, exchange, ticker }: CompetitionChartSectionProps): JSX.Element | null {
+export default function CompetitionChartSection({ dataPromise, tickerData, exchange, ticker }: CompetitionChartSectionProps): JSX.Element | null {
   const data = use(dataPromise);
 
-  if (!data || !data.ticker) {
+  if (!data) {
     return null;
   }
 
   const { competitorTickers } = data;
-  const tickerData = data.ticker;
 
   const quadrantDataPoints: QuadrantDataPoint[] = [];
 

--- a/insights-ui/src/utils/ticker-full-render-utils.ts
+++ b/insights-ui/src/utils/ticker-full-render-utils.ts
@@ -13,7 +13,7 @@ import { getMissingReportsForTicker } from '@/utils/missing-reports-utils';
 import { ensurePriceHistoryIsFresh } from '@/utils/price-history-utils';
 import { ensureStockAnalyzerDataIsFresh } from '@/utils/stock-analyzer-scraper-utils';
 import { SimilarTicker, TickerV1FastResponse, getCompetitorTickers, tickerV1IncludeWithRelations } from '@/utils/ticker-v1-model-utils';
-import { Prisma, TickerV1PriceHistory, TickerV1StockAnalyzerScrapperInfo, TickerV1VsCompetition } from '@prisma/client';
+import { Prisma, TickerV1PriceHistory, TickerV1StockAnalyzerScrapperInfo } from '@prisma/client';
 
 /**
  * Consolidated response payload for the main `/stocks/[exchange]/[ticker]` page.
@@ -281,17 +281,29 @@ export async function fetchTickerFullRenderData(rawSpaceId: string | undefined, 
     throw new Error(`fetchTickerFullRenderData: failed to get missing reports for ${symbol}`);
   }
 
-  const tickerResponse: TickerV1FastResponse = { ...tickerRecord, ...missingReports };
+  // Slim the response for the main page render. The fields stripped below
+  // are not read by `app/stocks/[exchange]/[ticker]/page.tsx` or any component
+  // it renders — they were inflating the consolidated payload by ~215 KB
+  // (4× that in the inlined RSC HTML). The standalone endpoints (e.g.
+  // `/competition`, the per-category data endpoints) continue to return the
+  // full shape for their subpage consumers.
+  //
+  //   ~42 KB  ticker.vsCompetition                     — not rendered on main page
+  //   ~132 KB competition.ticker                       — duplicate of top-level `ticker`
+  //   ~42 KB  competition.vsCompetition                — not rendered on main page
+  //   ~40 KB  competitorTickers[].detailedComparison   — only used on /competition subpage
+  const tickerResponse: TickerV1FastResponse = { ...tickerRecord, vsCompetition: null, ...missingReports };
 
   const summary = scraperInfo?.summary as StockFundamentalsSummary | null | undefined;
   const financialInfo = buildFinancialInfoFromSummary(summary, tickerRecord.symbol);
   const quarterlyChart = buildQuarterlyChartFromScraperInfo(scraperInfo);
   const priceHistory = buildPriceHistoryFromPriceInfo(priceInfo, tickerRecord.symbol);
 
+  const slimmedCompetitors = competitorTickers.map(({ detailedComparison: _detailedComparison, ...rest }) => rest);
   const competition: CompetitionResponse = {
-    vsCompetition: (tickerRecord.vsCompetition as TickerV1VsCompetition | null) || null,
-    competitorTickers,
-    ticker: tickerRecord,
+    vsCompetition: null,
+    competitorTickers: slimmedCompetitors,
+    // `ticker` intentionally omitted; consumers read from the top-level `ticker` field.
   };
 
   return {


### PR DESCRIPTION
## Summary

Strip four fields from `/api/koala_gains/tickers-v1/exchange/[e]/[t]/full-render` that the main ticker page (`app/stocks/[exchange]/[ticker]/page.tsx`) does not read but that were bloating every render:

| Field | Size | Why it's safe to drop |
|---|---|---|
| `ticker.vsCompetition` | ~42 KB | Zero reads on the main page or any component it renders |
| `competition.ticker` | ~132 KB | Verbatim duplicate of the top-level `ticker` field |
| `competition.vsCompetition` | ~42 KB | Zero reads on the main page; `CompetitionChartSection` ignored it |
| `competitorTickers[].detailedComparison` | ~40 KB (6.7 KB × 6) | Only used on `/competition` subpage, which uses a different endpoint |

The fields balloon ~4× further when serialized into the inline RSC stream in the page HTML, so removing ~215 KB of JSON cuts ~800 KB off the raw HTML size.

## Measured impact (on `/stocks/NASDAQ/VFF`)

| | Before | After (projected) |
|---|---|---|
| `/full-render` JSON (raw) | 407 KB | ~190 KB |
| `/full-render` JSON (brotli) | 54 KB | ~25 KB |
| Page HTML (raw) | 1.55 MB | ~600 KB |
| Page HTML (brotli) | 158 KB | ~60 KB |
| `<script>` tags in HTML | 510 | (proportional drop expected) |

Will measure on production after deploy.

## Component change

`CompetitionChartSection` used to read `data.ticker` (the duplicate). It now takes a `tickerData` prop sourced from the top-level `ticker` field that the parent already has in scope. Only consumer change: `TickerAnalysisInfo` passes `tickerData={d}` through.

## What is NOT changed

- **Standalone `/competition` endpoint** (`competition-tickers/route.ts`) keeps returning the full shape including `ticker`, `vsCompetition`, and `detailedComparison` — its subpage consumers (`Competition.tsx`, `CompetitorCard.tsx`) are untouched.
- **`categoryAnalysisResults`** with full `overallAnalysisDetails` markdown — still rendered in full by `CategorySummaryCard` on the main page (no UX change).
- All other API endpoints, other subpages, ETF / tariff trees — all unchanged.

## Test plan

- [ ] After deploy, `curl -s https://koalagains.com/api/koala_gains/tickers-v1/exchange/NASDAQ/VFF/full-render | wc -c` ≈ 190 KB raw.
- [ ] `curl -s https://koalagains.com/stocks/NASDAQ/VFF | wc -c` ≈ 600 KB raw.
- [ ] Load `/stocks/NASDAQ/VFF` in browser; verify the competition quadrant chart still renders and shows the main ticker + competitors.
- [ ] Load `/stocks/NASDAQ/VFF/competition` (subpage) and verify the full per-competitor detailed comparisons still render — that page uses the standalone endpoint which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)