### PR TITLE
docs(insights-ui/tasks): add ETF understanding/education task

### DIFF
--- a/docs/insights-ui/README.md
+++ b/docs/insights-ui/README.md
@@ -5,6 +5,7 @@ Topical reference docs for the Insights-UI (KoalaGains) app — patterns, prompt
 ## Subfolders
 
 - **[etf-analysis/](etf-analysis/)** — How the ETF analysis pipeline works end-to-end: report generation and the ETF Scenarios system (winner / loser model + admin/automation paths). See [etf-analysis/README.md](etf-analysis/README.md).
+- **[etf-education/](etf-education/)** — Short investor-education reference notes feeding the "Understanding ETFs in detail" primer surface: filters to use when picking an ETF, and ETF tax behavior + account-type guidance. See [etf-education/README.md](etf-education/README.md).
 - **[stock-analysis/](stock-analysis/)** — Runbooks for adding new stocks (`yarn stocks:add`) and triggering stock report generation (`yarn stocks:trigger`). See [stock-analysis/README.md](stock-analysis/README.md).
 - **[etf-prompts/](etf-prompts/)** — Source-of-truth prompt text for each ETF analysis category (past returns, cost & efficiency, risk, future outlook, intro/strategy, competition) plus the prompt-finalization approach. See [etf-prompts/README.md](etf-prompts/README.md).
 - **[scenario-prompts/](scenario-prompts/)** — Reusable prompt templates for stock & ETF scenario authoring. Currently: `detailed-analysis.md` for generating the optional `detailedAnalysis` long-form section.

--- a/docs/insights-ui/etf-education/README.md
+++ b/docs/insights-ui/etf-education/README.md
@@ -1,0 +1,8 @@
+# ETF Education
+
+Short, plain-English reference notes for the user-facing ETF primer / education surface (see the "Understanding ETFs in detail" task in [`../tasks/todo-tasks.md`](../tasks/todo-tasks.md)).
+
+## Files
+
+- **[etf-filters.md](etf-filters.md)** — The six filters that actually matter when picking an ETF: provider, expense ratio, AUM, turnover rate, index, and tax / dividend tax. One paragraph each, plus a sanity-check checklist.
+- **[etf-tax.md](etf-tax.md)** — The three things that drive ETF tax outcomes: capital-gains distributions (and the in-kind redemption mechanism that suppresses them), dividend tax treatment (qualified vs. non-qualified), and account type (taxable vs. IRA vs. Roth — "asset location"). Plus where to look before you buy.

--- a/docs/insights-ui/etf-education/etf-filters.md
+++ b/docs/insights-ui/etf-education/etf-filters.md
@@ -1,0 +1,28 @@
+# ETF Filters — What to Look At Before You Buy
+
+Short checklist of the fields that actually matter when picking an ETF. Read top-to-bottom; each is one paragraph.
+
+## Provider
+The issuer running the fund (Vanguard, iShares / BlackRock, State Street / SPDR, Schwab, Invesco, Fidelity). Big providers mean tighter bid-ask spreads, lower closure risk, and (for Vanguard / iShares Core / SPDR Portfolio / Schwab) consistently lower fees. Niche issuers can still be fine for specialty exposures, but expect higher costs and thinner trading.
+
+## Expense ratio
+Annual cost as a percent of assets, deducted continuously from NAV. Broad-market ETFs today are 0.03–0.10%; sector and factor ETFs 0.10–0.50%; thematic / active 0.40–0.95%+. Over a 30-year hold, a 0.50% gap vs a 0.05% peer eats roughly 13% of your end balance — pick the cheapest fund that gives you the exposure you want.
+
+## AUM (Assets Under Management)
+Total dollars the fund holds. Below ~$100M the fund is at real risk of closure (forced sale, taxable event for you); above ~$1B it's safe and usually liquid. Larger AUM also produces tighter spreads and lower tracking error. Treat AUM as a survival filter, not a quality signal.
+
+## Turnover rate
+How much of the portfolio the fund replaces in a year. Plain index ETFs (S&P 500, total market) sit at 2–5%. Factor / smart-beta ETFs run 15–40%. Active / thematic ETFs can exceed 100%. Higher turnover means more trading-cost drag and — for non-ETF wrappers — more taxable events; for ETFs the in-kind redemption mechanism mostly absorbs it (see [etf-tax.md](./etf-tax.md)).
+
+## Index
+The benchmark the ETF is built to track (S&P 500, CRSP US Total Market, MSCI ACWI, FTSE All-World ex-US, Bloomberg US Aggregate, etc.). Two ETFs with similar-sounding names can track very different indexes — different inclusion rules, weighting, reconstitution frequency. Read the index methodology before assuming two funds are interchangeable.
+
+## Tax & dividend tax
+The tax bill on what the fund distributes to you each year — capital-gains distributions, qualified vs non-qualified dividends, and how the account type (taxable vs IRA / 401k) changes everything. This is the most-overlooked filter and has its own page: **[etf-tax.md](./etf-tax.md)**.
+
+## Quick sanity check before buying
+- Expense ratio reasonable for the exposure?
+- AUM > $100M and ideally > $1B?
+- Turnover in line with the strategy (low for plain index, higher OK for factor/active)?
+- Index methodology matches what you think you're buying?
+- Tax behavior checked on the issuer page (see [etf-tax.md](./etf-tax.md))?

