### PR TITLE
Update schema descriptions to specify Markdown formatting

### DIFF
--- a/insights-ui/schemas/analysis-factors/final-summary/final-summary-analysis-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/final-summary/final-summary-analysis-output.schema.yaml
@@ -5,12 +5,15 @@ properties:
   finalSummary:
     type: string
     description: >-
-      Plain text, two paragraphs of 3–4 lines each. Paragraph 1: describe the
-      company's business model and rate its current state (excellent / very good /
-      good / fair / bad / very bad) with a brief supporting reason. Paragraph 2:
-      how the company compares with its competition and a conservative, actionable
-      investor takeaway sentence (e.g. "Suitable for long-term investors seeking
-      growth" or "High risk — best to avoid until profitability improves").
+      Markdown, two paragraphs of 3–4 lines each separated by a blank line (a
+      double newline "\n\n" in the JSON string value) so each renders as a distinct
+      paragraph. Do NOT use literal "Paragraph 1:" / "Paragraph 2:" labels. The first
+      paragraph describes the company's business model and rates its current state
+      (excellent / very good / good / fair / bad / very bad) with a brief supporting
+      reason. The second paragraph covers how the company compares with its competition
+      and ends with a conservative, actionable investor takeaway sentence (e.g.
+      "Suitable for long-term investors seeking growth" or "High risk — best to avoid
+      until profitability improves").
   metaDescription:
     type: string
     description: >-

--- a/insights-ui/schemas/analysis-factors/management-team/management-team-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/management-team/management-team-output.schema.yaml
@@ -4,10 +4,10 @@ additionalProperties: false
 properties:
   summary:
     type: string
-    description: '~2 paragraph summary suitable for the main ticker page. Cover who is leading the company, how aligned they are with long-term shareholder value, and any standout signals from compensation or insider transactions. End with a one-sentence investor takeaway.'
+    description: '~2 paragraph summary suitable for the main ticker page. Cover who is leading the company, how aligned they are with long-term shareholder value, and any standout signals from compensation or insider transactions. End with a one-sentence investor takeaway. Format as Markdown: separate each paragraph with a blank line (a double newline "\n\n" in the JSON string value) so each renders as a distinct paragraph.'
   detailedAnalysis:
     type: string
-    description: '5–7 paragraphs covering: (1) the names, roles, and tenure of the key management team members; (2) where the founders are now and the reason they are not (or are) on the management team; (3) ownership stakes (insider %), compensation structure, and how compensation incentives align with long-term company growth; (4) recent insider buying/selling activity and what it signals; (5) any past management issues — SEC investigations, lawsuits, abrupt CFO/CEO departures, governance controversies, or failed prior roles tied to current leadership; (6) leadership track record and capital allocation history; (7) overall alignment verdict and the reasoning behind it.'
+    description: '5–7 paragraphs covering: (1) the names, roles, and tenure of the key management team members; (2) where the founders are now and the reason they are not (or are) on the management team; (3) ownership stakes (insider %), compensation structure, and how compensation incentives align with long-term company growth; (4) recent insider buying/selling activity and what it signals; (5) any past management issues — SEC investigations, lawsuits, abrupt CFO/CEO departures, governance controversies, or failed prior roles tied to current leadership; (6) leadership track record and capital allocation history; (7) overall alignment verdict and the reasoning behind it. Format as Markdown: separate every paragraph with a blank line (a double newline "\n\n" in the JSON string value) so each renders as a distinct <p>. Do NOT return the paragraphs as one continuous block of text, and do NOT use inline "Paragraph 1:", "Paragraph 2:" labels.'
   alignmentVerdict:
     type: string
     enum:

--- a/insights-ui/schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml
+++ b/insights-ui/schemas/analysis-factors/outputs/whole-category-analysis-output.schema.yaml
@@ -7,7 +7,7 @@ properties:
     description: '3–5 sentence summary of the category analysis. Summarize the key points from overallAnalysisDetails and conclude with a clear investor takeaway (positive, negative, or mixed). Keep language simple and concise for retail investors.'
   overallAnalysisDetails:
     type: string
-    description: 'A detailed multi-paragraph analysis (typically 7–9 paragraphs, 1800–2500 words) following the structure and order specified in the prompt. Cover all key sub-topics for this category in the order laid out in the prompt instructions.'
+    description: 'A detailed multi-paragraph analysis (typically 7–9 paragraphs, 1800–2500 words) following the structure and order specified in the prompt. Cover all key sub-topics for this category in the order laid out in the prompt instructions. Format as Markdown: separate every paragraph with a blank line (i.e. a double newline "\n\n" in the JSON string value) so each paragraph renders as a distinct <p>. Do NOT return the paragraphs as one continuous block of text, and do NOT use inline "Paragraph 1:", "Paragraph 2:" labels.'
   factors:
     type: array
     description: 'Array of factor-level analyses.'
@@ -22,7 +22,7 @@ properties:
           description: '1 sentence giving the key takeaway or insight from this factor.'
         detailedExplanation:
           type: string
-          description: "1 paragraph of investor-focused analysis for this factor. Directly analyze the company's performance using available data. Clearly justify the Pass/Fail result, be critical in tone, and highlight risks or weaknesses along with strengths."
+          description: "1 paragraph of investor-focused analysis for this factor. Directly analyze the company's performance using available data. Clearly justify the Pass/Fail result, be critical in tone, and highlight risks or weaknesses along with strengths. If more than one paragraph is returned, separate each paragraph with a blank line (a double newline \"\\n\\n\" in the JSON string value) so it renders as distinct Markdown paragraphs."
         result:
           type: string
           enum: ['Pass', 'Fail']


### PR DESCRIPTION
## Description

Updates schema documentation across three analysis output files to clarify that content should be formatted as Markdown with proper paragraph separation. These changes ensure AI-generated content renders correctly with distinct paragraphs instead of continuous text blocks.

### Changes Made

1. **final-summary-analysis-output.schema.yaml**
   - Updated `finalSummary` description to specify Markdown format
   - Clarified that paragraphs must be separated by blank lines (`\n\n`)
   - Removed instruction to use "Paragraph 1:" / "Paragraph 2:" labels

2. **management-team-output.schema.yaml**
   - Updated `summary` description to include Markdown formatting instructions
   - Updated `detailedAnalysis` description to specify paragraph separation and prohibit inline labels

3. **whole-category-analysis-output.schema.yaml**
   - Updated `overallAnalysisDetails` description to specify Markdown formatting with proper paragraph separation
   - Updated `detailedExplanation` description to clarify handling of multi-paragraph responses

### Rationale

These schema updates ensure that:
- AI-generated content is consistently formatted as Markdown
- Paragraphs render as distinct `<p>` elements in HTML output
- Content is not returned as continuous text blocks
- Inline paragraph labels (e.g., "Paragraph 1:") are not used, improving readability

### Testing

No functional code changes. Schema documentation updates only. Existing tests and CI validation remain unaffected.

https://claude.ai/code/session_014Kk9zDrZLVXTFAEYwxnctw