### PR TITLE
Fix base-URL resolution for local/Vercel/AWS (split self-fetch vs canonical)

### DIFF
--- a/insights-ui/src/app/blogs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/blogs/sitemap.xml/route.ts
@@ -1,5 +1,5 @@
 import { getPostsData } from '@/util/blog-utils';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -38,7 +38,7 @@ async function generateBlogUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateBlogUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
+++ b/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { REPORT_TYPES_TO_DISPLAY } from '@/types/project/project';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import crowdFundingLastmod from '@/utils/lastmod/crowd-funding-lastmod.json';
@@ -62,7 +62,7 @@ async function generateCrowdFundingUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateCrowdFundingUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
+++ b/insights-ui/src/app/daily-top-movers/sitemap.xml/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 
 export const dynamic = 'force-dynamic';
 
@@ -80,7 +80,7 @@ async function generateDailyTopMoversUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateDailyTopMoversUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
+++ b/insights-ui/src/app/hts-codes/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { chapterDetailHref } from '@/utils/tariff-calculator/chapter-slug';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
@@ -38,7 +38,7 @@ async function generateHtsCodeUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateHtsCodeUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
+++ b/insights-ui/src/app/industry-tariff-report/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { Prisma } from '@prisma/client';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
@@ -52,7 +52,7 @@ async function generateTariffReportUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateTariffReportUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stock-scenarios/sitemap.xml/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import type { StockScenarioListingResponse } from '@/app/api/[spaceId]/stock-scenarios/listing/route';
 
 export const dynamic = 'force-dynamic';
@@ -47,7 +47,7 @@ async function generateStockScenarioUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateStockScenarioUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/business-and-moat-sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -55,7 +55,7 @@ async function generateBusinessAndMoatUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateBusinessAndMoatUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/competition-sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -52,7 +52,7 @@ async function generateCompetitionUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateCompetitionUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/fair-value-sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -53,7 +53,7 @@ async function generateFairValueUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFairValueUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/financial-statement-analysis-sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -54,7 +54,7 @@ async function generateFinancialStatementAnalysisUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFinancialStatementAnalysisUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/future-performance-sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -54,7 +54,7 @@ async function generateFuturePerformanceUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateFuturePerformanceUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/management-team-sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -64,7 +64,7 @@ async function GET(): Promise<NextResponse<Buffer | string>> {
       });
     }
 
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/past-performance-sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -54,7 +54,7 @@ async function generatePastPerformanceUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generatePastPerformanceUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -4,7 +4,7 @@ import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { ALL_SUPPORTED_COUNTRIES, SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 
 export const dynamic = 'force-dynamic';
 
@@ -149,7 +149,7 @@ async function generateTickerUrls(): Promise<SiteMapUrl[]> {
 async function GET(): Promise<NextResponse<Buffer>> {
   try {
     const urls = await generateTickerUrls();
-    const smStream = new SitemapStream({ hostname: getBaseUrlForServerSidePages() });
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
 
     for (const url of urls) {
       smStream.write(url);

--- a/insights-ui/src/utils/getBaseUrlForServerSidePages.ts
+++ b/insights-ui/src/utils/getBaseUrlForServerSidePages.ts
@@ -1,10 +1,34 @@
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 
-export function getBaseUrlForServerSidePages() {
-  const nextEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
-  const baseUrl = getBaseUrl();
-  if (!baseUrl.includes('localhost') && (nextEnv === 'production' || nextEnv === 'preview' || baseUrl.includes('vercel.app') || !nextEnv)) {
-    return 'https://koalagains.com';
-  }
-  return baseUrl;
+/**
+ * Canonical, user-facing site origin — ALWAYS the public domain, on every platform
+ * (local, Vercel, AWS), before and after the Vercel→AWS cut-over.
+ *
+ * Use this for sitemap hostnames, canonical tags, OpenGraph URLs, and any absolute URL that
+ * gets emitted into rendered output. Do NOT use it as a server-side fetch target: on AWS that
+ * would route SSR self-requests through CloudFront's long-TTL cache and serve stale data.
+ */
+export function getCanonicalUrl(): string {
+  return 'https://koalagains.com';
+}
+
+/**
+ * Base URL a Server Component / route handler uses to fetch THIS app's OWN `/api` routes during
+ * server render. Resolves to the RUNNING host so each deployment fetches itself directly:
+ *   - local:    `http://localhost:3000`
+ *   - AWS prod: `https://prod.koalagains.com`  (direct CNAME to the container — NOT behind
+ *               CloudFront, so reads are always fresh)
+ *   - Vercel:   `getBaseUrl()` is '' server-side → falls back to the canonical origin
+ *
+ * `getBaseUrl()` already returns the correct running host on every platform (it reads
+ * NEXT_PUBLIC_VERCEL_URL/ENV, which AWS bakes as prod.koalagains.com and Vercel leaves unset).
+ * This is byte-for-byte identical to the previous behavior on Vercel ('' → koalagains.com) and
+ * local (localhost:3000); only AWS changes — previously it hardcoded koalagains.com and hit
+ * CloudFront's stale cache, now it fetches its own fresh origin.
+ *
+ * NOTE: the name is kept for its many existing self-fetch call sites. For sitemap/canonical
+ * URLs use {@link getCanonicalUrl} instead.
+ */
+export function getBaseUrlForServerSidePages(): string {
+  return getBaseUrl() || getCanonicalUrl();
 }


### PR DESCRIPTION
Makes base-URL resolution correct on **local, Vercel, and AWS** for both browser and server. Designed via a 5-agent review (minimalism, env-matrix, web-core blast-radius, ideal-architecture, and runtime/ops lenses).

## Problem
`insights-ui/src/utils/getBaseUrlForServerSidePages.ts` was overloaded for two conflicting jobs and hardcoded `https://koalagains.com` in prod. On AWS, SSR pages self-fetched their own `/api` via `koalagains.com` → **CloudFront's 6-day cache** (`/api/koala_gains/tickers-v1/exchange/*`, `/country/*`) → stale data + coupling to Vercel, instead of the AWS app itself.

## Fix (shared web-core `getBaseUrl()` untouched — it already adapts)
- **`getBaseUrlForServerSidePages()`** → `getBaseUrl() || canonical` = the **running host** for SSR self-fetch. Provably identical on Vercel (`''` → koalagains.com) and local (`localhost:3000`); on AWS it becomes `https://prod.koalagains.com` (direct CNAME, not CloudFront → **fresh**). Auto-fixes ~57 self-fetch call sites; **zero Vercel/local regression**.
- **New `getCanonicalUrl()`** → always `https://koalagains.com`. The **14 sitemap routes** now use it, so they always emit the canonical domain (never the AWS host — avoids an SEO-leak class of bug).

## Why safe
- Grep-verified: every non-sitemap use of the helper is a `/api/` self-fetch — no hidden canonical/OG uses, so the split is exhaustive.
- Shared `getBaseURL.ts`/`getProtocol.ts` are **not changed** (used by ~430 sites across 7 apps).
- Typecheck: no errors reference the changed files (remaining local tsc errors are pre-existing missing-dep noise; CI `next build` compiles these files).

## Behavior table (server)
| | self-fetch | sitemap/canonical |
|---|---|---|
| local | `http://localhost:3000` | `https://koalagains.com` |
| Vercel | `https://koalagains.com` (unchanged) | `https://koalagains.com` |
| AWS | **`https://prod.koalagains.com`** (fresh) | `https://koalagains.com` |

Merging auto-triggers the AWS deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)