--- a/docs/insights-ui/etf-education/etf-tax.md
+++ b/docs/insights-ui/etf-education/etf-tax.md
@@ -8,7 +8,7 @@ When an ETF sells a stock at a profit inside the portfolio, US tax law forces it
 
 ETFs largely avoid this through **in-kind redemption**: when a big institutional investor cashes out, the ETF hands them a basket of stocks (the lowest-cost-basis lots) instead of selling for cash, so the unrealized gain walks out the door without becoming a taxable event. Result: most broad US-equity ETFs distribute **$0 in capital gains** year after year. Vanguard reports that 82% of its ETFs had no capital-gains distributions over the last 5 years.
 
-**Note on how it reaches you:** the ETF doesn't withhold tax. It pays the distribution to you in cash (alongside dividends), reports it on **Form 1099-DIV** (capital gains in Box 2a, dividends in Boxes 1a / 1b), and you pay the IRS yourself when you file your 1040.
+**How it reaches you:** capital-gain distributions and dividends are **two separate cash payouts**, not one combined "dividend with tax taken out." Dividends are paid through the year (quarterly / monthly); cap-gain distributions, if any, are paid once in December. The ETF withholds nothing — it sends you the full cash, reports the split on **Form 1099-DIV** (cap gains in Box 2a, dividends in Boxes 1a / 1b), and you pay the IRS yourself when you file.
 
 **Where the in-kind trick breaks down:**
 - Bond ETFs and REIT ETFs — their return is mostly interest / non-qualified dividends, which in-kind doesn't suppress.
@@ -23,6 +23,8 @@ What the ETF pays you as a regular dividend is taxed two ways:
 - **Non-qualified (ordinary) dividends** — taxed at your full ordinary-income rate. This covers most REIT distributions, bond interest, MLP payouts, and dividends from short-held stocks.
 
 Funds that **pay dividends often** (monthly distributors, REIT ETFs, high-yield bond ETFs, dividend-focused ETFs like SCHD/VYM/HDV) produce a steady ordinary-income stream. That's fine in a tax-sheltered account but is a real drag in a taxable account, especially at higher tax brackets. The ETF's 1099-DIV breaks it out: **Box 1a** = total ordinary dividends, **Box 1b** = qualified portion (the lower-taxed slice).
+
+**61-day rule (background only):** dividends only qualify for the lower rate if the fund held the underlying stock > 60 days around the ex-dividend date. ETF creation/redemption can force the fund to hand out shares before that window closes, so a small slice of dividends gets bumped to ordinary. Not a per-fund filter — already captured in Morningstar's Tax-Cost Ratio and in the Box 1a vs 1b split on your 1099-DIV.
 
 ## 3. Account type — taxable vs. tax-advantaged
 

