### PR TITLE
Add server-side sort control to ETF listing pages

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -12,7 +12,10 @@ import {
   parseRangeParam,
   extractCaptureRatioForPeriod,
   extractRiskLevelForPeriod,
+  getAppliedEtfSort,
+  buildEtfDbOrderBy,
   EtfFilterParamKey,
+  EtfSortField,
   MOR_ADVANCED_FILTERS,
 } from '@/utils/etf-filter-utils';
 import { getEtfExchangesByCountry, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
@@ -58,6 +61,18 @@ function isInRange(value: number | null, min?: number, max?: number): boolean {
   if (min !== undefined && value < min) return false;
   if (max !== undefined && value > max) return false;
   return true;
+}
+
+// AUM is stored as a formatted string ("$1.2B"), so numeric ordering happens in
+// app code. Nulls sort last; ties break on symbol to keep ordering stable.
+function compareByParsedAum(a: any, b: any, order: 'asc' | 'desc'): number {
+  const av = parseNumericStringValue(a.financialInfo?.aum);
+  const bv = parseNumericStringValue(b.financialInfo?.aum);
+  if (av === null && bv === null) return a.symbol.localeCompare(b.symbol);
+  if (av === null) return 1;
+  if (bv === null) return -1;
+  if (av !== bv) return order === 'asc' ? av - bv : bv - av;
+  return a.symbol.localeCompare(b.symbol);
 }
 
 function toEtfListingItem(etf: any): EtfListingItem {
@@ -159,9 +174,13 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     etfWhere.morRiskInfo = { isNot: null };
   }
 
-  // Check if we need application-level post-filtering
+  const sort = getAppliedEtfSort(searchParams);
+  const dbOrderBy = buildEtfDbOrderBy(sort);
+  const needsAppSort = sort?.field === EtfSortField.AUM;
+
+  // Check if we need application-level post-filtering / sorting
   const aumRange = parseRangeParam(filters[EtfFilterParamKey.AUM]);
-  const needsPostFilter = aumRange !== null || hasMorFilters;
+  const needsPostFilter = aumRange !== null || hasMorFilters || needsAppSort;
 
   // Pre-parse active Mor advanced filters for post-filtering
   const activeMorFilters = MOR_ADVANCED_FILTERS.map((def) => ({
@@ -176,7 +195,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     const allEtfs = await prisma.etf.findMany({
       where: etfWhere,
       include,
-      orderBy: [{ symbol: 'asc' }],
+      orderBy: dbOrderBy,
     });
 
     const filtered = allEtfs.filter((etf) => {
@@ -200,6 +219,10 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
       return true;
     });
 
+    if (needsAppSort && sort) {
+      filtered.sort((a, b) => compareByParsedAum(a, b, sort.order));
+    }
+
     const totalCount = filtered.length;
     const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
     const start = (page - 1) * pageSize;
@@ -220,7 +243,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     prisma.etf.findMany({
       where: etfWhere,
       include,
-      orderBy: [{ symbol: 'asc' }],
+      orderBy: dbOrderBy,
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),

--- a/insights-ui/src/components/etfs/EtfPageLayout.tsx
+++ b/insights-ui/src/components/etfs/EtfPageLayout.tsx
@@ -3,6 +3,7 @@ import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/B
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import EtfFiltersButton from '@/components/etfs/EtfFiltersButton';
+import EtfSortButton from '@/components/etfs/EtfSortButton';
 import EtfAppliedFilterChips from '@/components/etfs/EtfAppliedFilterChips';
 import EtfCountryAlternatives from '@/components/etfs/EtfCountryAlternatives';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
@@ -49,8 +50,9 @@ export default function EtfPageLayout({
         <Breadcrumbs
           breadcrumbs={breadcrumbs}
           rightButton={
-            <div className="flex">
+            <div className="flex items-center gap-2">
               <EtfFiltersButton />
+              <EtfSortButton />
             </div>
           }
         />

--- a/insights-ui/src/components/etfs/EtfSortButton.tsx
+++ b/insights-ui/src/components/etfs/EtfSortButton.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { ArrowsUpDownIcon, ArrowUpIcon, ArrowDownIcon, ChevronDownIcon, CheckIcon } from '@heroicons/react/20/solid';
+import {
+  ETF_SORT_FIELD_DEFS,
+  getAppliedEtfSort,
+  applyEtfSortToParams,
+  getEtfFilterDestination,
+  EtfSortField,
+  type EtfSortOrder,
+} from '@/utils/etf-filter-utils';
+
+export default function EtfSortButton(): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const applied = getAppliedEtfSort(searchParams);
+
+  const navigate = (field: EtfSortField | null, order: EtfSortOrder): void => {
+    const nextParams = applyEtfSortToParams(searchParams, field, order);
+    // Grid pages (e.g. /etfs, /etfs/groups/<group>) don't render a sortable ETF
+    // list, so — just like filters — route to the filterable listing and carry
+    // the path-derived scope (group) along as a filter param.
+    const { path, extraParams } = getEtfFilterDestination(pathname);
+    for (const [k, v] of Object.entries(extraParams)) {
+      if (!nextParams.get(k)) nextParams.set(k, v);
+    }
+    const qs = nextParams.toString();
+    router.push(qs ? `${path}?${qs}` : path);
+  };
+
+  const handleSelect = (field: EtfSortField): void => {
+    const def = ETF_SORT_FIELD_DEFS.find((d) => d.field === field)!;
+    // Re-selecting the active field flips its direction; a new field uses its default.
+    const order: EtfSortOrder = applied?.field === field ? (applied.order === 'asc' ? 'desc' : 'asc') : def.defaultOrder;
+    navigate(field, order);
+  };
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <MenuButton className="inline-flex items-center gap-2 bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] hover:from-[#F97316] hover:to-[#F59E0B] text-black font-medium rounded-lg px-4 py-2.5 text-sm shadow-md">
+        <ArrowsUpDownIcon className="h-5 w-5" />
+        Sort
+        {applied && (
+          <span className="inline-flex items-center gap-1 bg-blue-500 text-white px-2 py-0.5 font-semibold rounded-full text-xs">
+            {applied.def.label}
+            {applied.order === 'asc' ? <ArrowUpIcon className="h-3 w-3" /> : <ArrowDownIcon className="h-3 w-3" />}
+          </span>
+        )}
+        <ChevronDownIcon className="h-4 w-4" />
+      </MenuButton>
+
+      <MenuItems
+        portal={true}
+        anchor={{ to: 'bottom end', gap: 8 }}
+        className="z-30 w-60 rounded-lg bg-[#1F2937] border border-[#374151] shadow-xl focus:outline-none p-2"
+      >
+        <div className="px-2 py-1.5 text-gray-400 text-[11px] font-semibold uppercase tracking-wider">Sort by</div>
+        {ETF_SORT_FIELD_DEFS.map((def) => {
+          const isActive = applied?.field === def.field;
+          return (
+            <MenuItem key={def.field}>
+              <button
+                type="button"
+                onClick={() => handleSelect(def.field)}
+                className={`flex w-full items-center justify-between rounded-md px-3 py-2 text-sm data-[focus]:bg-[#374151] ${
+                  isActive ? 'bg-[#374151] text-white' : 'text-[#E5E7EB]'
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  {isActive ? <CheckIcon className="h-4 w-4 text-[#F59E0B]" /> : <span className="h-4 w-4" />}
+                  {def.label}
+                </span>
+                {isActive && (
+                  <span className="inline-flex items-center gap-1 text-xs text-gray-300">
+                    {applied!.order === 'asc' ? (
+                      <>
+                        <ArrowUpIcon className="h-3.5 w-3.5" />
+                        Asc
+                      </>
+                    ) : (
+                      <>
+                        <ArrowDownIcon className="h-3.5 w-3.5" />
+                        Desc
+                      </>
+                    )}
+                  </span>
+                )}
+              </button>
+            </MenuItem>
+          );
+        })}
+        {applied && (
+          <>
+            <div className="my-1 border-t border-[#374151]" />
+            <MenuItem>
+              <button
+                type="button"
+                onClick={() => navigate(null, 'desc')}
+                className="w-full rounded-md px-3 py-2 text-left text-xs text-gray-400 data-[focus]:bg-[#374151] data-[focus]:text-white"
+              >
+                Clear sort
+              </button>
+            </MenuItem>
+          </>
+        )}
+        <p className="px-3 pt-1 text-[10px] text-gray-500">Click the active field to flip direction.</p>
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/insights-ui/src/utils/etf-data-utils.ts
+++ b/insights-ui/src/utils/etf-data-utils.ts
@@ -1,6 +1,6 @@
 import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { hasEtfFiltersApplied, etfToSortedQueryString, EtfSearchParams } from '@/utils/etf-filter-utils';
+import { hasEtfFiltersApplied, hasEtfSortApplied, etfToSortedQueryString, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfListingFilterableTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
@@ -15,7 +15,8 @@ import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePag
 export async function fetchEtfListingData(searchParams?: EtfSearchParams, country?: EtfSupportedCountry): Promise<EtfListingResponse> {
   const baseUrl = getBaseUrlForServerSidePages();
   const filters = hasEtfFiltersApplied(searchParams);
-  const hasPageOrFilters = filters || (searchParams?.page && searchParams.page !== '1');
+  const sortApplied = hasEtfSortApplied(searchParams);
+  const hasPageOrFilters = filters || sortApplied || (searchParams?.page && searchParams.page !== '1');
 
   const baseUrlPath = `${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`;
   const qsParts: string[] = [];

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -903,6 +903,94 @@ export const hasEtfFiltersApplied = (sp?: EtfSearchParams): boolean => {
   return ALL_ETF_PARAM_KEYS.some((key) => Boolean(toScalar(sp[key])));
 };
 
+/** ----- Sort ----- */
+
+export enum EtfSortParamKey {
+  SORT_BY = 'sortBy',
+  SORT_ORDER = 'sortOrder',
+}
+
+export type EtfSortOrder = 'asc' | 'desc';
+
+export enum EtfSortField {
+  AUM = 'aum',
+  EXPENSE_RATIO = 'expenseRatio',
+  PE_RATIO = 'pe',
+  DIVIDEND_YIELD = 'dividendYield',
+}
+
+export interface EtfSortFieldDef {
+  field: EtfSortField;
+  label: string;
+  // The direction picked the first time a field is selected (largest AUM first,
+  // cheapest expense ratio first, etc.). Re-selecting the active field flips it.
+  defaultOrder: EtfSortOrder;
+}
+
+export const ETF_SORT_FIELD_DEFS: ReadonlyArray<EtfSortFieldDef> = [
+  { field: EtfSortField.AUM, label: 'AUM', defaultOrder: 'desc' },
+  { field: EtfSortField.EXPENSE_RATIO, label: 'Expense Ratio', defaultOrder: 'asc' },
+  { field: EtfSortField.PE_RATIO, label: 'P/E Ratio', defaultOrder: 'asc' },
+  { field: EtfSortField.DIVIDEND_YIELD, label: 'Dividend Yield', defaultOrder: 'desc' },
+] as const;
+
+const ETF_SORT_FIELD_VALUES: Set<string> = new Set(ETF_SORT_FIELD_DEFS.map((d) => d.field));
+
+export interface AppliedEtfSort {
+  field: EtfSortField;
+  order: EtfSortOrder;
+  def: EtfSortFieldDef;
+}
+
+type ReadableSearchParams = { get(name: string): string | null };
+
+/** Resolve the active sort from URL params. Works for both client
+ *  (ReadonlyURLSearchParams) and server (URLSearchParams) callers. */
+export function getAppliedEtfSort(searchParams: ReadableSearchParams): AppliedEtfSort | null {
+  const rawField = searchParams.get(EtfSortParamKey.SORT_BY)?.trim();
+  if (!rawField || !ETF_SORT_FIELD_VALUES.has(rawField)) return null;
+  const def = ETF_SORT_FIELD_DEFS.find((d) => d.field === rawField)!;
+  const rawOrder = searchParams.get(EtfSortParamKey.SORT_ORDER)?.trim();
+  const order: EtfSortOrder = rawOrder === 'asc' || rawOrder === 'desc' ? rawOrder : def.defaultOrder;
+  return { field: def.field, order, def };
+}
+
+export function applyEtfSortToParams(searchParams: ReadonlyURLSearchParams, field: EtfSortField | null, order: EtfSortOrder): URLSearchParams {
+  const params = new URLSearchParams(searchParams.toString());
+  if (field) {
+    params.set(EtfSortParamKey.SORT_BY, field);
+    params.set(EtfSortParamKey.SORT_ORDER, order);
+  } else {
+    params.delete(EtfSortParamKey.SORT_BY);
+    params.delete(EtfSortParamKey.SORT_ORDER);
+  }
+  params.delete('page');
+  return params;
+}
+
+export function hasEtfSortApplied(sp?: EtfSearchParams): boolean {
+  if (!sp) return false;
+  const field = toScalar(sp[EtfSortParamKey.SORT_BY]);
+  return Boolean(field && ETF_SORT_FIELD_VALUES.has(field));
+}
+
+/** Server-side Prisma orderBy. AUM is a formatted string column, so it can't be
+ *  ordered numerically in the DB — callers fall back to app-level sorting for it. */
+export function buildEtfDbOrderBy(sort: AppliedEtfSort | null): Prisma.EtfOrderByWithRelationInput[] {
+  if (!sort || sort.field === EtfSortField.AUM) return [{ symbol: 'asc' }];
+  const dir: Prisma.SortOrderInput = { sort: sort.order, nulls: 'last' };
+  switch (sort.field) {
+    case EtfSortField.EXPENSE_RATIO:
+      return [{ financialInfo: { expenseRatio: dir } }, { symbol: 'asc' }];
+    case EtfSortField.PE_RATIO:
+      return [{ financialInfo: { pe: dir } }, { symbol: 'asc' }];
+    case EtfSortField.DIVIDEND_YIELD:
+      return [{ financialInfo: { dividendYield: dir } }, { symbol: 'asc' }];
+    default:
+      return [{ symbol: 'asc' }];
+  }
+}
+
 /** ----- Server-side Helpers ----- */
 
 export function parseEtfFilterParams(req: NextRequest): EtfFilterParams {


### PR DESCRIPTION
## Summary

Adds a reusable **Sort** control next to the Filters button on all ETF pages (`/etfs`, `/etfs/asset-classes/<class>`, `/etfs/groups/<group>`, `/etfs/groups/<group>/categories/<category>`, and the filtered listings). Sort options: **AUM, Expense Ratio, P/E Ratio, Dividend Yield**.

- **Common component** — `EtfSortButton` lives in `EtfPageLayout`, so it appears on every ETF page automatically.
- **Server-side rendered** — sort state lives in the URL (`sortBy` / `sortOrder`), just like filters. The listing API applies the ordering in the query, and the fetch helper forwards the params and bypasses the long cache when a sort is active.
- **Composes with filters** — sort params are independent of the filter param set, so a sort survives filter changes and vice-versa.
- **Grid pages mirror filter behavior** — on pages that don't render a sortable ETF list (`/etfs`, `/etfs/groups/<group>`), applying a sort routes to the filterable listing carrying the path-derived scope (group), exactly like the Filters button does.

## Implementation notes

- Numeric columns (expense ratio, P/E, dividend yield) are ordered in the DB via Prisma `orderBy` with nulls last and a stable `symbol` tiebreaker.
- AUM is a formatted string column (`"$1.2B"`), so it can't be ordered numerically in SQL — it's sorted in app code using the existing `parseNumericStringValue`, reusing the listing route's post-filter path.
- UI uses the codebase's existing Headless UI `Menu` + `portal`/`anchor` pattern (same as `EllipsisDropdown`) so the dropdown isn't clipped by the breadcrumb row's `overflow-x-auto`. Styled to match the existing amber Filters button, with an active badge showing the current field + direction. Re-clicking the active field flips asc/desc; a "Clear sort" entry removes it.

## Files

- `components/etfs/EtfSortButton.tsx` (new)
- `components/etfs/EtfPageLayout.tsx`
- `utils/etf-filter-utils.ts`
- `utils/etf-data-utils.ts`
- `app/api/[spaceId]/etfs-v1/listing/route.ts`

## Test plan

- [x] `tsc` — no type errors in touched files (pre-existing `@/images/*` declaration errors are unrelated)
- [x] ESLint + Prettier clean on touched files
- [x] Dev server: `/etfs` renders the Sort button (HTTP 200); sorted URLs (`/etfs-filtered?sortBy=aum&sortOrder=desc`, `/etfs/asset-classes/equity?sortBy=expenseRatio&sortOrder=asc`) return 200
- [x] Prisma `orderBy` confirmed structurally valid (request reaches `prisma.etf.findMany()`)
- [ ] Verify actual sorted ordering against a populated database — **not possible in the build container** (no `DATABASE_URL`); needs a reviewer check on a real environment

https://claude.ai/code/session_0155N86EfbESSbw8S8VRMtfi

---
_Generated by [Claude Code](https://claude.ai/code/session_0155N86EfbESSbw8S8VRMtfi)_