### PR TITLE
Lazily construct Gemini clients (fix next build in AWS Docker)

### DIFF
--- a/insights-ui/src/scripts/llm‑utils‑gemini.ts
+++ b/insights-ui/src/scripts/llm‑utils‑gemini.ts
@@ -5,11 +5,20 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { GeminiModel, LLMProvider, getDefaultGeminiModel, getDefaultLLMProvider } from '@/types/llmConstants';
 import { getGroundedResponse, getGroundedStructuredResponse } from '@/util/llm-grounding-utils';
 
-export const geminiModel = new ChatGoogleGenerativeAI({
-  model: GeminiModel.GEMINI_2_5_PRO,
-  apiKey: process.env.GOOGLE_API_KEY,
-  temperature: 1,
-});
+// Lazily construct the client. Building it at module load throws when GOOGLE_API_KEY is unset,
+// which breaks `next build` (route page-data collection imports this module). The key is only
+// needed at runtime when getLlmResponse() actually invokes the model.
+let _geminiModel: ChatGoogleGenerativeAI | undefined;
+function getGeminiModel(): ChatGoogleGenerativeAI {
+  if (!_geminiModel) {
+    _geminiModel = new ChatGoogleGenerativeAI({
+      model: GeminiModel.GEMINI_2_5_PRO,
+      apiKey: process.env.GOOGLE_API_KEY,
+      temperature: 1,
+    });
+  }
+  return _geminiModel;
+}
 
 export const outputInstructions = `
 #  For output content:
@@ -63,7 +72,7 @@ export async function getLlmResponse<T extends Record<string, any>>(
 
             // Step 2: Convert grounded text to structured output using LangChain
             const structuredPrompt = `Please convert the given information into the given schema format.\n\n${searchResult.text}`;
-            const client = geminiModel;
+            const client = getGeminiModel();
             const llmWithSchema = client.withStructuredOutput<T>(schema);
             const res = await llmWithSchema.invoke(structuredPrompt);
             console.log('✅ Structured output conversion completed');
@@ -79,7 +88,7 @@ export async function getLlmResponse<T extends Record<string, any>>(
 
           // Now convert the search result to structured output using schema
           const structuredPrompt = `Please convert the given information into the given schema format.\n\n${searchResult.text}`;
-          const client = geminiModel;
+          const client = getGeminiModel();
           const llmWithSchema = client.withStructuredOutput<T>(schema);
           const res = await llmWithSchema.invoke(structuredPrompt);
           console.log('✅ Structured output conversion completed');
@@ -87,7 +96,7 @@ export async function getLlmResponse<T extends Record<string, any>>(
         }
       } else {
         // Use existing LangChain approach for regular gemini-2.5-pro
-        const client = geminiModel;
+        const client = getGeminiModel();
         const llmWithSchema = client.withStructuredOutput<T>(schema);
         const res = await llmWithSchema.invoke(prompt);
         console.log('✅ Gemini response received');

--- a/insights-ui/src/util/llm-grounding-utils.ts
+++ b/insights-ui/src/util/llm-grounding-utils.ts
@@ -1,9 +1,16 @@
 import { GoogleGenAI } from '@google/genai';
 import { GeminiModel, getDefaultGeminiModel } from '@/types/llmConstants';
 
-const geminiWithSearchModel = new GoogleGenAI({
-  apiKey: process.env.GOOGLE_API_KEY,
-});
+// Lazily construct the client. Constructing GoogleGenAI at module load throws when
+// GOOGLE_API_KEY is unset, which breaks `next build` (page-data collection imports this module
+// without runtime secrets). The key is only needed when a function below actually runs.
+let _geminiWithSearchModel: GoogleGenAI | undefined;
+function geminiWithSearchModel(): GoogleGenAI {
+  if (!_geminiWithSearchModel) {
+    _geminiWithSearchModel = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+  }
+  return _geminiWithSearchModel;
+}
 
 export interface GroundedResponse {
   text: string;
@@ -57,7 +64,7 @@ export async function getGroundedStructuredResponse<Output>(
   modelName: GeminiModel = getDefaultGeminiModel(),
   outputJsonSchema: object
 ): Promise<GroundedStructuredResponse<Output>> {
-  const resp: any = await geminiWithSearchModel.models.generateContent({
+  const resp: any = await geminiWithSearchModel().models.generateContent({
     model: modelName,
     contents: [
       {
@@ -106,7 +113,7 @@ export async function getGroundedResponse(prompt: string, modelName: GeminiModel
     tools: [groundingTool],
   };
 
-  const searchResponse: any = await geminiWithSearchModel.models.generateContent({
+  const searchResponse: any = await geminiWithSearchModel().models.generateContent({
     model: modelName,
     contents: [
       {


### PR DESCRIPTION
## Problem
The AWS Docker build reached `next build` and failed during page-data collection:
```
Error: API key must be set when using the Gemini API.
Failed to collect page data for /api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/generate-prompt
```
Two modules construct Gemini clients **at module load**, and both throw without `GOOGLE_API_KEY`:
- `src/util/llm-grounding-utils.ts` — `new GoogleGenAI({...})`
- `src/scripts/llm‑utils‑gemini.ts` — `new ChatGoogleGenerativeAI({...})` (imported by the `ticker-financials` route)

Vercel injects all env vars at build time so it never hit this; the AWS Docker build only passes the 3 `NEXT_PUBLIC_*` args (secrets are runtime-only, by design).

## Fix
Defer construction to first use (lazy singletons), so importing the modules at build time is side-effect-free and the key is only required at runtime. `geminiModel` was only used within its own file, so no API change.

Scanned for other module-scope SDK constructions: `PrismaClient` and AWS `LambdaClient` both resolve lazily and don't throw at construction, so they're build-safe.

Merging auto-triggers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)