### PR TITLE
Upgrade Lightsail container service from medium to large

### DIFF
--- a/deployments/insights-ui/variables.tf
+++ b/deployments/insights-ui/variables.tf
@@ -61,9 +61,9 @@ variable "image_tag" {
 
 # ---- Lightsail sizing --------------------------------------------------------------------
 variable "service_power" {
-  description = "Lightsail container service power. medium = 1 vCPU / 4 GB (Puppeteer headroom)."
+  description = "Lightsail container service power. large = 2 vCPU / 8 GB (extra Puppeteer + SSR headroom)."
   type        = string
-  default     = "medium"
+  default     = "large"
 }
 
 variable "service_scale" {

--- a/docs/insights-ui/aws-deployment.md
+++ b/docs/insights-ui/aws-deployment.md
@@ -16,7 +16,7 @@ yet (that's Phase B). Apex/Vercel is untouched.
 ## 1. What's deployed
 
 ```
-prod.koalagains.com ──(Route53 CNAME)──► Lightsail Container Service "insights-ui" (1 node, medium)
+prod.koalagains.com ──(Route53 CNAME)──► Lightsail Container Service "insights-ui" (1 node, large)
                                                 │  next start + system Chromium (Puppeteer)
 browser ──(assetPrefix)──► S3 insights-ui-static-assets/_next/static   └──► existing RDS Postgres (public + SSL)
 EventBridge Scheduler (4 crons) ──► Lambda insights-ui-cron-invoker ──► GET prod.koalagains.com/api/...


### PR DESCRIPTION
## Description

Upgrades the Insights-UI (KoalaGains) Lightsail container service from `medium` (1 vCPU / 4 GB) to `large` (2 vCPU / 8 GB) to provide additional headroom for Puppeteer (browser automation) and server-side rendering (SSR) workloads.

## Changes

- **deployments/insights-ui/variables.tf**: Updated `service_power` variable default from `"medium"` to `"large"` and updated description to reflect the new resource allocation and use case
- **docs/insights-ui/aws-deployment.md**: Updated deployment architecture documentation to reflect the new `large` instance size

## Rationale

The larger instance size provides:
- 2x vCPU (1 → 2)
- 2x memory (4 GB → 8 GB)
- Better performance for concurrent Puppeteer operations and SSR rendering
- Reduced risk of resource exhaustion under load

## Test Plan

N/A — Configuration change. The Lightsail service will be redeployed with the new instance size on next infrastructure update.

https://claude.ai/code/session_01WM6s7MrssGgJntGBP4HMMH