### PR TITLE
Recover ETF factor results when LLM returns title instead of key

### DIFF
--- a/insights-ui/etf-prompts/cost-efficiency-team.md
+++ b/insights-ui/etf-prompts/cost-efficiency-team.md
@@ -84,7 +84,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 ## 4. For each item in `factorAnalysisArray` produce
 
-- `factorAnalysisKey` — exact key from the input, unchanged.
+- `factorAnalysisKey` — the exact snake_case key from the input (the value wrapped in backticks at the start of each factor block below, e.g. `expense_ratio_vs_competition`). Use the backticked key, NOT the bolded title and NOT any rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway.
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per the factor's own description and Section 3.
@@ -102,7 +102,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 {{#each factorAnalysisArray}}
 
-- **{{factorAnalysisTitle}}** (`{{factorAnalysisKey}}`)
+- `{{factorAnalysisKey}}` — **{{factorAnalysisTitle}}**
   {{factorAnalysisDescription}}
   {{#if factorAnalysisGroupInstructions}}Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
   {{/if}}Metrics: {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/future-performance-outlook.md
+++ b/insights-ui/etf-prompts/future-performance-outlook.md
@@ -117,7 +117,7 @@ If a factor’s core metric is missing, use the lookup rule first; otherwise jud
 
 ## 4. For each item in `factorAnalysisArray` produce
 
-- `factorAnalysisKey` — exact key from the input, unchanged.
+- `factorAnalysisKey` — the exact snake_case key from the input (the value wrapped in backticks at the start of each factor block below, e.g. `short_term_hold_outlook`). Use the backticked key, NOT the bolded title and NOT any rephrased form.
 - `oneLineExplanation` — one sentence with the clearest investor takeaway.
 - `detailedExplanation` — one short paragraph that applies the factor’s bar to THIS ETF. Use the listed metrics and any strongly relevant input field or lookup result. Anchor conclusions with at least one concrete detail.
 - `result` — `"Pass"` or `"Fail"` per Section 3 and the factor’s own description.
@@ -152,7 +152,7 @@ Shorter horizons are inherently less certain than the 5-year figure — be more 
 
 {{#each factorAnalysisArray}}
 
-- **{{factorAnalysisTitle}}** (`{{factorAnalysisKey}}`)
+- `{{factorAnalysisKey}}` — **{{factorAnalysisTitle}}**
   {{factorAnalysisDescription}}
   {{#if factorAnalysisGroupInstructions}}Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
   {{/if}}Metrics: {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/past-returns.md
+++ b/insights-ui/etf-prompts/past-returns.md
@@ -74,7 +74,7 @@ Two cross-cutting reminders that apply on top of every factor:
 
 ## 4. For each item in `factorAnalysisArray` produce
 
-- `factorAnalysisKey` — exact key from the input, unchanged.
+- `factorAnalysisKey` — the exact snake_case key from the input (the value wrapped in backticks at the start of each factor block below, e.g. `historical_long_term_returns`). Use the backticked key, NOT the bolded title and NOT any rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway.
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per Section 3.
@@ -114,7 +114,7 @@ When the factor carries a `factorAnalysisGroupInstructions` string, treat it as 
 
 {{#each factorAnalysisArray}}
 
-- **{{factorAnalysisTitle}}** (`{{factorAnalysisKey}}`)
+- `{{factorAnalysisKey}}` — **{{factorAnalysisTitle}}**
   {{factorAnalysisDescription}}
   {{#if factorAnalysisGroupInstructions}}Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
   {{/if}}Metrics: {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/risk-analysis.md
+++ b/insights-ui/etf-prompts/risk-analysis.md
@@ -83,7 +83,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 ## 4. For each item in `factorAnalysisArray` produce
 
-- `factorAnalysisKey` — exact key from the input, unchanged.
+- `factorAnalysisKey` — the exact snake_case key from the input (the value wrapped in backticks at the start of each factor block below, e.g. `risk_adjusted_return`). Use the backticked key, NOT the bolded title and NOT any rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway, stated in terms a retail reader can act on (not a metric definition).
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. Every cited metric must sit next to a peer / category / benchmark comparison number plus a plain-English direction word (`better than`, `in line with`, `worse than`, `above`, `below`) — never leave a Sharpe, drawdown, capture, or risk score stranded. Close with one clause translating the `Pass` / `Fail` into what it means for an investor holding this fund (e.g. "Pass here means the fund is delivering the promised decorrelation", "Fail here means the fund's fate is tethered to a handful of mega-cap names"). If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per the factor's own description and Section 3.
@@ -106,7 +106,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 {{#each factorAnalysisArray}}
 
-- **{{factorAnalysisTitle}}** (`{{factorAnalysisKey}}`)
+- `{{factorAnalysisKey}}` — **{{factorAnalysisTitle}}**
   {{factorAnalysisDescription}}
   {{#if factorAnalysisGroupInstructions}}Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
   {{/if}}Metrics: {{factorAnalysisMetrics}}

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -130,12 +130,19 @@ export function getEtfAnalysisFactorsForCategory(categoryKey: EtfAnalysisCategor
 
 /**
  * Find a factor definition by key for a given category. Searches across every
- * group definition in that category.
+ * group definition in that category. Falls back to a case-insensitive title
+ * match when the key lookup misses, since the LLM occasionally returns the
+ * factor's bolded title in the `factorAnalysisKey` slot instead of the
+ * snake_case key — without this fallback every factor in such a response
+ * gets silently dropped by `saveEtfFactorAnalysisResponse`.
  */
 export function findFactorDefinition(categoryKey: EtfAnalysisCategory, factorKey: string): EtfAnalysisFactorDefinition | undefined {
   const config = CATEGORY_CONFIGS[categoryKey];
-  const found = config.factors.find((f) => f.factorKey === factorKey);
-  return found ? normalizeGroupFactor(found) : undefined;
+  const byKey = config.factors.find((f) => f.factorKey === factorKey);
+  if (byKey) return normalizeGroupFactor(byKey);
+  const normalized = factorKey.trim().toLowerCase();
+  const byTitle = config.factors.find((f) => f.factorTitle.trim().toLowerCase() === normalized);
+  return byTitle ? normalizeGroupFactor(byTitle) : undefined;
 }
 
 function prepareFactorAnalysisArray(factors: EtfAnalysisFactorDefinition[]) {

--- a/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/save-etf-report-utils.ts
@@ -27,13 +27,15 @@ export async function saveEtfFactorAnalysisResponse(
 
   // Keep only factors whose keys are recognized for this category. Unknown keys
   // are logged and dropped so they can't become stale rows on a replace.
-  const validFactors = response.factors.filter((factor) => {
+  // Resolve each factor to its canonical snake_case key here so the DB never
+  // stores the bolded title that the LLM sometimes returns by mistake.
+  const validFactors = response.factors.flatMap((factor) => {
     const factorDef = findFactorDefinition(categoryKey, factor.factorAnalysisKey);
     if (!factorDef) {
       console.warn(`Unknown factor key: ${factor.factorAnalysisKey} for ETF ${symbol}`);
-      return false;
+      return [];
     }
-    return true;
+    return [{ ...factor, factorAnalysisKey: factorDef.factorAnalysisKey }];
   });
 
   // Replace the category's factor results atomically: the current prompt


### PR DESCRIPTION
## Summary

- ETF category prompts render each factor as `**Title** (`key`)`. The bold title visually dominates, and the LLM occasionally fills `factorAnalysisKey` with the title (e.g. `"Short-Term Hold Outlook (1-3 Years)"`) instead of the snake_case key (`short_term_hold_outlook`).
- `saveEtfFactorAnalysisResponse` then silently dropped every such factor because `findFactorDefinition` only matched on `factorKey`, leaving the report with a populated summary + forward returns but zero factor rows and a 0 category score. Observed live on AVMV's Future Performance Outlook report.
- Fix is two layers:
  - **Save-side recovery.** `findFactorDefinition` now falls back to a case-insensitive title match; the save helper resolves each factor through the matched definition so the canonical snake_case key is what lands in the DB regardless of which form the LLM returned.
  - **Prompt-side hardening.** All four ETF category prompts (`past-returns`, `cost-efficiency-team`, `risk-analysis`, `future-performance-outlook`) now lead each factor block with the backticked key and demote the title, and section 4's instruction spells out which form to use with a concrete example.

## Test plan

- [x] `yarn lint`, `yarn prettier-check`, `yarn compile` all green in `insights-ui`.
- [ ] Re-trigger the AVMV Future Performance Outlook report (or any previously broken invocation) and confirm the factor rows now write and the category score increments.
- [ ] Spot-check the next live invocation: the LLM should return `factorAnalysisKey` values matching the snake_case keys in `etf-analysis-factors-*.json` directly (no fallback path needed).
- [ ] Verify the four prompt edits render correctly in any prompt-preview UI (the bullet now reads `` `key` — **Title** `` instead of `` **Title** (`key`) ``).


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9BsjrrqSGUxqgJF9fR2M2)_