### PR TITLE
Allow pnpm build scripts in insights-ui Docker build (final build unblock)

### DIFF
--- a/deployments/insights-ui/Dockerfile
+++ b/deployments/insights-ui/Dockerfile
@@ -23,8 +23,13 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY insights-ui/package.json insights-ui/
 COPY shared/web-core/package.json shared/web-core/
+# pnpm >= 10 blocks dependency build scripts by default and errors in CI
+# (ERR_PNPM_IGNORED_BUILDS). This is a trusted first-party dependency tree that needs those
+# scripts (prisma client generation, sharp/native addons, puppeteer, …), so allow them. Scoped
+# to this image build via the flag — not the shared pnpm-workspace.yaml — so local dev is
+# unaffected. (An `onlyBuiltDependencies` allow-list did not suppress the error under pnpm 11.5.1.)
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter insights-ui...
+    pnpm install --frozen-lockfile --filter insights-ui... --config.dangerouslyAllowAllBuilds=true
 
 # ---- Build -------------------------------------------------------------------------------
 FROM base AS build

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,22 +20,8 @@ overrides:
   react-dom: 18.3.1
   '@apollo/client': ^3.7.12
 
-# Dependency build scripts pnpm is allowed to run. pnpm >= 10 blocks dependency
-# postinstall/build scripts by default and errors in CI (ERR_PNPM_IGNORED_BUILDS) until
-# they're explicitly approved here. These are all first-class app deps that genuinely need
-# their build step (prisma client generation, native addons, etc.). Not tracked in
-# pnpm-lock.yaml, so this does not affect the frozen-lockfile check.
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@prisma/client'
-  - '@prisma/engines'
-  - '@reown/appkit'
-  - bufferutil
-  - esbuild
-  - keccak
-  - prisma
-  - protobufjs
-  - puppeteer
-  - sharp
-  - unrs-resolver
-  - utf-8-validate
+# NOTE on dependency build scripts: pnpm >= 10 blocks them by default and errors in CI
+# (ERR_PNPM_IGNORED_BUILDS). The insights-ui Docker build opts in via
+# `--config.dangerouslyAllowAllBuilds=true` on the install command (scoped to the container
+# build, not local dev). An `onlyBuiltDependencies` allow-list here did NOT suppress the error
+# under pnpm 11.5.1, so it is intentionally not used.


### PR DESCRIPTION
Replaces the non-working `onlyBuiltDependencies` approach with a scoped flag on the Docker install command.

## Why
After overrides were fixed, `pnpm install --frozen-lockfile` failed with `ERR_PNPM_IGNORED_BUILDS` (pnpm ≥10 blocks dependency build scripts by default and errors in CI). I added `onlyBuiltDependencies` to `pnpm-workspace.yaml`, but **it did not suppress the error under pnpm 11.5.1** — reproduced locally and confirmed it fails both with and without `--frozen-lockfile`, even though `pnpm config list` shows the key parsed.

`--config.dangerouslyAllowAllBuilds=true` does work (runs prisma postinstall, sharp, etc.). These are first-party app deps that genuinely need their build step.

## What changed
- `Dockerfile`: add `--config.dangerouslyAllowAllBuilds=true` to the deps-stage install — **scoped to the container build**, so local dev installs are unaffected.
- `pnpm-workspace.yaml`: drop the ineffective `onlyBuiltDependencies` block (keep `overrides`), with a note pointing to the Dockerfile flag.

## Validation
Reproduced the exact Docker deps stage locally (pnpm 11.5.1 / node 23, `CI=true`, same `--filter` + flag, clean `node_modules`): **exit 0**, build scripts ran, `pnpm-lock.yaml` unchanged.

Merging auto-triggers the deploy (touches `deployments/insights-ui/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)