--- a/docs/insights-ui/etf-education/etf-tax.md
+++ b/docs/insights-ui/etf-education/etf-tax.md
@@ -1,0 +1,54 @@
+# ETF Tax — What to Check Before You Buy
+
+Short page. Three things actually matter: **capital-gains distributions**, **dividend tax treatment**, and **account type**.
+
+## 1. Capital-gains distributions (the "invisible" tax)
+
+When an ETF sells a stock at a profit inside the portfolio, US tax law forces it to pass that realized gain through to shareholders at year-end as a **capital-gains distribution** (separate from the regular dividend). You owe tax on it even if you didn't sell anything and just held the fund.
+
+ETFs largely avoid this through **in-kind redemption**: when a big institutional investor cashes out, the ETF hands them a basket of stocks (the lowest-cost-basis lots) instead of selling for cash, so the unrealized gain walks out the door without becoming a taxable event. Result: most broad US-equity ETFs distribute **$0 in capital gains** year after year. Vanguard reports that 82% of its ETFs had no capital-gains distributions over the last 5 years.
+
+**Note on how it reaches you:** the ETF doesn't withhold tax. It pays the distribution to you in cash (alongside dividends), reports it on **Form 1099-DIV** (capital gains in Box 2a, dividends in Boxes 1a / 1b), and you pay the IRS yourself when you file your 1040.
+
+**Where the in-kind trick breaks down:**
+- Bond ETFs and REIT ETFs — their return is mostly interest / non-qualified dividends, which in-kind doesn't suppress.
+- Brand-new ETFs (years 1–2) — not enough cost-basis variety yet.
+- ETFs that change their underlying index — forced selling triggers a one-off distribution.
+- Leveraged / inverse ETFs, futures-based commodity ETFs — derivative-driven, can't use in-kind.
+
+## 2. Dividend tax — qualified vs. non-qualified
+
+What the ETF pays you as a regular dividend is taxed two ways:
+- **Qualified dividends** — taxed at the lower long-term capital-gains rate (0% / 15% / 20%). Requires you held the ETF > 60 days and the underlying stocks paid US-corp / treaty-country dividends.
+- **Non-qualified (ordinary) dividends** — taxed at your full ordinary-income rate. This covers most REIT distributions, bond interest, MLP payouts, and dividends from short-held stocks.
+
+Funds that **pay dividends often** (monthly distributors, REIT ETFs, high-yield bond ETFs, dividend-focused ETFs like SCHD/VYM/HDV) produce a steady ordinary-income stream. That's fine in a tax-sheltered account but is a real drag in a taxable account, especially at higher tax brackets. The ETF's 1099-DIV breaks it out: **Box 1a** = total ordinary dividends, **Box 1b** = qualified portion (the lower-taxed slice).
+
+## 3. Account type — taxable vs. tax-advantaged
+
+Where you hold the ETF matters more than which ETF you pick:
+
+| Account type | Tax treatment | Best holdings |
+|---|---|---|
+| **Taxable brokerage** | Pay tax every year on distributions + when you sell | Tax-efficient US-equity ETFs (low/zero cap-gain distribs, mostly qualified dividends) |
+| **Traditional IRA / 401(k)** | No tax inside the account; taxed as ordinary income on withdrawal | Bond ETFs, REIT ETFs, high-turnover or high-dividend ETFs |
+| **Roth IRA / Roth 401(k)** | After-tax in, no tax inside, **no tax on withdrawal** | Your highest-expected-return ETFs (small-cap, emerging markets, aggressive growth) |
+| **HSA** | Triple tax-advantaged (deduction + growth + qualified-medical withdrawal) | Same as Roth — long-horizon growth |
+| **529 plan** | No tax on growth if used for qualified education | Age-based glide-path ETFs |
+
+This is **"asset location."** A REIT ETF in a Roth IRA pays $0 in taxes for life. The same ETF in a taxable account loses 30%+ of its yield to ordinary-income tax every year. The right ETF in the wrong account is a much bigger leak than picking the wrong ETF.
+
+## Where to check before you buy
+
+1. **Issuer's fund page → Distributions / Tax tab.** Look for the **Capital Gains** column over the last 5 years. If it's $0.00 every year, you're in the 82%-of-Vanguard-ETFs club. Same page shows ordinary vs. qualified dividend split.
+2. **Morningstar (`morningstar.com/etfs/<ticker>`) → Tax tab.** Two numbers worth knowing:
+   - **Tax-Cost Ratio** — % of return lost to taxes for a top-bracket investor. < 0.5% is excellent.
+   - **Potential Capital Gains Exposure** — embedded unrealized gains. Negative = future cap-gain distributions essentially impossible.
+3. **The ETF's annual report (issuer site or SEC EDGAR).** "Capital gain distributions" line in financial highlights + "capital loss carryforwards" note.
+4. **Your own 1099-DIV after year 1.** Box 2a (cap gains), Box 1a / 1b (ordinary / qualified dividends), Box 3 (return-of-capital) — confirms what actually happened.
+
+## Quick rules of thumb
+- **Broad US-equity ETF (VTI / VOO / SCHB / ITOT):** very tax-efficient. Safe in any account, ideal in taxable.
+- **International / EM equity ETF:** mostly tax-efficient; foreign tax credit possible in taxable account (lost in IRA).
+- **Bond ETF, REIT ETF, high-yield ETF, MLP ETF:** tax-inefficient — prefer IRA / 401(k) / Roth.
+- **Leveraged / inverse / futures-based / single-country active ETF:** watch for one-off distributions; check the last 5 years before buying.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -95,6 +95,10 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] Quarterly re-ingest; admin verification UI for stale rows.
 - [ ] Open: compliance (store URL only); coverage threshold; cross-fund PM modelling (`Person` table vs denormalized); confirm we never render for passive products.
 
