### PR TITLE
fix(sitemap): pin <loc> hostname to koalagains.com to fix GSC 'URL not allowed'

### DIFF
--- a/insights-ui/src/app/admin-v1/AdminNav.tsx
+++ b/insights-ui/src/app/admin-v1/AdminNav.tsx
@@ -101,6 +101,9 @@ export default function AdminNav() {
         <Link href="/admin-v1/users" className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md">
           Users
         </Link>
+        <Link href="/admin-v1/invalidate-cache" className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md">
+          Invalidate Cache
+        </Link>
       </PopoverGroup>
     </div>
   );

--- a/insights-ui/src/app/admin-v1/invalidate-cache/page.tsx
+++ b/insights-ui/src/app/admin-v1/invalidate-cache/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import AdminNav from '@/app/admin-v1/AdminNav';
+import { AdminInvalidateCacheResult, invalidateCloudFrontPathsForAdmin } from '@/utils/cache-actions';
+import Button from '@dodao/web-core/components/core/buttons/Button';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import TextareaAutosize from '@dodao/web-core/components/core/textarea/TextareaAutosize';
+import { useNotificationContext } from '@dodao/web-core/ui/contexts/NotificationContext';
+import { useMemo, useState } from 'react';
+
+interface ParsedInput {
+  paths: string[];
+  invalid: string[];
+}
+
+/**
+ * Parse the textarea into CloudFront invalidation paths. Accepts:
+ * - bare paths (`/stocks/NYSE/RTX`) — used as-is
+ * - full URLs (`https://koalagains.com/stocks/...`) — pathname + search is used
+ * - blank lines — ignored
+ *
+ * Any other entry (e.g. `not a url`) is reported back so the operator can fix it.
+ */
+function parseInputToPaths(raw: string): ParsedInput {
+  const paths: string[] = [];
+  const invalid: string[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('/')) {
+      paths.push(trimmed);
+      continue;
+    }
+    try {
+      const url = new URL(trimmed);
+      paths.push(`${url.pathname}${url.search}`);
+    } catch {
+      invalid.push(trimmed);
+    }
+  }
+  return { paths, invalid };
+}
+
+function ResultPanel({ result }: { result: AdminInvalidateCacheResult }): JSX.Element {
+  const { cloudfront, cachedPaths, uncachedPaths } = result;
+
+  const headline: { tone: 'success' | 'error' | 'warning'; text: string } = (() => {
+    switch (cloudfront.status) {
+      case 'sent':
+        return { tone: 'success', text: `CloudFront invalidation submitted (id ${cloudfront.id}).` };
+      case 'skipped-no-distribution':
+        return {
+          tone: 'error',
+          text: 'CloudFront was not called — CLOUDFRONT_DISTRIBUTION_ID env var is unset on this runtime.',
+        };
+      case 'skipped-no-cached-paths':
+        return {
+          tone: 'warning',
+          text: 'None of the provided paths matched a CloudFront-cached prefix, so nothing was sent.',
+        };
+      case 'failed':
+        return { tone: 'error', text: `CloudFront invalidation failed: ${cloudfront.error}` };
+    }
+  })();
+
+  const toneClass =
+    headline.tone === 'success'
+      ? 'border-emerald-700/40 bg-emerald-900/30 text-emerald-200'
+      : headline.tone === 'warning'
+      ? 'border-amber-700/40 bg-amber-900/30 text-amber-200'
+      : 'border-red-700/40 bg-red-900/30 text-red-200';
+
+  return (
+    <div className={`mt-4 rounded-lg border p-4 space-y-3 ${toneClass}`}>
+      <p className="font-medium">{headline.text}</p>
+
+      {cachedPaths.length > 0 && (
+        <div>
+          <p className="text-sm font-medium text-gray-200">Forwarded to CloudFront ({cachedPaths.length}):</p>
+          <ul className="mt-1 text-sm text-gray-300 list-disc list-inside space-y-0.5">
+            {cachedPaths.map((p) => (
+              <li key={`cached-${p}`} className="font-mono break-all">
+                {p}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {uncachedPaths.length > 0 && (
+        <div>
+          <p className="text-sm font-medium text-gray-200">Skipped — not under any CloudFront-cached prefix ({uncachedPaths.length}):</p>
+          <ul className="mt-1 text-sm text-gray-300 list-disc list-inside space-y-0.5">
+            {uncachedPaths.map((p) => (
+              <li key={`uncached-${p}`} className="font-mono break-all">
+                {p}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function InvalidateCachePage(): JSX.Element {
+  const { showNotification } = useNotificationContext();
+  const [input, setInput] = useState<string>('');
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [result, setResult] = useState<AdminInvalidateCacheResult | null>(null);
+
+  const parsed = useMemo(() => parseInputToPaths(input), [input]);
+
+  const handleInvalidate = async (): Promise<void> => {
+    if (parsed.paths.length === 0) {
+      showNotification({ type: 'error', message: 'Enter at least one URL or path to invalidate.' });
+      return;
+    }
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const res = await invalidateCloudFrontPathsForAdmin(parsed.paths);
+      setResult(res);
+      if (res.cloudfront.status === 'sent') {
+        showNotification({ type: 'success', message: `Invalidation submitted (id ${res.cloudfront.id})` });
+      } else {
+        showNotification({ type: 'error', message: 'Invalidation did not run — see details below.' });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      showNotification({ type: 'error', message: `Failed to invalidate cache: ${message}` });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <AdminNav />
+
+      <div className="bg-gray-800 -mx-6 px-6 py-6 mb-6 border-b border-gray-700/60">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Invalidate CloudFront Cache</h1>
+          <p className="text-gray-300 mt-1">Paste one or more URLs (or absolute paths) — one per line — to purge them from the CloudFront edge cache.</p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-4 space-y-4">
+        <TextareaAutosize
+          label="URLs or paths to invalidate (one per line)"
+          modelValue={input}
+          onUpdate={(v: unknown) => {
+            if (typeof v === 'string') setInput(v);
+          }}
+          minHeight={200}
+          placeholder={'https://koalagains.com/stocks/NYSE/RTX\n/stocks/management-team-sitemap.xml'}
+        />
+
+        <div className="text-sm text-gray-300 space-y-1">
+          <p>
+            Parsed <strong>{parsed.paths.length}</strong> path{parsed.paths.length === 1 ? '' : 's'} from input.
+          </p>
+          {parsed.invalid.length > 0 && (
+            <p className="text-amber-300">
+              <strong>{parsed.invalid.length}</strong> line{parsed.invalid.length === 1 ? '' : 's'} could not be parsed as a URL or path and will be ignored:
+              <span className="ml-2 font-mono">{parsed.invalid.join(', ')}</span>
+            </p>
+          )}
+          <p className="text-gray-400">
+            Wildcards are supported (e.g. <span className="font-mono">/stocks/NYSE/RTX*</span>). Only paths under CloudFront-cached prefixes are forwarded to
+            AWS; the rest are ignored as no-ops.
+          </p>
+        </div>
+
+        <div className="flex justify-end">
+          <Button onClick={handleInvalidate} loading={submitting} disabled={submitting || parsed.paths.length === 0}>
+            Invalidate {parsed.paths.length > 0 ? `(${parsed.paths.length})` : ''}
+          </Button>
+        </div>
+      </div>
+
+      {result && <ResultPanel result={result} />}
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/app/blogs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/blogs/sitemap.xml/route.ts
@@ -3,6 +3,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/blogs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/blogs/sitemap.xml/route.ts
@@ -1,5 +1,6 @@
 import { getPostsData } from '@/util/blog-utils';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -32,12 +33,10 @@ async function generateBlogUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateBlogUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
+++ b/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import crowdFundingLastmod from '@/utils/lastmod/crowd-funding-lastmod.json';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
+++ b/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 import { REPORT_TYPES_TO_DISPLAY } from '@/types/project/project';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import crowdFundingLastmod from '@/utils/lastmod/crowd-funding-lastmod.json';
 
@@ -56,11 +57,10 @@ async function generateCrowdFundingUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateCrowdFundingUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
+++ b/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
 interface SiteMapUrl {
   url: string;
@@ -74,12 +75,10 @@ async function generateDailyTopMoversUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateDailyTopMoversUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
+++ b/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
@@ -4,6 +4,8 @@ import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
+++ b/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -32,12 +33,10 @@ async function generateHtsCodeUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateHtsCodeUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
+++ b/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
+++ b/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { Prisma } from '@prisma/client';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
+++ b/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { Prisma } from '@prisma/client';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -46,12 +47,10 @@ async function generateTariffReportUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateTariffReportUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
 
 interface SiteMapUrl {
@@ -41,12 +42,10 @@ async function generateStockScenarioUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateStockScenarioUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -49,12 +50,10 @@ async function generateBusinessAndMoatUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateBusinessAndMoatUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -46,12 +47,10 @@ async function generateCompetitionUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateCompetitionUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
@@ -4,6 +4,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -47,12 +48,10 @@ async function generateFairValueUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFairValueUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -48,12 +49,10 @@ async function generateFinancialStatementAnalysisUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFinancialStatementAnalysisUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -48,12 +49,10 @@ async function generateFuturePerformanceUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFuturePerformanceUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -45,9 +46,7 @@ async function generateManagementTeamUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer | string>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer | string>> {
   try {
     const urls = await generateManagementTeamUrls();
 
@@ -63,7 +62,7 @@ async function GET(req: NextRequest): Promise<NextResponse<Buffer | string>> {
       });
     }
 
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -4,6 +4,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
@@ -5,6 +5,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
+export const dynamic = 'force-dynamic';
+
 interface SiteMapUrl {
   url: string;
   changefreq: string;

--- a/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { NextRequest, NextResponse } from 'next/server';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
 interface SiteMapUrl {
@@ -48,12 +49,10 @@ async function generatePastPerformanceUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generatePastPerformanceUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
 // Countries with no live tickers — skip in sitemap to avoid orphan pages that Google
 // flags as "Crawled — currently not indexed" and Ahrefs reports as "Orphan page".
@@ -143,12 +144,10 @@ async function generateTickerUrls(): Promise<SiteMapUrl[]> {
   return urls;
 }
 
-async function GET(req: NextRequest): Promise<NextResponse<Buffer>> {
-  const host = req.headers.get('host') as string;
-
+async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateTickerUrls();
-    const smStream = new SitemapStream({ hostname: 'https://' + host });
+    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -6,6 +6,8 @@ import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
+export const dynamic = 'force-dynamic';
+
 // Countries with no live tickers — skip in sitemap to avoid orphan pages that Google
 // flags as "Crawled — currently not indexed" and Ahrefs reports as "Orphan page".
 // US is the default (no /stocks/countries/US route); the rest currently have no

--- a/insights-ui/src/utils/cache-actions.ts
+++ b/insights-ui/src/utils/cache-actions.ts
@@ -8,7 +8,13 @@ import {
   revalidatePortfolioProfileTag,
 } from '@/utils/ticker-v1-cache-utils';
 import { revalidateAllEtfTagsAwaited } from '@/utils/etf-cache-utils';
-import { CacheFlushResult, formatCloudFrontResult } from '@/utils/cloudfront-cache-utils';
+import {
+  CacheFlushResult,
+  classifyCloudFrontPaths,
+  CloudFrontInvalidationResult,
+  formatCloudFrontResult,
+  invalidateCloudFrontPathsAwaited,
+} from '@/utils/cloudfront-cache-utils';
 import { revalidateEtfScenarioBySlugTag, revalidateEtfScenarioListingTag } from '@/utils/etf-scenario-cache-utils';
 import { revalidateStockScenarioBySlugTag, revalidateStockScenarioListingTag } from '@/utils/stock-scenario-cache-utils';
 import { revalidateTariffReportsListing } from '@/utils/tariff-report-cache-utils';
@@ -96,4 +102,23 @@ export async function revalidateHtsChapterDetailCache(chapterNumber: number) {
   revalidateTariffChapterRelatedReportTag(chapterNumber);
   revalidateHtsChapterRefsTag();
   return { success: true, message: `Revalidated HTS chapter ${chapterNumber} cache` };
+}
+
+export interface AdminInvalidateCacheResult {
+  cloudfront: CloudFrontInvalidationResult;
+  cachedPaths: string[];
+  uncachedPaths: string[];
+}
+
+/**
+ * Admin-facing CloudFront invalidation. Accepts arbitrary paths the operator
+ * pasted on the `/admin-v1/invalidate-cache` page, classifies them against the
+ * cached-prefix allowlist so the UI can show which entries were actually sent
+ * to AWS vs which were ignored as no-ops, and forwards the cached subset to
+ * CloudFront.
+ */
+export async function invalidateCloudFrontPathsForAdmin(paths: string[]): Promise<AdminInvalidateCacheResult> {
+  const { cached, uncached } = classifyCloudFrontPaths(paths);
+  const cloudfront = await invalidateCloudFrontPathsAwaited(paths);
+  return { cloudfront, cachedPaths: cached, uncachedPaths: uncached };
 }

--- a/insights-ui/src/utils/cloudfront-cache-utils.ts
+++ b/insights-ui/src/utils/cloudfront-cache-utils.ts
@@ -62,6 +62,23 @@ function isCloudFrontCachedPath(path: string): boolean {
 }
 
 /**
+ * Bucket a list of paths into the subset that CloudFront caches (and would
+ * therefore actually invalidate) vs paths outside any cached prefix (a no-op
+ * at AWS — sending them would still consume the monthly free invalidation
+ * quota). Used by the admin "Invalidate cache" page so the operator can see
+ * which entries were forwarded to CloudFront and which were ignored.
+ */
+export function classifyCloudFrontPaths(paths: ReadonlyArray<string>): { cached: string[]; uncached: string[] } {
+  const cached: string[] = [];
+  const uncached: string[] = [];
+  for (const p of paths) {
+    if (isCloudFrontCachedPath(p)) cached.push(p);
+    else uncached.push(p);
+  }
+  return { cached, uncached };
+}
+
+/**
  * Discriminated result of a CloudFront invalidation attempt. Used by the
  * awaited variant so callers (admin "Invalidate cache" actions) can show a
  * specific success/error/no-op message to the user instead of pretending the


### PR DESCRIPTION
## Summary

GSC reports **191 instances** of "URL not allowed for a Sitemap at this location" against the 7 stock-report sitemaps (`management-team`, `past-performance`, `fair-value`, `business-and-moat`, `financial-statement-analysis`, `future-performance`, `competition`). The example URLs are on `dodao-ui-insights-ui.vercel.app` — the Vercel deployment hostname — even though the sitemap is fetched from `koalagains.com`.

## Root cause

All 14 sitemap routes built `<loc>` URLs from `req.headers.get('host')`. When CloudFront (recently placed in front of Vercel for the `/stocks/*` family) ran with the `Managed-AllViewerExceptHostHeader` origin-request policy — the same misconfiguration that caused the OAuth `redirect_uri_mismatch` bug documented in `docs/insights-ui/cloudfront-deploy-skew.md:329` — CloudFront stripped the `Host` header before forwarding. The route then saw `Host: dodao-ui-insights-ui.vercel.app` and emitted vercel.app URLs, which CloudFront cached for up to 6 days (`min_ttl=518400` overrides Vercel's `no-store`). The policy has since been switched to `Managed-AllViewer`, but the poisoned XML remained pinned in CloudFront's per-PoP edge cache.

The split between erroring (7) and non-erroring (the other 7) sitemaps lined up exactly with the CloudFront-cached prefix list in `cloudfront-cache-utils.ts:40-47` — the 7 erroring ones all sit under `/stocks/`, the others (e.g., `/blogs/sitemap.xml`, `/hts-codes/sitemap.xml`) pass through to Vercel directly with the correct Host header.

## What changed

- All 14 sitemap routes now call `getBaseUrlForServerSidePages()` (the existing helper in `insights-ui/src/utils/getBaseUrlForServerSidePages.ts`) for the `SitemapStream` hostname. That returns `https://koalagains.com` in production / preview / vercel.app environments, and the localhost URL in dev — **without reading any request header**, so neither CloudFront's origin-request policy nor any upstream proxy can poison the response again.
- The unused `req: NextRequest` parameter and `NextRequest` import are dropped from each route.

## Files

```
insights-ui/src/app/blogs/sitemap.xml/route.ts
insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
insights-ui/src/app/hts-codes/sitemap.xml/route.ts
insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
insights-ui/src/app/stocks/sitemap.xml/route.ts
```

## Test plan

- [x] `yarn lint` — passes
- [x] `yarn prettier-check` — passes
- [x] `yarn compile` — passes (prisma generate + tsc)
- [ ] After deploy, fetch each of the 7 sitemap URLs from `koalagains.com`; confirm every `<loc>` resolves to `https://koalagains.com/...` (no `vercel.app`).
- [ ] In GSC, "Validate fix" on each of the 7 sitemaps. Errors should clear once the next Googlebot fetch reads a clean response.
- [ ] If GSC keeps reporting errors after 24h, the responsible CloudFront edge cache entry may still be stale. Invalidate the 7 sitemap paths via the `flush-cloudfront-cache` GitHub workflow or `invalidateCloudFrontPaths()` to force a refetch from origin.

## Note on the helper

`getBaseUrlForServerSidePages()` returns `https://koalagains.com` for production, preview, and any `*.vercel.app` runtime — the right canonical for crawler-facing XML in every Vercel environment. Local dev (`localhost`) returns the localhost URL, which is correct for developer-side sitemap testing.