### PR TITLE
Fix insights-ui Terraform: ECR pull ordering, enable_crons consistency, cleanup

### DIFF
--- a/deployments/insights-ui/cloudfront.tf
+++ b/deployments/insights-ui/cloudfront.tf
@@ -11,8 +11,8 @@
 # from S3 via assetPrefix, so there is no S3 origin/behavior here.
 
 locals {
-  cf_count          = var.manage_cloudfront ? 1 : 0
-  lightsail_origin  = "lightsail-app"
+  cf_count         = var.manage_cloudfront ? 1 : 0
+  lightsail_origin = "lightsail-app"
 }
 
 # CloudFront cert (us-east-1) for the apex once CloudFront fronts the app.

--- a/deployments/insights-ui/container.tf
+++ b/deployments/insights-ui/container.tf
@@ -95,4 +95,9 @@ resource "aws_lightsail_container_service_deployment_version" "app" {
       success_codes       = "200-299"
     }
   }
+
+  # The puller role's ECR access (aws_ecr_repository_policy.pull) is only graph-linked through the
+  # service, not this resource — without an explicit dep Terraform can create this deployment (and
+  # have Lightsail try to pull the image) before the grant exists → "access denied" image pull.
+  depends_on = [aws_ecr_repository_policy.pull]
 }

--- a/deployments/insights-ui/s3_static.tf
+++ b/deployments/insights-ui/s3_static.tf
@@ -58,6 +58,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "assets" {
   rule {
     id     = "expire-old-build-assets"
     status = "Enabled"
+    # Empty filter = apply to every object (the bucket holds only /_next/static build assets).
+    # Required by the provider; without it the rule emits a deprecation warning that becomes a
+    # hard error in a future AWS provider version.
+    filter {}
     # Comfortably exceed the 6-day CloudFront HTML TTL + deploy cadence (object age based, so
     # leave wide margin). There is no Vercel-Skew-Protection equivalent — chunk retention is the
     # only safeguard against a cached page referencing an expired chunk.

--- a/deployments/insights-ui/scheduler.tf
+++ b/deployments/insights-ui/scheduler.tf
@@ -40,7 +40,7 @@ data "archive_file" "cron_invoker" {
       exports.handler = async (event) => {
         const url = process.env.BASE_URL + event.path;
         const r = await fetch(url, { method: "GET" });
-        if (!r.ok) throw new Error(`cron ${event.path} -> ${r.status}`);
+        if (!r.ok) throw new Error(`cron $${event.path} -> $${r.status}`);
         return { status: r.status };
       };
     JS

--- a/deployments/insights-ui/scheduler.tf
+++ b/deployments/insights-ui/scheduler.tf
@@ -1,7 +1,7 @@
-# Replacement for the 4 Vercel crons. The invoker Lambda is always created, but the SCHEDULES
-# are gated by enable_crons (default false) so they don't double-run against the shared RDS
-# while Vercel still owns the crons. Flip enable_crons=true at cut-over (and remove the crons
-# from vercel.json). See the plan.
+# Replacement for the 4 Vercel crons. The invoker Lambda is always created; the SCHEDULES are
+# gated by enable_crons (default true — AWS owns the crons in Phase A and they are removed from
+# vercel.json, so there's a single owner against the shared RDS). Set enable_crons=false only if
+# you intentionally hand cron ownership back to Vercel during coexistence. See the plan.
 
 locals {
   # During coexistence, point crons at the direct host; at cut-over they can target the apex.

--- a/deployments/insights-ui/terraform.tfvars.example
+++ b/deployments/insights-ui/terraform.tfvars.example
@@ -14,9 +14,9 @@ service_power = "medium" # 1 vCPU / 4 GB (Puppeteer headroom); "small" = 2 GB if
 service_scale = 1
 
 # ---- Rollout gates ----
-# Phase A (now): direct prod.koalagains.com, parallel with Vercel. Both OFF.
+# Phase A (now): direct prod.koalagains.com, parallel with Vercel.
 manage_cloudfront = false # Phase B: flip true to put CloudFront in front of the app
-enable_crons      = false # crons stay on Vercel during coexistence; flip true at cut-over
+enable_crons      = true  # AWS owns the crons in Phase A (removed from vercel.json); single owner vs shared RDS
 
 # Phase B reuse target:
 existing_cloudfront_distribution_id = "EZI5H8FKNE9R1"

--- a/deployments/insights-ui/variables.tf
+++ b/deployments/insights-ui/variables.tf
@@ -31,7 +31,10 @@ variable "direct_domain_name" {
   default     = "prod.koalagains.com"
 }
 
-# ---- Rollout gates — both default OFF so Phase A is just the parallel, direct deployment ----
+# ---- Rollout gates ----------------------------------------------------------------------
+# manage_cloudfront defaults OFF (Phase A is the parallel, direct deployment — Vercel still
+# fronts koalagains.com). enable_crons defaults ON: AWS owns the crons in Phase A and they are
+# removed from vercel.json, so there is a single owner against the shared RDS.
 variable "manage_cloudfront" {
   description = "Phase B: manage CloudFront and point it at the Lightsail service. Keep false while running in parallel with Vercel."
   type        = bool

--- a/deployments/insights-ui/versions.tf
+++ b/deployments/insights-ui/versions.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.4"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6"
-    }
   }
 
   # Remote state is REQUIRED — without it, CI starts from empty local state every run and


### PR DESCRIPTION
Review fixes for the insights-ui AWS-migration Terraform.

## Changes
- **`container.tf`** — add `depends_on = [aws_ecr_repository_policy.pull]` to the Lightsail deployment version. The puller-role ECR grant was only graph-linked through the service, so Terraform could create the deployment (and have Lightsail pull the image) **before** the grant existed → "access denied" image pull on first apply.
- **`variables.tf` / `scheduler.tf` / `terraform.tfvars.example`** — reconcile the contradictory `enable_crons` docs. The variable default is `true` and the README's Phase-A design has AWS owning the crons (removed from `vercel.json`, single owner vs the shared RDS), but the header comment said "both default OFF", scheduler.tf said "default false", and the example tfvars set `false`. All now consistently say `true`.
- **`versions.tf`** — drop the unused `random` provider.
- **`cloudfront.tf`** — `terraform fmt` (locals alignment).

## Verification
- `terraform fmt -check` passes on all files.
- `terraform validate` not run locally: local terraform is 1.4.6 but `versions.tf` requires `>= 1.6.0`; CI runs a newer version.

## Not addressed (flagged for follow-up, no code change)
- ECR `IMMUTABLE` tags + git-SHA image tag → re-deploying the same commit fails `docker push` (needs a tagging-scheme decision).
- Lightsail cert attaches while `PENDING_VALIDATION` → first apply needs a re-run (no TF wait resource for Lightsail certs).
- Unauthenticated cron endpoints and the public CloudWatch dashboard (intentional/documented, but carry exposure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)