### PR TITLE
Add debian-openssl-3.0.x Prisma binary target (fix container crash)

### DIFF
--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -3,6 +3,11 @@
 
 generator client {
   provider = "prisma-client-js"
+  // The runtime image (node:22-bookworm-slim + libssl3) uses OpenSSL 3.0.x, but the slim build
+  // stage has no openssl binary so `prisma generate` mis-detects and defaults to 1.1.x. Pin both
+  // engines so the debian-openssl-3.0.x query engine is generated and present at runtime,
+  // otherwise the container crashes on startup with PrismaClientInitializationError.
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 generator json {


### PR DESCRIPTION
## Problem
After the image built and Terraform created the Lightsail service, the container crashed on startup and the deployment never reached ACTIVE:
```
PrismaClientInitializationError: could not locate the Query Engine for runtime "debian-openssl-3.0.x".
Prisma Client was generated for "debian-openssl-1.1.x", but the deployment required "debian-openssl-3.0.x".
```
The build stage (`node:22-bookworm-slim`) has no openssl binary, so `prisma generate` couldn't detect the version and defaulted to **1.1.x** (seen as a warning in the build log). The runtime image has **OpenSSL 3.0.x** (libssl3) → engine mismatch → crash.

## Fix
Pin `binaryTargets = ["native", "debian-openssl-3.0.x"]` in the Prisma generator so the 3.0.x query engine is generated and shipped regardless of build-stage detection.

## Other apply errors from that run (already resolved)
- The `Invalid for_each` cert error is fixed (#1577) — cert now creates fine.
- The S3 `PutBucketPolicy` 403 was eventual-consistency (BPA propagation); the bucket policy is now set and bucket-level `BlockPublicPolicy=false`, so it won't recur.

Merging auto-triggers the deploy (rebuilds the image with the correct engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)