+### Understanding ETFs in detail (user education)
+
+- [ ] **ETF primer / education surface** — give first-time users a concrete grasp of how ETFs work before they read individual reports. Cover ETF structure (creation/redemption, AP role), expense ratio + total cost of ownership, NAV vs. market price + premium/discount, tracking error, replication (full vs. sampled vs. synthetic), distributions + tax treatment (qualified dividends, 19a, ROC, K-1 vs. 1099, in-kind tax efficiency), securities lending revenue, holdings overlap, and how active vs. passive vs. derivative-income mandates change what the report should emphasize. Decide form: standalone `/learn/etfs` primer page vs. a glossary surface vs. contextual help tooltips on ETF detail pages (or a mix). Cross-link from ETF detail pages, the ETFs list, and category pages so users land on the explainer one click away from any ETF.
+
 ### Misc prompt updates
 
 - [ ] Include the **report-generation date** in the Final Summary prompt so the date appears in the output.


### PR DESCRIPTION
## Summary

Adds a new task entry under the **ETFs** section of `docs/insights-ui/tasks/todo-tasks.md` for a user-facing ETF primer / education surface.

The entry captures what first-time users need to grasp before they can usefully read an individual ETF report:
- ETF structure (creation/redemption, AP role)
- Expense ratio + total cost of ownership
- NAV vs. market price + premium/discount
- Tracking error
- Replication style (full vs. sampled vs. synthetic)
- Distributions + tax treatment (qualified dividends, 19a, ROC, K-1 vs. 1099, in-kind tax efficiency)
- Securities lending revenue
- Holdings overlap
- How active vs. passive vs. derivative-income mandates change report emphasis

Form is left as an open decision (standalone `/learn/etfs` primer page vs. glossary surface vs. contextual help tooltips, or a mix), with a note to cross-link from ETF detail / list / category pages.

## Test plan

- [x] Markdown renders correctly in the todo list under the existing ETFs heading
- [x] No code changes — lint/prettier/compile not applicable (prettier-check targets `src/**` only)