### PR TITLE
perf(insights-ui): defer Microsoft Clarity init until after window.load

### DIFF
--- a/insights-ui/src/app/ClarityComponent.tsx
+++ b/insights-ui/src/app/ClarityComponent.tsx
@@ -6,12 +6,53 @@ import { PROD_HOST } from './LogRocketComponent';
 
 const CLARITY_PROJECT_ID = 'u82d3rnsxw';
 
+/**
+ * Defer Clarity until *after* `window.load` (so it doesn't compete with image
+ * decoding, font loading, or any other LCP-bound work) and then further
+ * postpone it to the next idle moment. This keeps Clarity out of the critical
+ * rendering path for Core Web Vitals while still capturing the session.
+ */
 export default function ClarityComponent(): null {
   useEffect(() => {
-    // Only initialize on production
-    if (typeof window !== 'undefined' && window.location.hostname === PROD_HOST) {
-      Clarity.init(CLARITY_PROJECT_ID);
+    if (typeof window === 'undefined' || window.location.hostname !== PROD_HOST) {
+      return;
     }
+
+    let cancelled = false;
+
+    const init = (): void => {
+      if (cancelled) return;
+      try {
+        Clarity.init(CLARITY_PROJECT_ID);
+      } catch {
+        /* swallow — analytics must not break the app */
+      }
+    };
+
+    const scheduleIdle = (): void => {
+      type IdleWindow = Window & {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      };
+      const ric = (window as IdleWindow).requestIdleCallback;
+      if (typeof ric === 'function') {
+        ric(init, { timeout: 4000 });
+      } else {
+        window.setTimeout(init, 2000);
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      scheduleIdle();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    window.addEventListener('load', scheduleIdle, { once: true });
+    return () => {
+      cancelled = true;
+      window.removeEventListener('load', scheduleIdle);
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary

Microsoft Clarity was firing `Clarity.init` inside a `useEffect` with no gate, so it ran in parallel with hydration on every prod page load — competing with image decoding, font loading, and other LCP-bound work for the same main-thread budget. This PR defers it.

## What changed

`insights-ui/src/app/ClarityComponent.tsx` now:

1. If `document.readyState === 'complete'` already, schedule init via `requestIdleCallback` (4 s timeout, `setTimeout(2 s)` fallback).
2. Otherwise wait for the `window.load` event, *then* schedule via `requestIdleCallback`.

The `cancelled` flag + `removeEventListener` cleanup keep StrictMode-friendly behavior.

## Why this and not "remove Clarity entirely"

The previous discussion identified Clarity as a duplicate of LogRocket. Removing it is a separate decision — this PR is the minimum behavioral change: keep Clarity, just stop letting it run during the critical render path.

If the team decides to drop Clarity entirely, this code goes away with it; no harm done.

## Test plan

- [x] `yarn lint` — passes.
- [x] `yarn prettier-check` — passes.
- [x] `yarn compile` — only pre-existing error in `api/auth/custom-email/login-signup-by-email/route.ts` (unrelated, present on main).
- [ ] After deploy, load `/stocks/NYSE/RTX`, open DevTools Network panel, and confirm `clarity.ms` requests start firing *after* the `load` event (visible as a vertical blue line in the waterfall) rather than during initial render.
- [ ] Verify Clarity dashboard still records the session (open the page, click around, confirm session shows up in Clarity within ~5 min).
- [ ] Run PageSpeed Insights on `/stocks/NYSE/RTX` again and confirm TBT/INP didn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)