### PR TITLE
Fix variable name typo in report generation

### DIFF
--- a/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
@@ -338,7 +338,7 @@ export async function triggerGenerationOfAReportSimplified(symbol: string, excha
             id: generationRequest.id,
           },
           data: {
-            failedSteps: Array.from(new Set(failedStep)), // Remove duplicates
+            failedSteps: Array.from(new Set(failedSteps)), // Remove duplicates
             inProgressStep: null,
             updatedAt: new Date(),
           },


### PR DESCRIPTION
## Description

Fixed a variable name typo in `triggerGenerationOfAReportSimplified` where `failedStep` was used instead of `failedSteps` when updating the report generation request data.

### Changes

- **File:** `insights-ui/src/utils/analysis-reports/generation-report-utils.ts`
- **Line 341:** Changed `failedStep` to `failedSteps` to match the correct variable name
- This ensures the failed steps array is properly deduplicated and passed to the database update

### Impact

This fixes a bug where the report generation status update would fail or use an undefined variable, potentially causing issues with tracking failed steps in the report generation process.

### Testing

No additional testing needed — this is a straightforward variable name correction. Existing code paths that call this function will now correctly pass the deduplicated failed steps array.

https://claude.ai/code/session_01YAc3ymPCX8etu6pEqNWJPJ