### PR TITLE
Fix Lightsail cert-validation for_each (unblocks terraform apply)

### DIFF
--- a/deployments/insights-ui/domains.tf
+++ b/deployments/insights-ui/domains.tf
@@ -17,20 +17,20 @@ resource "aws_lightsail_certificate" "app" {
   domain_name = var.direct_domain_name
 }
 
-# DNS validation records for the Lightsail certificate.
-resource "aws_route53_record" "lightsail_cert_validation" {
-  for_each = {
-    for o in aws_lightsail_certificate.app.domain_validation_options : o.domain_name => {
-      name   = o.resource_record_name
-      type   = o.resource_record_type
-      record = o.resource_record_value
-    }
-  }
+# DNS validation record for the Lightsail certificate. The cert covers exactly one domain
+# (var.direct_domain_name), so there is exactly one validation option. We index it directly
+# rather than using for_each: for_each keys derived from the cert's *computed*
+# domain_validation_options aren't known until apply, which fails the first apply with
+# "Invalid for_each argument" (keys cannot be determined until apply).
+locals {
+  lightsail_cert_dvo = tolist(aws_lightsail_certificate.app.domain_validation_options)[0]
+}
 
+resource "aws_route53_record" "lightsail_cert_validation" {
   zone_id         = data.aws_route53_zone.main.zone_id
-  name            = each.value.name
-  type            = each.value.type
-  records         = [each.value.record]
+  name            = local.lightsail_cert_dvo.resource_record_name
+  type            = local.lightsail_cert_dvo.resource_record_type
+  records         = [local.lightsail_cert_dvo.resource_record_value]
   ttl             = 60
   allow_overwrite = true
 }


### PR DESCRIPTION
## Problem
The Lightsail `terraform apply` step failed (after the image built + assets uploaded):
```
Error: Invalid for_each argument
  on domains.tf line 22, in resource "aws_route53_record" "lightsail_cert_validation":
The "for_each" map includes keys derived from resource attributes that cannot be
determined until apply ...
```
`for_each` iterated the certificate's **computed** `domain_validation_options` keyed by `o.domain_name`. On the first apply the cert doesn't exist yet, so the key set is unknown.

## Fix
The cert covers exactly one domain (`var.direct_domain_name`), so there's exactly one validation option. Replace `for_each` with a single record that indexes `tolist(...domain_validation_options)[0]`. A single resource may reference unknown-until-apply values; only `for_each`/`count` keys must be known at plan time. `container.tf`'s `depends_on` still resolves (single resource).

## Validation
Ran a real `terraform plan` against the remote state (AWS creds + S3 backend): **plan succeeds, no for_each error** (23 to add).

Merging auto-triggers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)