### PR TITLE
Approve pnpm build scripts (unblock insights-ui Docker build, step 2)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,23 @@ overrides:
   react: 18.3.1
   react-dom: 18.3.1
   '@apollo/client': ^3.7.12
+
+# Dependency build scripts pnpm is allowed to run. pnpm >= 10 blocks dependency
+# postinstall/build scripts by default and errors in CI (ERR_PNPM_IGNORED_BUILDS) until
+# they're explicitly approved here. These are all first-class app deps that genuinely need
+# their build step (prisma client generation, native addons, etc.). Not tracked in
+# pnpm-lock.yaml, so this does not affect the frozen-lockfile check.
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@prisma/client'
+  - '@prisma/engines'
+  - '@reown/appkit'
+  - bufferutil
+  - esbuild
+  - keccak
+  - prisma
+  - protobufjs
+  - puppeteer
+  - sharp
+  - unrs-resolver
+  - utf-8-validate


### PR DESCRIPTION
Follow-up to the overrides fix. With overrides resolved, `pnpm install --frozen-lockfile` in the Docker build now gets through resolution and fails at the next pnpm 10/11 gate:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher, @prisma/client,
@prisma/engines, @reown/appkit, bufferutil, esbuild, keccak, prisma, protobufjs,
puppeteer, sharp, unrs-resolver, utf-8-validate
```

pnpm ≥ 10 blocks dependency build scripts by default and errors in CI until approved. These are all legitimate app deps that need their build step (prisma client gen, sharp, puppeteer, native addons), so approve them via `onlyBuiltDependencies` in `pnpm-workspace.yaml`.

`onlyBuiltDependencies` is not recorded in `pnpm-lock.yaml` (v9.0 only tracks `autoInstallPeers`/`excludeLinksFromLockfile`), so this does not affect the frozen-lockfile check — re-verified locally (`--frozen-lockfile --lockfile-only` passes, lockfile unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)