### PR TITLE
Fix pnpm frozen-lockfile overrides mismatch (unblocks insights-ui Docker build)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,14 @@ packages:
   - 'news-reader'
   - 'simulations'
   - 'shared/web-core'
+
+# Dependency overrides. pnpm >= 10 reads these from pnpm-workspace.yaml (NOT package.json's
+# "pnpm.overrides", which newer pnpm ignores). These mirror the root package.json "resolutions"
+# (read by yarn/Vercel) and must stay in lockstep with the `overrides:` block in pnpm-lock.yaml,
+# or `pnpm install --frozen-lockfile` (the Docker build) fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+overrides:
+  '@types/react': 18.3.12
+  '@types/react-dom': 18.3.1
+  react: 18.3.1
+  react-dom: 18.3.1
+  '@apollo/client': ^3.7.12


### PR DESCRIPTION
## Problem
The insights-ui AWS deploy reached the Docker build and failed at `pnpm install --frozen-lockfile` (`Dockerfile:26`):

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] the current "overrides" configuration doesn't match the value found in the lockfile
```

`pnpm-lock.yaml` records 5 `overrides`, but **pnpm ≥ 10/11 no longer reads `pnpm.overrides` from `package.json`**, and the root only declares these pins under `resolutions` (which only yarn/Vercel read). So pnpm computed "current overrides = none" vs the lockfile's 5 entries → frozen install aborts.

This was latent: the Docker build had never completed before (every prior AWS deploy run died earlier, at `terraform init`).

## Fix
Move the overrides into `pnpm-workspace.yaml` (pnpm's current home), mirroring the existing `resolutions` and the lockfile's `overrides:` block **exactly**. No lockfile regeneration.

## Validation
Local repro with the same pnpm the Docker build uses:
```
$ corepack pnpm install --frozen-lockfile --lockfile-only   # pnpm v11.5.1, node 23
✓ Lockfile passes supply-chain policies
Done in 22.9s        # exit 0 — no CONFIG_MISMATCH; pnpm-lock.yaml unchanged
```

After merge, the deploy workflow re-runs and should proceed past the build into the Lightsail apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)