### PR TITLE
Allow pnpm build scripts via workspace setting (fix build-stage implicit install)

### DIFF
--- a/deployments/insights-ui/Dockerfile
+++ b/deployments/insights-ui/Dockerfile
@@ -23,13 +23,10 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY insights-ui/package.json insights-ui/
 COPY shared/web-core/package.json shared/web-core/
-# pnpm >= 10 blocks dependency build scripts by default and errors in CI
-# (ERR_PNPM_IGNORED_BUILDS). This is a trusted first-party dependency tree that needs those
-# scripts (prisma client generation, sharp/native addons, puppeteer, …), so allow them. Scoped
-# to this image build via the flag — not the shared pnpm-workspace.yaml — so local dev is
-# unaffected. (An `onlyBuiltDependencies` allow-list did not suppress the error under pnpm 11.5.1.)
+# Dependency build scripts are allowed via `dangerouslyAllowAllBuilds: true` in
+# pnpm-workspace.yaml (applies to this install AND the build stage's implicit install).
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter insights-ui... --config.dangerouslyAllowAllBuilds=true
+    pnpm install --frozen-lockfile --filter insights-ui...
 
 # ---- Build -------------------------------------------------------------------------------
 FROM base AS build

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,10 @@ overrides:
   react-dom: 18.3.1
   '@apollo/client': ^3.7.12
 
-# NOTE on dependency build scripts: pnpm >= 10 blocks them by default and errors in CI
-# (ERR_PNPM_IGNORED_BUILDS). The insights-ui Docker build opts in via
-# `--config.dangerouslyAllowAllBuilds=true` on the install command (scoped to the container
-# build, not local dev). An `onlyBuiltDependencies` allow-list here did NOT suppress the error
-# under pnpm 11.5.1, so it is intentionally not used.
+# Allow dependency build scripts to run. pnpm >= 10 blocks them by default and errors in CI
+# (ERR_PNPM_IGNORED_BUILDS); the insights-ui Docker build runs prisma generate, sharp, puppeteer,
+# native addons, etc., which need their build step. An `onlyBuiltDependencies` allow-list did NOT
+# suppress the error under pnpm 11.5.1. This setting must live here (not a CLI flag) because the
+# Docker build stage also triggers an implicit install (verify-deps-before-run) that a flag on the
+# deps-stage command can't reach. This is a trusted first-party dependency tree.
+dangerouslyAllowAllBuilds: true


### PR DESCRIPTION
Follow-up to #1573. The deps-stage CLI flag wasn't enough: the Docker **build** stage runs
`pnpm --filter insights-ui exec prisma generate && pnpm --filter insights-ui build`, and `COPY . .`
brings in all workspace manifests, so pnpm's verify-deps-before-run triggers an **implicit install**
that re-hit `ERR_PNPM_IGNORED_BUILDS` (for `@reown/appkit`, `@sentry/cli`, `core-js`) — and a
deps-stage CLI flag can't reach an implicit install.

## Fix
Set `dangerouslyAllowAllBuilds: true` in `pnpm-workspace.yaml` (applies to **all** pnpm installs,
explicit and implicit) and revert the redundant Dockerfile flag. Trusted first-party dependency tree
that needs these build steps (prisma client gen, sharp, puppeteer, native addons).

## Validation
Local repro (pnpm 11.5.1 / node 23, `CI=true`, clean `node_modules`) with the setting alone (no CLI
flag): **exit 0**, build scripts ran, lockfile unchanged.

Merging auto-triggers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)