### PR TITLE
Color externalization + typography consistency for report pages

### DIFF
--- a/docs/insights-ui/next-ui-cleanups.md
+++ b/docs/insights-ui/next-ui-cleanups.md
@@ -94,14 +94,44 @@ once clean.
 | stock/ETF listing cards (`CompactIndustryCard`, `EtfCategoryCard`, …) | needs `ListingCard`/`ScoreDisplay`/`SymbolBadge` | ⬜ |
 | `blogs/**`, `home-page/**` | needs `HeroHeader`/`FilterButton`/`GridResponsive` | ⬜ |
 
-## 4. Token adoption
+## 4. Token adoption / color externalization (PR #1564)
 
-- ⬜ Migrate existing leaves from ad-hoc `bg-gray-*` to the semantic tokens
-  (`bg-block`, `text-body`, `text-primary`, …) where it does not change the
-  rendered color, so theming is centralized. Do this deliberately (the tokens
-  resolve to specific grays; verify no visual change before switching).
-- ⬜ Audit ad-hoc theme classes already in the codebase (`text-color`,
-  `bg-block-bg-color`) and fold them into the token set.
+The color system is now tokenized (see the "Color system" section in
+`ui-leaf-component-system.md`). Rollout status:
+
+- ✅ Token foundation: retuned 3-tier palette in `theme-colors.ts` +
+  `tailwind.config.ts` tokens + shadcn-name bridge.
+- ✅ Leaf layer tokenized (surfaces/text/border → tokens) and chips consolidated
+  into the 6-tone `badgeTone` vocabulary (PassFailBadge, StatusBadge,
+  ReportFooter, header exchange pill; EmptyStateCard CTA → `bg-primary`).
+- ⬜ **Remaining chips:** route `ScenarioOutlookBadge` (8 ad-hoc tones),
+  `EtfMetadataBadges` (5-hue quartets → `info`/`accent`), and `AppliedFilterChip`
+  (amber gradient → `warning`) through `badgeTone`.
+- ⬜ **Component migrations (report pages → tokens + leaves):** the bulk. Replace
+  raw `bg-gray-*`/`text-gray-*`/hand-written headings with tokens + the
+  `Heading`/`SectionHeading`/`Text` leaves across: Competition pair,
+  management-team, StockMoverDetails, the two main `page.tsx`, EtfMorInfo,
+  EtfHoldings, charts (inline hex → token map), and the ~50 hand-written headings.
+- ⬜ **New leaves needed by those migrations:** `SummaryCard`, `ScoreChip`
+  (primary `x/total` pill), `CardSection` `chart` padding variant, `DeferredBlock`
+  (`content-visibility`), a ticker-side `CompetitionQuadrantWithLegend`, a
+  sentiment text/badge leaf (verdict + price-change), and `ReportSectionHeader`/
+  `ReportFooter` slot extensions (sentiment meta, `verb`/`timeItemProp`).
+- ⬜ **Legacy vocabulary sweep:** migrate remaining `text-color`/`border-color`/
+  `block-bg-color` SCSS classes → `text-body`/`border-border`/`bg-surface`.
+
+### Typography consistency (same PR)
+Headings/body text are inconsistent (6 h1 variants, h2 `font-bold`+`border-gray-700`
+vs `font-semibold`+`border-border`, h3 `text-gray-100 mb-4` vs `text-body mb-3`, 3
+muted tokens). Canonicalize via the leaves:
+- h1 report title → `text-2xl md:text-3xl font-bold text-body mb-2` (a title leaf/variant).
+- h2 section → `SectionHeading` (default), bordered → `SectionHeading bordered`.
+- h3 sub → `SectionHeading size="sm"` / `Heading as="h3" size="lg"`.
+- body/muted → `Text` tones (`body`/`muted`); markdown → `MarkdownContent`.
+
+### Out of scope (separate follow-ups, flagged by the audit)
+- `markdown.scss` hardcodes a *light* GitHub theme; report bodies render on dark.
+- `@tailwindcss/typography` is not installed, so `prose prose-invert` is inert.
 
 ## 5. Verification discipline
 

--- a/docs/insights-ui/ui-leaf-component-system.md
+++ b/docs/insights-ui/ui-leaf-component-system.md
@@ -45,6 +45,46 @@ Why:
 - **High-level components (must be style-free):** everything else under
   `src/app/**` and `src/components/**`.
 
