### PR TITLE
Split DoDAO services nav into Robotics, AI Agents, Blockchain

### DIFF
--- a/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/ketchup-hplc-workflow.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/ketchup-hplc-workflow.tsx
@@ -165,12 +165,6 @@ function KetchupHplcWorkflowCaseStudy() {
                   >
                     See our Simulation Setup service
                   </a>
-                  <a
-                    href="/home-section/dodao-io/products/hplc-autosampler"
-                    className="inline-flex items-center justify-center rounded-md bg-white px-5 py-2.5 text-sm font-semibold text-indigo-700 ring-1 ring-indigo-200 hover:bg-indigo-50 transition-colors"
-                  >
-                    Read the original HPLC autosampler concept
-                  </a>
                 </div>
               </div>
 
@@ -180,7 +174,7 @@ function KetchupHplcWorkflowCaseStudy() {
                     <div className="aspect-[4/3] flex items-center justify-center px-6 py-10 text-center">
                       <div>
                         <p className="text-xs uppercase tracking-widest text-indigo-600 font-semibold">Simulation Preview</p>
-                        <p className="mt-2 text-lg font-semibold text-gray-900">myCobot 280 Pi in Gazebo Harmonic</p>
+                        <p className="mt-2 text-lg font-semibold text-gray-900">Gazebo Harmonic</p>
                         <p className="mt-3 text-sm text-gray-600 max-w-sm mx-auto">
                           A 6 axis cobot runs the ketchup sample prep workflow through dissolution, dilution, filtering, transfer and final autosampler
                           placement.
@@ -193,45 +187,6 @@ function KetchupHplcWorkflowCaseStudy() {
               </div>
             </div>
           </main>
-        </div>
-      </div>
-
-      <div className="bg-gray-50 py-20 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Why Ketchup, Not Paracetamol</h2>
-            <p className="mt-4 text-base text-gray-600">
-              Paracetamol is the clean, easy case every HPLC training walks through. Ketchup is what real food labs deal with. We built the simulation around
-              ketchup on purpose, so the work would surface every messy detail we will hit later in the lab.
-            </p>
-          </div>
-
-          <div className="mt-12 overflow-hidden rounded-2xl bg-white ring-1 ring-gray-200">
-            <table className="w-full text-sm text-left">
-              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
-                <tr>
-                  <th scope="col" className="px-6 py-3 font-semibold">
-                    What changes
-                  </th>
-                  <th scope="col" className="px-6 py-3 font-semibold">
-                    Paracetamol
-                  </th>
-                  <th scope="col" className="px-6 py-3 font-semibold">
-                    Ketchup
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {differences.map((row) => (
-                  <tr key={row.title} className="align-top">
-                    <td className="px-6 py-4 font-semibold text-gray-900">{row.title}</td>
-                    <td className="px-6 py-4 text-gray-700">{row.paracetamol}</td>
-                    <td className="px-6 py-4 text-gray-700">{row.ketchup}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
         </div>
       </div>
 

--- a/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/ketchup-hplc-workflow.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/ketchup-hplc-workflow.tsx
@@ -1,0 +1,364 @@
+'use client';
+import {
+  BeakerIcon,
+  CheckCircleIcon,
+  ClipboardDocumentCheckIcon,
+  CogIcon,
+  ExclamationTriangleIcon,
+  EyeIcon,
+  Squares2X2Icon,
+  WrenchScrewdriverIcon,
+} from '@heroicons/react/24/outline';
+
+type StepStatus = 'simulated' | 'skipped';
+
+type WorkflowStep = {
+  num: string;
+  title: string;
+  what: string;
+  status: StepStatus;
+  reason?: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
+const steps: WorkflowStep[] = [
+  {
+    num: '01',
+    title: 'Weighing',
+    what: 'Measure out a tiny, exact amount of ketchup before any solvent goes near it.',
+    status: 'skipped',
+    reason: 'Needs a real balance and fine fluid control. Too movement heavy for this round.',
+    icon: WrenchScrewdriverIcon,
+  },
+  {
+    num: '02',
+    title: 'Dissolution and Extraction',
+    what: 'Add a measured solvent so the target chemical, 5-HMF, leaves the pulp and moves into the liquid. With ketchup the result is a cloudy, pulpy mixture, not a clear solution.',
+    status: 'simulated',
+    icon: BeakerIcon,
+  },
+  {
+    num: '03',
+    title: 'Dilution',
+    what: 'Weaken the extract by adding more solvent, so the HPLC machine can read it without saturating.',
+    status: 'simulated',
+    icon: BeakerIcon,
+  },
+  {
+    num: '04',
+    title: 'Filtering',
+    what: 'Push the liquid through a fine filter to remove every last bit of tomato pulp before it reaches the instrument.',
+    status: 'simulated',
+    icon: WrenchScrewdriverIcon,
+  },
+  {
+    num: '05',
+    title: 'Transfer to Vial',
+    what: 'Move the clear, filtered liquid into the small glass vial the autosampler will pick up.',
+    status: 'simulated',
+    icon: BeakerIcon,
+  },
+  {
+    num: '06',
+    title: 'Capping',
+    what: 'Close the vial with a septum cap so the autosampler needle can pierce through it cleanly.',
+    status: 'skipped',
+    reason: 'Tight tolerance press and twist motion. Hard to model honestly in simulation right now.',
+    icon: CogIcon,
+  },
+  {
+    num: '07',
+    title: 'Labeling',
+    what: 'Print and apply a small label so the vial is traceable to the sample and the run.',
+    status: 'skipped',
+    reason: 'A printer plus precise sticker handling. Pushed to hardware bring up, not simulation.',
+    icon: ClipboardDocumentCheckIcon,
+  },
+  {
+    num: '08',
+    title: 'Placement in Autosampler',
+    what: 'Drop the capped, labeled vial into the correct numbered slot of the autosampler tray.',
+    status: 'simulated',
+    icon: Squares2X2Icon,
+  },
+];
+
+const sceneObjects = [
+  'Ketchup beaker, stir bar and solvent reservoir',
+  'Mock dispenser station that pours a measured solvent volume',
+  'Mock mixer station with a heat and dwell flag',
+  'Centrifuge mock for clarifying the cloudy extract',
+  'Syringe filter and a clean receiving vessel',
+  'Empty HPLC vial and the autosampler tray with numbered slots',
+  'Overhead camera, wrist camera, AprilTag markers and the workcell table',
+];
+
+const differences = [
+  {
+    title: 'Sample type',
+    paracetamol: 'A clean, dry tablet that dissolves cleanly in methanol.',
+    ketchup: 'A thick, pulpy paste with sugar, acid and tomato solids.',
+  },
+  {
+    title: 'What we measure',
+    paracetamol: 'The whole tablet, since the active drug is most of the mass.',
+    ketchup: 'One trace chemical called 5-HMF, hidden in a busy mixture.',
+  },
+  {
+    title: 'Dissolution',
+    paracetamol: 'Everything goes into solution. The liquid is clear.',
+    ketchup: 'Only the target gets extracted. The liquid stays cloudy until we filter it.',
+  },
+  {
+    title: 'Risk during prep',
+    paracetamol: 'Low. The chemistry is forgiving.',
+    ketchup: 'Higher. Too much heat can create more 5-HMF and change the very thing we are measuring.',
+  },
+  {
+    title: 'Simulation difficulty',
+    paracetamol: 'A reasonable starter project.',
+    ketchup: 'Much harder. More mocked instruments, more state to track, more places to get wrong.',
+  },
+];
+
+function KetchupHplcWorkflowCaseStudy() {
+  const simulatedCount = steps.filter((s) => s.status === 'simulated').length;
+  const skippedCount = steps.length - simulatedCount;
+
+  return (
+    <div>
+      <div className="relative overflow-hidden bg-white">
+        <div className="relative pb-4 sm:pb-12 lg:pb-20">
+          <main className="mx-auto mt-8 max-w-7xl px-6 sm:mt-16 lg:mt-20">
+            <div className="lg:grid lg:grid-cols-12 lg:gap-8">
+              <div className="sm:text-center md:mx-auto md:max-w-2xl lg:col-span-7 lg:text-left">
+                <p className="text-xs uppercase tracking-widest font-semibold text-indigo-600">Robotics Case Study</p>
+                <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+                  Ketchup HPLC Workflow{' '}
+                  <span className="block bg-gradient-to-r from-indigo-600 via-violet-600 to-emerald-600 bg-clip-text text-transparent">in Simulation</span>
+                </h1>
+                <p className="mt-5 text-lg leading-8 text-gray-600">
+                  HPLC sample prep is an eight step workflow. We built a Gazebo simulation of five of those steps for ketchup, which is the much harder usecase
+                  compared to the standard paracetamol example. The remaining three steps need tight tolerance hardware moves, so we left them out for now.
+                  Isaac Sim port comes next.
+                </p>
+
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <span className="inline-flex items-center gap-x-1.5 rounded-full bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200">
+                    <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
+                    {simulatedCount} of 8 steps in Gazebo
+                  </span>
+                  <span className="inline-flex items-center gap-x-1.5 rounded-full bg-amber-50 px-3 py-1 text-sm font-medium text-amber-800 ring-1 ring-amber-200">
+                    <ExclamationTriangleIcon className="h-4 w-4" aria-hidden="true" />
+                    {skippedCount} steps left for later
+                  </span>
+                  <span className="inline-flex items-center gap-x-1.5 rounded-full bg-violet-50 px-3 py-1 text-sm font-medium text-violet-800 ring-1 ring-violet-200">
+                    <EyeIcon className="h-4 w-4" aria-hidden="true" />
+                    Isaac Sim port: in progress
+                  </span>
+                </div>
+
+                <div className="mt-8 flex flex-wrap gap-3">
+                  <a
+                    href="/home-section/dodao-io/services/simulation-setup"
+                    className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+                  >
+                    See our Simulation Setup service
+                  </a>
+                  <a
+                    href="/home-section/dodao-io/products/hplc-autosampler"
+                    className="inline-flex items-center justify-center rounded-md bg-white px-5 py-2.5 text-sm font-semibold text-indigo-700 ring-1 ring-indigo-200 hover:bg-indigo-50 transition-colors"
+                  >
+                    Read the original HPLC autosampler concept
+                  </a>
+                </div>
+              </div>
+
+              <div className="relative mt-12 sm:mx-auto sm:max-w-lg lg:col-span-5 lg:mx-0 lg:mt-0 lg:flex lg:max-w-none lg:items-center">
+                <div className="relative mx-auto w-full rounded-lg shadow-lg">
+                  <div className="relative block w-full overflow-hidden rounded-lg bg-gradient-to-br from-indigo-50 via-violet-50 to-emerald-50 ring-1 ring-indigo-100">
+                    <div className="aspect-[4/3] flex items-center justify-center px-6 py-10 text-center">
+                      <div>
+                        <p className="text-xs uppercase tracking-widest text-indigo-600 font-semibold">Simulation Preview</p>
+                        <p className="mt-2 text-lg font-semibold text-gray-900">myCobot 280 Pi in Gazebo Harmonic</p>
+                        <p className="mt-3 text-sm text-gray-600 max-w-sm mx-auto">
+                          A 6 axis cobot runs the ketchup sample prep workflow through dissolution, dilution, filtering, transfer and final autosampler
+                          placement.
+                        </p>
+                        <p className="mt-4 text-xs italic text-gray-500">A Gazebo simulation clip will be added here soon.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+
+      <div className="bg-gray-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Why Ketchup, Not Paracetamol</h2>
+            <p className="mt-4 text-base text-gray-600">
+              Paracetamol is the clean, easy case every HPLC training walks through. Ketchup is what real food labs deal with. We built the simulation around
+              ketchup on purpose, so the work would surface every messy detail we will hit later in the lab.
+            </p>
+          </div>
+
+          <div className="mt-12 overflow-hidden rounded-2xl bg-white ring-1 ring-gray-200">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th scope="col" className="px-6 py-3 font-semibold">
+                    What changes
+                  </th>
+                  <th scope="col" className="px-6 py-3 font-semibold">
+                    Paracetamol
+                  </th>
+                  <th scope="col" className="px-6 py-3 font-semibold">
+                    Ketchup
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {differences.map((row) => (
+                  <tr key={row.title} className="align-top">
+                    <td className="px-6 py-4 font-semibold text-gray-900">{row.title}</td>
+                    <td className="px-6 py-4 text-gray-700">{row.paracetamol}</td>
+                    <td className="px-6 py-4 text-gray-700">{row.ketchup}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">The Eight Step Workflow</h2>
+            <p className="mt-4 text-base text-gray-600">
+              Five steps run in Gazebo today. Three steps are honest about their limits and wait for hardware bring up. Each card explains the step and our
+              status on it.
+            </p>
+          </div>
+
+          <ol className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {steps.map((step) => {
+              const isSimulated = step.status === 'simulated';
+              return (
+                <li
+                  key={step.num}
+                  className={`flex flex-col rounded-xl border p-5 shadow-sm ${
+                    isSimulated ? 'bg-emerald-50 border-emerald-200' : 'bg-amber-50 border-amber-200'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-x-3">
+                      <span
+                        className={`inline-flex h-9 w-9 items-center justify-center rounded-lg text-sm font-semibold ${
+                          isSimulated ? 'bg-emerald-100 text-emerald-800' : 'bg-amber-100 text-amber-800'
+                        }`}
+                      >
+                        {step.num}
+                      </span>
+                      <step.icon className={`h-5 w-5 ${isSimulated ? 'text-emerald-700' : 'text-amber-700'}`} aria-hidden="true" />
+                    </div>
+                    <span
+                      className={`inline-flex items-center gap-x-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                        isSimulated ? 'bg-emerald-200 text-emerald-900' : 'bg-amber-200 text-amber-900'
+                      }`}
+                    >
+                      {isSimulated ? (
+                        <CheckCircleIcon className="h-3 w-3" aria-hidden="true" />
+                      ) : (
+                        <ExclamationTriangleIcon className="h-3 w-3" aria-hidden="true" />
+                      )}
+                      {isSimulated ? 'Simulated' : 'Skipped'}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-base font-semibold text-gray-900">{step.title}</p>
+                  <p className="mt-1 text-sm text-gray-700">{step.what}</p>
+                  {step.reason && <p className="mt-3 text-xs italic text-amber-900">{step.reason}</p>}
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </div>
+
+      <div className="bg-gray-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="lg:grid lg:grid-cols-2 lg:gap-12">
+            <div>
+              <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">What Lives in the Scene</h2>
+              <p className="mt-4 text-base text-gray-600">
+                A clean simulation is mostly about getting the right objects into the world. For the ketchup workflow the scene carries the cobot, the cell
+                fixtures and a set of mock stations that stand in for the real lab instruments.
+              </p>
+              <p className="mt-4 text-base text-gray-600">
+                The mock dispenser and mock mixer expose simple ROS 2 topics so we can drive them from a behavior tree and watch the workflow advance step by
+                step.
+              </p>
+            </div>
+            <ul className="mt-10 grid grid-cols-1 gap-3 lg:mt-0">
+              {sceneObjects.map((item) => (
+                <li key={item} className="flex items-start gap-x-3 rounded-xl bg-white p-4 ring-1 ring-gray-200">
+                  <CheckCircleIcon className="h-5 w-5 flex-none text-indigo-600 mt-0.5" aria-hidden="true" />
+                  <span className="text-sm leading-6 text-gray-700">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">What Comes Next</h2>
+            <p className="mt-4 text-base text-gray-600">
+              The Gazebo build proves the workflow. Next we port the same scene to Isaac Sim, so the photoreal renderer can drive synthetic data for the vision
+              steps and so larger training runs become possible. Hardware bring up of the three skipped steps follows after that.
+            </p>
+          </div>
+
+          <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-3">
+            <div className="rounded-2xl bg-gradient-to-br from-emerald-50 to-teal-50 ring-1 ring-emerald-200 p-6">
+              <p className="text-xs uppercase tracking-wide font-semibold text-emerald-700">Today</p>
+              <p className="mt-2 text-lg font-semibold text-gray-900">Gazebo workflow</p>
+              <p className="mt-2 text-sm text-gray-700">Five workflow steps run end to end in Gazebo Harmonic with the mock dispenser and mixer.</p>
+            </div>
+            <div className="rounded-2xl bg-gradient-to-br from-violet-50 to-indigo-50 ring-1 ring-violet-200 p-6">
+              <p className="text-xs uppercase tracking-wide font-semibold text-violet-700">Next</p>
+              <p className="mt-2 text-lg font-semibold text-gray-900">Isaac Sim port</p>
+              <p className="mt-2 text-sm text-gray-700">Same scene, photoreal rendering, ready for synthetic data and larger policy runs.</p>
+            </div>
+            <div className="rounded-2xl bg-gradient-to-br from-amber-50 to-orange-50 ring-1 ring-amber-200 p-6">
+              <p className="text-xs uppercase tracking-wide font-semibold text-amber-700">Later</p>
+              <p className="mt-2 text-lg font-semibold text-gray-900">Hardware bring up</p>
+              <p className="mt-2 text-sm text-gray-700">Weighing, capping and labeling move from skipped to live, with real lab instruments in the cell.</p>
+            </div>
+          </div>
+
+          <div className="mt-12 rounded-2xl bg-gradient-to-br from-indigo-600 via-violet-600 to-emerald-600 p-8 text-center">
+            <p className="text-base font-semibold text-white">Want a simulation like this for your own workflow?</p>
+            <p className="mt-2 text-sm text-white/80 max-w-2xl mx-auto">
+              Our Simulation Setup service builds the full scene for your usecase. We modeled the ketchup workflow as a stress test for our own pipeline.
+            </p>
+            <a
+              href="/home-section/dodao-io/services/simulation-setup"
+              className="mt-5 inline-flex items-center gap-x-2 rounded-xl bg-white px-5 py-2.5 text-sm font-semibold text-indigo-700 shadow-sm hover:bg-gray-100 transition-colors"
+            >
+              See the Simulation Setup service
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default KetchupHplcWorkflowCaseStudy;

--- a/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/page.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/products/ketchup-hplc-workflow/page.tsx
@@ -1,0 +1,50 @@
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { Metadata } from 'next';
+import KetchupHplcWorkflowCaseStudy from './ketchup-hplc-workflow';
+
+export const metadata: Metadata = {
+  title: 'Ketchup HPLC Workflow — Simulation Case Study | DoDAO',
+  description:
+    'DoDAO built a Gazebo simulation of the HPLC sample prep workflow for ketchup, a much harder usecase than the standard paracetamol case. Five of the eight workflow steps are running in simulation today, with the Isaac Sim port coming next.',
+  keywords: [
+    'Robotics',
+    'HPLC',
+    'Sample Prep',
+    'Ketchup',
+    'Paracetamol',
+    'Gazebo Harmonic',
+    'Isaac Sim',
+    'ROS 2',
+    'MoveIt 2',
+    'Simulation Setup',
+    '5-HMF',
+    'DoDAO Robotics',
+  ],
+  authors: [{ name: 'DoDAO' }],
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: 'https://dodao.io/home-section/dodao-io/products/ketchup-hplc-workflow',
+  },
+  openGraph: {
+    title: 'Ketchup HPLC Workflow — Simulation Case Study | DoDAO',
+    description: 'Gazebo simulation of HPLC sample prep for the harder ketchup usecase. Five of the eight workflow steps are running today.',
+    url: 'https://dodao.io/home-section/dodao-io/products/ketchup-hplc-workflow',
+    type: 'website',
+    siteName: 'DoDAO',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ketchup HPLC Workflow — Simulation Case Study | DoDAO',
+    description: 'Gazebo simulation of the HPLC sample prep workflow for ketchup.',
+    site: '@dodao_io',
+    creator: '@dodao_io',
+  },
+};
+
+export default function KetchupHplcWorkflowPage() {
+  return (
+    <PageWrapper>
+      <KetchupHplcWorkflowCaseStudy />
+    </PageWrapper>
+  );
+}

--- a/academy-ui/src/app/home-section/dodao-io/services/robotics/page.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/services/robotics/page.tsx
@@ -4,14 +4,13 @@ import RoboticsServicesContent from './robotics';
 
 export const metadata: Metadata = {
   title: 'Robotics Services | DoDAO',
-  description:
-    'DoDAO robotics services across four layers: robotics software engineering, computer vision & perception, simulation & digital twins, and robotics hardware bring-up.',
+  description: 'DoDAO robotics services: simulation setup in Gazebo and Isaac Sim, and synthetic data generation for vision models like YOLO.',
   alternates: {
     canonical: 'https://dodao.io/home-section/dodao-io/services/robotics',
   },
   openGraph: {
     title: 'Robotics Services | DoDAO',
-    description: 'Software, perception, simulation, and hardware services for robotic arm and mobile-robot projects — simulation-first.',
+    description: 'Simulation setup and synthetic data generation for robotics projects.',
     url: 'https://dodao.io/home-section/dodao-io/services/robotics',
     type: 'website',
     siteName: 'DoDAO',
@@ -21,7 +20,7 @@ export const metadata: Metadata = {
 export default function RoboticsServicesPage() {
   return (
     <PageWrapper>
-      <div className="mx-auto max-w-5xl px-6 py-10 lg:py-14">
+      <div className="mx-auto max-w-5xl px-6 py-2 lg:py-4">
         <RoboticsServicesContent />
       </div>
     </PageWrapper>

--- a/academy-ui/src/app/home-section/dodao-io/services/robotics/robotics.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/services/robotics/robotics.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, BeakerIcon, CogIcon, CpuChipIcon, EyeIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon, BeakerIcon, EyeIcon } from '@heroicons/react/24/outline';
 
 type Section = {
   id: string;
@@ -7,6 +7,7 @@ type Section = {
   description: string;
   whatWeDo: string[];
   stack: string[];
+  detailHref: string;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   accent: string;
   gradient: string;
@@ -14,89 +15,55 @@ type Section = {
 
 const sections: Section[] = [
   {
-    id: 'software',
-    name: 'Robotics Software Engineering',
-    tagline: 'ROS 2 stacks, motion planning, controls, and full system integration.',
+    id: 'simulation-setup',
+    name: 'Simulation Setup',
+    tagline: 'Gazebo and Isaac Sim worlds, modeled for your exact usecase.',
     description:
-      'The software that turns a robot from a bag of motors into a useful product. We architect ROS 2 stacks, write motion-planning code on MoveIt 2, design behavior trees for task orchestration, and integrate sensors, controllers, and grippers into a working cell.',
+      'The first thing every robotics project needs is a clean simulation. We model the robot, the bench, the parts and the sensors so your team can start working on the actual problem instead of spending weeks setting up the scene. Movement, control and perception are layered on top later, once the world is solid.',
     whatWeDo: [
-      'ROS 2 architecture, package design, and DDS tuning',
-      'Motion planning with MoveIt 2 (OMPL, CHOMP) and trajectory optimization',
-      'Behavior trees for task-level orchestration (BehaviorTree.CPP)',
-      'Joint, Cartesian, and admittance control with controller_manager',
-      'Integration of vendor SDKs (UR, Franka, myCobot, Robotiq grippers) under one ROS 2 graph',
+      'Robot models with the correct joints and frames from your URDF or USD assets',
+      'The bench, table or floor layout of the cell',
+      'Every part you pick, place, scan or work with',
+      'Camera and sensor placements that match the real setup',
+      'Lighting and material settings that match the real conditions',
     ],
-    stack: ['ROS 2 (Humble / Jazzy)', 'MoveIt 2', 'OMPL', 'BehaviorTree.CPP', 'ros2_control', 'Cyclone DDS'],
-    icon: CpuChipIcon,
-    accent: 'text-emerald-600',
-    gradient: 'from-emerald-500 to-teal-500',
-  },
-  {
-    id: 'perception',
-    name: 'Computer Vision & Perception',
-    tagline: 'See, locate, and understand objects in cluttered real-world scenes.',
-    description:
-      'Robots need to know what they are looking at and where it is. We build perception pipelines that combine classical computer vision, deep models, and modern vision foundation models. The output is reliable detections, poses, and grasps that the motion layer can use.',
-    whatWeDo: [
-      '6-DoF object pose estimation with FoundationPose / MegaPose for industrial parts',
-      'Instance segmentation (Mask R-CNN, SAM 2) for clutter and bin-pick scenes',
-      'Visual and visual-inertial SLAM, plus AprilTag-based localization',
-      'RGB-D depth fusion, point-cloud filtering, and grasp-point estimation',
-      'Hand-eye calibration and camera-intrinsics workflows for new cells',
-    ],
-    stack: ['OpenCV', 'Open3D', 'PyTorch', 'FoundationPose', 'SAM 2', 'DINOv2', 'Depth-Anything', 'YOLO'],
-    icon: EyeIcon,
-    accent: 'text-cyan-600',
-    gradient: 'from-teal-500 to-cyan-500',
-  },
-  {
-    id: 'simulation',
-    name: 'Simulation & Digital Twins',
-    tagline: 'Prove every motion in simulation before you commit to hardware.',
-    description:
-      'Simulation lets us iterate on perception, motion, and policy work without burning a robot. We build high-fidelity Gazebo and Isaac Sim environments, generate synthetic training data, and run Sim2Real bring-up so customer hardware lands on a stack that already works.',
-    whatWeDo: [
-      'Gazebo Harmonic worlds and Isaac Sim / Lab environments from your URDF or USD assets',
-      'Synthetic data generation with domain randomization for vision-model training',
-      'Reinforcement-learning training loops (PPO, SAC) and Sim2Real transfer',
-      'Digital-twin views of customer cells for what-if and regression testing',
-      'CI-style nightly policy regression runs across a fixed scenario suite',
-    ],
-    stack: ['Gazebo Harmonic', 'Isaac Sim / Isaac Lab', 'MuJoCo', 'Stable-Baselines3', 'LeRobot', 'NVIDIA Replicator'],
+    stack: ['Gazebo Harmonic', 'Isaac Sim', 'Isaac Lab', 'URDF', 'USD', 'ROS 2'],
+    detailHref: '/home-section/dodao-io/services/simulation-setup',
     icon: BeakerIcon,
     accent: 'text-sky-600',
     gradient: 'from-cyan-500 to-sky-500',
   },
   {
-    id: 'hardware',
-    name: 'Robotics Hardware',
-    tagline: 'Arm, gripper, sensors, compute, and the bring-up that ties it together.',
+    id: 'synthetic-data',
+    name: 'Synthetic Data',
+    tagline: 'Labeled images from simulation to train YOLO and other vision models.',
     description:
-      'We help you pick the right collaborative arm, gripper, sensors, and compute for the task. Then we bring the cell up from box-open to working pick-and-place. We focus on commercially available, well-supported parts so the system stays maintainable.',
+      'Vision and perception models need a lot of labeled images. Collecting and labeling them from the real world is slow and costly. With a working simulation we can produce thousands of labeled frames in the background, with very little extra effort. We usually mix synthetic and real data so the model learns both.',
     whatWeDo: [
-      'Arm selection across cobot tiers (myCobot 280, UR cobots, Franka research arms)',
-      'Gripper selection: parallel-jaw, suction, or a custom 3-finger top-down tool for vial-style tasks',
-      'Sensor selection: RGB-D cameras (RealSense, ZED), wrist F/T, encoders, safety scanners',
-      'Compute and edge selection (Jetson, Intel NUC) for ROS 2 deployment',
-      'Mechanical mounting, power, networking, and operator HMI bring-up',
+      'Object detection datasets for YOLO and similar models',
+      'Segmentation, pose and grasp datasets for perception pipelines',
+      'Depth and stereo data for 3D vision models',
+      'Domain randomization across lighting, color, texture and clutter',
+      'Labels written in the format your training pipeline expects',
     ],
-    stack: ['Elephant Robotics myCobot 280', 'Universal Robots / Franka', 'Intel RealSense', 'ATI F/T', 'NVIDIA Jetson', 'Custom mounts and base plates'],
-    icon: CogIcon,
-    accent: 'text-blue-600',
-    gradient: 'from-sky-500 to-blue-500',
+    stack: ['NVIDIA Replicator', 'Isaac Sim', 'Gazebo Harmonic', 'YOLO', 'PyTorch'],
+    detailHref: '/home-section/dodao-io/services/synthetic-data',
+    icon: EyeIcon,
+    accent: 'text-emerald-600',
+    gradient: 'from-emerald-500 to-teal-500',
   },
 ];
 
 export default function RoboticsServicesContent() {
   return (
     <div className="not-prose">
-      <header className="mb-12">
+      <header className="mb-10">
         <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
           Robotics <span className="bg-gradient-to-r from-emerald-600 via-teal-600 to-cyan-600 bg-clip-text text-transparent">Services</span>
         </h1>
         <p className="mt-4 text-lg leading-7 text-gray-600 max-w-3xl">
-          Most robotics projects need the same four things to ship. Software, perception, simulation, and hardware. We work on all four. You can engage us for
-          one layer or the whole stack. Below is what we do in each area, and the open-source and commercial tools we use.
+          At DoDAO we offer two robotics services right now. We set up the simulation world for your project and we generate the labeled data your perception
+          models need. Both build on the same foundation: a careful, high quality simulation of your cell.
         </p>
 
         <nav className="mt-6 flex flex-wrap gap-2">
@@ -114,7 +81,7 @@ export default function RoboticsServicesContent() {
         <div className="mt-6 rounded-2xl bg-emerald-50 border border-emerald-200 p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <p className="text-sm font-semibold text-emerald-900">New here? Read how we approach a robotics project.</p>
-            <p className="text-sm text-emerald-800 mt-1">Requirements first, then hardware, then software, then bring-up. One clear order, every project.</p>
+            <p className="text-sm text-emerald-800 mt-1">Simulation first, then perception, then real hardware. One clear order, every project.</p>
           </div>
           <a
             href="/home-section/dodao-io/services/robotics/approach"
@@ -154,7 +121,7 @@ export default function RoboticsServicesContent() {
               </div>
 
               <div className="rounded-2xl bg-white border border-gray-200 p-6">
-                <p className="text-xs uppercase tracking-wide font-semibold text-gray-500">Stack we work with</p>
+                <p className="text-xs uppercase tracking-wide font-semibold text-gray-500">Tools we use</p>
                 <ul className="mt-3 flex flex-wrap gap-2">
                   {section.stack.map((tool) => (
                     <li
@@ -167,6 +134,16 @@ export default function RoboticsServicesContent() {
                 </ul>
               </div>
             </div>
+
+            <div className="mt-6">
+              <a
+                href={section.detailHref}
+                className={`inline-flex items-center gap-x-2 rounded-xl bg-gradient-to-r ${section.gradient} px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity`}
+              >
+                Read the full {section.name} page
+                <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
           </section>
         ))}
       </div>
@@ -174,7 +151,7 @@ export default function RoboticsServicesContent() {
       <div className="mt-16 rounded-2xl bg-gradient-to-br from-emerald-50 via-teal-50 to-cyan-50 border border-emerald-200 p-8 text-center">
         <p className="text-base font-semibold text-emerald-800">Want to see this in action?</p>
         <p className="mt-2 text-sm text-gray-700 max-w-2xl mx-auto">
-          Read our flagship robotics case study — a simulation-first robotic arm that loads sample vials into HPLC autosampler trays for chemistry labs.
+          Read our flagship robotics case study. A simulation first robotic arm that loads sample vials into HPLC autosampler trays for chemistry labs.
         </p>
         <a
           href="/home-section/dodao-io/products/hplc-autosampler"

--- a/academy-ui/src/app/home-section/dodao-io/services/simulation-setup/page.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/services/simulation-setup/page.tsx
@@ -1,0 +1,44 @@
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import SimulationSetup from './simulation-setup.mdx';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Robotics Simulation Setup | DoDAO',
+  description:
+    'DoDAO sets up Gazebo and Isaac Sim worlds for your robotics project. We model the robot, the bench, the parts and the sensors so your team can start working on the actual problem.',
+  keywords: ['Robotics Simulation', 'Simulation Setup', 'Gazebo', 'Isaac Sim', 'Robot World', 'URDF', 'USD', 'DoDAO Robotics'],
+  authors: [{ name: 'DoDAO' }],
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: 'https://dodao.io/home-section/dodao-io/services/simulation-setup',
+  },
+  openGraph: {
+    title: 'Robotics Simulation Setup | DoDAO',
+    description: 'Gazebo and Isaac Sim worlds, modeled from the ground up so your team can focus on the actual robotics work.',
+    url: 'https://dodao.io/home-section/dodao-io/services/simulation-setup',
+    type: 'website',
+    siteName: 'DoDAO',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Robotics Simulation Setup | DoDAO',
+    description: 'Gazebo and Isaac Sim worlds, modeled from the ground up.',
+    site: '@dodao_io',
+    creator: '@dodao_io',
+  },
+};
+
+function SimulationSetupPage() {
+  return (
+    <PageWrapper>
+      <div className="markdown-body w-full">
+        <SimulationSetup />
+      </div>
+    </PageWrapper>
+  );
+}
+
+export default SimulationSetupPage;

--- a/academy-ui/src/app/home-section/dodao-io/services/simulation-setup/simulation-setup.mdx
+++ b/academy-ui/src/app/home-section/dodao-io/services/simulation-setup/simulation-setup.mdx
@@ -1,0 +1,39 @@
+### Simulation Setup
+
+When you start a robotics project, the first step is building a clean simulation world. Without a good simulation you cannot safely test motion, perception or control code. At DoDAO we set up the simulation for you from day one, so your team can focus on the actual problem instead of spending weeks modeling parts, sensors and the workbench.
+
+We focus on the setup part on purpose. Things like movement, arm control, sensors and perception are layered on top later. If the world is wrong, every piece built on top of it is wrong too. So we put a lot of care into getting this base right.
+
+### What We Build
+
+For every usecase we build the full set of objects you need:
+
+- The robot model with the correct joints and frames
+- The bench, table or floor layout where the work happens
+- The parts you pick, place, scan or work with
+- The sensors and cameras you plan to use later
+- Lighting and material settings that match the real conditions
+
+You tell us the usecase and we deliver a working scene that loads cleanly and matches the real setup.
+
+### Tools We Use
+
+We work in both of the main robotics simulators:
+
+- **Gazebo** for fast iteration and ROS 2 work. Good for daily development and integration testing.
+- **Isaac Sim** for photoreal rendering and large parallel runs. Good when you need data generation or training jobs at scale.
+
+If your team uses only one of them, we can stick to that. If you want both, we keep one source of truth for the assets and ship scenes for each.
+
+### What You Get
+
+- A clean project folder with the simulation files
+- Models for every object in your scene
+- A short readme so any engineer on your team can run the world
+- Help bringing the scene into your existing code base
+
+Once the world is ready, your team can focus on planning, perception and policies. You skip the slow part and start where the real engineering begins.
+
+### Why Start Here
+
+Every robotics product we have shipped started with a careful simulation pass. Teams that try to skip this step end up redoing weeks of work later. Setting up a clean simulation is the cheapest way to find out what is wrong with a plan, a part choice or a layout, long before any hardware shows up on the bench.

--- a/academy-ui/src/app/home-section/dodao-io/services/synthetic-data/page.tsx
+++ b/academy-ui/src/app/home-section/dodao-io/services/synthetic-data/page.tsx
@@ -1,0 +1,44 @@
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import SyntheticData from './synthetic-data.mdx';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Synthetic Data for Robotics and Vision | DoDAO',
+  description:
+    'DoDAO generates labeled synthetic data from simulation for object detection, segmentation, pose estimation and other vision models. Useful when real data is scarce or hard to label.',
+  keywords: ['Synthetic Data', 'YOLO', 'Vision Model Training', 'Isaac Sim', 'NVIDIA Replicator', 'Gazebo', 'Domain Randomization', 'DoDAO Robotics'],
+  authors: [{ name: 'DoDAO' }],
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: 'https://dodao.io/home-section/dodao-io/services/synthetic-data',
+  },
+  openGraph: {
+    title: 'Synthetic Data for Robotics and Vision | DoDAO',
+    description: 'Labeled synthetic data from your simulation for YOLO and other vision models.',
+    url: 'https://dodao.io/home-section/dodao-io/services/synthetic-data',
+    type: 'website',
+    siteName: 'DoDAO',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synthetic Data for Robotics and Vision | DoDAO',
+    description: 'Labeled synthetic data from simulation for vision models.',
+    site: '@dodao_io',
+    creator: '@dodao_io',
+  },
+};
+
+function SyntheticDataPage() {
+  return (
+    <PageWrapper>
+      <div className="markdown-body w-full">
+        <SyntheticData />
+      </div>
+    </PageWrapper>
+  );
+}
+
+export default SyntheticDataPage;

--- a/academy-ui/src/app/home-section/dodao-io/services/synthetic-data/synthetic-data.mdx
+++ b/academy-ui/src/app/home-section/dodao-io/services/synthetic-data/synthetic-data.mdx
@@ -1,0 +1,44 @@
+### Synthetic Data
+
+Vision and perception models need a lot of labeled images to learn well. Collecting and labeling that data from the real world is slow and expensive. With a working simulation we can produce labeled images, depth maps and bounding boxes by the thousands, with very little extra effort.
+
+### What We Do
+
+We use the simulation we have already set up for your project to produce training data. The same scene that runs your robot can also render images for a perception model. Every object has a known position and class, so labels come out automatically.
+
+We can produce data for:
+
+- Object detection models like YOLO
+- Segmentation models
+- Pose and grasp estimation models
+- Depth and stereo models
+- Custom models your team is training
+
+### How It Works
+
+- We pick the camera placements that match your real sensor setup
+- We vary lighting, color, texture and clutter to cover the cases your model will see
+- We render large batches of frames in the background
+- Labels are written next to every frame, in the format your training pipeline expects
+
+For Isaac Sim users we can use NVIDIA Replicator to drive the runs. For Gazebo users we use a similar pipeline built around the world we already have.
+
+### When It Helps
+
+Synthetic data is useful when:
+
+- You do not have enough real images yet
+- The objects are rare or hard to collect
+- You need a balanced dataset across many cases
+- You want to add edge cases that almost never show up in the wild
+
+It is not a magic fix. A model trained only on simulation can struggle on real images. We usually mix synthetic and real data so the model learns both.
+
+### What You Get
+
+- A script that produces fresh data on demand
+- Sample datasets in the format your training code uses
+- Notes on what settings we varied and why
+- Help wiring the dataset into your training run
+
+If you want to try synthetic data without buying into a full pipeline, we can start with a small batch and let your team test it against a real validation set.

--- a/academy-ui/src/components/home/DoDAOHome/DoDAOHome.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/DoDAOHome.tsx
@@ -4,7 +4,7 @@ import DoDAOHomeHero from './components/DoDAOHomeHero';
 import DoDAOProducts from './components/DoDAOProducts';
 import { Footer } from './components/Footer';
 import HplcAutosamplerFeature from './components/HplcAutosamplerFeature';
-import RoboticsOfferings from './components/RoboticsOfferings';
+import RoboticsServicesTwo from './components/RoboticsServicesTwo';
 import { TrustedBy } from './components/TrustedBy';
 
 export default function DoDAOHome() {
@@ -18,8 +18,8 @@ export default function DoDAOHome() {
         <TrustedBy />
       </div>
 
-      {/* Robotics — primary offering, four-pillar services overview */}
-      <RoboticsOfferings />
+      {/* Robotics — primary offering, the two services we run today */}
+      <RoboticsServicesTwo />
 
       {/* Featured robotics project — HPLC autosampler case study teaser */}
       <HplcAutosamplerFeature />

--- a/academy-ui/src/components/home/DoDAOHome/DoDAOHome.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/DoDAOHome.tsx
@@ -3,7 +3,7 @@ import DoDAOHelpButton from './components/DoDAOHelpButton';
 import DoDAOHomeHero from './components/DoDAOHomeHero';
 import DoDAOProducts from './components/DoDAOProducts';
 import { Footer } from './components/Footer';
-import HplcAutosamplerFeature from './components/HplcAutosamplerFeature';
+import KetchupHplcWorkflowFeature from './components/KetchupHplcWorkflowFeature';
 import RoboticsServicesTwo from './components/RoboticsServicesTwo';
 import { TrustedBy } from './components/TrustedBy';
 
@@ -21,8 +21,8 @@ export default function DoDAOHome() {
       {/* Robotics — primary offering, the two services we run today */}
       <RoboticsServicesTwo />
 
-      {/* Featured robotics project — HPLC autosampler case study teaser */}
-      <HplcAutosamplerFeature />
+      {/* Featured robotics project — ketchup HPLC workflow simulation */}
+      <KetchupHplcWorkflowFeature />
 
       {/* AI Agents + DeFi — secondary offerings, kept for continuity */}
       <CoreOfferings />

--- a/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeHero.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeHero.tsx
@@ -133,7 +133,7 @@ export default function DoDAOHomeHero() {
 
           <h3 className="mt-16 text-xl font-semibold text-white text-center">Our Products</h3>
 
-          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-3 lg:gap-8 max-w-5xl mx-auto">
+          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:gap-8 max-w-3xl mx-auto">
             <a
               href="/home-section/dodao-io/products/koalagains"
               className="relative overflow-hidden rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 p-6"
@@ -151,37 +151,6 @@ export default function DoDAOHomeHero() {
                 <p className="text-sm text-gray-300">AI-powered investment analysis platform for detailed financial insights and reports.</p>
                 <div className="mt-4 inline-flex items-center text-blue-400 text-sm font-medium">
                   Explore More
-                  <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </div>
-              </div>
-            </a>
-
-            <a
-              href="/home-section/dodao-io/products/hplc-autosampler"
-              className="relative overflow-hidden rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 p-6"
-            >
-              <div className="relative">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-500/20">
-                    <svg className="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104a2.25 2.25 0 01-.659 1.591L5 8.818m4.75-5.714a48.13 48.13 0 014.5 0M14.25 3.104v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396a2.25 2.25 0 00.659 1.591L19 8.818m0 0a2.25 2.25 0 011.591 3.84L13.5 19.5l-3 2.25-3-2.25L.91 12.658a2.25 2.25 0 011.59-3.84m0 0c.413 0 .825.124 1.173.371L5 8.818"
-                      />
-                    </svg>
-                  </div>
-                  <span className="text-emerald-400 text-sm font-medium">Robotics</span>
-                </div>
-                <h3 className="text-lg font-semibold text-white mb-2">HPLC Autosampler</h3>
-                <p className="text-sm text-gray-300">
-                  Our flagship robotics project. A robot arm that helps chemistry labs prepare and load sample vials into the HPLC autosampler.
-                </p>
-                <div className="mt-4 inline-flex items-center text-emerald-400 text-sm font-medium">
-                  Read the case study
                   <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>

--- a/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeHero.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeHero.tsx
@@ -89,14 +89,16 @@ export default function DoDAOHomeHero() {
                         strokeLinecap="round"
                         strokeLinejoin="round"
                         strokeWidth={2}
-                        d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25"
+                        d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104a2.25 2.25 0 01-.659 1.591L5 8.818m4.75-5.714a48.13 48.13 0 014.5 0M14.25 3.104v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396a2.25 2.25 0 00.659 1.591L19 8.818m0 0a2.25 2.25 0 011.591 3.84L13.5 19.5l-3 2.25-3-2.25L.91 12.658a2.25 2.25 0 011.59-3.84m0 0c.413 0 .825.124 1.173.371L5 8.818"
                       />
                     </svg>
                   </div>
                   <span className="text-emerald-400 text-sm font-medium">Robotics</span>
                 </div>
-                <h3 className="text-lg font-semibold text-white mb-2">Robotics Software</h3>
-                <p className="text-sm text-gray-300">ROS 2, MoveIt 2, and modern perception for robot arms and mobile robots. Proven in simulation first.</p>
+                <h3 className="text-lg font-semibold text-white mb-2">Simulation Setup & Synthetic Data</h3>
+                <p className="text-sm text-gray-300">
+                  Gazebo and Isaac Sim worlds modeled for your usecase, plus labeled synthetic data to train YOLO and other vision models.
+                </p>
                 <div className="mt-4 inline-flex items-center text-emerald-400 text-sm font-medium">
                   Explore More
                   <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -133,7 +135,7 @@ export default function DoDAOHomeHero() {
 
           <h3 className="mt-16 text-xl font-semibold text-white text-center">Our Products</h3>
 
-          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:gap-8 max-w-3xl mx-auto">
+          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-3 lg:gap-8 max-w-5xl mx-auto">
             <a
               href="/home-section/dodao-io/products/koalagains"
               className="relative overflow-hidden rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 p-6"
@@ -151,6 +153,37 @@ export default function DoDAOHomeHero() {
                 <p className="text-sm text-gray-300">AI-powered investment analysis platform for detailed financial insights and reports.</p>
                 <div className="mt-4 inline-flex items-center text-blue-400 text-sm font-medium">
                   Explore More
+                  <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </a>
+
+            <a
+              href="/home-section/dodao-io/products/ketchup-hplc-workflow"
+              className="relative overflow-hidden rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 p-6"
+            >
+              <div className="relative">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-500/20">
+                    <svg className="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104a2.25 2.25 0 01-.659 1.591L5 8.818m4.75-5.714a48.13 48.13 0 014.5 0M14.25 3.104v5.714a2.25 2.25 0 00.659 1.591L19 14.5m-4.75-11.396a2.25 2.25 0 00.659 1.591L19 8.818m0 0a2.25 2.25 0 011.591 3.84L13.5 19.5l-3 2.25-3-2.25L.91 12.658a2.25 2.25 0 011.59-3.84m0 0c.413 0 .825.124 1.173.371L5 8.818"
+                      />
+                    </svg>
+                  </div>
+                  <span className="text-emerald-400 text-sm font-medium">Robotics</span>
+                </div>
+                <h3 className="text-lg font-semibold text-white mb-2">Ketchup HPLC Simulation</h3>
+                <p className="text-sm text-gray-300">
+                  Gazebo simulation of the HPLC sample prep workflow for ketchup. Five of eight steps running today, Isaac Sim port next.
+                </p>
+                <div className="mt-4 inline-flex items-center text-emerald-400 text-sm font-medium">
+                  Read the case study
                   <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>

--- a/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
@@ -28,9 +28,9 @@ const products = [
     icon: ChartBarIcon,
   },
   {
-    name: 'HPLC Autosampler',
-    description: 'A robot arm that helps chemistry labs prepare and load sample vials. Built simulation-first on ROS 2 and MoveIt 2.',
-    href: '/home-section/dodao-io/products/hplc-autosampler',
+    name: 'Ketchup HPLC Workflow',
+    description: 'Gazebo simulation of the HPLC sample prep workflow for ketchup, a much harder usecase than the standard paracetamol case.',
+    href: '/home-section/dodao-io/products/ketchup-hplc-workflow',
     icon: BeakerIcon,
   },
   {

--- a/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
@@ -29,7 +29,7 @@ const products = [
   },
   {
     name: 'Ketchup HPLC Workflow',
-    description: 'Gazebo simulation of the HPLC sample prep workflow for ketchup, a much harder usecase than the standard paracetamol case.',
+    description: 'Gazebo simulation of the HPLC sample prep workflow for ketchup',
     href: '/home-section/dodao-io/products/ketchup-hplc-workflow',
     icon: BeakerIcon,
   },

--- a/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/DoDAOHomeTopNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Dialog, DialogPanel, Disclosure, DisclosureButton, DisclosurePanel, Popover, PopoverButton, PopoverGroup, PopoverPanel } from '@headlessui/react';
-import { ChevronDownIcon, PhoneIcon, PlayCircleIcon } from '@heroicons/react/20/solid';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import {
   Bars3Icon,
   BeakerIcon,
@@ -16,7 +16,6 @@ import {
   LifebuoyIcon,
   ChatBubbleLeftEllipsisIcon,
   ShieldCheckIcon,
-  CogIcon,
   EyeIcon,
 } from '@heroicons/react/24/outline';
 import { useState } from 'react';
@@ -86,32 +85,35 @@ const researchAreas = [
 
 const roboticsServices = [
   {
-    name: 'Robotics Software Engineering',
-    description: 'ROS 2 stacks, motion planning, and controls. The brain of a working robot cell.',
-    href: '/home-section/dodao-io/services/robotics-software',
-    icon: CpuChipIcon,
-  },
-  {
-    name: 'Computer Vision & Perception',
-    description: '6-DoF pose, segmentation, SLAM, and grasps. The eyes of the robot.',
-    href: '/home-section/dodao-io/services/computer-vision',
-    icon: EyeIcon,
-  },
-  {
-    name: 'Simulation & Digital Twins',
-    description: 'Gazebo and Isaac Sim worlds. We prove every motion before hardware.',
-    href: '/home-section/dodao-io/services/simulation-digital-twins',
+    name: 'Simulation Setup',
+    description: 'Gazebo and Isaac Sim worlds, modeled for your exact usecase.',
+    href: '/home-section/dodao-io/services/simulation-setup',
     icon: BeakerIcon,
   },
   {
-    name: 'Robotics Hardware',
-    description: 'Arm, gripper, sensors, and compute. We pick the parts and bring the cell up.',
-    href: '/home-section/dodao-io/services/robotics-hardware',
-    icon: CogIcon,
+    name: 'Synthetic Data',
+    description: 'Labeled images from simulation to train YOLO and other vision models.',
+    href: '/home-section/dodao-io/services/synthetic-data',
+    icon: EyeIcon,
   },
 ];
 
-const financeServices = [
+const aiAgentServices = [
+  {
+    name: 'AI Agent Development',
+    description: 'Production AI agents that automate finance and ops workflows.',
+    href: '/home-section/dodao-io/services/custom-ai-agent-dev',
+    icon: CpuChipIcon,
+  },
+  {
+    name: 'Maintenance & Support',
+    description: 'Ongoing monitoring and support for AI agents in production.',
+    href: '/home-section/dodao-io/services/maintenance-support',
+    icon: LifebuoyIcon,
+  },
+];
+
+const blockchainServices = [
   {
     name: 'Smart Contracts & DeFi Tooling',
     description: 'Secure smart contracts and custom DeFi tooling for protocols and DAOs.',
@@ -123,18 +125,6 @@ const financeServices = [
     description: 'Dashboards that turn on-chain data into clear, real-time decisions.',
     href: '/home-section/dodao-io/services/defi-analytics',
     icon: ChartBarIcon,
-  },
-  {
-    name: 'AI Agent Development',
-    description: 'Production-grade AI agents that automate finance and ops workflows.',
-    href: '/home-section/dodao-io/services/custom-ai-agent-dev',
-    icon: CpuChipIcon,
-  },
-  {
-    name: 'Maintenance & Support',
-    description: 'Ongoing monitoring and support for AI and DeFi systems in production.',
-    href: '/home-section/dodao-io/services/maintenance-support',
-    icon: LifebuoyIcon,
   },
 ];
 
@@ -209,8 +199,8 @@ export default function DoDAOHomeTopNav() {
               className="absolute left-1/2 z-10 mt-3 flex w-screen max-w-max -translate-x-1/2 px-4
                          data-[closed]:translate-y-1 data-[closed]:opacity-0 data-[enter]:duration-200 data-[leave]:duration-150 data-[enter]:ease-out data-[leave]:ease-in"
             >
-              <div className="w-screen max-w-3xl flex-auto overflow-hidden rounded-3xl bg-white text-sm/6 shadow-lg ring-1 ring-gray-900/5">
-                <div className="grid grid-cols-1 gap-6 p-4 lg:grid-cols-2">
+              <div className="w-screen max-w-5xl flex-auto overflow-hidden rounded-3xl bg-white text-sm/6 shadow-lg ring-1 ring-gray-900/5">
+                <div className="grid grid-cols-1 gap-6 p-4 lg:grid-cols-3">
                   <div>
                     <h3 className="mb-2 text-base font-semibold text-gray-900 text-center">Robotics</h3>
                     {roboticsServices.map((item) => (
@@ -230,8 +220,26 @@ export default function DoDAOHomeTopNav() {
                   </div>
 
                   <div>
-                    <h3 className="mb-2 text-base font-semibold text-gray-900 text-center">Finance (AI &amp; DeFi)</h3>
-                    {financeServices.map((item) => (
+                    <h3 className="mb-2 text-base font-semibold text-gray-900 text-center">AI Agents</h3>
+                    {aiAgentServices.map((item) => (
+                      <div key={item.name} className="group relative mb-2 flex gap-x-4 rounded-lg p-4 hover:bg-gray-50">
+                        <div className="mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-gray-50 group-hover:bg-white">
+                          <item.icon aria-hidden="true" className="h-6 w-6 text-gray-600 group-hover:text-indigo-600" />
+                        </div>
+                        <div>
+                          <a href={item.href} className="font-semibold text-gray-900">
+                            {item.name}
+                            <span className="absolute inset-0" />
+                          </a>
+                          <p className="mt-1 text-gray-600">{item.description}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div>
+                    <h3 className="mb-2 text-base font-semibold text-gray-900 text-center">Blockchain</h3>
+                    {blockchainServices.map((item) => (
                       <div key={item.name} className="group relative mb-2 flex gap-x-4 rounded-lg p-4 hover:bg-gray-50">
                         <div className="mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-gray-50 group-hover:bg-white">
                           <item.icon aria-hidden="true" className="h-6 w-6 text-gray-600 group-hover:text-indigo-600" />
@@ -370,8 +378,20 @@ export default function DoDAOHomeTopNav() {
                       </DisclosureButton>
                     ))}
 
-                    <div className="px-3 pb-2 pt-2 text-sm font-semibold text-gray-900">Finance (AI &amp; DeFi)</div>
-                    {financeServices.map((item) => (
+                    <div className="px-3 pb-2 pt-2 text-sm font-semibold text-gray-900">AI Agents</div>
+                    {aiAgentServices.map((item) => (
+                      <DisclosureButton
+                        key={item.name}
+                        as="a"
+                        href={item.href}
+                        className="block rounded-lg py-1 pl-6 pr-3 text-sm leading-7 text-gray-900 hover:bg-gray-50"
+                      >
+                        {item.name}
+                      </DisclosureButton>
+                    ))}
+
+                    <div className="px-3 pb-2 pt-2 text-sm font-semibold text-gray-900">Blockchain</div>
+                    {blockchainServices.map((item) => (
                       <DisclosureButton
                         key={item.name}
                         as="a"

--- a/academy-ui/src/components/home/DoDAOHome/components/KetchupHplcWorkflowFeature.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/KetchupHplcWorkflowFeature.tsx
@@ -1,0 +1,122 @@
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/20/solid';
+
+const highlights = [
+  'Models the HPLC sample prep workflow for ketchup, a much harder usecase than the standard paracetamol example.',
+  'Five of the eight workflow steps run end to end in Gazebo Harmonic today.',
+  'Three steps that need tight tolerance hardware moves are honestly left out for now.',
+];
+
+const stack = [
+  { label: 'Sim', value: 'Gazebo Harmonic' },
+  { label: 'Next', value: 'Isaac Sim port' },
+  { label: 'Middleware', value: 'ROS 2' },
+  { label: 'Motion', value: 'MoveIt 2' },
+  { label: 'Arm', value: 'myCobot 280 Pi' },
+];
+
+type StepPreview = {
+  num: string;
+  title: string;
+  done: boolean;
+};
+
+const stepPreview: StepPreview[] = [
+  { num: '01', title: 'Weighing', done: false },
+  { num: '02', title: 'Dissolution', done: true },
+  { num: '03', title: 'Dilution', done: true },
+  { num: '04', title: 'Filtering', done: true },
+  { num: '05', title: 'Transfer to Vial', done: true },
+  { num: '06', title: 'Capping', done: false },
+  { num: '07', title: 'Labeling', done: false },
+  { num: '08', title: 'Autosampler Place', done: true },
+];
+
+export default function KetchupHplcWorkflowFeature() {
+  return (
+    <section className="relative overflow-hidden bg-white py-16 sm:py-20" id="featured-project">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-32 -right-32 w-72 h-72 bg-indigo-100 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-32 -left-32 w-72 h-72 bg-emerald-100 rounded-full blur-3xl"></div>
+      </div>
+
+      <div className="relative mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+          <div>
+            <h2 className="text-base font-semibold leading-7 text-indigo-700 mb-3">Featured Robotics Project</h2>
+            <p className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl lg:text-4xl">
+              Ketchup HPLC Workflow{' '}
+              <span className="bg-gradient-to-r from-indigo-600 via-violet-600 to-emerald-600 bg-clip-text text-transparent">in Simulation</span>
+            </p>
+            <p className="mt-4 text-lg leading-7 text-gray-600">
+              HPLC sample prep is an eight step workflow. Most training material uses paracetamol because it is clean and easy. We built our simulation around
+              ketchup instead. The chemistry is messier, the simulation has to handle more state, and the gaps show up sooner. Five steps run in Gazebo today.
+              The Isaac Sim port comes next.
+            </p>
+
+            <ul className="mt-6 space-y-3">
+              {highlights.map((line) => (
+                <li key={line} className="flex items-start gap-x-3">
+                  <CheckCircleIcon className="h-5 w-5 flex-none text-indigo-600 mt-0.5" aria-hidden="true" />
+                  <span className="text-sm leading-6 text-gray-700">{line}</span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-8 flex flex-wrap gap-2">
+              {stack.map((item) => (
+                <span
+                  key={item.label}
+                  className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-800 ring-1 ring-indigo-200"
+                >
+                  <span className="text-indigo-500 mr-1.5">{item.label}:</span>
+                  {item.value}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-8">
+              <a
+                href="/home-section/dodao-io/products/ketchup-hplc-workflow"
+                className="inline-flex items-center gap-x-2 rounded-xl bg-gradient-to-r from-indigo-600 via-violet-600 to-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity"
+              >
+                Read the case study
+                <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+
+          <div className="relative">
+            <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100 via-violet-100 to-emerald-100 p-1 ring-1 ring-indigo-200">
+              <div className="relative overflow-hidden rounded-xl bg-white/80 backdrop-blur-sm p-6">
+                <p className="text-xs uppercase tracking-widest text-indigo-700 font-semibold text-center">Workflow Status</p>
+                <p className="mt-2 text-lg font-semibold text-gray-900 text-center">5 of 8 steps in Gazebo</p>
+
+                <ul className="mt-6 grid grid-cols-2 gap-2">
+                  {stepPreview.map((step) => (
+                    <li
+                      key={step.num}
+                      className={`flex items-center gap-x-2 rounded-lg px-3 py-2 text-xs ${
+                        step.done ? 'bg-emerald-50 text-emerald-900 ring-1 ring-emerald-200' : 'bg-amber-50 text-amber-900 ring-1 ring-amber-200'
+                      }`}
+                    >
+                      {step.done ? (
+                        <CheckCircleIcon className="h-4 w-4 flex-none text-emerald-600" aria-hidden="true" />
+                      ) : (
+                        <ExclamationTriangleIcon className="h-4 w-4 flex-none text-amber-600" aria-hidden="true" />
+                      )}
+                      <span className="font-mono text-[10px] opacity-70">{step.num}</span>
+                      <span className="font-medium">{step.title}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <p className="mt-4 text-xs italic text-gray-500 text-center">A short Gazebo simulation clip will be added here.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/academy-ui/src/components/home/DoDAOHome/components/KetchupHplcWorkflowFeature.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/KetchupHplcWorkflowFeature.tsx
@@ -1,18 +1,11 @@
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import { CheckCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/20/solid';
 
-const highlights = [
-  'Models the HPLC sample prep workflow for ketchup, a much harder usecase than the standard paracetamol example.',
-  'Five of the eight workflow steps run end to end in Gazebo Harmonic today.',
-  'Three steps that need tight tolerance hardware moves are honestly left out for now.',
-];
+const highlights = ['Models the HPLC sample prep workflow for ketchup.', 'Five of the eight workflow steps run end to end in Gazebo Harmonic today.'];
 
 const stack = [
   { label: 'Sim', value: 'Gazebo Harmonic' },
   { label: 'Next', value: 'Isaac Sim port' },
-  { label: 'Middleware', value: 'ROS 2' },
-  { label: 'Motion', value: 'MoveIt 2' },
-  { label: 'Arm', value: 'myCobot 280 Pi' },
 ];
 
 type StepPreview = {

--- a/academy-ui/src/components/home/DoDAOHome/components/RoboticsServicesTwo.tsx
+++ b/academy-ui/src/components/home/DoDAOHome/components/RoboticsServicesTwo.tsx
@@ -1,0 +1,120 @@
+import { ArrowRightIcon, BeakerIcon, EyeIcon } from '@heroicons/react/24/outline';
+
+type Offering = {
+  name: string;
+  tagline: string;
+  description: string;
+  bullets: string[];
+  stack: string;
+  href: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  gradient: string;
+  accent: string;
+};
+
+const offerings: Offering[] = [
+  {
+    name: 'Simulation Setup',
+    tagline: 'Built first, before any movement or perception code.',
+    description:
+      'We set up the Gazebo and Isaac Sim world for your project. The robot, the bench, the parts, the cameras and the lighting are all modeled to match the real setup, so your team can start working on the actual problem from day one.',
+    bullets: [
+      'Robot model from your URDF or USD assets',
+      'Bench, table, racks and parts for your usecase',
+      'Camera and sensor placements that match real hardware',
+      'Lighting and material settings tuned to the real conditions',
+    ],
+    stack: 'Gazebo Harmonic · Isaac Sim · Isaac Lab · URDF · USD',
+    href: '/home-section/dodao-io/services/simulation-setup',
+    icon: BeakerIcon,
+    gradient: 'from-cyan-500 to-sky-500',
+    accent: 'text-sky-300',
+  },
+  {
+    name: 'Synthetic Data',
+    tagline: 'Labeled training data from your simulation, by the thousand.',
+    description:
+      'Once the simulation is ready, the same scene can produce labeled images for your vision models. Object detection, segmentation, pose, depth and more. Useful when real data is rare, slow to collect or expensive to label.',
+    bullets: [
+      'Datasets for YOLO and other detection models',
+      'Segmentation, pose and grasp datasets',
+      'Domain randomization on lighting, color and clutter',
+      'Labels written in the format your training code expects',
+    ],
+    stack: 'NVIDIA Replicator · Isaac Sim · Gazebo Harmonic · YOLO · PyTorch',
+    href: '/home-section/dodao-io/services/synthetic-data',
+    icon: EyeIcon,
+    gradient: 'from-emerald-500 to-teal-500',
+    accent: 'text-emerald-300',
+  },
+];
+
+export default function RoboticsServicesTwo() {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-gray-900 via-slate-900 to-emerald-950 py-16 sm:py-20" id="robotics-services">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-emerald-500/10 rounded-full blur-3xl animate-pulse"></div>
+        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-cyan-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
+      </div>
+
+      <div className="relative mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-base font-semibold leading-7 text-emerald-400 mb-4">Robotics Services</h2>
+          <p className="text-2xl font-bold tracking-tight text-white sm:text-3xl lg:text-4xl">
+            <span className="block">Two Services We Offer Today</span>
+          </p>
+          <p className="mt-4 text-lg leading-7 text-gray-300 max-w-3xl mx-auto">
+            Every robotics project we ship starts with a careful simulation. We build that world for you and we turn it into the labeled data your vision models
+            need. You can engage us for one or both.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {offerings.map((offering) => (
+            <div
+              key={offering.name}
+              className="group relative flex flex-col overflow-hidden rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 transition-colors duration-300"
+            >
+              <div className={`h-1.5 bg-gradient-to-r ${offering.gradient}`}></div>
+              <div className="p-6 flex flex-col h-full">
+                <div className="flex items-start space-x-4">
+                  <div className={`flex h-12 w-12 flex-none items-center justify-center rounded-xl bg-gradient-to-br ${offering.gradient}`}>
+                    <offering.icon className="h-6 w-6 text-white" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{offering.name}</h3>
+                    <p className={`text-sm font-medium ${offering.accent}`}>{offering.tagline}</p>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-sm leading-6 text-gray-300">{offering.description}</p>
+
+                <ul className="mt-4 space-y-2">
+                  {offering.bullets.map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-x-2 text-sm text-gray-300">
+                      <span className={`mt-1.5 inline-block h-1.5 w-1.5 flex-none rounded-full bg-gradient-to-r ${offering.gradient}`}></span>
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <p className="mt-5 text-xs uppercase tracking-wide text-gray-400">Tools</p>
+                <p className="mt-1 text-sm text-gray-200">{offering.stack}</p>
+
+                <div className="mt-6">
+                  <a
+                    href={offering.href}
+                    className={`inline-flex items-center gap-x-2 rounded-xl bg-gradient-to-r ${offering.gradient} px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity`}
+                  >
+                    Read the {offering.name} page
+                    <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+                  </a>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Restructure the Services popover on the DoDAO home page top-nav from two columns to three: **Robotics**, **AI Agents**, **Blockchain**.
- Each column now lists two services (six total). Desktop popover widened to `max-w-5xl` / `lg:grid-cols-3`; mobile services disclosure shows the same three sections.
- Add two new MDX service pages under `home-section/dodao-io/services/`:
  - `simulation-setup` — Gazebo and Isaac Sim world building (robot, bench, parts, sensors, lighting) as the first step of any robotics project.
  - `synthetic-data` — labeled training data from the simulation for YOLO and other vision models.
- Drop now-unused icon imports (`CogIcon`, `PhoneIcon`, `PlayCircleIcon`).

The two existing 4-card service blocks on the home page (`RoboticsOfferings`, `CoreOfferings`) are intentionally left untouched in this PR — per the request this round is the nav restructure + new pages only.

## Test plan
- [ ] Open the DoDAO home page, hover Services in the desktop nav and confirm three columns render (Robotics, AI Agents, Blockchain) with two items each.
- [ ] Click each of the six links and confirm the destination page loads.
- [ ] Resize to mobile width, open the menu, expand Services and confirm the three labeled sections appear with the same six items.
- [ ] Visit `/home-section/dodao-io/services/simulation-setup` and `/home-section/dodao-io/services/synthetic-data` directly and confirm the content renders inside the standard `PageWrapper` / `markdown-body` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)