+## Color system (tiny, tokenized)
+
+All color is externalized into a small semantic token set backed by CSS
+variables in `src/util/theme-colors.ts` and surfaced as Tailwind tokens in
+`tailwind.config.ts`. **Outside chips/badges and buttons, only the structural
+tokens below may appear — never raw `bg-gray-*` / `text-gray-*` / hex.**
+
+**Structural tokens (the only colors in 99% of the UI)**
+
+| Token (utility) | Role | Var |
+|---|---|---|
+| `bg-bg` | page background (darkest) | `--bg-color` |
+| `bg-surface` | cards / report sections | `--surface` |
+| `bg-surface-2` | inset / inline boxes / hovers | `--surface-2` |
+| `text-heading` | headings (white) | `--heading-color` |
+| `text-body` | body text | `--text-color` |
+| `text-muted` | secondary / muted text | `--text-muted` |
+| `border-border` | borders / dividers | `--border-color` |
+| `text-primary` / `bg-primary` / `text-primary-text` | brand / primary actions | `--primary-color` |
+| `text-link` | links | `--link-color` |
+
+The surfaces form a deliberate 3-tier dark ramp: `bg` < `surface` < `surface-2`.
+Legacy aliases (`bg-block`, `bg-background`, `border-block-border`) and bridged
+shadcn names (`text-muted-foreground`→muted, `bg-card`→surface, `text-foreground`,
+`border-input`, `ring`) all resolve to the same vars so older call-sites stay
+consistent during migration.
+
+**Chips / badges — the ONE place color variety lives**
+
+Every badge routes color through the single 6-tone vocabulary in
+`src/components/ui/badges/badgeTone.ts` (`success`/`danger`/`warning`/`info`/
+`accent`/`neutral`, one translucent `…/15 + border …/40` recipe each). Map the
+domain meaning onto a tone — do **not** invent new color pairs per component.
+`PassFailBadge`, `StatusBadge`, `ReportFooter` tags, and the header exchange pill
+already use it. Buttons route through `var(--primary-color)` (web-core `Button`
+or `bg-primary`).
+
+When adding a leaf: use the structural tokens for surfaces/text/border, and
+`badgeTone` for any chip. Adding a raw gray or a new hue is a review red flag.
+
 ## Authoring a leaf component
 
 Use [`class-variance-authority`](https://cva.style) (`cva`) for variants plus the

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/financial-data/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/financial-data/page.tsx
@@ -44,7 +44,7 @@ function JsonSection({ title, data }: { title: string; data: unknown }) {
   return (
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-2 text-green-400">{title}</h3>
-      <pre className="bg-gray-900 p-4 rounded-lg overflow-x-auto text-xs text-gray-300 max-h-96 overflow-y-auto">{JSON.stringify(data, null, 2)}</pre>
+      <pre className="bg-surface p-4 rounded-lg overflow-x-auto text-xs text-body max-h-96 overflow-y-auto">{JSON.stringify(data, null, 2)}</pre>
     </div>
   );
 }
@@ -56,20 +56,20 @@ function FieldTable({ title, fields }: { title: string; fields: Record<string, u
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-700">
-          <thead className="bg-gray-800">
+        <table className="min-w-full divide-y divide-border">
+          <thead className="bg-surface-2">
             <tr>
-              <th className="px-4 py-2 text-left text-xs font-medium text-gray-400 uppercase">Field</th>
-              <th className="px-4 py-2 text-left text-xs font-medium text-gray-400 uppercase">Value</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Field</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-muted uppercase">Value</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-700">
+          <tbody className="divide-y divide-border">
             {entries.map(([key, value]) => (
               <tr key={key}>
-                <td className="px-4 py-2 text-sm font-mono text-gray-300">{key}</td>
-                <td className="px-4 py-2 text-sm text-gray-200">
+                <td className="px-4 py-2 text-sm font-mono text-body">{key}</td>
+                <td className="px-4 py-2 text-sm text-body">
                   {value === null ? (
-                    <span className="text-gray-500 italic">null</span>
+                    <span className="text-muted italic">null</span>
                   ) : typeof value === 'object' ? (
                     <span className="text-blue-400">[JSON]</span>
                   ) : (
@@ -111,7 +111,7 @@ export default async function EtfFinancialDataPage({ params }: { params: RoutePa
         <h1 className="text-2xl font-bold">
           {etfData.name} ({etfData.symbol}) — Raw Financial Data
         </h1>
-        <p className="text-sm text-gray-400 mt-1">
+        <p className="text-sm text-muted mt-1">
           Exchange: {etfData.exchange} | Inception: {etfData.inception || 'N/A'} | ID: {etfData.id}
         </p>
       </div>

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -119,7 +119,7 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
           <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-3xl" itemProp="headline">
             {etfData.name} ({symbol}) &mdash; Holdings
           </h1>
-          <p className="text-sm text-gray-400 mt-1" itemProp="description">
+          <p className="text-sm text-muted mt-1" itemProp="description">
             Top holdings reported by this ETF.
           </p>
         </header>
@@ -127,8 +127,8 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
         {totalHoldings > 0 ? (
           <EtfHoldings data={holdings} title="Top Holdings" relatedSections={relatedSections} />
         ) : (
-          <section className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
-            <p className="text-sm text-gray-400">No holdings data available for this ETF.</p>
+          <section className="bg-surface rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
+            <p className="text-sm text-muted">No holdings data available for this ETF.</p>
             {relatedSections}
           </section>
         )}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -88,7 +88,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
 
 function EtfFinancialInfoSkeleton(): JSX.Element {
   return (
-    <section id="etf-financial-info" className="bg-gray-900 rounded-lg shadow-sm px-2 py-2 sm:p-3 mt-6">
+    <section id="etf-financial-info" className="bg-surface rounded-lg shadow-sm px-2 py-2 sm:p-3 mt-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <FinancialCard label="AUM" isLoading={true} />
         <FinancialCard label="Expense Ratio" isLoading={true} />
@@ -225,7 +225,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
               {etfData.name} ({etfData.symbol})
             </h1>
             <div className="flex items-center gap-3 flex-shrink-0">
-              <span className="text-sm font-medium text-gray-400">{formatExchangeWithCountry(etfData.exchange)}</span>
+              <span className="text-sm font-medium text-muted">{formatExchangeWithCountry(etfData.exchange)}</span>
             </div>
           </div>
 

--- a/insights-ui/src/app/industry-tariff-report/[industryId]/layout.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/layout.tsx
@@ -87,7 +87,7 @@ export default async function IndustryTariffReportLayout({ children, params }: {
               <div className="flex-1 bg-background p-2 sm:p-3">
                 <div className="mx-auto max-w-4xl">
                   <div className="relative min-h-[calc(100vh-10rem)] rounded-lg block-bg-color p-2 sm:p-2 shadow-md">
-                    <div className="absolute right-0 top-0 h-12 w-12 bg-muted/20">
+                    <div className="absolute right-0 top-0 h-12 w-12 bg-surface-2">
                       <div className="absolute right-0 top-0 h-0 w-0 border-l-[48px] border-b-[48px] border-l-transparent border-b-[var(--block-bg)]"></div>
                     </div>
 

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/RadarSkeleton.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/RadarSkeleton.tsx
@@ -4,7 +4,7 @@ export function RadarSkeleton(): JSX.Element {
   return (
     <div className="w-full max-w-lg mx-auto" style={{ minHeight: '360px' }}>
       {/* Match the actual radar container dimensions: max-w-lg and ~360px height */}
-      <div className="w-full aspect-square max-w-[360px] mx-auto rounded-full bg-surface-2 relative overflow-hidden">
+      <div className="w-full aspect-square max-w-[360px] mx-auto rounded-full bg-surface relative overflow-hidden">
         <div className="absolute inset-0 animate-pulse" />
         {/* simple rings + spokes for a "radar-ish" look */}
         <div className="absolute inset-[10%] rounded-full border border-border" />

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/RadarSkeleton.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/RadarSkeleton.tsx
@@ -4,15 +4,15 @@ export function RadarSkeleton(): JSX.Element {
   return (
     <div className="w-full max-w-lg mx-auto" style={{ minHeight: '360px' }}>
       {/* Match the actual radar container dimensions: max-w-lg and ~360px height */}
-      <div className="w-full aspect-square max-w-[360px] mx-auto rounded-full bg-gray-800 relative overflow-hidden">
+      <div className="w-full aspect-square max-w-[360px] mx-auto rounded-full bg-surface-2 relative overflow-hidden">
         <div className="absolute inset-0 animate-pulse" />
         {/* simple rings + spokes for a "radar-ish" look */}
-        <div className="absolute inset-[10%] rounded-full border border-gray-700" />
-        <div className="absolute inset-[20%] rounded-full border border-gray-700" />
-        <div className="absolute inset-[30%] rounded-full border border-gray-700" />
-        <div className="absolute inset-[40%] rounded-full border border-gray-700" />
+        <div className="absolute inset-[10%] rounded-full border border-border" />
+        <div className="absolute inset-[20%] rounded-full border border-border" />
+        <div className="absolute inset-[30%] rounded-full border border-border" />
+        <div className="absolute inset-[40%] rounded-full border border-border" />
         {Array.from({ length: 8 }).map((_, i: number) => (
-          <div key={i} className="absolute left-1/2 top-1/2 h-1/2 w-[1px] bg-gray-700 origin-top" style={{ transform: `rotate(${(360 / 8) * i}deg)` }} />
+          <div key={i} className="absolute left-1/2 top-1/2 h-1/2 w-[1px] bg-surface-2 origin-top" style={{ transform: `rotate(${(360 / 8) * i}deg)` }} />
         ))}
       </div>
     </div>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -82,7 +82,7 @@ function getVerdictBadgeClasses(verdict: ManagementTeamAlignmentVerdict): string
     case ManagementTeamAlignmentVerdict.MISALIGNED:
       return 'bg-red-500/15 text-red-300 border border-red-500/40';
     default:
-      return 'bg-surface-2 text-body';
+      return 'bg-gray-500/15 text-gray-300 border border-gray-500/40';
   }
 }
 

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -74,15 +74,15 @@ function getVerdictBadgeClasses(verdict: ManagementTeamAlignmentVerdict): string
   switch (verdict) {
     case ManagementTeamAlignmentVerdict.OWNER_OPERATOR:
     case ManagementTeamAlignmentVerdict.STRONGLY_ALIGNED:
-      return 'bg-green-900 text-green-200';
+      return 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40';
     case ManagementTeamAlignmentVerdict.ALIGNED:
-      return 'bg-blue-900 text-blue-200';
+      return 'bg-sky-500/15 text-sky-300 border border-sky-500/40';
     case ManagementTeamAlignmentVerdict.WEAKLY_ALIGNED:
-      return 'bg-yellow-900 text-yellow-200';
+      return 'bg-amber-500/15 text-amber-300 border border-amber-500/40';
     case ManagementTeamAlignmentVerdict.MISALIGNED:
-      return 'bg-red-900 text-red-200';
+      return 'bg-red-500/15 text-red-300 border border-red-500/40';
     default:
-      return 'bg-gray-800 text-gray-200';
+      return 'bg-surface-2 text-body';
   }
 }
 
@@ -218,7 +218,7 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
 
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
 
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+      <article className="bg-surface rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <section className="mb-6">
           <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-4xl" itemProp="headline">
             {tickerData.name} ({tickerData.symbol}) — Management Team Experience &amp; Alignment
@@ -226,7 +226,7 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
         </section>
 
         <section className="mb-8" itemProp="articleBody">
-          <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-700">
+          <div className="flex items-center gap-2 mb-4 pb-2 border-b border-border">
             <h2 className="text-xl font-bold">Alignment Verdict</h2>
             <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium ${getVerdictBadgeClasses(verdict)}`}>
               {verdictLabel}
@@ -236,12 +236,12 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
 
           <div className="mb-6">
             <h3 className="text-lg font-semibold mb-2">Summary</h3>
-            <div className="markdown markdown-body text-gray-300" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.summary) }} />
+            <div className="markdown markdown-body text-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.summary) }} />
           </div>
 
           <div>
             <h3 className="text-lg font-semibold mb-2">Detailed Analysis</h3>
-            <div className="markdown markdown-body text-gray-300" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.detailedAnalysis) }} />
+            <div className="markdown markdown-body text-body" dangerouslySetInnerHTML={{ __html: parseMarkdown(report.detailedAnalysis) }} />
           </div>
         </section>
 
@@ -268,10 +268,10 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
               </time>
             </div>
             <div className="flex gap-2">
-              <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+              <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
                 Stock Analysis
               </span>
-              <span className="inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-300">
+              <span className="inline-flex items-center rounded-full bg-amber-500/15 border border-amber-500/40 px-2.5 py-0.5 text-xs font-medium text-amber-300">
                 Management Team
               </span>
             </div>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -599,7 +599,7 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
   const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
   const link = CATEGORY_DETAIL_LINKS[categoryKey];
   return (
-    <div className="bg-surface-2 p-3 sm:p-4 rounded-md shadow-sm">
+    <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-lg font-semibold">{CATEGORY_MAPPINGS[categoryKey]}</h3>
@@ -645,7 +645,7 @@ function TickerAnalysisInfo({
   const managementTeamReport = d.managementTeamReports?.[0];
 
   return (
-    <section id="summary-analysis" className="bg-surface rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
+    <section id="summary-analysis" className="mb-4 sm:py-6" itemProp="abstract">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Summary Analysis</h2>
       <div className="space-y-4">
         <CategorySummaryCard categoryKey={TickerAnalysisCategory.BusinessAndMoat} d={d} />
@@ -660,7 +660,7 @@ function TickerAnalysisInfo({
           <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
 
           {managementTeamReport && (
-            <div className="bg-surface-2 p-3 sm:p-4 rounded-md shadow-sm">
+            <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
               <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                 <div className="flex flex-wrap items-center gap-2">
                   <h3 className="text-lg font-semibold">Management Team Experience &amp; Alignment</h3>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -306,7 +306,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
 ============================================================================= */
 function FinancialInfoSkeleton(): JSX.Element {
   return (
-    <section id="financial-info" className="bg-gray-900 rounded-lg shadow-sm px-2 py-2 sm:p-3 mt-6">
+    <section id="financial-info" className="bg-surface rounded-lg shadow-sm px-2 py-2 sm:p-3 mt-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <FinancialCard label="Current Price" isLoading={true} />
         <FinancialCard label="52 Week Range" isLoading={true} />
@@ -327,38 +327,38 @@ function FinancialInfoSkeleton(): JSX.Element {
 
 function QuarterlyChartSkeleton(): JSX.Element {
   return (
-    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
+    <section id="quarterly-metrics-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
-          <div className="h-6 w-48 rounded bg-gray-800 animate-pulse" />
-          <div className="h-4 w-32 rounded bg-gray-800 animate-pulse mt-1" />
+          <div className="h-6 w-48 rounded bg-surface-2 animate-pulse" />
+          <div className="h-4 w-32 rounded bg-surface-2 animate-pulse mt-1" />
         </div>
         <div className="flex flex-wrap gap-2">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-8 w-20 rounded-md bg-gray-800 animate-pulse" />
+            <div key={i} className="h-8 w-20 rounded-md bg-surface-2 animate-pulse" />
           ))}
         </div>
       </div>
-      <div className="h-64 sm:h-72 rounded bg-gray-800 animate-pulse" />
+      <div className="h-64 sm:h-72 rounded bg-surface-2 animate-pulse" />
     </section>
   );
 }
 
 function PriceChartSkeleton(): JSX.Element {
   return (
-    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
+    <section id="price-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mt-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div>
-          <div className="h-6 w-36 rounded bg-gray-800 animate-pulse" />
-          <div className="h-4 w-24 rounded bg-gray-800 animate-pulse mt-1" />
+          <div className="h-6 w-36 rounded bg-surface-2 animate-pulse" />
+          <div className="h-4 w-24 rounded bg-surface-2 animate-pulse mt-1" />
         </div>
         <div className="flex flex-wrap gap-2">
           {['1M', '6M', '1Y', '3Y', '5Y'].map((label) => (
-            <div key={label} className="h-8 w-12 rounded-md bg-gray-800 animate-pulse" />
+            <div key={label} className="h-8 w-12 rounded-md bg-surface-2 animate-pulse" />
           ))}
         </div>
       </div>
-      <div className="h-64 sm:h-72 rounded bg-gray-800 animate-pulse" />
+      <div className="h-64 sm:h-72 rounded bg-surface-2 animate-pulse" />
     </section>
   );
 }
@@ -378,7 +378,7 @@ function ChartsInfoSkeleton(): JSX.Element {
         <div className="lg:w-1/2 flex justify-center">
           <div className="w-full max-w-lg relative pb-4" style={{ minHeight: '400px', contain: 'layout size' }}>
             <div className="absolute top-20 right-0 flex space-x-2" style={{ zIndex: 10 }}>
-              <div className="h-8 w-12 rounded bg-gray-800 animate-pulse" />
+              <div className="h-8 w-12 rounded bg-surface-2 animate-pulse" />
             </div>
             <RadarSkeleton />
           </div>
@@ -462,7 +462,7 @@ function TickerSummaryInfo({ data }: { data: Promise<TickerV1FastResponse> }): J
   return (
     <section id="introduction" className="text-left mb-2">
       {/* About Report - displayed above the main heading */}
-      {d.aboutReport && <div className="text-gray-400 markdown-body text-sm pb-4" dangerouslySetInnerHTML={{ __html: parseMarkdown(d.aboutReport) }} />}
+      {d.aboutReport && <div className="text-muted markdown-body text-sm pb-4" dangerouslySetInnerHTML={{ __html: parseMarkdown(d.aboutReport) }} />}
 
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-4 mb-4">
         <h1 className="text-pretty text-2xl font-semibold tracking-tight sm:text-4xl min-w-0" itemProp="headline">
@@ -474,7 +474,7 @@ function TickerSummaryInfo({ data }: { data: Promise<TickerV1FastResponse> }): J
           )}
         </h1>
         <div className="flex items-center gap-3 flex-shrink-0">
-          <span className="text-sm font-medium text-gray-400">{formatExchangeWithCountry(d.exchange)}</span>
+          <span className="text-sm font-medium text-muted">{formatExchangeWithCountry(d.exchange)}</span>
           <CompetitionAnalysisButton exchange={d.exchange.toUpperCase()} ticker={d.symbol.toUpperCase()} />
         </div>
       </div>
@@ -560,15 +560,15 @@ function getManagementTeamVerdictBadgeClasses(verdict: ManagementTeamAlignmentVe
   switch (verdict) {
     case ManagementTeamAlignmentVerdict.OWNER_OPERATOR:
     case ManagementTeamAlignmentVerdict.STRONGLY_ALIGNED:
-      return 'bg-green-900 text-green-200';
+      return 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40';
     case ManagementTeamAlignmentVerdict.ALIGNED:
-      return 'bg-blue-900 text-blue-200';
+      return 'bg-sky-500/15 text-sky-300 border border-sky-500/40';
     case ManagementTeamAlignmentVerdict.WEAKLY_ALIGNED:
-      return 'bg-yellow-900 text-yellow-200';
+      return 'bg-amber-500/15 text-amber-300 border border-amber-500/40';
     case ManagementTeamAlignmentVerdict.MISALIGNED:
-      return 'bg-red-900 text-red-200';
+      return 'bg-red-500/15 text-red-300 border border-red-500/40';
     default:
-      return 'bg-gray-800 text-gray-200';
+      return 'bg-gray-500/15 text-body border border-gray-500/40';
   }
 }
 
@@ -599,7 +599,7 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
   const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
   const link = CATEGORY_DETAIL_LINKS[categoryKey];
   return (
-    <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+    <div className="bg-surface-2 p-3 sm:p-4 rounded-md shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-lg font-semibold">{CATEGORY_MAPPINGS[categoryKey]}</h3>
@@ -623,7 +623,7 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
         </Link>
       </div>
       <div
-        className="text-gray-300 markdown markdown-body"
+        className="text-body markdown markdown-body"
         dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult?.overallAnalysisDetails || 'No summary available.') }}
       />
     </div>
@@ -645,8 +645,8 @@ function TickerAnalysisInfo({
   const managementTeamReport = d.managementTeamReports?.[0];
 
   return (
-    <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
-      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Summary Analysis</h2>
+    <section id="summary-analysis" className="bg-surface rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Summary Analysis</h2>
       <div className="space-y-4">
         <CategorySummaryCard categoryKey={TickerAnalysisCategory.BusinessAndMoat} d={d} />
 
@@ -660,7 +660,7 @@ function TickerAnalysisInfo({
           <CompetitionChartSection dataPromise={competitionPromise} exchange={exchange} ticker={ticker} />
 
           {managementTeamReport && (
-            <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+            <div className="bg-surface-2 p-3 sm:p-4 rounded-md shadow-sm">
               <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                 <div className="flex flex-wrap items-center gap-2">
                   <h3 className="text-lg font-semibold">Management Team Experience &amp; Alignment</h3>
@@ -684,7 +684,7 @@ function TickerAnalysisInfo({
                 </Link>
               </div>
               <div
-                className="text-gray-300 markdown markdown-body"
+                className="text-body markdown markdown-body"
                 dangerouslySetInnerHTML={{ __html: parseMarkdown(managementTeamReport.summary || 'No summary available.') }}
               />
             </div>
@@ -702,7 +702,7 @@ function TickerAnalysisInfo({
 
 function TickerArticleFooter({ modifiedDate, formattedModifiedDate }: { modifiedDate: Date; formattedModifiedDate: string }): JSX.Element {
   return (
-    <footer className="mt-8 pt-6 border-t border-color">
+    <footer className="mt-8 pt-6 border-t border-border">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="text-sm text-muted-foreground">
           <span>Last updated by </span>
@@ -715,10 +715,10 @@ function TickerArticleFooter({ modifiedDate, formattedModifiedDate }: { modified
           </time>
         </div>
         <div className="flex gap-2">
-          <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+          <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
             Stock Analysis
           </span>
-          <span className="inline-flex items-center rounded-full bg-purple-100 dark:bg-purple-900 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:text-purple-300">
+          <span className="inline-flex items-center rounded-full bg-indigo-500/15 border border-indigo-500/40 px-2.5 py-0.5 text-xs font-medium text-indigo-300">
             Investment Report
           </span>
         </div>

--- a/insights-ui/src/app/styles/markdown.scss
+++ b/insights-ui/src/app/styles/markdown.scss
@@ -61,7 +61,7 @@
 
 .markdown-body a {
   background-color: transparent;
-  color: #0969da;
+  color: var(--link-color);
   text-decoration: none;
 }
 
@@ -242,8 +242,7 @@
 .markdown-body kbd {
   display: inline-block;
   padding: 3px 5px;
-  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
-    Liberation Mono, monospace;
+  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   line-height: 10px;
   vertical-align: middle;
   border: solid 1px rgba(175, 184, 193, 0.2);
@@ -290,7 +289,7 @@
 .markdown-body h6 {
   font-weight: 600;
   font-size: 0.85em;
-  color: #57606a;
+  color: var(--text-muted);
 }
 
 .markdown-body p {
@@ -301,7 +300,7 @@
 .markdown-body blockquote {
   margin: 0;
   padding: 0 1em;
-  color: #57606a;
+  color: var(--text-muted);
   border-left: 0.25em solid #d0d7de;
 }
 
@@ -336,8 +335,7 @@
 
 .markdown-body tt,
 .markdown-body code {
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
-    Liberation Mono, monospace;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   font-size: 0.75em;
   color: #a9a9a9;
 }
@@ -345,8 +343,7 @@
 .markdown-body pre {
   margin-top: 0;
   margin-bottom: 0;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
-    Liberation Mono, monospace;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   font-size: 0.75em;
   word-wrap: normal;
 }

--- a/insights-ui/src/components/etf-reportsv1/EtfApplicableInvestorGoals.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfApplicableInvestorGoals.tsx
@@ -67,7 +67,7 @@ export default function EtfApplicableInvestorGoals({ investorGoals }: EtfApplica
 
   return (
     <section id="applicable-investor-goals" className="mb-8">
-      <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+      <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
         <h3 className="text-lg font-semibold text-color mb-3">Who This ETF Suits</h3>
         <div className="space-y-4">
           {groups.map(({ investor, goals }) => {
@@ -77,13 +77,13 @@ export default function EtfApplicableInvestorGoals({ investorGoals }: EtfApplica
                 <div className="mb-2">
                   <HoverTooltip text={investor.shortDescription}>
                     <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-color">
-                      <Icon className="h-5 w-5 flex-shrink-0 text-gray-400" aria-hidden="true" />
+                      <Icon className="h-5 w-5 flex-shrink-0 text-muted" aria-hidden="true" />
                       {investor.name}
                     </span>
                   </HoverTooltip>
                 </div>
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="mr-1 text-xs font-medium uppercase tracking-wide text-gray-400">Goals</span>
+                  <span className="mr-1 text-xs font-medium uppercase tracking-wide text-muted">Goals</span>
                   {goals.map((goal) => (
                     <HoverTooltip key={goal.key} text={goal.shortDescription}>
                       <span className="inline-flex rounded-full border border-color block-bg-color px-2.5 py-1 text-xs font-medium text-color transition-colors hover:border-primary-color">

--- a/insights-ui/src/components/etf-reportsv1/EtfChartTabs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfChartTabs.tsx
@@ -91,7 +91,7 @@ export default function EtfChartTabs({ priceHistory, performanceMetrics, etfSymb
                   type="button"
                   onClick={() => setPriceRange(r)}
                   className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                    priceRange === r ? 'text-heading' : 'text-body hover:bg-surface-2/60 hover:text-heading'
+                    priceRange === r ? 'text-heading' : 'text-body hover:bg-surface-3 hover:text-heading'
                   }`}
                   style={priceRange === r ? { backgroundColor: ACCENT_COLOR } : {}}
                   aria-pressed={priceRange === r}
@@ -110,7 +110,7 @@ export default function EtfChartTabs({ priceHistory, performanceMetrics, etfSymb
               type="button"
               onClick={() => setActiveTab(tab)}
               className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                safeTab === tab ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
+                safeTab === tab ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-3 hover:text-heading'
               }`}
               style={safeTab === tab ? { backgroundColor: ACCENT_COLOR } : {}}
             >

--- a/insights-ui/src/components/etf-reportsv1/EtfChartTabs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfChartTabs.tsx
@@ -72,11 +72,11 @@ export default function EtfChartTabs({ priceHistory, performanceMetrics, etfSymb
       : null;
 
   return (
-    <section id="etf-chart-tabs" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
+    <section id="etf-chart-tabs" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <div className="sm:flex-shrink-0 min-w-0">
-          <h3 className="text-lg font-semibold text-gray-100">{TAB_HEADINGS[safeTab]}</h3>
-          {metaLine && <p className="text-xs text-gray-400 mt-1 truncate">{metaLine}</p>}
+          <h3 className="text-lg font-semibold text-heading">{TAB_HEADINGS[safeTab]}</h3>
+          {metaLine && <p className="text-xs text-muted mt-1 truncate">{metaLine}</p>}
         </div>
 
         {/* Center: range pill (Price tab only). Sits in its own segmented-
@@ -84,14 +84,14 @@ export default function EtfChartTabs({ priceHistory, performanceMetrics, etfSymb
            distinct from the main Price/Returns/CAGR tabs on the right. */}
         {safeTab === 'price' && (
           <div className="sm:flex-1 flex sm:justify-center">
-            <div className="inline-flex items-center gap-1 rounded-lg bg-gray-800/70 p-1 ring-1 ring-gray-700/70">
+            <div className="inline-flex items-center gap-1 rounded-lg bg-surface-2 p-1 ring-1 ring-border">
               {PRICE_CHART_RANGES.map((r) => (
                 <button
                   key={r}
                   type="button"
                   onClick={() => setPriceRange(r)}
                   className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                    priceRange === r ? 'text-white' : 'text-gray-300 hover:bg-gray-700/60 hover:text-white'
+                    priceRange === r ? 'text-heading' : 'text-body hover:bg-surface-2/60 hover:text-heading'
                   }`}
                   style={priceRange === r ? { backgroundColor: ACCENT_COLOR } : {}}
                   aria-pressed={priceRange === r}
@@ -110,7 +110,7 @@ export default function EtfChartTabs({ priceHistory, performanceMetrics, etfSymb
               type="button"
               onClick={() => setActiveTab(tab)}
               className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                safeTab === tab ? 'text-white' : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100'
+                safeTab === tab ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
               }`}
               style={safeTab === tab ? { backgroundColor: ACCENT_COLOR } : {}}
             >
@@ -139,7 +139,7 @@ function PerformanceBars({ series, etfSymbol }: PerformanceBarsProps): JSX.Eleme
   const hasCategoryAverage = visible.some((v) => v.categoryAverage !== null);
 
   if (visible.length === 0) {
-    return <div className="h-64 sm:h-72 flex items-center justify-center text-sm text-gray-400">No data available for this ETF.</div>;
+    return <div className="h-64 sm:h-72 flex items-center justify-center text-sm text-muted">No data available for this ETF.</div>;
   }
 
   const labels = visible.map((v) => {

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionChartSection.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionChartSection.tsx
@@ -29,12 +29,12 @@ export default function EtfCompetitionChartSection({ data, exchange, etf }: EtfC
 
   return (
     <section id="competition">
-      <div className="bg-gray-900 rounded-lg shadow-sm p-6">
-        <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-700">
+      <div className="bg-surface rounded-lg shadow-sm p-6">
+        <div className="flex items-center justify-between mb-4 pb-2 border-b border-border">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link
             href={`/etfs/${exchange}/${etf}/competition`}
-            className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+            className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-heading shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
             style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
           >
             View Full Analysis →

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
@@ -46,7 +46,7 @@ export default function EtfCompetitionFullView({ data, availableSlugs }: EtfComp
 
   return (
     <div className="py-4">
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+      <article className="bg-surface rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={publishedDate.toISOString()} />
 
         <header className="mb-6 pb-4 border-b border-color">
@@ -56,7 +56,7 @@ export default function EtfCompetitionFullView({ data, availableSlugs }: EtfComp
                 {etf.name} <span className="text-muted-foreground">({etf.symbol})</span>
               </h1>
               <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
-                <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+                <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
                   {etf.exchange}
                 </span>
                 <span className="text-muted-foreground">•</span>
@@ -140,10 +140,10 @@ export default function EtfCompetitionFullView({ data, availableSlugs }: EtfComp
               </time>
             </div>
             <div className="flex gap-2">
-              <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+              <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
                 ETF Analysis
               </span>
-              <span className="inline-flex items-center rounded-full bg-purple-100 dark:bg-purple-900 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:text-purple-300">
+              <span className="inline-flex items-center rounded-full bg-indigo-500/15 border border-indigo-500/40 px-2.5 py-0.5 text-xs font-medium text-indigo-300">
                 Competitive Analysis
               </span>
             </div>

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionQuadrantChart.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionQuadrantChart.tsx
@@ -9,12 +9,12 @@ const EtfReturnsVsEfficiencyQuadrant = dynamic<EtfReturnsVsEfficiencyQuadrantPro
     ssr: false,
     loading: () => (
       <div className="animate-pulse max-w-md mx-auto lg:mx-0">
-        <div className="aspect-square bg-gray-800 rounded" />
+        <div className="aspect-square bg-surface-2 rounded" />
         <div className="flex flex-wrap gap-4 mt-3 px-4 justify-center">
-          <div className="h-3 w-20 bg-gray-800 rounded" />
-          <div className="h-3 w-16 bg-gray-800 rounded" />
-          <div className="h-3 w-18 bg-gray-800 rounded" />
-          <div className="h-3 w-20 bg-gray-800 rounded" />
+          <div className="h-3 w-20 bg-surface-2 rounded" />
+          <div className="h-3 w-16 bg-surface-2 rounded" />
+          <div className="h-3 w-18 bg-surface-2 rounded" />
+          <div className="h-3 w-20 bg-surface-2 rounded" />
         </div>
       </div>
     ),

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionQuadrantWithLegend.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionQuadrantWithLegend.tsx
@@ -49,7 +49,7 @@ export default function EtfCompetitionQuadrantWithLegend({
             <h3 className="text-lg font-semibold text-color mb-3">{heading}</h3>
           )}
 
-          <p className={headingAs === 'h2' ? 'text-color leading-relaxed mb-5' : 'text-sm text-gray-400 mb-4'} {...descriptionProps}>
+          <p className={headingAs === 'h2' ? 'text-color leading-relaxed mb-5' : 'text-sm text-muted mb-4'} {...descriptionProps}>
             {description}
           </p>
 
@@ -63,15 +63,12 @@ export default function EtfCompetitionQuadrantWithLegend({
                   <span className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0 mt-1.5" style={{ backgroundColor: dotColor(dp) }} />
                   <div className="min-w-0">
                     <div className="flex items-baseline gap-2 flex-wrap">
-                      <span
-                        className={dp.isMainEtf ? 'font-semibold text-amber-400' : 'text-gray-200 group-hover:text-[#F59E0B] transition-colors'}
-                        itemProp="name"
-                      >
+                      <span className={dp.isMainEtf ? 'font-semibold text-amber-400' : 'text-body group-hover:text-link transition-colors'} itemProp="name">
                         {dp.name}
                       </span>
-                      <span className={dp.isMainEtf ? 'text-amber-400 text-xs' : 'text-gray-500 text-xs'}>({dp.symbol})</span>
+                      <span className={dp.isMainEtf ? 'text-amber-400 text-xs' : 'text-muted text-xs'}>({dp.symbol})</span>
                     </div>
-                    <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                    <div className="flex items-center gap-2 text-xs text-muted mt-0.5">
                       <span>{dp.classification}</span>
                       <span>·</span>
                       <span>Returns {dp.returnsScore.toFixed(0)}%</span>

--- a/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfHoldings.tsx
@@ -28,37 +28,37 @@ export default function EtfHoldings({ data, maxRows, viewMoreHref, title, relate
   const resolvedTitle = title ?? (typeof maxRows === 'number' && list.length > maxRows ? `Top ${displayRows.length} Holdings` : 'Holdings');
 
   return (
-    <section id="etf-holdings" className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6 mb-8">
-      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-gray-700">
+    <section id="etf-holdings" className="bg-surface rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6 mb-8">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-border">
         <div>
-          <h2 className="text-xl font-bold text-gray-100">{resolvedTitle}</h2>
-          {subtitle ? <p className="text-xs text-gray-400 mt-1">{subtitle}</p> : null}
+          <h2 className="text-xl font-bold text-heading">{resolvedTitle}</h2>
+          {subtitle ? <p className="text-xs text-muted mt-1">{subtitle}</p> : null}
         </div>
-        <div className="text-xs text-gray-400">
+        <div className="text-xs text-muted">
           Showing {displayRows.length} of {list.length}
         </div>
       </div>
 
-      <div className="mt-4 overflow-x-auto rounded-lg border border-gray-700">
+      <div className="mt-4 overflow-x-auto rounded-lg border border-border">
         <table className="min-w-full">
-          <thead className="bg-gray-800">
+          <thead className="bg-surface-2">
             <tr>
               {colDefs.map((c) => (
-                <th key={c.field} className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap">
+                <th key={c.field} className="px-4 py-3 text-left text-xs font-medium text-body uppercase tracking-wider whitespace-nowrap">
                   {c.label}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-700">
+          <tbody className="divide-y divide-border">
             {displayRows.map((row, idx) => (
-              <tr key={idx} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
+              <tr key={idx} className={idx % 2 === 0 ? 'bg-surface' : 'bg-surface-2'}>
                 {colDefs.map((c) => {
                   const cellValue = row[c.field];
                   const isEmpty = cellValue === null || cellValue === undefined || String(cellValue).trim() === '';
                   return (
-                    <td key={c.field} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap">
-                      {isEmpty ? <span className="text-gray-500">&mdash;</span> : String(cellValue)}
+                    <td key={c.field} className="px-4 py-3 text-sm text-body whitespace-nowrap">
+                      {isEmpty ? <span className="text-muted">&mdash;</span> : String(cellValue)}
                     </td>
                   );
                 })}

--- a/insights-ui/src/components/etf-reportsv1/EtfKeyFactsFlags.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfKeyFactsFlags.tsx
@@ -22,7 +22,7 @@ export default function EtfKeyFactsFlags({ greenFlags, redFlags }: EtfKeyFactsFl
 
   return (
     <section id="key-facts-flags" className="mb-8">
-      <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+      <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
         <h3 className="text-lg font-semibold text-color mb-3">Key Facts</h3>
         <ul className="divide-y divide-gray-800">
           {flags.map((f, i) => {
@@ -42,7 +42,7 @@ export default function EtfKeyFactsFlags({ greenFlags, redFlags }: EtfKeyFactsFl
                     <PassFailBadge passed={f.result === 'Pass'} className="py-0.5 font-medium flex-shrink-0" passLabel={f.result} failLabel={f.result} />
                   </div>
                   {explanation && (
-                    <div className="markdown markdown-body text-sm text-gray-400" dangerouslySetInnerHTML={{ __html: parseMarkdown(explanation) }} />
+                    <div className="markdown markdown-body text-sm text-muted" dangerouslySetInnerHTML={{ __html: parseMarkdown(explanation) }} />
                   )}
                 </div>
               </li>

--- a/insights-ui/src/components/etf-reportsv1/EtfKeyFactsFlags.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfKeyFactsFlags.tsx
@@ -24,7 +24,7 @@ export default function EtfKeyFactsFlags({ greenFlags, redFlags }: EtfKeyFactsFl
     <section id="key-facts-flags" className="mb-8">
       <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
         <h3 className="text-lg font-semibold text-color mb-3">Key Facts</h3>
-        <ul className="divide-y divide-gray-800">
+        <ul className="divide-y divide-border">
           {flags.map((f, i) => {
             const explanation = f.explanation?.trim() || [f.oneLineExplanation, f.detailedExplanation].filter(Boolean).join(' ').trim();
             return (

--- a/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMetadataBadges.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { getEtfGroupName, getEtfGroupKey, slugifyEtfCategory } from '@/utils/etf-categorization-utils';
 import { getCountryByExchange, SupportedCountries, toExchange } from '@/utils/countryExchangeUtils';
 import { slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
+import { badgeTone, type BadgeTone } from '@/components/ui/badges/badgeTone';
 
 export interface EtfMetadataBadgesProps {
   exchange?: string | null;
@@ -16,14 +17,8 @@ interface BadgeItem {
   label: string;
   value: string;
   href: string | null;
-  colorClasses: string;
+  tone: BadgeTone;
 }
-
-const ASSET_CLASS_COLORS = 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800';
-const GROUP_COLORS = 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300 hover:bg-cyan-200 dark:hover:bg-cyan-800';
-const CATEGORY_COLORS = 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800';
-const PROVIDER_COLORS = 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800';
-const INDEX_COLORS = 'bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-300';
 
 function getCountryPathPrefix(exchange: string | null | undefined): string {
   if (!exchange) return '/etfs';
@@ -48,7 +43,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       label: 'Asset Class',
       value: assetClass,
       href: `${prefix}/asset-classes/${slugifyEtfTag(assetClass)}`,
-      colorClasses: ASSET_CLASS_COLORS,
+      tone: 'info',
     });
   }
   if (groupName && groupKey) {
@@ -56,7 +51,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       label: 'Group',
       value: groupName,
       href: `${prefix}/groups/${groupKey}`,
-      colorClasses: GROUP_COLORS,
+      tone: 'neutral',
     });
   }
   if (category) {
@@ -64,7 +59,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       label: 'Category',
       value: category,
       href: groupKey ? `${prefix}/groups/${groupKey}/categories/${slugifyEtfCategory(category)}` : null,
-      colorClasses: CATEGORY_COLORS,
+      tone: 'accent',
     });
   }
   if (trimmedIssuer) {
@@ -72,7 +67,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       label: 'Provider',
       value: trimmedIssuer,
       href: `${prefix}/providers/${slugifyEtfTag(trimmedIssuer)}`,
-      colorClasses: PROVIDER_COLORS,
+      tone: 'success',
     });
   }
   if (trimmedIndexName) {
@@ -80,7 +75,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
       label: 'Index',
       value: trimmedIndexName,
       href: null,
-      colorClasses: INDEX_COLORS,
+      tone: 'accent',
     });
   }
 
@@ -93,7 +88,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
           <Link
             key={item.label}
             href={item.href}
-            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${item.colorClasses}`}
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${badgeTone({ tone: item.tone })}`}
             aria-label={`View all ETFs in ${item.label}: ${item.value}`}
           >
             <span className="opacity-80">{item.label}:</span>
@@ -102,7 +97,7 @@ export default function EtfMetadataBadges({ exchange, assetClass, category, issu
         ) : (
           <span
             key={item.label}
-            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${item.colorClasses}`}
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${badgeTone({ tone: item.tone })}`}
             aria-label={`${item.label}: ${item.value}`}
           >
             <span className="opacity-80">{item.label}:</span>

--- a/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
@@ -154,7 +154,7 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
             </thead>
             <tbody className="divide-y divide-border bg-surface-2">
               {tableRows.map((r, idx) => (
-                <tr key={idx} className="hover:bg-surface-2">
+                <tr key={idx} className="hover:bg-surface-3">
                   {columns.map((c) => {
                     const cellValue = (r as any)[c];
                     return (

--- a/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfMorInfo.tsx
@@ -16,9 +16,9 @@ import { buildEtfHoldingColumnDefs } from '@/utils/etf-holdings-utils';
 
 function SectionHeading({ title, subtitle }: { title: string; subtitle?: string }): JSX.Element {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-gray-700">
-      <h2 className="text-xl font-bold text-gray-100">{title}</h2>
-      {subtitle ? <div className="text-xs text-gray-400">{subtitle}</div> : null}
+    <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-border">
+      <h2 className="text-xl font-bold text-heading">{title}</h2>
+      {subtitle ? <div className="text-xs text-muted">{subtitle}</div> : null}
     </div>
   );
 }
@@ -28,9 +28,9 @@ function MetricCard({ label, value }: { label: string; value?: string | null }):
   const isNA = displayValue === 'N/A';
 
   return (
-    <div className="bg-gray-800 px-3 py-2 rounded-md">
-      <div className="text-xs text-gray-400 mb-1">{label}</div>
-      <div className={`text-sm font-medium ${isNA ? 'text-gray-500' : 'text-gray-200'}`}>{displayValue}</div>
+    <div className="bg-surface-2 px-3 py-2 rounded-md">
+      <div className="text-xs text-muted mb-1">{label}</div>
+      <div className={`text-sm font-medium ${isNA ? 'text-muted' : 'text-body'}`}>{displayValue}</div>
     </div>
   );
 }
@@ -38,24 +38,24 @@ function MetricCard({ label, value }: { label: string; value?: string | null }):
 function TextCard({ title, content, className = '' }: { title: string; content?: string | null; className?: string }): JSX.Element {
   if (!content || String(content).trim() === '') {
     return (
-      <div className={`bg-gray-800 rounded-md p-4 ${className}`}>
-        <h3 className="text-sm font-medium text-gray-200 mb-2">{title}</h3>
-        <p className="text-sm text-gray-500">No {title.toLowerCase()} available.</p>
+      <div className={`bg-surface-2 rounded-md p-4 ${className}`}>
+        <h3 className="text-sm font-medium text-body mb-2">{title}</h3>
+        <p className="text-sm text-muted">No {title.toLowerCase()} available.</p>
       </div>
     );
   }
 
   return (
-    <div className={`bg-gray-800 rounded-md p-4 ${className}`}>
-      <h3 className="text-sm font-medium text-gray-200 mb-3">{title}</h3>
-      <p className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{String(content)}</p>
+    <div className={`bg-surface-2 rounded-md p-4 ${className}`}>
+      <h3 className="text-sm font-medium text-body mb-3">{title}</h3>
+      <p className="text-sm text-body leading-relaxed whitespace-pre-wrap">{String(content)}</p>
     </div>
   );
 }
 
 function MetricGrid({ items }: { items: Array<{ label: string; value: unknown }> }): JSX.Element {
   const visible = items.filter((i) => i.value !== null && i.value !== undefined && String(i.value).trim() !== '');
-  if (!visible.length) return <div className="text-sm text-gray-400">No data available.</div>;
+  if (!visible.length) return <div className="text-sm text-muted">No data available.</div>;
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
@@ -69,36 +69,36 @@ function MetricGrid({ items }: { items: Array<{ label: string; value: unknown }>
 function DataTable({ columns, rows, title }: { columns: string[]; rows: Array<Record<string, unknown>>; title?: string }): JSX.Element {
   if (!rows.length) {
     return (
-      <div className="bg-gray-800 rounded-md p-4 mt-4">
-        {title && <h4 className="text-sm font-medium text-gray-200 mb-2">{title}</h4>}
-        <p className="text-sm text-gray-500">No data available.</p>
+      <div className="bg-surface-2 rounded-md p-4 mt-4">
+        {title && <h4 className="text-sm font-medium text-body mb-2">{title}</h4>}
+        <p className="text-sm text-muted">No data available.</p>
       </div>
     );
   }
 
   return (
     <div className="mt-4">
-      {title && <h4 className="text-sm font-medium text-gray-200 mb-3">{title}</h4>}
-      <div className="overflow-x-auto rounded-lg border border-gray-700">
+      {title && <h4 className="text-sm font-medium text-body mb-3">{title}</h4>}
+      <div className="overflow-x-auto rounded-lg border border-border">
         <table className="min-w-full">
-          <thead className="bg-gray-800">
+          <thead className="bg-surface-2">
             <tr>
               {columns.map((c) => (
-                <th key={c} className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap">
+                <th key={c} className="px-4 py-3 text-left text-xs font-medium text-body uppercase tracking-wider whitespace-nowrap">
                   {c}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-700">
+          <tbody className="divide-y divide-border">
             {rows.map((r, idx) => (
-              <tr key={idx} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
+              <tr key={idx} className={idx % 2 === 0 ? 'bg-surface' : 'bg-surface-2'}>
                 {columns.map((c) => {
                   const cellValue = (r as any)[c];
                   return (
-                    <td key={c} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap">
+                    <td key={c} className="px-4 py-3 text-sm text-body whitespace-nowrap">
                       {cellValue === null || cellValue === undefined || String(cellValue).trim() === '' ? (
-                        <span className="text-gray-500">&mdash;</span>
+                        <span className="text-muted">&mdash;</span>
                       ) : (
                         String(cellValue)
                       )}
@@ -118,12 +118,12 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
   const r = (Array.isArray(rows) ? rows : []) as Array<{ label: string; values: Record<string, string> }>;
   if (!r.length) {
     return (
-      <div className="mt-4 rounded-lg border border-gray-700 bg-gray-900 overflow-hidden">
-        <div className="px-4 py-3 border-b border-gray-700">
-          <h4 className="text-sm font-medium text-gray-200">{title}</h4>
+      <div className="mt-4 rounded-lg border border-border bg-surface overflow-hidden">
+        <div className="px-4 py-3 border-b border-border">
+          <h4 className="text-sm font-medium text-body">{title}</h4>
         </div>
         <div className="px-4 py-4">
-          <p className="text-sm text-gray-400">No {title.toLowerCase()} data available.</p>
+          <p className="text-sm text-muted">No {title.toLowerCase()} data available.</p>
         </div>
       </div>
     );
@@ -137,30 +137,30 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
 
   return (
     <div className="mt-4">
-      <div className="rounded-lg border border-gray-700 bg-gray-900 shadow-sm overflow-hidden">
-        <div className="px-4 py-3 border-b border-gray-700 sm:px-6">
-          <h4 className="text-sm font-medium text-gray-100">{title}</h4>
+      <div className="rounded-lg border border-border bg-surface shadow-sm overflow-hidden">
+        <div className="px-4 py-3 border-b border-border sm:px-6">
+          <h4 className="text-sm font-medium text-heading">{title}</h4>
         </div>
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-700">
-            <thead className="bg-gray-800">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-surface-2">
               <tr>
                 {columns.map((c) => (
-                  <th key={c} className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap sm:px-6">
+                  <th key={c} className="px-4 py-3 text-left text-xs font-medium text-body uppercase tracking-wider whitespace-nowrap sm:px-6">
                     {c}
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-700 bg-gray-800">
+            <tbody className="divide-y divide-border bg-surface-2">
               {tableRows.map((r, idx) => (
-                <tr key={idx} className="hover:bg-gray-700">
+                <tr key={idx} className="hover:bg-surface-2">
                   {columns.map((c) => {
                     const cellValue = (r as any)[c];
                     return (
-                      <td key={c} className="px-4 py-3 text-sm text-gray-300 whitespace-nowrap sm:px-6">
+                      <td key={c} className="px-4 py-3 text-sm text-body whitespace-nowrap sm:px-6">
                         {cellValue === null || cellValue === undefined || String(cellValue).trim() === '' ? (
-                          <span className="text-gray-500">&mdash;</span>
+                          <span className="text-muted">&mdash;</span>
                         ) : (
                           String(cellValue)
                         )}
@@ -180,8 +180,8 @@ function ReturnsTable({ title, rows }: { title: string; rows: any }): JSX.Elemen
 function MorAnalysis({ analysis }: { analysis: EtfMorAnalysis | null }): JSX.Element {
   if (!analysis || !analysis.available) {
     return (
-      <div className="bg-gray-800 rounded-md p-4">
-        <p className="text-sm text-gray-400">No analysis available.</p>
+      <div className="bg-surface-2 rounded-md p-4">
+        <p className="text-sm text-muted">No analysis available.</p>
       </div>
     );
   }
@@ -198,18 +198,18 @@ function MorAnalysis({ analysis }: { analysis: EtfMorAnalysis | null }): JSX.Ele
           {analysis.sections.map((s, idx) => {
             const meta = [s.date, s.author, s.rating].filter(Boolean).join(' \u2022 ');
             return (
-              <div key={idx} className="bg-gray-800 rounded-md px-4 py-3">
+              <div key={idx} className="bg-surface-2 rounded-md px-4 py-3">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 mb-2">
-                  <h5 className="text-sm font-semibold text-gray-200">{s.pillar}</h5>
-                  {meta && <div className="text-xs text-gray-400">{meta}</div>}
+                  <h5 className="text-sm font-semibold text-body">{s.pillar}</h5>
+                  {meta && <div className="text-xs text-muted">{meta}</div>}
                 </div>
-                <div className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{s.content}</div>
+                <div className="text-sm text-body leading-relaxed whitespace-pre-wrap">{s.content}</div>
               </div>
             );
           })}
         </div>
       ) : (
-        <div className="text-sm text-gray-400">No analysis sections available.</div>
+        <div className="text-sm text-muted">No analysis sections available.</div>
       )}
     </div>
   );
@@ -218,8 +218,8 @@ function MorAnalysis({ analysis }: { analysis: EtfMorAnalysis | null }): JSX.Ele
 function MorHoldings({ holdings }: { holdings: EtfMorHoldings | null }): JSX.Element {
   if (!holdings) {
     return (
-      <div className="bg-gray-800 rounded-md p-4">
-        <p className="text-sm text-gray-400">No holdings data available.</p>
+      <div className="bg-surface-2 rounded-md p-4">
+        <p className="text-sm text-muted">No holdings data available.</p>
       </div>
     );
   }
@@ -251,8 +251,8 @@ function MorHoldings({ holdings }: { holdings: EtfMorHoldings | null }): JSX.Ele
 function MorRisk({ riskPeriods }: { riskPeriods: EtfMorRiskPeriods | null }): JSX.Element {
   if (!riskPeriods) {
     return (
-      <div className="bg-gray-800 rounded-md p-4">
-        <p className="text-sm text-gray-400">No risk data available.</p>
+      <div className="bg-surface-2 rounded-md p-4">
+        <p className="text-sm text-muted">No risk data available.</p>
       </div>
     );
   }
@@ -260,8 +260,8 @@ function MorRisk({ riskPeriods }: { riskPeriods: EtfMorRiskPeriods | null }): JS
   const periods = (['3-Yr', '5-Yr', '10-Yr'] as const).filter((p) => (riskPeriods as any)?.[p]);
   if (!periods.length) {
     return (
-      <div className="bg-gray-800 rounded-md p-4">
-        <p className="text-sm text-gray-400">No risk periods available.</p>
+      <div className="bg-surface-2 rounded-md p-4">
+        <p className="text-sm text-muted">No risk periods available.</p>
       </div>
     );
   }
@@ -280,10 +280,10 @@ function MorRisk({ riskPeriods }: { riskPeriods: EtfMorRiskPeriods | null }): JS
         ];
 
         return (
-          <div key={p} className="bg-gray-800 rounded-md p-4">
-            <div className="flex items-center justify-between gap-3 mb-4 pb-2 border-b border-gray-700">
-              <h4 className="text-sm font-semibold text-gray-200">{p} Risk Analysis</h4>
-              {d?.period && <div className="text-xs text-gray-400">{d.period}</div>}
+          <div key={p} className="bg-surface-2 rounded-md p-4">
+            <div className="flex items-center justify-between gap-3 mb-4 pb-2 border-b border-border">
+              <h4 className="text-sm font-semibold text-body">{p} Risk Analysis</h4>
+              {d?.period && <div className="text-xs text-muted">{d.period}</div>}
             </div>
 
             <MetricGrid
@@ -490,10 +490,10 @@ function MorPortfolioHoldingsBlock({ data }: { data: EtfMorPortfolioHoldings | n
     <div className="space-y-4">
       {hasSummary ? <MetricGrid items={metaItems} /> : null}
       {hasList ? (
-        <div className="rounded-lg border border-gray-700 overflow-hidden">
-          <div className="px-4 py-3 border-b border-gray-700 bg-gray-800">
-            <h4 className="text-sm font-medium text-gray-200">Holdings detail ({holdingRows.length})</h4>
-            <p className="text-xs text-gray-500 mt-1">{detailSubtitle}</p>
+        <div className="rounded-lg border border-border overflow-hidden">
+          <div className="px-4 py-3 border-b border-border bg-surface-2">
+            <h4 className="text-sm font-medium text-body">Holdings detail ({holdingRows.length})</h4>
+            <p className="text-xs text-muted mt-1">{detailSubtitle}</p>
           </div>
           <div className="max-h-[32rem] overflow-auto -mt-4">
             <DataTable columns={colDefs.map((c) => c.label)} rows={holdingRows} />
@@ -588,18 +588,18 @@ export default function EtfMorInfo({ data }: { data: EtfMorInfoOptionalWrapper }
   const updatedLabel = updatedAt ? `Last updated: ${new Date(updatedAt as any).toLocaleString('en-US')}` : undefined;
 
   return (
-    <section id="etf-mor-info" className="bg-gray-900 rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
+    <section id="etf-mor-info" className="bg-surface rounded-lg shadow-sm px-3 py-6 sm:p-6 mt-6">
       <SectionHeading title="Detailed Financial Data" subtitle={updatedLabel} />
 
       {!hasAny ? (
-        <div className="mt-6 bg-gray-800 rounded-md p-6 text-center">
-          <p className="text-gray-400">No detailed financial data saved yet.</p>
-          <p className="text-sm text-gray-500 mt-1">Use the admin panel to trigger data collection.</p>
+        <div className="mt-6 bg-surface-2 rounded-md p-6 text-center">
+          <p className="text-muted">No detailed financial data saved yet.</p>
+          <p className="text-sm text-muted mt-1">Use the admin panel to trigger data collection.</p>
         </div>
       ) : (
         <div className="mt-6 space-y-8">
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Overview</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Overview</h3>
             <MetricGrid
               items={[
                 { label: 'NAV', value: analyzer?.overviewNav },
@@ -631,41 +631,41 @@ export default function EtfMorInfo({ data }: { data: EtfMorInfoOptionalWrapper }
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Analysis</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Analysis</h3>
             <MorAnalysis analysis={analysis} />
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Returns</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Returns</h3>
             <ReturnsTable title="Annual Returns" rows={returnsAnnual} />
             <ReturnsTable title="Trailing Returns" rows={returnsTrailing} />
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Holdings</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Holdings</h3>
             <MorHoldings holdings={holdings} />
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Portfolio breakdown</h3>
-            <p className="text-xs text-gray-500 mb-4">Asset mix, style and sector exposure, bond quality views, and full holdings page.</p>
+            <h3 className="text-lg font-semibold text-heading mb-4">Portfolio breakdown</h3>
+            <p className="text-xs text-muted mb-4">Asset mix, style and sector exposure, bond quality views, and full holdings page.</p>
             {portfolio && morPortfolioHasContent(portfolio) ? (
               <MorPortfolio portfolio={portfolio} />
             ) : (
-              <div className="bg-gray-800 rounded-md p-4">
-                <p className="text-sm text-gray-400">No portfolio breakdown saved yet.</p>
-                <p className="text-sm text-gray-500 mt-1">Trigger &quot;Mor Portfolio&quot; from the admin ETF reports tool to collect this data.</p>
+              <div className="bg-surface-2 rounded-md p-4">
+                <p className="text-sm text-muted">No portfolio breakdown saved yet.</p>
+                <p className="text-sm text-muted mt-1">Trigger &quot;Mor Portfolio&quot; from the admin ETF reports tool to collect this data.</p>
               </div>
             )}
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Risk Analysis</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Risk Analysis</h3>
             <MorRisk riskPeriods={riskPeriods} />
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-100 mb-4">Management</h3>
+            <h3 className="text-lg font-semibold text-heading mb-4">Management</h3>
             <MetricGrid
               items={[
                 { label: 'Inception Date', value: people?.inceptionDate },

--- a/insights-ui/src/components/etf-reportsv1/EtfReturnsTable.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfReturnsTable.tsx
@@ -35,7 +35,7 @@ export interface EtfReturnsTableProps {
  * none of the visible rows have a real value — so a fund with only YTD
  * data does not show ten empty year columns.
  *
- * Designed to render inside an existing `bg-gray-900` card (e.g. the ETF
+ * Designed to render inside an existing `bg-surface` card (e.g. the ETF
  * category article), so it carries no outer card chrome of its own.
  */
 export default function EtfReturnsTable({ rows, title = 'Returns', subtitle }: EtfReturnsTableProps): JSX.Element | null {
@@ -65,35 +65,35 @@ export default function EtfReturnsTable({ rows, title = 'Returns', subtitle }: E
 
   return (
     <section id="etf-returns" className="mb-6">
-      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-gray-700">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 pb-2 border-b border-border">
         <div>
           <h2 className="text-xl font-semibold text-color">{title}</h2>
-          {subtitle ? <p className="text-xs text-gray-400 mt-1">{subtitle}</p> : null}
+          {subtitle ? <p className="text-xs text-muted mt-1">{subtitle}</p> : null}
         </div>
       </div>
 
-      <div className="mt-4 overflow-x-auto rounded-lg border border-gray-700">
+      <div className="mt-4 overflow-x-auto rounded-lg border border-border">
         <table className="min-w-full">
-          <thead className="bg-gray-800">
+          <thead className="bg-surface-2">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap">Label</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-body uppercase tracking-wider whitespace-nowrap">Label</th>
               {visiblePeriods.map((p) => (
-                <th key={p} className="px-4 py-3 text-right text-xs font-medium text-gray-300 uppercase tracking-wider whitespace-nowrap">
+                <th key={p} className="px-4 py-3 text-right text-xs font-medium text-body uppercase tracking-wider whitespace-nowrap">
                   {p}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-700">
+          <tbody className="divide-y divide-border">
             {visibleRows.map((row, idx) => (
-              <tr key={`${row.label}-${idx}`} className={idx % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800/50'}>
-                <td className="px-4 py-3 text-sm text-gray-200 font-medium whitespace-nowrap">{renameLabel(row.label)}</td>
+              <tr key={`${row.label}-${idx}`} className={idx % 2 === 0 ? 'bg-surface' : 'bg-surface-2'}>
+                <td className="px-4 py-3 text-sm text-body font-medium whitespace-nowrap">{renameLabel(row.label)}</td>
                 {visiblePeriods.map((p) => {
                   const cell = row.values?.[p];
                   const empty = isPlaceholder(cell);
                   return (
-                    <td key={p} className="px-4 py-3 text-sm text-gray-300 text-right whitespace-nowrap">
-                      {empty ? <span className="text-gray-500">&mdash;</span> : String(cell)}
+                    <td key={p} className="px-4 py-3 text-sm text-body text-right whitespace-nowrap">
+                      {empty ? <span className="text-muted">&mdash;</span> : String(cell)}
                     </td>
                   );
                 })}

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -69,7 +69,7 @@ function SimilarEtfMobileCard({ etf }: { etf: SimilarEtf }): JSX.Element {
       </Link>
       <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
         {COLUMNS.map((col) => (
-          <div key={col.key} className="flex justify-between border-b border-border/60 pb-1">
+          <div key={col.key} className="flex justify-between border-b border-border pb-1">
             <dt className="text-muted">{col.label}</dt>
             <dd className="text-heading font-mono tabular-nums text-right ml-2 truncate">{col.render(etf)}</dd>
           </div>
@@ -106,8 +106,8 @@ export default function SimilarEtfs({ data: similarEtfs }: SimilarEtfsProps): JS
           </thead>
           <tbody className="divide-y divide-border">
             {similarEtfs.map((etf) => (
-              <tr key={etf.id} className="hover:bg-surface-2 transition-colors">
-                <td className="sticky left-0 z-10 bg-surface hover:bg-surface-2 transition-colors px-3 py-2 whitespace-nowrap">
+              <tr key={etf.id} className="hover:bg-surface-3 transition-colors">
+                <td className="sticky left-0 z-10 bg-surface hover:bg-surface-3 transition-colors px-3 py-2 whitespace-nowrap">
                   <Link href={`/etfs/${etf.exchange.toUpperCase()}/${etf.symbol.toUpperCase()}`} className="group inline-flex items-center gap-1.5">
                     <span className="font-medium bg-primary text-primary-text text-xs px-1.5 py-0.5 rounded">{etf.symbol}</span>
                     <span className="text-link group-hover:text-link transition-colors max-w-[16rem] truncate">{etf.name}</span>

--- a/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
+++ b/insights-ui/src/components/etf-reportsv1/SimilarEtfs.tsx
@@ -57,21 +57,21 @@ const COLUMNS: ColumnDef[] = [
 
 function SimilarEtfMobileCard({ etf }: { etf: SimilarEtf }): JSX.Element {
   return (
-    <div className="bg-gray-800 border border-gray-700 rounded-md p-4">
+    <div className="bg-surface-2 border border-border rounded-md p-4">
       <Link href={`/etfs/${etf.exchange.toUpperCase()}/${etf.symbol.toUpperCase()}`} className="flex items-start justify-between gap-2 group">
         <div className="min-w-0">
-          <h3 className="font-semibold text-[#F59E0B] group-hover:text-[#F97316] transition-colors truncate">{etf.name}</h3>
-          <div className="text-xs text-gray-400 mt-0.5">
+          <h3 className="font-semibold text-link group-hover:text-link transition-colors truncate">{etf.name}</h3>
+          <div className="text-xs text-muted mt-0.5">
             {etf.symbol} • {etf.exchange.toUpperCase()}
           </div>
         </div>
-        <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0 mt-1" />
+        <ArrowTopRightOnSquareIcon className="size-4 text-muted group-hover:text-link transition-colors flex-shrink-0 mt-1" />
       </Link>
       <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
         {COLUMNS.map((col) => (
-          <div key={col.key} className="flex justify-between border-b border-gray-700/60 pb-1">
-            <dt className="text-gray-400">{col.label}</dt>
-            <dd className="text-white font-mono tabular-nums text-right ml-2 truncate">{col.render(etf)}</dd>
+          <div key={col.key} className="flex justify-between border-b border-border/60 pb-1">
+            <dt className="text-muted">{col.label}</dt>
+            <dd className="text-heading font-mono tabular-nums text-right ml-2 truncate">{col.render(etf)}</dd>
           </div>
         ))}
       </dl>
@@ -85,16 +85,16 @@ export default function SimilarEtfs({ data: similarEtfs }: SimilarEtfsProps): JS
   }
 
   return (
-    <div id="similar-etfs" className="bg-gray-900 rounded-lg shadow-sm p-4 sm:p-6 mb-8">
-      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Similar ETFs</h2>
-      <p className="text-gray-300 mb-4">True peers tracking the same or a very similar index in the same category:</p>
+    <div id="similar-etfs" className="bg-surface rounded-lg shadow-sm p-4 sm:p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Similar ETFs</h2>
+      <p className="text-body mb-4">True peers tracking the same or a very similar index in the same category:</p>
 
       {/* Desktop / tablet — horizontally-scrollable table. */}
-      <div className="hidden md:block overflow-x-auto rounded-md border border-gray-700">
+      <div className="hidden md:block overflow-x-auto rounded-md border border-border">
         <table className="min-w-full text-sm">
-          <thead className="bg-gray-800 text-gray-300">
+          <thead className="bg-surface-2 text-body">
             <tr>
-              <th scope="col" className="sticky left-0 z-10 bg-gray-800 px-3 py-2 text-left font-semibold whitespace-nowrap">
+              <th scope="col" className="sticky left-0 z-10 bg-surface-2 px-3 py-2 text-left font-semibold whitespace-nowrap">
                 ETF
               </th>
               {COLUMNS.map((col) => (
@@ -104,20 +104,20 @@ export default function SimilarEtfs({ data: similarEtfs }: SimilarEtfsProps): JS
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-700">
+          <tbody className="divide-y divide-border">
             {similarEtfs.map((etf) => (
-              <tr key={etf.id} className="hover:bg-gray-800/60 transition-colors">
-                <td className="sticky left-0 z-10 bg-gray-900 hover:bg-gray-800/60 transition-colors px-3 py-2 whitespace-nowrap">
+              <tr key={etf.id} className="hover:bg-surface-2 transition-colors">
+                <td className="sticky left-0 z-10 bg-surface hover:bg-surface-2 transition-colors px-3 py-2 whitespace-nowrap">
                   <Link href={`/etfs/${etf.exchange.toUpperCase()}/${etf.symbol.toUpperCase()}`} className="group inline-flex items-center gap-1.5">
-                    <span className="font-medium bg-[#4F46E5] text-white text-xs px-1.5 py-0.5 rounded">{etf.symbol}</span>
-                    <span className="text-[#F59E0B] group-hover:text-[#F97316] transition-colors max-w-[16rem] truncate">{etf.name}</span>
-                    <ArrowTopRightOnSquareIcon className="size-3.5 text-gray-400 group-hover:text-[#F59E0B] transition-colors flex-shrink-0" />
+                    <span className="font-medium bg-primary text-primary-text text-xs px-1.5 py-0.5 rounded">{etf.symbol}</span>
+                    <span className="text-link group-hover:text-link transition-colors max-w-[16rem] truncate">{etf.name}</span>
+                    <ArrowTopRightOnSquareIcon className="size-3.5 text-muted group-hover:text-link transition-colors flex-shrink-0" />
                   </Link>
                 </td>
                 {COLUMNS.map((col) => (
                   <td
                     key={col.key}
-                    className={`px-3 py-2 whitespace-nowrap font-mono tabular-nums text-white ${col.align === 'right' ? 'text-right' : 'text-left'}`}
+                    className={`px-3 py-2 whitespace-nowrap font-mono tabular-nums text-heading ${col.align === 'right' ? 'text-right' : 'text-left'}`}
                   >
                     {col.render(etf)}
                   </td>

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
@@ -43,15 +43,15 @@ export default function EtfAnalysisSections({
   }
 
   return (
-    <section id="summary-analysis" className="bg-gray-800 rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
-      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Summary Analysis</h2>
+    <section id="summary-analysis" className="bg-surface-2 rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Summary Analysis</h2>
       <div className="space-y-4">
         {CATEGORY_ORDER.map((categoryKey) => {
           const categoryResult = data.categories.find((r) => r.categoryKey === categoryKey);
           const display = CATEGORY_DISPLAY[categoryKey] || { name: categoryKey, order: 99, slug: '' };
           return (
             <Fragment key={categoryKey}>
-              <div className="bg-gray-900 p-3 sm:p-4 rounded-md shadow-sm">
+              <div className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
                 <div className="flex items-center justify-between gap-2 mb-2">
                   <div className="flex items-center gap-2">
                     <h3 className="text-lg font-semibold">{display.name}</h3>
@@ -68,7 +68,7 @@ export default function EtfAnalysisSections({
                   {categoryResult && display.slug && (
                     <Link
                       href={`/etfs/${exchange}/${symbol}/${display.slug}`}
-                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+                      className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-heading shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
                       style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
                     >
                       View Detailed Analysis →
@@ -77,7 +77,7 @@ export default function EtfAnalysisSections({
                 </div>
                 {categoryKey === EtfAnalysisCategory.FuturePerformanceOutlook && futureOutlookTop}
                 <div
-                  className="text-gray-300 markdown markdown-body"
+                  className="text-body markdown markdown-body"
                   dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult?.overallAnalysisDetails || 'No summary available.') }}
                 />
               </div>

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfAnalysisSections.tsx
@@ -43,7 +43,7 @@ export default function EtfAnalysisSections({
   }
 
   return (
-    <section id="summary-analysis" className="bg-surface-2 rounded-lg shadow-sm mb-4 sm:py-6" itemProp="abstract">
+    <section id="summary-analysis" className="mb-4 sm:py-6" itemProp="abstract">
       <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Summary Analysis</h2>
       <div className="space-y-4">
         {CATEGORY_ORDER.map((categoryKey) => {

--- a/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
+++ b/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
@@ -18,7 +18,7 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
 
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={href} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
+      <Link href={href} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-3 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-0.5 text-left flex justify-between items-start gap-2" title={title}>
           <span className="whitespace-normal break-words">{title}</span>
           {typeof totalCount === 'number' && totalCount > 0 && <span className="text-xs font-normal text-body shrink-0">{totalCount} ETFs</span>}
@@ -36,7 +36,7 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
                 <li key={etf.id}>
                   <Link
                     href={`/etfs/${etf.exchange}/${etf.symbol}`}
-                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-3 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
                       <span className={`${textColorClass} text-xs font-mono`}>{scoreLabel}</span>

--- a/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
+++ b/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
@@ -18,10 +18,10 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
 
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={href} className="block px-3 py-1.5 bg-[#374151] hover:bg-[#2D3748] transition-colors">
+      <Link href={href} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-0.5 text-left flex justify-between items-start gap-2" title={title}>
           <span className="whitespace-normal break-words">{title}</span>
-          {typeof totalCount === 'number' && totalCount > 0 && <span className="text-xs font-normal text-gray-300 shrink-0">{totalCount} ETFs</span>}
+          {typeof totalCount === 'number' && totalCount > 0 && <span className="text-xs font-normal text-body shrink-0">{totalCount} ETFs</span>}
         </h3>
       </Link>
 
@@ -36,13 +36,13 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
                 <li key={etf.id}>
                   <Link
                     href={`/etfs/${etf.exchange}/${etf.symbol}`}
-                    className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
                       <span className={`${textColorClass} text-xs font-mono`}>{scoreLabel}</span>
                     </p>
-                    <span className="text-xs font-medium bg-[#4F46E5] text-white ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>
-                    <span className="text-xs text-white truncate">{etf.name}</span>
+                    <span className="text-xs font-medium bg-primary text-primary-text ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>
+                    <span className="text-xs text-heading truncate">{etf.name}</span>
                   </Link>
                 </li>
               );
@@ -51,7 +51,7 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
         </div>
       ) : (
         <div className="px-3 py-2">
-          <p className="text-xs text-gray-400">No ETFs available.</p>
+          <p className="text-xs text-muted">No ETFs available.</p>
         </div>
       )}
     </div>

--- a/insights-ui/src/components/etfs/EtfCategoryCard.tsx
+++ b/insights-ui/src/components/etfs/EtfCategoryCard.tsx
@@ -20,7 +20,7 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
 
   return (
     <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
-      <Link href={href} className="block px-3 py-2 sm:px-4 border-b border-color bg-surface-2 hover:bg-surface-2 transition-colors">
+      <Link href={href} className="block px-3 py-2 sm:px-4 border-b border-color bg-surface-2 hover:bg-surface-3 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug break-words pr-24" title={categoryName}>
           {categoryName}
         </h3>
@@ -33,7 +33,7 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
           const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
           const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
           return (
-            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
+            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-surface-3 transition-colors">
               <Link
                 href={`/etfs/${etf.exchange}/${etf.symbol}`}
                 className="flex gap-1.5 items-center min-w-0 w-full"

--- a/insights-ui/src/components/etfs/EtfCategoryCard.tsx
+++ b/insights-ui/src/components/etfs/EtfCategoryCard.tsx
@@ -20,12 +20,12 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
 
   return (
     <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
-      <Link href={href} className="block px-3 py-2 sm:px-4 border-b border-color bg-[#374151] hover:bg-[#2D3748] transition-colors">
+      <Link href={href} className="block px-3 py-2 sm:px-4 border-b border-color bg-surface-2 hover:bg-surface-2 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug break-words pr-24" title={categoryName}>
           {categoryName}
         </h3>
       </Link>
-      <div className="absolute top-2 right-2 z-10 text-[13px] text-white bg-[#4F46E5] px-2 py-0.5 rounded-full" aria-label={etfLabel} title={etfLabel}>
+      <div className="absolute top-2 right-2 z-10 text-[13px] text-heading bg-primary px-2 py-0.5 rounded-full" aria-label={etfLabel} title={etfLabel}>
         {etfLabel}
       </div>
       <ul className="divide-y divide-color flex-1">
@@ -33,7 +33,7 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
           const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
           const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
           return (
-            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-[#2D3748] transition-colors">
+            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
               <Link
                 href={`/etfs/${etf.exchange}/${etf.symbol}`}
                 className="flex gap-1.5 items-center min-w-0 w-full"
@@ -43,10 +43,10 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
                 <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
                   <span className={`${textColorClass} font-mono tabular-nums text-right text-xs`}>{scoreLabel}</span>
                 </p>
-                <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-[#4F46E5] text-white self-center shadow-sm shrink-0">
+                <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-primary text-primary-text self-center shadow-sm shrink-0">
                   {etf.symbol}
                 </p>
-                <p className="text-sm font-medium text-break break-words text-white truncate min-w-0 flex-1">{etf.name}</p>
+                <p className="text-sm font-medium text-break break-words text-heading truncate min-w-0 flex-1">{etf.name}</p>
               </Link>
             </li>
           );

--- a/insights-ui/src/components/etfs/EtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfListingGrid.tsx
@@ -66,12 +66,12 @@ function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
   return (
     <Link
       href={`/etfs/${etf.exchange}/${etf.symbol}`}
-      className="block bg-gray-900 border border-[#374151] rounded-lg p-4 hover:border-[#F59E0B] hover:shadow-lg transition-all duration-200"
+      className="block bg-surface border border-border rounded-lg p-4 hover:border-primary hover:shadow-lg transition-all duration-200"
     >
       <div className="flex items-center justify-between mb-3 gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <span className="bg-gradient-to-r from-[#F59E0B] to-[#FBBF24] text-black text-xs font-bold px-2 py-0.5 rounded">{etf.symbol}</span>
-          <span className="text-xs text-gray-400">{etf.exchange}</span>
+          <span className="text-xs text-muted">{etf.exchange}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {showScore && (
@@ -82,28 +82,30 @@ function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
               {score}/20
             </span>
           )}
-          {etf.payoutFrequency && <span className="text-xs text-gray-400 bg-[#374151] px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
+          {etf.payoutFrequency && <span className="text-xs text-muted bg-surface-2 px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
         </div>
       </div>
 
-      <h3 className="text-white text-sm font-medium mb-3 line-clamp-2 min-h-[2.5rem]">{etf.name}</h3>
+      <h3 className="text-heading text-sm font-medium mb-3 line-clamp-2 min-h-[2.5rem]">{etf.name}</h3>
 
       <div className="grid grid-cols-2 gap-2 text-xs">
         <div>
-          <span className="text-gray-400">AUM</span>
-          <p className="text-white font-medium">{formatCompactAmount(etf.aum)}</p>
+          <span className="text-muted">AUM</span>
+          <p className="text-heading font-medium">{formatCompactAmount(etf.aum)}</p>
         </div>
         <div>
-          <span className="text-gray-400">Expense Ratio</span>
-          <p className="text-white font-medium">{etf.expenseRatio !== null ? `${etf.expenseRatio}%` : 'N/A'}</p>
+          <span className="text-muted">Expense Ratio</span>
+          <p className="text-heading font-medium">{etf.expenseRatio !== null ? `${etf.expenseRatio}%` : 'N/A'}</p>
         </div>
         <div>
-          <span className="text-gray-400">{third.label}</span>
-          <p className="text-white font-medium">{third.value}</p>
+          <span className="text-muted">{third.label}</span>
+          <p className="text-heading font-medium">{third.value}</p>
         </div>
         <div>
-          <span className="text-gray-400">Dividend Yield</span>
-          <p className="text-white font-medium">{etf.dividendYield !== null && etf.dividendYield !== 0 ? formatPercentageDecimal(etf.dividendYield) : '--'}</p>
+          <span className="text-muted">Dividend Yield</span>
+          <p className="text-heading font-medium">
+            {etf.dividendYield !== null && etf.dividendYield !== 0 ? formatPercentageDecimal(etf.dividendYield) : '--'}
+          </p>
         </div>
       </div>
     </Link>
@@ -134,7 +136,7 @@ export default function EtfListingGrid({
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-muted">
           Showing {resolvedData.etfs.length} of {totalCount.toLocaleString()} ETF{totalCount !== 1 ? 's' : ''}
           {totalPages > 1 && ` (Page ${page} of ${totalPages})`}
         </p>

--- a/insights-ui/src/components/favourites/TickerBadge.tsx
+++ b/insights-ui/src/components/favourites/TickerBadge.tsx
@@ -19,8 +19,8 @@ export default function TickerBadge({ ticker, showScore = false, showName = fals
   const content = (
     <div className="inline-flex items-center gap-1 px-2 py-0.5 border border-gray-600 rounded hover:border-gray-500 transition-colors">
       {showScore && <span className={`${textColorClass} px-1 rounded ${bgColorClass} bg-opacity-15 text-[11px] font-mono`}>{score}/25</span>}
-      <span className="text-xs font-semibold bg-[#4F46E5] text-white px-1 rounded shrink-0">{ticker.symbol}</span>
-      {showName && <span className={`text-xs text-gray-300 ${showFullName ? '' : 'truncate max-w-[130px]'}`}>{ticker.name}</span>}
+      <span className="text-xs font-semibold bg-primary text-primary-text px-1 rounded shrink-0">{ticker.symbol}</span>
+      {showName && <span className={`text-xs text-body ${showFullName ? '' : 'truncate max-w-[130px]'}`}>{ticker.name}</span>}
       {onRemove && (
         <button
           onClick={(e) => {
@@ -28,7 +28,7 @@ export default function TickerBadge({ ticker, showScore = false, showName = fals
             e.stopPropagation();
             onRemove();
           }}
-          className="text-gray-400 hover:text-red-400 -ml-0.5"
+          className="text-muted hover:text-red-400 -ml-0.5"
         >
           <XMarkIcon className="w-3.5 h-3.5" />
         </button>

--- a/insights-ui/src/components/industry-tariff/book-content.tsx
+++ b/insights-ui/src/components/industry-tariff/book-content.tsx
@@ -13,7 +13,7 @@ export default function BookContent({ report, activePage }: BookContentProps) {
       <div className="mx-auto max-w-4xl">
         <div className="relative min-h-[calc(100vh-16rem)] rounded-lg block-bg-color p-8 shadow-md">
           {/* Page corner fold effect */}
-          <div className="absolute right-0 top-0 h-12 w-12 bg-muted/20">
+          <div className="absolute right-0 top-0 h-12 w-12 bg-surface-2">
             <div className="absolute right-0 top-0 h-0 w-0 border-l-[48px] border-b-[48px] border-l-transparent border-b-[var(--block-bg)]"></div>
           </div>
 

--- a/insights-ui/src/components/industry-tariff/collapsible-layout.tsx
+++ b/insights-ui/src/components/industry-tariff/collapsible-layout.tsx
@@ -42,7 +42,7 @@ export default function CollapsibleLayout({ children, basePath, lastModified }: 
         <div className="flex-1 bg-background p-2 sm:p-3 lg:p-4">
           <div className={cn('mx-auto transition-all duration-300', isSidebarOpen ? 'max-w-4xl' : 'max-w-6xl')}>
             <div className="relative min-h-[calc(100vh-10rem)] rounded-lg block-bg-color p-2 sm:p-2 lg:p-4 shadow-md">
-              <div className="absolute right-0 top-0 h-12 w-12 bg-muted/20">
+              <div className="absolute right-0 top-0 h-12 w-12 bg-surface-2">
                 <div className="absolute right-0 top-0 h-0 w-0 border-l-[48px] border-b-[48px] border-l-transparent border-b-[var(--block-bg)]"></div>
               </div>
 

--- a/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
+++ b/insights-ui/src/components/industry-tariff/report-left-navigation.tsx
@@ -49,12 +49,12 @@ export default function ReportLeftNavigation({
           <h2 className="text-xl font-bold">Explore Report</h2>
           <div className="flex items-center gap-2">
             {showToggle && onToggle && (
-              <button onClick={onToggle} className="p-1 rounded-md hover:bg-muted transition-colors" title="Hide navigation">
+              <button onClick={onToggle} className="p-1 rounded-md hover:bg-surface-2 transition-colors" title="Hide navigation">
                 <X className="h-5 w-5" />
               </button>
             )}
             {isMobile && (
-              <Link href={basePath} className="p-1 rounded-full hover:bg-muted link-color" onClick={handleNavClick}>
+              <Link href={basePath} className="p-1 rounded-full hover:bg-surface-2 link-color" onClick={handleNavClick}>
                 <Home className="h-5 w-5" />
               </Link>
             )}

--- a/insights-ui/src/components/rjsf/SelectWidget/SelectWidget.tsx
+++ b/insights-ui/src/components/rjsf/SelectWidget/SelectWidget.tsx
@@ -74,14 +74,14 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
       aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {!multiple && schema.default === undefined && (
-        <option value="" className="bg-muted">
+        <option value="" className="bg-surface-2">
           {placeholder}
         </option>
       )}
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any = Array.isArray(enumDisabled) && (enumDisabled as any).indexOf(value) != -1;
         return (
-          <option key={i} id={label} value={String(i)} disabled={disabled} className="bg-muted">
+          <option key={i} id={label} value={String(i)} disabled={disabled} className="bg-surface-2">
             {label}
           </option>
         );

--- a/insights-ui/src/components/stocks/AllStocksGridForCountry.tsx
+++ b/insights-ui/src/components/stocks/AllStocksGridForCountry.tsx
@@ -30,7 +30,7 @@ export default function AllStocksGridForCountry({ stocks, stocksPromise, country
         const displayExchange = formatExchangeWithCountry(stock.exchange);
 
         return (
-          <div key={stock.id} className="bg-gray-900 rounded-lg border border-color p-3 hover:bg-[#2D3748] transition-colors">
+          <div key={stock.id} className="bg-surface rounded-lg border border-color p-3 hover:bg-surface-2 transition-colors">
             <StockTickerItem
               symbol={stock.symbol}
               name={stock.name}

--- a/insights-ui/src/components/stocks/AllStocksGridForCountry.tsx
+++ b/insights-ui/src/components/stocks/AllStocksGridForCountry.tsx
@@ -30,7 +30,7 @@ export default function AllStocksGridForCountry({ stocks, stocksPromise, country
         const displayExchange = formatExchangeWithCountry(stock.exchange);
 
         return (
-          <div key={stock.id} className="bg-surface rounded-lg border border-color p-3 hover:bg-surface-2 transition-colors">
+          <div key={stock.id} className="bg-surface rounded-lg border border-color p-3 hover:bg-surface-3 transition-colors">
             <StockTickerItem
               symbol={stock.symbol}
               name={stock.name}

--- a/insights-ui/src/components/stocks/CompactIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactIndustryCard.tsx
@@ -16,11 +16,11 @@ export default function CompactIndustryCard({ industryKey, industryName, topTick
 
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-[#374151] hover:bg-[#2D3748] transition-colors">
+      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-1 text-left flex justify-between items-start" title={industryName}>
           {/* Wrap long headings instead of truncating */}
           <span className="whitespace-normal break-words mr-2">{industryName}</span>
-          <span className="text-[#F59E0B] hover:text-[#F97316] transition-colors text-sm flex-shrink-0">→</span>
+          <span className="text-link hover:text-[#F97316] transition-colors text-sm flex-shrink-0">→</span>
         </h3>
       </Link>
 
@@ -36,13 +36,13 @@ export default function CompactIndustryCard({ industryKey, industryName, topTick
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
                     prefetch={false}
-                    className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>
                       <span className={`${textColorClass} text-xs font-mono w-8 text-right`}>{score}/25</span>
                     </p>
-                    <span className="text-xs font-medium bg-[#4F46E5] text-white ml-1.5 px-1.5 py-0.5 rounded">{ticker.symbol}</span>
-                    <span className="text-xs text-white truncate">{ticker.name}</span>
+                    <span className="text-xs font-medium bg-primary text-primary-text ml-1.5 px-1.5 py-0.5 rounded">{ticker.symbol}</span>
+                    <span className="text-xs text-heading truncate">{ticker.name}</span>
                   </Link>
                 </li>
               );

--- a/insights-ui/src/components/stocks/CompactIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactIndustryCard.tsx
@@ -16,7 +16,7 @@ export default function CompactIndustryCard({ industryKey, industryName, topTick
 
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
+      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-3 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-1 text-left flex justify-between items-start" title={industryName}>
           {/* Wrap long headings instead of truncating */}
           <span className="whitespace-normal break-words mr-2">{industryName}</span>
@@ -36,7 +36,7 @@ export default function CompactIndustryCard({ industryKey, industryName, topTick
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
                     prefetch={false}
-                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-3 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>
                       <span className={`${textColorClass} text-xs font-mono w-8 text-right`}>{score}/25</span>

--- a/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
@@ -14,7 +14,7 @@ export default function CompactSubIndustryCard({ industryKey, subIndustryName, t
   const sortedTickers = tickers.sort((t1, t2) => (t2.cachedScoreEntry?.finalScore || 0) - (t1.cachedScoreEntry?.finalScore || 0)).slice(0, 3);
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
+      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-3 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-1 text-left flex justify-between items-start" title={subIndustryName}>
           <span className="whitespace-normal break-words mr-2">{subIndustryName}</span>
         </h3>
@@ -32,7 +32,7 @@ export default function CompactSubIndustryCard({ industryKey, subIndustryName, t
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
                     prefetch={false}
-                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-3 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>
                       <span className={`${textColorClass} text-xs font-mono w-8 text-right`}>{score}/25</span>

--- a/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/CompactSubIndustryCard.tsx
@@ -14,7 +14,7 @@ export default function CompactSubIndustryCard({ industryKey, subIndustryName, t
   const sortedTickers = tickers.sort((t1, t2) => (t2.cachedScoreEntry?.finalScore || 0) - (t1.cachedScoreEntry?.finalScore || 0)).slice(0, 3);
   return (
     <div className="bg-block-bg-color rounded-lg border border-color overflow-hidden">
-      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-[#374151] hover:bg-[#2D3748] transition-colors">
+      <Link href={`/stocks/industries/${encodeURIComponent(industryKey)}`} className="block px-3 py-1.5 bg-surface-2 hover:bg-surface-2 transition-colors">
         <h3 className="text-sm font-semibold heading-color leading-snug mb-1 text-left flex justify-between items-start" title={subIndustryName}>
           <span className="whitespace-normal break-words mr-2">{subIndustryName}</span>
         </h3>
@@ -32,13 +32,13 @@ export default function CompactSubIndustryCard({ industryKey, subIndustryName, t
                   <Link
                     href={`/stocks/${ticker.exchange}/${ticker.symbol}`}
                     prefetch={false}
-                    className="flex items-center gap-1.5 py-1 hover:bg-[#2D3748] transition-colors rounded px-1 -mx-1"
+                    className="flex items-center gap-1.5 py-1 hover:bg-surface-2 transition-colors rounded px-1 -mx-1"
                   >
                     <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right`}>
                       <span className={`${textColorClass} text-xs font-mono w-8 text-right`}>{score}/25</span>
                     </p>
-                    <span className="text-xs font-medium bg-[#4F46E5] text-white ml-1.5 px-1.5 py-0.5 rounded">{ticker.symbol}</span>
-                    <span className="text-xs text-white truncate">{ticker.name}</span>
+                    <span className="text-xs font-medium bg-primary text-primary-text ml-1.5 px-1.5 py-0.5 rounded">{ticker.symbol}</span>
+                    <span className="text-xs text-heading truncate">{ticker.name}</span>
                   </Link>
                 </li>
               );

--- a/insights-ui/src/components/stocks/SelectableSubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/SelectableSubIndustryCard.tsx
@@ -97,7 +97,7 @@ export default function SelectableSubIndustryCard({
           // Regular display mode (original behavior)
           <ul className="divide-y divide-color">
             {tickers.map((ticker) => (
-              <li key={`${ticker.exchange}-${ticker.symbol}`} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
+              <li key={`${ticker.exchange}-${ticker.symbol}`} className="px-3 sm:px-4 py-1.5 hover:bg-surface-3 transition-colors">
                 <div className="min-w-0 w-full">
                   <StockTickerItem symbol={ticker.symbol} name={ticker.name} exchange={ticker.exchange} score={ticker.cachedScoreEntry?.finalScore ?? 0} />
                 </div>
@@ -126,7 +126,7 @@ export default function SelectableSubIndustryCard({
         )}
       </div>
 
-      {tickers.length === 0 && <div className="px-3 sm:px-4 py-8 text-center text-muted dark:text-muted">No tickers found for this sub-industry.</div>}
+      {tickers.length === 0 && <div className="px-3 sm:px-4 py-8 text-center text-muted">No tickers found for this sub-industry.</div>}
     </div>
   );
 }

--- a/insights-ui/src/components/stocks/SelectableSubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/SelectableSubIndustryCard.tsx
@@ -52,7 +52,7 @@ export default function SelectableSubIndustryCard({
   return (
     <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
       {/* Header */}
-      <div className={`px-3 py-2 sm:px-4 border-b border-color bg-[#374151]`}>
+      <div className={`px-3 py-2 sm:px-4 border-b border-color bg-surface-2`}>
         <div className="flex items-center justify-between">
           <h3 className={`text-sm font-semibold heading-color leading-snug break-words ${selectionMode ? 'pr-8' : 'pr-28'}`} title={displayName}>
             {displayName}
@@ -73,20 +73,20 @@ export default function SelectableSubIndustryCard({
       </div>
 
       {/* Company count badge */}
-      <div className="absolute top-2 right-2 z-10 text-[13px] text-white bg-[#4F46E5] px-2 py-0.5 rounded-full" aria-label={companyLabel} title={companyLabel}>
+      <div className="absolute top-2 right-2 z-10 text-[13px] text-heading bg-primary px-2 py-0.5 rounded-full" aria-label={companyLabel} title={companyLabel}>
         {companyLabel}
       </div>
 
       {/* Selection summary (when in selection mode) */}
       {selectionMode && (
-        <div className="px-3 sm:px-4 py-2 bg-gray-100 dark:bg-gray-700 border-b border-color">
+        <div className="px-3 sm:px-4 py-2 bg-surface-2 border-b border-color">
           <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600 dark:text-gray-300">
+            <span className="text-muted">
               {selectedTickerIds.length === 0 && 'No tickers selected'}
               {selectedTickerIds.length > 0 && `${selectedTickerIds.length} of ${tickers.length} selected`}
             </span>
-            {someSelected && <span className="text-blue-600 dark:text-blue-400 font-medium">Partial Selection</span>}
-            {allSelected && <span className="text-green-600 dark:text-green-400 font-medium">All Selected</span>}
+            {someSelected && <span className="text-sky-300 font-medium">Partial Selection</span>}
+            {allSelected && <span className="text-emerald-300 font-medium">All Selected</span>}
           </div>
         </div>
       )}
@@ -97,7 +97,7 @@ export default function SelectableSubIndustryCard({
           // Regular display mode (original behavior)
           <ul className="divide-y divide-color">
             {tickers.map((ticker) => (
-              <li key={`${ticker.exchange}-${ticker.symbol}`} className="px-3 sm:px-4 py-1.5 hover:bg-[#2D3748] transition-colors">
+              <li key={`${ticker.exchange}-${ticker.symbol}`} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
                 <div className="min-w-0 w-full">
                   <StockTickerItem symbol={ticker.symbol} name={ticker.name} exchange={ticker.exchange} score={ticker.cachedScoreEntry?.finalScore ?? 0} />
                 </div>
@@ -126,7 +126,7 @@ export default function SelectableSubIndustryCard({
         )}
       </div>
 
-      {tickers.length === 0 && <div className="px-3 sm:px-4 py-8 text-center text-gray-500 dark:text-gray-400">No tickers found for this sub-industry.</div>}
+      {tickers.length === 0 && <div className="px-3 sm:px-4 py-8 text-center text-muted dark:text-muted">No tickers found for this sub-industry.</div>}
     </div>
   );
 }

--- a/insights-ui/src/components/stocks/StockTickerItem.tsx
+++ b/insights-ui/src/components/stocks/StockTickerItem.tsx
@@ -46,10 +46,10 @@ export default function StockTickerItem({ symbol, name, exchange, score, display
           <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[45px] text-right shrink-0`}>
             <span className="font-mono tabular-nums text-right text-xs">{score}/25</span>
           </p>
-          <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-[#4F46E5] text-white self-center shadow-sm shrink-0">{symbol}</p>
-          <p className="text-sm font-medium text-break break-words text-white truncate min-w-0 flex-1">{name}</p>
-          {industry && <p className="text-xs font-medium text-gray-400 whitespace-nowrap shrink-0 ml-2">{industry}</p>}
-          {displayExchange && !industry && <p className="text-xs font-medium text-gray-400 whitespace-nowrap shrink-0 ml-2">{displayExchange}</p>}
+          <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-primary text-primary-text self-center shadow-sm shrink-0">{symbol}</p>
+          <p className="text-sm font-medium text-break break-words text-heading truncate min-w-0 flex-1">{name}</p>
+          {industry && <p className="text-xs font-medium text-muted whitespace-nowrap shrink-0 ml-2">{industry}</p>}
+          {displayExchange && !industry && <p className="text-xs font-medium text-muted whitespace-nowrap shrink-0 ml-2">{displayExchange}</p>}
           {tickerNotes && (
             <button onClick={handleNotesClick} className="shrink-0" title="View notes">
               <DocumentTextIcon className="w-4 h-4 text-green-300 hover:text-green-200" />

--- a/insights-ui/src/components/stocks/SubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/SubIndustryCard.tsx
@@ -29,7 +29,7 @@ export default function SubIndustryCard({ subIndustry, subIndustryName, tickers,
       {/* ----- LIST ----- */}
       <ul className="divide-y divide-color flex-1">
         {tickers.map((ticker) => (
-          <li key={ticker.symbol} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
+          <li key={ticker.symbol} className="px-3 sm:px-4 py-1.5 hover:bg-surface-3 transition-colors">
             <div className="min-w-0 w-full">
               <StockTickerItem
                 symbol={ticker.symbol}

--- a/insights-ui/src/components/stocks/SubIndustryCard.tsx
+++ b/insights-ui/src/components/stocks/SubIndustryCard.tsx
@@ -18,18 +18,18 @@ export default function SubIndustryCard({ subIndustry, subIndustryName, tickers,
 
   return (
     <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
-      <div className={`px-3 py-2 sm:px-4 border-b border-color bg-[#374151]`}>
+      <div className={`px-3 py-2 sm:px-4 border-b border-color bg-surface-2`}>
         <h3 className="text-sm font-semibold heading-color leading-snug break-words pr-24" title={displayName}>
           {displayName}
         </h3>
       </div>
-      <div className="absolute top-2 right-2 z-10 text-[13px] text-white bg-[#4F46E5] px-2 py-0.5 rounded-full" aria-label={companyLabel} title={companyLabel}>
+      <div className="absolute top-2 right-2 z-10 text-[13px] text-heading bg-primary px-2 py-0.5 rounded-full" aria-label={companyLabel} title={companyLabel}>
         {companyLabel}
       </div>
       {/* ----- LIST ----- */}
       <ul className="divide-y divide-color flex-1">
         {tickers.map((ticker) => (
-          <li key={ticker.symbol} className="px-3 sm:px-4 py-1.5 hover:bg-[#2D3748] transition-colors">
+          <li key={ticker.symbol} className="px-3 sm:px-4 py-1.5 hover:bg-surface-2 transition-colors">
             <div className="min-w-0 w-full">
               <StockTickerItem
                 symbol={ticker.symbol}

--- a/insights-ui/src/components/stocks/SubIndustryCardSkeleton.tsx
+++ b/insights-ui/src/components/stocks/SubIndustryCardSkeleton.tsx
@@ -4,7 +4,7 @@ export function SubIndustryCardSkeleton() {
   return (
     <div className="bg-block-bg-color rounded-lg shadow-lg border border-color overflow-hidden flex flex-col">
       <div className="px-3 py-2 sm:px-4 border-b border-color bg-surface-2">
-        <div className="h-4 w-40 rounded bg-surface-2 animate-pulse" />
+        <div className="h-4 w-40 rounded bg-surface-3 animate-pulse" />
       </div>
       <ul className="divide-y divide-color p-2">
         <li className="py-2">

--- a/insights-ui/src/components/stocks/SubIndustryCardSkeleton.tsx
+++ b/insights-ui/src/components/stocks/SubIndustryCardSkeleton.tsx
@@ -3,21 +3,21 @@
 export function SubIndustryCardSkeleton() {
   return (
     <div className="bg-block-bg-color rounded-lg shadow-lg border border-color overflow-hidden flex flex-col">
-      <div className="px-3 py-2 sm:px-4 border-b border-color bg-gradient-to-r from-[#374151] to-[#2D3748]">
-        <div className="h-4 w-40 rounded bg-[#4B5563] animate-pulse" />
+      <div className="px-3 py-2 sm:px-4 border-b border-color bg-surface-2">
+        <div className="h-4 w-40 rounded bg-surface-2 animate-pulse" />
       </div>
       <ul className="divide-y divide-color p-2">
         <li className="py-2">
-          <div className="h-5 w-full rounded bg-[#374151] animate-pulse" />
+          <div className="h-5 w-full rounded bg-surface-2 animate-pulse" />
         </li>
         <li className="py-2">
-          <div className="h-5 w-11/12 rounded bg-[#374151] animate-pulse" />
+          <div className="h-5 w-11/12 rounded bg-surface-2 animate-pulse" />
         </li>
         <li className="py-2">
-          <div className="h-5 w-10/12 rounded bg-[#374151] animate-pulse" />
+          <div className="h-5 w-10/12 rounded bg-surface-2 animate-pulse" />
         </li>
         <li className="py-2">
-          <div className="h-5 w-9/12 rounded bg-[#374151] animate-pulse" />
+          <div className="h-5 w-9/12 rounded bg-surface-2 animate-pulse" />
         </li>
       </ul>
     </div>

--- a/insights-ui/src/components/ticker-reportsv1/BusinessAndMoat.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/BusinessAndMoat.tsx
@@ -24,7 +24,7 @@ export default function BusinessAndMoat({ tickerData, data }: BusinessAndMoatPro
       categoryResult={categoryResult}
       analysisTitle={analysisTitle}
       categoryBadgeText="Business & Moat"
-      categoryBadgeClassName="bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-300"
+      categoryBadgeClassName="bg-sky-500/15 border border-sky-500/40 text-sky-300"
       pageSlug="business-and-moat"
     />
   );

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -95,7 +95,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-      <article className="bg-gray-900 rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
+      <article className="bg-surface rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         {/* Hidden datePublished for schema - machine readable only */}
         <meta itemProp="datePublished" content={publishedDate.toISOString()} />
 
@@ -107,7 +107,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
                 {analysisTitle}
               </h1>
               <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
-                <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+                <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
                   {tickerData.exchange}
                 </span>
                 <span className="text-muted-foreground">•</span>
@@ -161,12 +161,12 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
                           />
                           <div className="min-w-0">
                             <div className="flex items-baseline gap-2 flex-wrap">
-                              <span className={dp.isMainTicker ? 'font-semibold text-amber-400' : 'text-gray-200 group-hover:text-[#F59E0B] transition-colors'}>
+                              <span className={dp.isMainTicker ? 'font-semibold text-amber-400' : 'text-body group-hover:text-link transition-colors'}>
                                 {dp.companyName}
                               </span>
-                              <span className={dp.isMainTicker ? 'text-amber-400 text-xs' : 'text-gray-500 text-xs'}>({dp.ticker})</span>
+                              <span className={dp.isMainTicker ? 'text-amber-400 text-xs' : 'text-muted text-xs'}>({dp.ticker})</span>
                             </div>
-                            <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                            <div className="flex items-center gap-2 text-xs text-muted mt-0.5">
                               <span>{dp.classification}</span>
                               <span>·</span>
                               <span>Quality {dp.qualityScore.toFixed(0)}%</span>
@@ -291,10 +291,10 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
               </time>
             </div>
             <div className="flex gap-2">
-              <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+              <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
                 Stock Analysis
               </span>
-              <span className="inline-flex items-center rounded-full bg-purple-100 dark:bg-purple-900 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:text-purple-300">
+              <span className="inline-flex items-center rounded-full bg-indigo-500/15 border border-indigo-500/40 px-2.5 py-0.5 text-xs font-medium text-indigo-300">
                 Competitive Analysis
               </span>
             </div>

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -57,7 +57,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
 
   return (
     <section id="competition">
-      <div className="bg-surface rounded-lg shadow-sm p-3 sm:p-6">
+      <div className="bg-surface-2 rounded-lg shadow-sm p-3 sm:p-6">
         <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-border">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -57,7 +57,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
 
   return (
     <section id="competition">
-      <div className="bg-surface-2 rounded-lg shadow-sm p-3 sm:p-6">
+      <div className="bg-surface rounded-lg shadow-sm p-3 sm:p-6">
         <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-border">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -57,13 +57,13 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
 
   return (
     <section id="competition">
-      <div className="bg-gray-900 rounded-lg shadow-sm p-3 sm:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-gray-700">
+      <div className="bg-surface rounded-lg shadow-sm p-3 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-border">
           <h2 className="text-xl font-bold">Competition</h2>
           <Link
             href={`/stocks/${exchange}/${ticker}/competition`}
             prefetch={false}
-            className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
+            className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold text-heading shadow-sm hover:opacity-90 transition-opacity whitespace-nowrap"
             style={{ backgroundColor: 'var(--primary-color, #3b82f6)' }}
           >
             View Full Analysis →
@@ -73,7 +73,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
         <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
           <div className="lg:w-1/2">
             <h3 className="text-lg font-semibold text-color mb-3">Quality vs Value Comparison</h3>
-            <p className="text-sm text-gray-400 mb-4">
+            <p className="text-sm text-muted mb-4">
               Compare {tickerData.name} ({tickerData.symbol}) against key competitors on quality and value metrics.
             </p>
 
@@ -99,12 +99,12 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
                     />
                     <div className="min-w-0">
                       <div className="flex items-baseline gap-2 flex-wrap">
-                        <span className={dp.isMainTicker ? 'font-semibold text-amber-400' : 'text-gray-200 group-hover:text-[#F59E0B] transition-colors'}>
+                        <span className={dp.isMainTicker ? 'font-semibold text-amber-400' : 'text-body group-hover:text-link transition-colors'}>
                           {dp.companyName}
                         </span>
-                        <span className={dp.isMainTicker ? 'text-amber-400 text-xs' : 'text-gray-500 text-xs'}>({dp.ticker})</span>
+                        <span className={dp.isMainTicker ? 'text-amber-400 text-xs' : 'text-muted text-xs'}>({dp.ticker})</span>
                       </div>
-                      <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                      <div className="flex items-center gap-2 text-xs text-muted mt-0.5">
                         <span>{dp.classification}</span>
                         <span>·</span>
                         <span>Quality {dp.qualityScore.toFixed(0)}%</span>

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionQuadrantChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionQuadrantChart.tsx
@@ -7,12 +7,12 @@ import dynamic from 'next/dynamic';
 function QuadrantSkeleton(): JSX.Element {
   return (
     <div className="animate-pulse max-w-md mx-auto lg:mx-0">
-      <div className="aspect-square bg-gray-800 rounded" />
+      <div className="aspect-square bg-surface-2 rounded" />
       <div className="flex flex-wrap gap-4 mt-3 px-4 justify-center">
-        <div className="h-3 w-20 bg-gray-800 rounded" />
-        <div className="h-3 w-16 bg-gray-800 rounded" />
-        <div className="h-3 w-18 bg-gray-800 rounded" />
-        <div className="h-3 w-20 bg-gray-800 rounded" />
+        <div className="h-3 w-20 bg-surface-2 rounded" />
+        <div className="h-3 w-16 bg-surface-2 rounded" />
+        <div className="h-3 w-18 bg-surface-2 rounded" />
+        <div className="h-3 w-20 bg-surface-2 rounded" />
       </div>
     </div>
   );

--- a/insights-ui/src/components/ticker-reportsv1/FairValue.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FairValue.tsx
@@ -24,7 +24,7 @@ export default function FairValue({ tickerData, data }: FairValueProps): JSX.Ele
       categoryResult={categoryResult}
       analysisTitle={analysisTitle}
       categoryBadgeText="Fair Value"
-      categoryBadgeClassName="bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300"
+      categoryBadgeClassName="bg-amber-500/15 border border-amber-500/40 text-amber-300"
       pageSlug="fair-value"
     />
   );

--- a/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FinancialStatementAnalysis.tsx
@@ -24,7 +24,7 @@ export default function FinancialStatementAnalysis({ tickerData, data }: Financi
       categoryResult={categoryResult}
       analysisTitle={analysisTitle}
       categoryBadgeText="Financial Statements"
-      categoryBadgeClassName="bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300"
+      categoryBadgeClassName="bg-amber-500/15 border border-amber-500/40 text-amber-300"
       pageSlug="financial-statement-analysis"
     />
   );

--- a/insights-ui/src/components/ticker-reportsv1/FloatingNavigation.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FloatingNavigation.tsx
@@ -277,7 +277,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
         aria-label="Open navigation"
         onClick={open}
         className={cx(
-          'fixed z-10 bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 rounded-full shadow-lg transition-all duration-200 hover:scale-105 flex items-center gap-2',
+          'fixed z-10 bg-blue-600 hover:bg-blue-700 text-heading px-4 py-3 rounded-full shadow-lg transition-all duration-200 hover:scale-105 flex items-center gap-2',
           isXL ? 'top-3 right-2' : 'bottom-2 left-2'
         )}
       >
@@ -296,7 +296,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
       aria-label={title}
       aria-modal={panelAriaModal}
       className={cx(
-        'z-50 bg-gray-900 text-white border-l border-gray-700 shadow-xl',
+        'z-50 bg-surface text-heading border-l border-border shadow-xl',
         'w-96 max-w-md', // keep in sync with width prop
         isDocked ? 'fixed top-24 right-0 bottom-6' : 'fixed inset-y-0 right-0 transform transition-transform duration-300 ease-in-out',
         isDocked ? (isOpen ? '' : 'pointer-events-none invisible') : isOpen ? 'translate-x-0' : 'translate-x-full'
@@ -304,9 +304,9 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
       style={{ width: dockWidthPxXL }}
     >
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-700">
+      <div className="flex items-center justify-between p-4 border-b border-border">
         <h2 className="text-lg font-semibold">{title}</h2>
-        <button type="button" aria-label="Close navigation" onClick={close} className="p-2 hover:bg-gray-800 rounded-lg transition-colors">
+        <button type="button" aria-label="Close navigation" onClick={close} className="p-2 hover:bg-surface-2 rounded-lg transition-colors">
           <XMarkIcon className="h-5 w-5" />
         </button>
       </div>
@@ -325,7 +325,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
                   onClick={(): void => scrollToId(s.id)}
                   className={cx(
                     'w-full text-left px-3 py-2 rounded-lg transition-colors duration-200 flex items-center justify-between group',
-                    isSectionActive ? 'bg-blue-600 text-white' : 'hover:bg-gray-800 text-gray-300 hover:text-white'
+                    isSectionActive ? 'bg-blue-600 text-heading' : 'hover:bg-surface-2 text-body hover:text-heading'
                   )}
                   aria-current={activeId === s.id ? 'true' : undefined}
                 >
@@ -342,7 +342,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
                           onClick={(): void => scrollToId(sub.id)}
                           className={cx(
                             'w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors duration-200 flex items-center justify-between group',
-                            activeId === sub.id ? 'bg-blue-500 text-white' : 'hover:bg-gray-800 text-gray-400 hover:text-gray-200'
+                            activeId === sub.id ? 'bg-blue-500 text-heading' : 'hover:bg-surface-2 text-muted hover:text-body'
                           )}
                           aria-current={activeId === sub.id ? 'true' : undefined}
                         >
@@ -359,8 +359,8 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
         </ul>
       </nav>
       {/* Footer hint */}
-      <div className="p-4 border-t border-gray-700">
-        <p className="text-sm text-gray-400 text-center">Click a section to jump</p>
+      <div className="p-4 border-t border-border">
+        <p className="text-sm text-muted text-center">Click a section to jump</p>
       </div>
     </div>
   );

--- a/insights-ui/src/components/ticker-reportsv1/FloatingNavigation.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FloatingNavigation.tsx
@@ -306,7 +306,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-border">
         <h2 className="text-lg font-semibold">{title}</h2>
-        <button type="button" aria-label="Close navigation" onClick={close} className="p-2 hover:bg-surface-2 rounded-lg transition-colors">
+        <button type="button" aria-label="Close navigation" onClick={close} className="p-2 hover:bg-surface-3 rounded-lg transition-colors">
           <XMarkIcon className="h-5 w-5" />
         </button>
       </div>
@@ -325,7 +325,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
                   onClick={(): void => scrollToId(s.id)}
                   className={cx(
                     'w-full text-left px-3 py-2 rounded-lg transition-colors duration-200 flex items-center justify-between group',
-                    isSectionActive ? 'bg-blue-600 text-heading' : 'hover:bg-surface-2 text-body hover:text-heading'
+                    isSectionActive ? 'bg-blue-600 text-heading' : 'hover:bg-surface-3 text-body hover:text-heading'
                   )}
                   aria-current={activeId === s.id ? 'true' : undefined}
                 >
@@ -342,7 +342,7 @@ export default function FloatingNavigation(props: FloatingNavigationProps): JSX.
                           onClick={(): void => scrollToId(sub.id)}
                           className={cx(
                             'w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors duration-200 flex items-center justify-between group',
-                            activeId === sub.id ? 'bg-blue-500 text-heading' : 'hover:bg-surface-2 text-muted hover:text-body'
+                            activeId === sub.id ? 'bg-blue-500 text-heading' : 'hover:bg-surface-3 text-muted hover:text-body'
                           )}
                           aria-current={activeId === sub.id ? 'true' : undefined}
                         >

--- a/insights-ui/src/components/ticker-reportsv1/FuturePerformance.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/FuturePerformance.tsx
@@ -24,7 +24,7 @@ export default function FuturePerformance({ tickerData, data }: FuturePerformanc
       categoryResult={categoryResult}
       analysisTitle={analysisTitle}
       categoryBadgeText="Future Performance"
-      categoryBadgeClassName="bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300"
+      categoryBadgeClassName="bg-indigo-500/15 border border-indigo-500/40 text-indigo-300"
       pageSlug="future-performance"
     />
   );

--- a/insights-ui/src/components/ticker-reportsv1/PastPerformance.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PastPerformance.tsx
@@ -24,7 +24,7 @@ export default function PastPerformance({ tickerData, data }: PastPerformancePro
       categoryResult={categoryResult}
       analysisTitle={analysisTitle}
       categoryBadgeText="Past Performance"
-      categoryBadgeClassName="bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300"
+      categoryBadgeClassName="bg-emerald-500/15 border border-emerald-500/40 text-emerald-300"
       pageSlug="past-performance"
     />
   );

--- a/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
@@ -164,7 +164,7 @@ export default function PriceChart({ data, embedded = false, range, hideRangeBut
           key={r}
           onClick={() => setSelectedRange(r)}
           className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-            selectedRange === r ? 'text-white' : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100'
+            selectedRange === r ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
           }`}
           style={selectedRange === r ? { backgroundColor: LINE_COLOR.border } : {}}
         >
@@ -179,7 +179,7 @@ export default function PriceChart({ data, embedded = false, range, hideRangeBut
       {hasData ? (
         <Line data={chartData} options={options} />
       ) : (
-        <div className="h-full flex items-center justify-center text-sm text-gray-400">No price data available for this range.</div>
+        <div className="h-full flex items-center justify-center text-sm text-muted">No price data available for this range.</div>
       )}
     </div>
   );
@@ -199,12 +199,12 @@ export default function PriceChart({ data, embedded = false, range, hideRangeBut
   }
 
   return (
-    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
+    <section id="price-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       {/* min-h locks the header height so swapping the lazy skeleton with the rendered chart causes no layout shift. */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4 min-h-[44px]">
         <div>
-          <h3 className="text-lg font-semibold text-gray-100">Price History</h3>
-          {metaLine && <p className="text-xs text-gray-400 mt-1">{metaLine}</p>}
+          <h3 className="text-lg font-semibold text-heading">Price History</h3>
+          {metaLine && <p className="text-xs text-muted mt-1">{metaLine}</p>}
         </div>
         {rangeButtons}
       </div>

--- a/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PriceChart.tsx
@@ -164,7 +164,7 @@ export default function PriceChart({ data, embedded = false, range, hideRangeBut
           key={r}
           onClick={() => setSelectedRange(r)}
           className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-            selectedRange === r ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
+            selectedRange === r ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-3 hover:text-heading'
           }`}
           style={selectedRange === r ? { backgroundColor: LINE_COLOR.border } : {}}
         >

--- a/insights-ui/src/components/ticker-reportsv1/PriceChartLazy.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/PriceChartLazy.tsx
@@ -28,21 +28,21 @@ interface PriceChartLazyProps {
 
 function PriceChartSkeleton(): JSX.Element {
   return (
-    <section id="price-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
+    <section id="price-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       {/* min-h matches the real chart's header row (text-lg title + text-xs meta + mt-1 = ~44px). */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4 min-h-[44px]">
         <div>
-          <div className="h-6 w-32 rounded bg-gray-800 animate-pulse" />
-          <div className="h-3 w-20 rounded bg-gray-800 animate-pulse mt-1" />
+          <div className="h-6 w-32 rounded bg-surface-2 animate-pulse" />
+          <div className="h-3 w-20 rounded bg-surface-2 animate-pulse mt-1" />
         </div>
         <div className="flex flex-wrap gap-2">
           {/* h-7 = 28px, matching the real button's px-3 py-1.5 text-xs = ~28px total height. */}
           {['1M', '6M', '1Y', '3Y', '5Y'].map((label) => (
-            <div key={label} className="h-7 w-12 rounded-md bg-gray-800 animate-pulse" />
+            <div key={label} className="h-7 w-12 rounded-md bg-surface-2 animate-pulse" />
           ))}
         </div>
       </div>
-      <div className="h-64 sm:h-72 rounded bg-gray-800 animate-pulse" />
+      <div className="h-64 sm:h-72 rounded bg-surface-2 animate-pulse" />
     </section>
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
@@ -145,7 +145,7 @@ export default function QuarterlyMetricsChart({ data }: QuarterlyMetricsChartPro
               key={metric}
               onClick={() => setSelectedMetric(metric)}
               className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                selectedMetric === metric ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
+                selectedMetric === metric ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-3 hover:text-heading'
               }`}
               style={selectedMetric === metric ? { backgroundColor: METRIC_COLORS[metric].border } : {}}
             >

--- a/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChart.tsx
@@ -132,14 +132,12 @@ export default function QuarterlyMetricsChart({ data }: QuarterlyMetricsChartPro
   }
 
   return (
-    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
+    <section id="quarterly-metrics-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       {/* min-h locks the header height so swapping the lazy skeleton with the rendered chart causes no layout shift. */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4 min-h-[44px]">
         <div>
-          <h3 className="text-lg font-semibold text-gray-100">
-            {data.dataFrequency === 'annual' ? 'Annual Financial Metrics' : 'Quarterly Financial Metrics'}
-          </h3>
-          {metaInfo.length > 0 && <p className="text-xs text-gray-400 mt-1">{metaInfo.join(' • ')}</p>}
+          <h3 className="text-lg font-semibold text-heading">{data.dataFrequency === 'annual' ? 'Annual Financial Metrics' : 'Quarterly Financial Metrics'}</h3>
+          {metaInfo.length > 0 && <p className="text-xs text-muted mt-1">{metaInfo.join(' • ')}</p>}
         </div>
         <div className="flex flex-wrap gap-2">
           {data.availableMetrics.map((metric) => (
@@ -147,7 +145,7 @@ export default function QuarterlyMetricsChart({ data }: QuarterlyMetricsChartPro
               key={metric}
               onClick={() => setSelectedMetric(metric)}
               className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                selectedMetric === metric ? 'text-white' : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100'
+                selectedMetric === metric ? 'text-heading' : 'bg-surface-2 text-body hover:bg-surface-2 hover:text-heading'
               }`}
               style={selectedMetric === metric ? { backgroundColor: METRIC_COLORS[metric].border } : {}}
             >

--- a/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChartLazy.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/QuarterlyMetricsChartLazy.tsx
@@ -17,22 +17,22 @@ interface QuarterlyMetricsChartLazyProps {
 
 function QuarterlyMetricsChartSkeleton(): JSX.Element {
   return (
-    <section id="quarterly-metrics-chart" className="bg-gray-900 rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
+    <section id="quarterly-metrics-chart" className="bg-surface rounded-lg shadow-sm px-2 py-3 sm:p-4 mb-6">
       {/* min-h matches the real chart's header row (text-lg title + text-xs meta + mt-1 = ~44px). */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4 min-h-[44px]">
         <div>
-          <div className="h-6 w-56 rounded bg-gray-800 animate-pulse" />
-          <div className="h-3 w-24 rounded bg-gray-800 animate-pulse mt-1" />
+          <div className="h-6 w-56 rounded bg-surface-2 animate-pulse" />
+          <div className="h-3 w-24 rounded bg-surface-2 animate-pulse mt-1" />
         </div>
         <div className="flex flex-wrap gap-2">
           {/* h-7 matches the real button's 28px effective height. Always 6 placeholders;
               real chart may have fewer (1–6) — see PR description for the residual mobile-wrap consideration. */}
           {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="h-7 w-16 rounded-md bg-gray-800 animate-pulse" />
+            <div key={i} className="h-7 w-16 rounded-md bg-surface-2 animate-pulse" />
           ))}
         </div>
       </div>
-      <div className="h-64 sm:h-72 rounded bg-gray-800 animate-pulse" />
+      <div className="h-64 sm:h-72 rounded bg-surface-2 animate-pulse" />
     </section>
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
@@ -34,7 +34,7 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
               <div className="flex flex-col gap-y-2">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-x-2">
-                    <h3 className="font-semibold text-lg  text-link group-hover:text-link transition-colors">{similarTicker.name}</h3>
+                    <h3 className="font-semibold text-lg  text-link group-hover:text-heading transition-colors">{similarTicker.name}</h3>
                     <ArrowTopRightOnSquareIcon className="size-4 text-muted group-hover:text-link transition-colors" />
                   </div>
                 </div>

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
@@ -16,30 +16,30 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
   }
 
   return (
-    <div id="similar-tickers" className="bg-gray-900 rounded-lg shadow-sm p-3 sm:p-6 mb-8">
-      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-gray-700">Top Similar Companies</h2>
-      <p className="text-gray-300 mb-4">Based on industry classification and performance score:</p>
+    <div id="similar-tickers" className="bg-surface rounded-lg shadow-sm p-3 sm:p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4 pb-2 border-b border-border">Top Similar Companies</h2>
+      <p className="text-body mb-4">Based on industry classification and performance score:</p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {similarTickers.map((similarTicker) => {
           const scoreValue: number | '-' = similarTicker.cachedScoreEntry?.finalScore ?? '-';
-          const { textColorClass } = typeof scoreValue === 'number' ? getScoreColorClasses(scoreValue) : { textColorClass: 'text-gray-400' };
+          const { textColorClass } = typeof scoreValue === 'number' ? getScoreColorClasses(scoreValue) : { textColorClass: 'text-muted' };
 
           return (
             <Link
               key={similarTicker.id}
               href={`/stocks/${similarTicker.exchange.toUpperCase()}/${similarTicker.symbol.toUpperCase()}`}
               prefetch={false}
-              className="block bg-gray-800 p-3 sm:p-4 rounded-md border border-gray-700 hover:border-[#F97316] transition-colors group"
+              className="block bg-surface-2 p-3 sm:p-4 rounded-md border border-border hover:border-primary transition-colors group"
             >
               <div className="flex flex-col gap-y-2">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-x-2">
-                    <h3 className="font-semibold text-lg  text-[#F59E0B] group-hover:text-[#F97316] transition-colors">{similarTicker.name}</h3>
-                    <ArrowTopRightOnSquareIcon className="size-4 text-gray-400 group-hover:text-[#F59E0B] transition-colors" />
+                    <h3 className="font-semibold text-lg  text-link group-hover:text-link transition-colors">{similarTicker.name}</h3>
+                    <ArrowTopRightOnSquareIcon className="size-4 text-muted group-hover:text-link transition-colors" />
                   </div>
                 </div>
                 <div className="flex items-center justify-between">
-                  <div className="text-sm text-gray-400">
+                  <div className="text-sm text-muted">
                     {similarTicker.symbol} • {similarTicker.exchange.toUpperCase()}
                   </div>
                   <span className={`text-sm font-medium ${textColorClass}`}>

--- a/insights-ui/src/components/ticker-reportsv1/TickerComparison.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerComparison.tsx
@@ -130,7 +130,7 @@ export function TickerComparison({ comparisonTickers, removeTicker, isModal = fa
             {getCategoryFactorRows().map((row, rowIndex) => (
               <div
                 key={`${row.category}-${row.factorIndex}`}
-                className={`grid ${row.isCategoryHeader ? 'bg-surface-2' : 'hover:bg-surface-2'}`}
+                className={`grid ${row.isCategoryHeader ? 'bg-surface-2' : 'hover:bg-surface-3'}`}
                 style={{ gridTemplateColumns: `minmax(140px, 1fr) repeat(${comparisonTickers.length}, minmax(130px, 1fr))` }}
               >
                 <div className={`px-2 py-3 sticky left-0 text-left min-w-0 bg-surface`}>
@@ -143,7 +143,7 @@ export function TickerComparison({ comparisonTickers, removeTicker, isModal = fa
                 {comparisonTickers.map((ticker) => {
                   if (row.isCategoryHeader) {
                     return (
-                      <div key={`${ticker.symbol}-header`} className="px-1 py-3 text-left" style={{ backgroundColor: 'rgb(17 24 39)' }}>
+                      <div key={`${ticker.symbol}-header`} className="px-1 py-3 text-left" style={{ backgroundColor: 'var(--surface-2)' }}>
                         <span className="text-muted text-sm">-</span>
                       </div>
                     );

--- a/insights-ui/src/components/ticker-reportsv1/TickerComparison.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerComparison.tsx
@@ -95,56 +95,56 @@ export function TickerComparison({ comparisonTickers, removeTicker, isModal = fa
   };
 
   return (
-    <div className="bg-gray-900 rounded-lg overflow-hidden">
+    <div className="bg-surface rounded-lg overflow-hidden">
       <div className="overflow-x-auto">
-        <div className="min-w-full divide-y divide-gray-700">
+        <div className="min-w-full divide-y divide-border">
           {/* Header */}
-          <div className="bg-gray-800 grid" style={{ gridTemplateColumns: `minmax(140px, 1fr) repeat(${comparisonTickers.length}, minmax(130px, 1fr))` }}>
-            <div className="px-2 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider sticky left-0 bg-gray-800">Factors</div>
+          <div className="bg-surface-2 grid" style={{ gridTemplateColumns: `minmax(140px, 1fr) repeat(${comparisonTickers.length}, minmax(130px, 1fr))` }}>
+            <div className="px-2 py-3 text-left text-xs font-medium text-body uppercase tracking-wider sticky left-0 bg-surface-2">Factors</div>
             {comparisonTickers.map((ticker) => (
-              <div key={ticker.symbol} className="px-1 py-3 text-left text-xs font-medium text-gray-300 tracking-wider">
+              <div key={ticker.symbol} className="px-1 py-3 text-left text-xs font-medium text-body tracking-wider">
                 <div className="flex flex-col space-y-1">
                   <div className="flex items-center space-x-1">
                     {ticker.cachedScoreEntry?.finalScore !== undefined ? (
                       <span className={getScoreColorClasses(ticker.cachedScoreEntry.finalScore).textColorClass}>{ticker.cachedScoreEntry.finalScore}/25</span>
                     ) : (
-                      <span className="text-gray-400">-/25</span>
+                      <span className="text-muted">-/25</span>
                     )}
                     <span className="ml-1 font-bold">{ticker.symbol}</span>
                     <button
                       onClick={() => removeTicker(ticker.symbol)}
-                      className="text-gray-400 hover:text-red-400 flex-shrink-0"
+                      className="text-muted hover:text-red-400 flex-shrink-0"
                       disabled={comparisonTickers.length === 1}
                     >
                       <XMarkIcon className="h-3 w-3" />
                     </button>
                   </div>
-                  <div className="text-xs text-gray-400 truncate">{ticker.name}</div>
+                  <div className="text-xs text-muted truncate">{ticker.name}</div>
                 </div>
               </div>
             ))}
           </div>
 
           {/* Body */}
-          <div className="bg-gray-900 divide-y divide-gray-700">
+          <div className="bg-surface divide-y divide-border">
             {getCategoryFactorRows().map((row, rowIndex) => (
               <div
                 key={`${row.category}-${row.factorIndex}`}
-                className={`grid ${row.isCategoryHeader ? 'bg-gray-800' : 'hover:bg-gray-800'}`}
+                className={`grid ${row.isCategoryHeader ? 'bg-surface-2' : 'hover:bg-surface-2'}`}
                 style={{ gridTemplateColumns: `minmax(140px, 1fr) repeat(${comparisonTickers.length}, minmax(130px, 1fr))` }}
               >
-                <div className={`px-2 py-3 sticky left-0 text-left min-w-0 bg-gray-900`}>
+                <div className={`px-2 py-3 sticky left-0 text-left min-w-0 bg-surface`}>
                   {row.isCategoryHeader ? (
-                    <div className="font-bold text-gray-100 text-base">{row.categoryName}</div>
+                    <div className="font-bold text-heading text-base">{row.categoryName}</div>
                   ) : (
-                    <div className="text-gray-300 text-sm leading-tight pl-4 break-words overflow-wrap-anywhere">{row.factorTitle}</div>
+                    <div className="text-body text-sm leading-tight pl-4 break-words overflow-wrap-anywhere">{row.factorTitle}</div>
                   )}
                 </div>
                 {comparisonTickers.map((ticker) => {
                   if (row.isCategoryHeader) {
                     return (
                       <div key={`${ticker.symbol}-header`} className="px-1 py-3 text-left" style={{ backgroundColor: 'rgb(17 24 39)' }}>
-                        <span className="text-gray-400 text-sm">-</span>
+                        <span className="text-muted text-sm">-</span>
                       </div>
                     );
                   }
@@ -165,10 +165,10 @@ export function TickerComparison({ comparisonTickers, removeTicker, isModal = fa
                               {factorResult.result}
                             </span>
                           </div>
-                          <div className="text-xs text-gray-400 leading-tight break-words">{factorResult.explanation}</div>
+                          <div className="text-xs text-muted leading-tight break-words">{factorResult.explanation}</div>
                         </div>
                       ) : (
-                        <span className="text-gray-500 text-sm">-</span>
+                        <span className="text-muted text-sm">-</span>
                       )}
                     </div>
                   );

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -98,7 +98,7 @@ export default function TickerRelatedSections({
             <Link
               href={`/stocks/${ex}/${tk}/${s.slug}`}
               prefetch={false}
-              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface-2 hover:bg-surface-2 text-body hover:text-heading transition-colors"
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface-2 hover:bg-surface-3 text-body hover:text-heading transition-colors"
             >
               {s.label} &rarr;
             </Link>

--- a/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/TickerRelatedSections.tsx
@@ -98,7 +98,7 @@ export default function TickerRelatedSections({
             <Link
               href={`/stocks/${ex}/${tk}/${s.slug}`}
               prefetch={false}
-              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface-2 hover:bg-surface-2 text-body hover:text-heading transition-colors"
             >
               {s.label} &rarr;
             </Link>

--- a/insights-ui/src/components/ui/EmptyStateCard.tsx
+++ b/insights-ui/src/components/ui/EmptyStateCard.tsx
@@ -15,7 +15,7 @@ interface EmptyStateCardProps {
   /** Label for the call-to-action link. */
   ctaLabel?: string;
   /**
-   * `card` renders a padded `bg-gray-800 rounded-lg p-8 text-center` box with an optional
+   * `card` renders a padded `bg-surface rounded-lg p-8 text-center` box with an optional
    * icon, title, description and CTA. `inline` renders lightweight centered text intended for
    * the simple grid "no results" messages.
    */
@@ -38,21 +38,21 @@ export default function EmptyStateCard({
   if (variant === 'inline') {
     return (
       <div className={`text-center py-12${className ? ` ${className}` : ''}`}>
-        {title && <p className="text-[#E5E7EB] text-lg">{title}</p>}
-        {description && <p className="text-[#E5E7EB] text-sm mt-2">{description}</p>}
+        {title && <p className="text-body text-lg">{title}</p>}
+        {description && <p className="text-body text-sm mt-2">{description}</p>}
       </div>
     );
   }
 
   return (
-    <div className={`bg-gray-800 rounded-lg p-8 text-center${className ? ` ${className}` : ''}`}>
-      {Icon && <Icon className="w-16 h-16 text-gray-600 mx-auto mb-4" />}
+    <div className={`bg-surface rounded-lg p-8 text-center${className ? ` ${className}` : ''}`}>
+      {Icon && <Icon className="w-16 h-16 text-muted mx-auto mb-4" />}
       {title && <h3 className="text-xl font-semibold mb-2">{title}</h3>}
-      {description && <p className="text-gray-400 mb-4">{description}</p>}
+      {description && <p className="text-muted mb-4">{description}</p>}
       {ctaHref && ctaLabel && (
         <Link
           href={ctaHref}
-          className="inline-flex items-center px-5 py-2.5 bg-blue-600 hover:bg-blue-700 transition-colors rounded-lg text-white text-sm font-semibold"
+          className="inline-flex items-center px-5 py-2.5 bg-primary hover:opacity-90 transition-colors rounded-lg text-primary-text text-sm font-semibold"
         >
           {ctaLabel}
         </Link>

--- a/insights-ui/src/components/ui/Heading.tsx
+++ b/insights-ui/src/components/ui/Heading.tsx
@@ -11,7 +11,7 @@ const heading = cva('', {
   variants: {
     size: { inherit: '', xs: 'text-xs', sm: 'text-sm', md: 'text-base', lg: 'text-lg', xl: 'text-xl', '2xl': 'text-2xl' },
     weight: { medium: 'font-medium', semibold: 'font-semibold', bold: 'font-bold' },
-    tone: { inherit: '', default: 'text-gray-100', bright: 'text-gray-200', white: 'text-white', muted: 'text-gray-400', themed: 'text-body' },
+    tone: { inherit: '', default: 'text-body', bright: 'text-body', white: 'text-heading', muted: 'text-muted', themed: 'text-body' },
   },
   defaultVariants: { size: 'lg', weight: 'semibold', tone: 'default' },
 });

--- a/insights-ui/src/components/ui/MetricCell.tsx
+++ b/insights-ui/src/components/ui/MetricCell.tsx
@@ -9,7 +9,7 @@ import React from 'react';
  * `sentiment` drives the value color: positive (green) / negative (red) /
  * neutral (gray-100) / none (inherit the surrounding text color).
  */
-const cellBox = cva('rounded-md bg-gray-800', {
+const cellBox = cva('rounded-md bg-surface-2', {
   variants: {
     size: { sm: 'px-2 py-1.5', xs: 'px-2 py-1' },
   },
@@ -19,7 +19,7 @@ const cellBox = cva('rounded-md bg-gray-800', {
 const cellValue = cva('font-semibold', {
   variants: {
     size: { sm: 'text-sm', xs: 'text-xs' },
-    sentiment: { positive: 'text-green-400', negative: 'text-red-400', neutral: 'text-gray-100', none: '' },
+    sentiment: { positive: 'text-emerald-400', negative: 'text-red-400', neutral: 'text-body', none: '' },
   },
   defaultVariants: { size: 'sm', sentiment: 'none' },
 });
@@ -35,7 +35,7 @@ export type MetricCellProps = VariantProps<typeof cellBox> & {
 export default function MetricCell({ label, value, size, sentiment, loading = false, className }: MetricCellProps): React.JSX.Element {
   return (
     <div className={cn(cellBox({ size }), className)}>
-      <div className="text-xs text-gray-400 mb-1">{label}</div>
+      <div className="text-xs text-muted mb-1">{label}</div>
       {loading ? <div className="rounded animate-pulse">--</div> : <div className={cn(cellValue({ size, sentiment }))}>{value ?? '—'}</div>}
     </div>
   );

--- a/insights-ui/src/components/ui/PassFailBadge.tsx
+++ b/insights-ui/src/components/ui/PassFailBadge.tsx
@@ -1,5 +1,6 @@
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
+import { badgeTone } from '@/components/ui/badges/badgeTone';
 import React from 'react';
 
 interface PassFailBadgeProps {
@@ -13,11 +14,10 @@ interface PassFailBadgeProps {
 const passFailBadge = cva('px-2 py-1 rounded-full', {
   variants: {
     size: { sm: 'text-sm', xs: 'text-xs' },
-    tone: { pass: 'bg-green-900 text-green-200', fail: 'bg-red-900 text-red-200' },
   },
   defaultVariants: { size: 'sm' },
 });
 
 export default function PassFailBadge({ passed, size = 'sm', passLabel = 'Pass', failLabel = 'Fail', className }: PassFailBadgeProps): React.JSX.Element {
-  return <span className={cn(passFailBadge({ size, tone: passed ? 'pass' : 'fail' }), className)}>{passed ? passLabel : failLabel}</span>;
+  return <span className={cn(passFailBadge({ size }), badgeTone({ tone: passed ? 'success' : 'danger' }), className)}>{passed ? passLabel : failLabel}</span>;
 }

--- a/insights-ui/src/components/ui/StatusBadge.tsx
+++ b/insights-ui/src/components/ui/StatusBadge.tsx
@@ -1,5 +1,6 @@
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
+import { badgeTone, type BadgeTone } from '@/components/ui/badges/badgeTone';
 import React from 'react';
 
 export type StatusBadgeVariant = 'success' | 'warning' | 'neutral' | 'archived';
@@ -14,12 +15,6 @@ interface StatusBadgeProps {
 
 const statusBadge = cva('text-xs', {
   variants: {
-    variant: {
-      success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-      warning: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-      neutral: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
-      archived: 'text-gray-400 bg-gray-800 border border-gray-700',
-    },
     size: {
       xs: 'px-2 py-1 rounded-full',
       sm: 'px-2 py-0.5 rounded',
@@ -28,6 +23,13 @@ const statusBadge = cva('text-xs', {
   defaultVariants: { size: 'xs' },
 });
 
+const VARIANT_TONE: Record<StatusBadgeVariant, BadgeTone> = {
+  success: 'success',
+  warning: 'warning',
+  neutral: 'neutral',
+  archived: 'neutral',
+};
+
 export default function StatusBadge({ variant, label, size = 'xs', className }: StatusBadgeProps): React.JSX.Element {
-  return <span className={cn(statusBadge({ variant, size }), className)}>{label}</span>;
+  return <span className={cn(statusBadge({ size }), badgeTone({ tone: VARIANT_TONE[variant] }), className)}>{label}</span>;
 }

--- a/insights-ui/src/components/ui/Text.tsx
+++ b/insights-ui/src/components/ui/Text.tsx
@@ -10,7 +10,7 @@ const text = cva('', {
   variants: {
     size: { inherit: '', xs: 'text-xs', sm: 'text-sm', base: 'text-base', lg: 'text-lg' },
     weight: { normal: '', medium: 'font-medium', semibold: 'font-semibold', bold: 'font-bold' },
-    tone: { body: 'text-gray-300', muted: 'text-gray-400', subtle: 'text-gray-500', bright: 'text-gray-200', white: 'text-white', theme: 'text-color' },
+    tone: { body: 'text-body', muted: 'text-muted', subtle: 'text-muted', bright: 'text-body', white: 'text-heading', theme: 'text-body' },
     leading: { normal: '', snug: 'leading-snug', relaxed: 'leading-relaxed' },
   },
   defaultVariants: { size: 'sm', weight: 'normal', tone: 'body', leading: 'normal' },

--- a/insights-ui/src/components/ui/badges/badgeTone.ts
+++ b/insights-ui/src/components/ui/badges/badgeTone.ts
@@ -1,0 +1,34 @@
+import { cva } from 'class-variance-authority';
+
+/**
+ * The single chip/badge color vocabulary for the report pages.
+ *
+ * Chips/badges (and buttons) are the ONLY elements allowed to carry color
+ * beyond the structural tokens (`surface`, `text`, `border`, `primary`). Every
+ * badge routes its color through one of these 6 semantic tones — one
+ * translucent `…/15 + border …/40` recipe each — so the whole app reads as a
+ * single badge family instead of ~30 ad-hoc color combinations.
+ *
+ * Map domain meanings onto tones:
+ *   success → pass / positive / "good" / gainer
+ *   danger  → fail / negative / "bad" / loser
+ *   warning → caution / in-progress / medium
+ *   info    → identity / exchange / asset-class / upside
+ *   accent  → special / index / future / competitive
+ *   neutral → archived / past / unknown
+ */
+export const badgeTone = cva('', {
+  variants: {
+    tone: {
+      success: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40',
+      danger: 'bg-red-500/15 text-red-300 border border-red-500/40',
+      warning: 'bg-amber-500/15 text-amber-300 border border-amber-500/40',
+      info: 'bg-sky-500/15 text-sky-300 border border-sky-500/40',
+      accent: 'bg-indigo-500/15 text-indigo-300 border border-indigo-500/40',
+      neutral: 'bg-gray-500/15 text-gray-300 border border-gray-500/40',
+    },
+  },
+  defaultVariants: { tone: 'neutral' },
+});
+
+export type BadgeTone = 'success' | 'danger' | 'warning' | 'info' | 'accent' | 'neutral';

--- a/insights-ui/src/components/ui/sections/CardSection.tsx
+++ b/insights-ui/src/components/ui/sections/CardSection.tsx
@@ -3,11 +3,11 @@ import { cn } from '@/lib/utils';
 import React from 'react';
 
 /**
- * Dark "report section" surface (`bg-gray-900 rounded-lg shadow-sm`) with
+ * Dark "report section" surface (`bg-surface rounded-lg shadow-sm`) with
  * preset padding. Use instead of hand-writing the card chrome on report
  * sections (financial info, holdings, competition, etc.).
  */
-const cardSection = cva('bg-gray-900 rounded-lg shadow-sm', {
+const cardSection = cva('bg-surface rounded-lg shadow-sm', {
   variants: {
     padding: { compact: 'px-2 py-2 sm:p-3', normal: 'px-3 py-6 sm:p-6', flush: '' },
     mt: { none: '', md: 'mt-6' },

--- a/insights-ui/src/components/ui/sections/InlineCard.tsx
+++ b/insights-ui/src/components/ui/sections/InlineCard.tsx
@@ -6,7 +6,7 @@ import React from 'react';
  * Minimal filled info box (`bg-gray-800 rounded-md`) for small grouped content
  * such as a label + explanation. A lighter-weight surface than `CardSection`.
  */
-const inlineCard = cva('bg-gray-800 rounded-md', {
+const inlineCard = cva('bg-surface-2 rounded-md', {
   variants: {
     padding: { snug: 'px-3 py-2', cozy: 'px-3 py-3', roomy: 'p-4', factor: 'px-2 py-4 sm:p-4' },
   },

--- a/insights-ui/src/components/ui/sections/MarkdownContent.tsx
+++ b/insights-ui/src/components/ui/sections/MarkdownContent.tsx
@@ -7,15 +7,15 @@ import React from 'react';
  * Centralizes the `markdown markdown-body …` class recipes that report
  * sections otherwise hand-write next to every `dangerouslySetInnerHTML`.
  *
- * - `summary` — the executive-summary body (`text-color leading-relaxed`).
+ * - `summary` — the executive-summary body (`text-body leading-relaxed`).
  * - `body` — full prose-styled analysis body.
  * - `plain` — bare markdown body (e.g. per-factor detail).
  */
 const markdown = cva('', {
   variants: {
     variant: {
-      summary: 'text-color leading-relaxed',
-      body: 'markdown markdown-body prose-headings:text-color prose-p:text-color prose-strong:text-color prose-code:text-color prose-a:text-primary hover:prose-a:text-primary/80',
+      summary: 'text-body leading-relaxed',
+      body: 'markdown markdown-body prose-headings:text-body prose-p:text-body prose-strong:text-body prose-code:text-body prose-a:text-primary hover:prose-a:text-primary/80',
       plain: 'markdown markdown-body',
     },
   },

--- a/insights-ui/src/components/ui/sections/RelatedSectionsNav.tsx
+++ b/insights-ui/src/components/ui/sections/RelatedSectionsNav.tsx
@@ -26,7 +26,7 @@ export interface RelatedSectionsNavProps {
  */
 export default function RelatedSectionsNav({ ariaLabel, heading, items, className }: RelatedSectionsNavProps): React.JSX.Element {
   return (
-    <nav aria-label={ariaLabel} className={cn('mt-10 pt-6 border-t border-color', className)}>
+    <nav aria-label={ariaLabel} className={cn('mt-10 pt-6 border-t border-border', className)}>
       <h2 className="text-lg font-semibold mb-3">{heading}</h2>
       <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
         {items.map((item) => (
@@ -34,7 +34,7 @@ export default function RelatedSectionsNav({ ariaLabel, heading, items, classNam
             <Link
               href={item.href}
               prefetch={false}
-              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-gray-800 hover:bg-gray-700 text-gray-200 hover:text-white transition-colors"
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface hover:bg-surface-2 text-body hover:text-heading transition-colors"
             >
               {item.label}
             </Link>

--- a/insights-ui/src/components/ui/sections/ReportArticleShell.tsx
+++ b/insights-ui/src/components/ui/sections/ReportArticleShell.tsx
@@ -8,7 +8,7 @@ import React from 'react';
  * border, and responsive padding, plus the schema.org `Article` microdata and
  * the optional `datePublished` meta tag (so SEO can't be omitted per call-site).
  */
-const article = cva('bg-gray-900 rounded-lg shadow-sm border border-color', {
+const article = cva('bg-surface rounded-lg shadow-sm border border-border', {
   variants: {
     // `default` is the normalized standard; `lg` is the wider competition/mover layout.
     padding: { default: 'p-3 sm:p-6 md:p-8', lg: 'p-6 md:p-8' },

--- a/insights-ui/src/components/ui/sections/ReportFooter.tsx
+++ b/insights-ui/src/components/ui/sections/ReportFooter.tsx
@@ -9,10 +9,10 @@ export type ReportTagTone = 'family' | 'competitive' | 'category' | 'movers' | '
 const tag = cva('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', {
   variants: {
     tone: {
-      family: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300',
-      competitive: 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300',
-      category: 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-300',
-      movers: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300',
+      family: 'bg-sky-500/15 text-sky-300 border border-sky-500/40',
+      competitive: 'bg-indigo-500/15 text-indigo-300 border border-indigo-500/40',
+      category: 'bg-amber-500/15 text-amber-300 border border-amber-500/40',
+      movers: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40',
       none: '',
     },
   },
@@ -40,7 +40,7 @@ export interface ReportFooterProps {
  */
 export default function ReportFooter({ modifiedDate, formattedModifiedDate, tags, className }: ReportFooterProps): React.JSX.Element {
   return (
-    <footer className={cn('mt-8 pt-6 border-t border-color', className)}>
+    <footer className={cn('mt-8 pt-6 border-t border-border', className)}>
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="text-sm text-muted-foreground">
           <span>Last updated by </span>

--- a/insights-ui/src/components/ui/sections/ReportSectionHeader.tsx
+++ b/insights-ui/src/components/ui/sections/ReportSectionHeader.tsx
@@ -42,15 +42,15 @@ export default function ReportSectionHeader({
   className,
 }: ReportSectionHeaderProps): React.JSX.Element {
   return (
-    <header className={cn('mb-6 pb-4 border-b border-color', className)}>
+    <header className={cn('mb-6 pb-4 border-b border-border', className)}>
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
         <div className="flex-1">
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-color mb-2" itemProp="headline">
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-body mb-2" itemProp="headline">
             {title}
             {symbol && <span className="text-muted-foreground"> ({symbol})</span>}
           </h1>
           <div className="flex flex-wrap items-center gap-2 md:gap-3 text-sm">
-            <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-300">
+            <span className="inline-flex items-center rounded-full bg-sky-500/15 border border-sky-500/40 px-2.5 py-0.5 text-xs font-medium text-sky-300">
               {exchange}
             </span>
             {score && (

--- a/insights-ui/src/components/ui/sections/SectionHeading.tsx
+++ b/insights-ui/src/components/ui/sections/SectionHeading.tsx
@@ -3,15 +3,15 @@ import { cn } from '@/lib/utils';
 import React from 'react';
 
 /**
- * In-article section heading (the `text-xl font-semibold text-color mb-3` H2
+ * In-article section heading (the `text-xl font-semibold text-body mb-3` H2
  * repeated ~18× across report sections). `bordered` covers the "Summary
- * Analysis"-style header with an underline (normalized to `border-color`).
+ * Analysis"-style header with an underline (normalized to `border-border`).
  */
-const sectionHeading = cva('text-color', {
+const sectionHeading = cva('text-body', {
   variants: {
     size: { md: 'text-xl', sm: 'text-lg' },
     weight: { semibold: 'font-semibold', bold: 'font-bold' },
-    bordered: { true: 'mb-4 pb-2 border-b border-color', false: 'mb-3' },
+    bordered: { true: 'mb-4 pb-2 border-b border-border', false: 'mb-3' },
   },
   defaultVariants: { size: 'md', weight: 'semibold', bordered: false },
 });

--- a/insights-ui/src/components/ui/tabs.tsx
+++ b/insights-ui/src/components/ui/tabs.tsx
@@ -13,7 +13,7 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
-      className={cn('bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]', className)}
+      className={cn('bg-surface-2 text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]', className)}
       {...props}
     />
   );

--- a/insights-ui/src/util/theme-colors.ts
+++ b/insights-ui/src/util/theme-colors.ts
@@ -22,6 +22,7 @@ export const themeColors = {
   '--bg-color': '#111827', // Page background (gray-900)
   '--surface': '#1f2937', // Cards / report sections (gray-800)
   '--surface-2': '#374151', // Inset / inline rows / chips track (gray-700)
+  '--surface-3': '#4b5563', // Raised / hover state — one step above surface-2 (gray-600)
   '--block-bg': '#1f2937', // Legacy alias → surface
 
   // Text

--- a/insights-ui/src/util/theme-colors.ts
+++ b/insights-ui/src/util/theme-colors.ts
@@ -1,13 +1,36 @@
 import { CSSProperties } from 'react';
 
+/**
+ * Single source of truth for the KoalaGains color system. These CSS variables
+ * are injected once on `<body>` (see `src/app/layout.tsx`) and surfaced as
+ * Tailwind color tokens in `tailwind.config.ts`. Components should use the
+ * tokens (`bg-surface`, `text-muted`, `border-border`, …) — NOT raw `bg-gray-*`.
+ *
+ * Structural palette is a deliberate 3-tier dark ramp:
+ *   bg (page) < surface (cards) < surface-2 (inset/inline)
+ * with two text levels (text / text-muted), one heading, one border, one link,
+ * and the brand primary. Everything outside chips/badges/buttons should resolve
+ * to one of these.
+ */
 export const themeColors = {
-  '--primary-color': '#7f78ff', // Indigo-600 for primary actions
-  '--primary-text-color': '#ffffff', // Crisp white text on primary elements
-  '--bg-color': '#1F2937', // Gray-800 for the main background
-  '--text-color': '#D1D5DB', // Gray-300 for body text for good contrast
-  '--link-color': '#a09bff', // Matching the primary color for links
-  '--heading-color': '#ffffff', // White for headings
-  '--border-color': '#374151', // Gray-700 for subtle borders
-  '--block-bg': '#374151', // A slightly lighter dark for block backgrounds
-  '--swiper-theme-color': '#7f78ff', // Consistent with the primary color for Swiper components
+  // Brand
+  '--primary-color': '#7f78ff', // Indigo — primary actions
+  '--primary-text-color': '#ffffff', // Text on primary elements
+  '--link-color': '#a09bff', // Links
+
+  // Surfaces (3-tier ramp)
+  '--bg-color': '#111827', // Page background (gray-900)
+  '--surface': '#1f2937', // Cards / report sections (gray-800)
+  '--surface-2': '#374151', // Inset / inline rows / chips track (gray-700)
+  '--block-bg': '#1f2937', // Legacy alias → surface
+
+  // Text
+  '--heading-color': '#ffffff', // Headings
+  '--text-color': '#e5e7eb', // Body text (gray-200)
+  '--text-muted': '#9ca3af', // Secondary / muted text (gray-400)
+
+  // Lines
+  '--border-color': '#374151', // Borders / dividers (gray-700)
+
+  '--swiper-theme-color': '#7f78ff',
 } as CSSProperties;

--- a/insights-ui/src/util/theme-colors.ts
+++ b/insights-ui/src/util/theme-colors.ts
@@ -27,8 +27,8 @@ export const themeColors = {
 
   // Text
   '--heading-color': '#ffffff', // Headings
-  '--text-color': '#e5e7eb', // Body text (gray-200)
-  '--text-muted': '#9ca3af', // Secondary / muted text (gray-400)
+  '--text-color': '#f3f4f6', // Body text (gray-100) — brightened for readability on dark surfaces
+  '--text-muted': '#cbd5e1', // Secondary / muted text (slate-300) — brightened for readability
 
   // Lines
   '--border-color': '#374151', // Borders / dividers (gray-700)

--- a/insights-ui/tailwind.config.ts
+++ b/insights-ui/tailwind.config.ts
@@ -28,6 +28,7 @@ export default {
         bg: 'var(--bg-color)',
         surface: 'var(--surface)',
         'surface-2': 'var(--surface-2)',
+        'surface-3': 'var(--surface-3)',
 
         // Text — `text-heading` / `text-body` / `text-muted`
         heading: 'var(--heading-color)',

--- a/insights-ui/tailwind.config.ts
+++ b/insights-ui/tailwind.config.ts
@@ -29,18 +29,17 @@ export default {
         surface: 'var(--surface)',
         'surface-2': 'var(--surface-2)',
 
-        // Text
+        // Text — `text-heading` / `text-body` / `text-muted`
         heading: 'var(--heading-color)',
-        text: 'var(--text-color)',
-        'text-muted': 'var(--text-muted)',
+        body: 'var(--text-color)',
+        muted: 'var(--text-muted)',
 
-        // Lines
+        // Lines — `border-border`
         border: 'var(--border-color)',
 
-        // Legacy aliases (kept so existing `bg-block`/`text-body`/`bg-background`
-        // usages keep resolving while call-sites migrate to the canonical names).
+        // Legacy aliases (kept so existing `bg-block`/`bg-background` usages
+        // keep resolving while call-sites migrate to the canonical names).
         background: 'var(--bg-color)',
-        body: 'var(--text-color)',
         block: 'var(--surface)',
         'block-border': 'var(--border-color)',
 
@@ -50,7 +49,6 @@ export default {
         card: 'var(--surface)',
         'card-foreground': 'var(--text-color)',
         foreground: 'var(--text-color)',
-        muted: 'var(--surface-2)',
         'muted-foreground': 'var(--text-muted)',
         input: 'var(--border-color)',
         ring: 'var(--primary-color)',

--- a/insights-ui/tailwind.config.ts
+++ b/insights-ui/tailwind.config.ts
@@ -13,18 +13,48 @@ export default {
   theme: {
     extend: {
       // Semantic color tokens backed by the CSS variables in
-      // `src/util/theme-colors.ts`. Leaf UI components should prefer these
-      // (e.g. `bg-block`, `text-body`) over ad-hoc `bg-gray-*` so theming /
-      // dark-mode stays centralized. Additive: the default palette is unchanged.
+      // `src/util/theme-colors.ts`. Components MUST prefer these
+      // (e.g. `bg-surface`, `text-muted`, `border-border`) over ad-hoc
+      // `bg-gray-*` so the palette stays tiny and theming is centralized.
+      // Outside chips/badges/buttons, only these structural tokens should appear.
       colors: {
+        // Brand
         primary: 'var(--primary-color)',
         'primary-text': 'var(--primary-text-color)',
+        'primary-foreground': 'var(--primary-text-color)',
+        link: 'var(--link-color)',
+
+        // Surfaces (3-tier ramp): bg (page) < surface (cards) < surface-2 (inset)
+        bg: 'var(--bg-color)',
+        surface: 'var(--surface)',
+        'surface-2': 'var(--surface-2)',
+
+        // Text
+        heading: 'var(--heading-color)',
+        text: 'var(--text-color)',
+        'text-muted': 'var(--text-muted)',
+
+        // Lines
+        border: 'var(--border-color)',
+
+        // Legacy aliases (kept so existing `bg-block`/`text-body`/`bg-background`
+        // usages keep resolving while call-sites migrate to the canonical names).
         background: 'var(--bg-color)',
         body: 'var(--text-color)',
-        heading: 'var(--heading-color)',
-        link: 'var(--link-color)',
-        block: 'var(--block-bg)',
+        block: 'var(--surface)',
         'block-border': 'var(--border-color)',
+
+        // Bridge previously-orphaned shadcn token names to the same vars so
+        // `text-muted-foreground`, `bg-card`, etc. resolve consistently instead
+        // of rendering nothing.
+        card: 'var(--surface)',
+        'card-foreground': 'var(--text-color)',
+        foreground: 'var(--text-color)',
+        muted: 'var(--surface-2)',
+        'muted-foreground': 'var(--text-muted)',
+        input: 'var(--border-color)',
+        ring: 'var(--primary-color)',
+        destructive: '#ef4444',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
## Goal

Externalize all colors on the stock + ETF report pages into a tiny semantic palette and make typography (h1/h2/h3, section headings, body text) consistent.

**Targets**
- **Structural colors → ~8 tokens** (`bg`, `surface`, `surface-2`, `text`, `text-muted`, `border`, `primary`, `heading`/`link`). Outside chips/badges/buttons, only these appear.
- **Chips/badges → 5-6 semantic tones** (the only multi-color elements, besides buttons which already route through `var(--primary-color)`).
- **Typography** routed through the `Heading`/`SectionHeading`/`Text`/`MarkdownContent` leaves with one canonical recipe per level.

This is stacked on #1560 (the leaf-component foundation), so the diff shows only the color/typography work.

## Decisions (confirmed with the author)
- **Retune the palette** to a clean 3-tier dark ramp (page `bg` darkest < `surface` < `surface-2`), intentionally adjusting some pixels.
- **Scope: everything on the report pages** — token system + chip consolidation + leaf tokenization + migrate the remaining report chrome (Competition pair, management-team, StockMoverDetails, main pages) and deep components.

## Status (staged, WIP)
- [x] Token foundation: retuned CSS vars + Tailwind tokens + shadcn-name bridge
- [ ] Tokenize the leaf layer (surfaces/text → tokens)
- [ ] Consolidate chips/badges into 5-6 tones
- [ ] Typography canon in the leaves
- [ ] Migrate Competition pair, management-team, StockMoverDetails, main pages
- [ ] Deep components (EtfMorInfo, EtfHoldings, charts) + remaining hand-written headings

⚠️ The retune changes the global theme vars, so please sanity-check the **Vercel preview** visually — I can't screenshot from here.

https://claude.ai/code/session_01JoqKpzpAFG1kdnHq4Rugc4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoqKpzpAFG1kdnHq4Rugc4)_