### PR TITLE
Add BlogPosting JSON-LD + fix duplicate H1s on indexed blog pages

### DIFF
--- a/insights-ui/blogs/2025-04-10-simple-investing-models.mdx
+++ b/insights-ui/blogs/2025-04-10-simple-investing-models.mdx
@@ -25,13 +25,13 @@ seoKeywords:
   ]
 ---
 
-# 1. **Summary**
+## 1. **Summary**
 
 This article provides a **comprehensive discussion** of ten fundamental equity valuation models. It begins by explaining each model’s **underlying theory**, **key assumptions**, **historical contributors**, and **mathematical formulas**. It then demonstrates **detailed, step-by-step examples** for applying each model. Additionally, it reviews **which four models** tend to work best in each **Global Industry Classification Standard (GICS)** sector and **which three** are less recommended (along with reasons why). Finally, it includes **comparison tables** for quick reference and a full **references section** with hyperlinks for those wishing to learn more.
 
 ---
 
-# 2. **Ten Fundamental Valuation Models**
+## 2. **Ten Fundamental Valuation Models**
 
 Below is a **more in-depth look** at each of the ten simplified models. For each model, you will find:
 1. A **detailed explanation** of how the model works, where it comes from, and what its key assumptions are.
@@ -41,9 +41,9 @@ Creators, contributors, and approximate years are mentioned to give historical c
 
 ---
 
-## 2.1. **Dividend Discount Model (DDM)**
+### 2.1. **Dividend Discount Model (DDM)**
 
-### 2.1.1. **Detailed Explanation**
+#### 2.1.1. **Detailed Explanation**
 
 - **Core Concept:** The DDM values a stock by summing the present value of all future expected dividend payments. It assumes that a company’s intrinsic worth is determined by the stream of cash dividends it can pay to shareholders.
 
@@ -64,7 +64,7 @@ Creators, contributors, and approximate years are mentioned to give historical c
     where \(P_0\) is the current price, \(D_1\) is the next dividend, \(r\) is the required rate of return, and \(g\) is the constant growth rate.
   - **Multi-stage DDM** (if growth rates change over different periods).
 
-### 2.1.2. **Expanded Example**
+#### 2.1.2. **Expanded Example**
 
 Suppose you have a **mature utility** company known for reliable dividends:
   - Last dividend paid (\(D_0\)): \$2.00 per share
@@ -93,9 +93,9 @@ Suppose you have a **mature utility** company known for reliable dividends:
 
 ---
 
-## 2.2. **Free Cash Flow to Equity (FCFE)**
+### 2.2. **Free Cash Flow to Equity (FCFE)**
 
-### 2.2.1. **Detailed Explanation**
+#### 2.2.1. **Detailed Explanation**
 
 - **Core Concept:** FCFE represents the **cash flow available** to equity shareholders after covering all **operational expenses, taxes, capital expenditures, changes in working capital, and net debt transactions**.
 
@@ -110,7 +110,7 @@ Suppose you have a **mature utility** company known for reliable dividends:
   - Capital expenditures (CapEx).
   - Net debt issued or repaid.
 
-### 2.2.2. **Expanded Example**
+#### 2.2.2. **Expanded Example**
 
 Imagine **Company B**, a fast-growing tech firm paying **no dividends**, but you want to estimate its equity value.
 
@@ -161,9 +161,9 @@ The model suggests a per-share equity value of ~\$86.67, **assuming** a 4% growt
 
 ---
 
-## 2.3. **Free Cash Flow to the Firm (FCFF)**
+### 2.3. **Free Cash Flow to the Firm (FCFF)**
 
-### 2.3.1. **Detailed Explanation**
+#### 2.3.1. **Detailed Explanation**
 
 - **Core Concept:**
 FCFF looks at the total operating cash flow available to **all** providers of capital (both debt and equity).
@@ -174,7 +174,7 @@ Also rooted in the broader discounted cash flow approach. Its modern usage in va
 - **Why It Matters:**
 Often used for **M&A** or when you want a valuation approach **independent of capital structure**. After you discount FCFF at the Weighted Average Cost of Capital (WACC), you can subtract net debt to get the equity value.
 
-### 2.3.2. **Expanded Example**
+#### 2.3.2. **Expanded Example**
 
 Assume you’re evaluating **Company C**, a manufacturing firm:
 
@@ -231,9 +231,9 @@ By focusing on **all** operating cash flows and discounting at the **WACC**, you
 
 ---
 
-## 2.4. **Residual Income Model (RIM)**
+### 2.4. **Residual Income Model (RIM)**
 
-### 2.4.1. **Detailed Explanation**
+#### 2.4.1. **Detailed Explanation**
 
 - **Core Concept:**
 Also called the **Economic Profit** approach. It starts with the firm’s **book value of equity** and adds the present value of “residual income”—the portion of net income that **exceeds** the required return on the beginning book value of equity.
@@ -244,7 +244,7 @@ The modern formulation is frequently linked to **James Ohlson (1995)** and the O
 - **When to Use:**
 It is especially helpful when a firm’s **free cash flow is erratic** but accounting earnings and book values are more predictable.
 
-### 2.4.2. **Expanded Example**
+#### 2.4.2. **Expanded Example**
 
 Consider **Company D**, a bank:
 
@@ -293,9 +293,9 @@ Even if short-term cash flows fluctuate, **residual income** can reveal how much
 
 ---
 
-## 2.5. **Capital Asset Pricing Model (CAPM)**
+### 2.5. **Capital Asset Pricing Model (CAPM)**
 
-### 2.5.1. **Detailed Explanation**
+#### 2.5.1. **Detailed Explanation**
 
 - **Core Concept:**
 CAPM **is not** a direct valuation model. Instead, it estimates the **required return on equity**—often used as the **discount rate** in DDM, FCFE, or FCFF models.
@@ -311,7 +311,7 @@ Investors expect a premium over the risk-free rate for taking on systematic (mar
 r_e = R_f + \beta (R_m - R_f)
 \]
 
-### 2.5.2. **Expanded Example**
+#### 2.5.2. **Expanded Example**
 
 A large consumer staples firm:
 
@@ -334,9 +334,9 @@ You would use **11.2%** as the **required return on equity** when discounting th
 
 ---
 
-## 2.6. **Price/Earnings (P/E) Ratio**
+### 2.6. **Price/Earnings (P/E) Ratio**
 
-### 2.6.1. **Detailed Explanation**
+#### 2.6.1. **Detailed Explanation**
 
 - **Core Concept:**
 The **P/E ratio** is a straightforward, **relative** valuation multiple that indicates how much investors are willing to pay for **each dollar of current earnings**.
@@ -352,7 +352,7 @@ Widely used since **Benjamin Graham and David Dodd (1934)** emphasized earnings-
     - Does **not** capture **growth** prospects directly.
     - One-time charges or cyclical swings in earnings can distort the ratio.
 
-### 2.6.2. **Expanded Example**
+#### 2.6.2. **Expanded Example**
 
 A stable industrial firm:
 
@@ -371,9 +371,9 @@ If its major competitors trade at an average P/E of 18, this firm **might** be u
 
 ---
 
-## 2.7. **PEG Ratio (P/E to Growth)**
+### 2.7. **PEG Ratio (P/E to Growth)**
 
-### 2.7.1. **Detailed Explanation**
+#### 2.7.1. **Detailed Explanation**
 
 - **Core Concept:**
 The PEG ratio adds a **growth dimension** to the P/E ratio, dividing P/E by the expected annual **EPS growth rate**.
@@ -389,7 +389,7 @@ Often linked to **Peter Lynch (1989)** in his book *One Up on Wall Street*.
 - **Caveat:**
 A **small error** in growth projections can significantly skew the ratio.
 
-### 2.7.2. **Expanded Example**
+#### 2.7.2. **Expanded Example**
 
 Consider a **growth-focused** consumer discretionary firm:
 
@@ -408,9 +408,9 @@ A PEG of 1.5 suggests the stock’s **P/E is higher** than its **growth rate**, 
 
 ---
 
-## 2.8. **Price-to-Book (P/B) Ratio**
+### 2.8. **Price-to-Book (P/B) Ratio**
 
-### 2.8.1. **Detailed Explanation**
+#### 2.8.1. **Detailed Explanation**
 
 - **Core Concept:**
 **P/B** compares the **market value of equity** (market cap) to the **book value of equity**. It is especially relevant for **financial institutions** or asset-heavy sectors.
@@ -425,7 +425,7 @@ Benjamin Graham (1934) also explored **book value** as a protective margin in st
 - **Limitations:**
     - Book value can be misleading for companies with significant **intangible** assets (e.g., tech, brand value).
 
-### 2.8.2. **Expanded Example**
+#### 2.8.2. **Expanded Example**
 
 A regional bank:
 
@@ -444,9 +444,9 @@ If peer banks trade at **1.0×**, this **1.2×** ratio suggests a **premium**—
 
 ---
 
-## 2.9. **Earnings Yield (Inverse of P/E)**
+### 2.9. **Earnings Yield (Inverse of P/E)**
 
-### 2.9.1. **Detailed Explanation**
+#### 2.9.1. **Detailed Explanation**
 
 - **Core Concept:**
 **Earnings Yield** = EPS / Price. It is the **reciprocal** of the P/E ratio and lets investors compare equity returns to bond yields.
@@ -460,7 +460,7 @@ If a stock’s earnings yield is **above** comparable bond yields, some consider
 - **Limitations:**
 - Like P/E, one-year EPS might not be sustainable if earnings are **cyclical** or **distorted** by unusual items.
 
-### 2.9.2. **Expanded Example**
+#### 2.9.2. **Expanded Example**
 
 A consumer staples firm with **consistent profits**:
 
@@ -479,9 +479,9 @@ If the 10-year Treasury yield is around **4%**, the stock’s 5% earnings yield 
 
 ---
 
-## 2.10. **Enterprise Value to EBITDA (EV/EBITDA)**
+### 2.10. **Enterprise Value to EBITDA (EV/EBITDA)**
 
-### 2.10.1. **Detailed Explanation**
+#### 2.10.1. **Detailed Explanation**
 
 - **Core Concept:**
 **EV/EBITDA** is a **capital-structure-neutral** multiple. Enterprise Value (EV) is market cap + total debt − cash, while EBITDA approximates operating cash flow before interest, taxes, depreciation, and amortization.
@@ -496,7 +496,7 @@ Gained traction among practitioners and in leveraged buyout (LBO) analyses in th
 - **Caveats:**
   - **Ignores capital expenditures**. A firm with high ongoing CapEx might look cheap on EV/EBITDA even though free cash flow is low.
 
-### 2.10.2. **Expanded Example**
+#### 2.10.2. **Expanded Example**
 
 A private equity target:
 
@@ -515,7 +515,7 @@ If peers trade at **10× EBITDA**, you might initially see this as an undervalua
 
 ---
 
-# 3. **Sector-by-Sector Analysis (GICS)**
+## 3. **Sector-by-Sector Analysis (GICS)**
 
 GICS has **11 main sectors**, each with unique **financial** and **operational** nuances. Below are guidelines on:
 
@@ -524,7 +524,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.1. **Energy**
+### 3.1. **Energy**
 
 - **Examples:** ExxonMobil, Chevron
 - **Characteristics:** Capital-intensive, revenues fluctuate with commodity prices, big players often pay stable dividends.
@@ -542,7 +542,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.2. **Materials**
+### 3.2. **Materials**
 
 - **Examples:** Dow, DuPont, Newmont
 - **Characteristics:** Asset-heavy (mining, chemicals), cyclical with commodity pricing.
@@ -560,7 +560,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.3. **Industrials**
+### 3.3. **Industrials**
 
 - **Examples:** GE, Caterpillar, Boeing
 - **Characteristics:** Broad cyclical sector; many large companies with significant capex and varied product lines.
@@ -578,7 +578,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.4. **Consumer Discretionary**
+### 3.4. **Consumer Discretionary**
 
 - **Examples:** Tesla, Nike, Amazon
 - **Characteristics:** Often higher-growth, brand-driven, or cyclical consumer spending.
@@ -596,7 +596,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.5. **Consumer Staples**
+### 3.5. **Consumer Staples**
 
 - **Examples:** Procter & Gamble, Coca-Cola, Walmart
 - **Characteristics:** Stable demand, dependable cash flow, many pay consistent dividends.
@@ -614,7 +614,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.6. **Health Care**
+### 3.6. **Health Care**
 
 - **Examples:** Pfizer, Johnson & Johnson, Biotech Startups
 - **Characteristics:** Includes stable pharma, large health care providers, and high-risk biotech with uncertain cash flows.
@@ -632,7 +632,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.7. **Financials**
+### 3.7. **Financials**
 
 - **Examples:** JPMorgan, Goldman Sachs, Berkshire Hathaway, Visa
 - **Characteristics:** Highly regulated, unique treatment of **debt vs. deposits**, intangible drivers in some subsectors (like payments).
@@ -650,7 +650,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.8. **Information Technology**
+### 3.8. **Information Technology**
 
 - **Examples:** Apple, Microsoft, Nvidia, Salesforce
 - **Characteristics:** Often asset-light, intangible-driven, can be very high growth.
@@ -668,7 +668,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.9. **Communication Services**
+### 3.9. **Communication Services**
 
 - **Examples:** Alphabet (Google), Meta, Verizon, Disney
 - **Characteristics:** Telecom (stable dividends, heavy capex) + digital media (high growth, intangible assets).
@@ -686,7 +686,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.10. **Utilities**
+### 3.10. **Utilities**
 
 - **Examples:** Duke Energy, NextEra Energy
 - **Characteristics:** Regulated, steady cash flows, large infrastructure investments, notable dividends.
@@ -704,7 +704,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-## 3.11. **Real Estate (including REITs)**
+### 3.11. **Real Estate (including REITs)**
 
 - **Examples:** Simon Property Group, Prologis
 - **Characteristics:** Asset-backed revenue streams, high dividend payouts (for REITs), property values are central.
@@ -722,9 +722,9 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-# 4. **Quick Comparison Tables**
+## 4. **Quick Comparison Tables**
 
-## 4.1. **Recommended Models by Sector**
+### 4.1. **Recommended Models by Sector**
 
 | **GICS Sector**            | **4 Recommended Models**                     |
 |----------------------------|----------------------------------------------|
@@ -740,7 +740,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 | **Utilities**              | DDM, FCFF, EV/EBITDA, Earnings Yield         |
 | **Real Estate**            | P/B, FCFE, EV/EBITDA, DDM                    |
 
-## 4.2. **Three Models Often Not Recommended, by Sector**
+### 4.2. **Three Models Often Not Recommended, by Sector**
 
 | **GICS Sector**            | **3 Not Recommended**                | **Core Reasons (Summary)**                                                                      |
 |----------------------------|--------------------------------------|-------------------------------------------------------------------------------------------------|
@@ -758,7 +758,7 @@ GICS has **11 main sectors**, each with unique **financial** and **operational**
 
 ---
 
-# 5. **Closing Notes**
+## 5. **Closing Notes**
 
 1. **No single model is perfect.**
 Each model relies on assumptions about growth, discount rates, and accounting measures.
@@ -774,7 +774,7 @@ Always see how valuation changes if **growth**, **discount rate**, or **margins*
 
 ---
 
-# 6. **References**
+## 6. **References**
 
 Below are select resources and historical attributions:
 

--- a/insights-ui/blogs/2025-06-23-public-vs-private-reits.mdx
+++ b/insights-ui/blogs/2025-06-23-public-vs-private-reits.mdx
@@ -75,8 +75,6 @@ seoKeywords:
 
 ***
 
-# **<a name="article-title"></a>Public REITs vs. Public Non-Listed REITs vs. Private REITs**
-
 Real Estate Investment Trusts (REITs) come in three broad varieties—publicly traded, publicly registered non-listed, and private—each offering distinct structures, liquidity profiles, fee burdens, and investor requirements. This article provides a comprehensive comparison, illustrating how these vehicles operate, who they serve, and their relative advantages and drawbacks.
 
 ---

--- a/insights-ui/blogs/2025-07-08-generative-ai-customer-service-capabilities.mdx
+++ b/insights-ui/blogs/2025-07-08-generative-ai-customer-service-capabilities.mdx
@@ -39,168 +39,168 @@ seoKeywords:
   - 'Customer Feedback'
 ---
 
-# What This Article Is About
+## What This Article Is About
 
 This article explores how **Generative AI (Gen AI)** empowers modern **customer service** through a spectrum of capabilities—from **real-time chat** and **automated bots** to **knowledge bases** and **proactive support triggers**—and highlights the **leading tools** that enable each innovation.
 
-# Introduction
+## Introduction
 
 In today’s world, customers expect **instant**, **personalized**, and **always-on** support across every channel. **Gen AI**, with its advanced **natural language processing** and **machine learning**, allows businesses to **automate** repetitive tasks, deliver **context-aware** assistance, and gain **proactive** insights to prevent issues before they arise. In this article, we’ll dive into the **key Gen AI capabilities** that are transforming customer experiences and showcase the **tools** powering these solutions.
 
-# Automated (Bot)
+## Automated (Bot)
 
 **Automated (Bot)** lets businesses deploy **smart virtual agents** that can **start**, **understand**, and **solve** routine customer questions on their own. These bots work **around the clock**, handle common requests instantly, and free up human agents for more complex tasks.
 
-## Human Customer Agent Interaction
+### Human Customer Agent Interaction
 
 When a bot can’t fully resolve an issue, it hands the conversation off to a human agent—complete with the **full context** of what’s been discussed—so customers enjoy a **seamless**, **personalized** experience even for tricky problems.
 
-### Intercom
+#### Intercom
 
 **Link:** [https://www.intercom.com/suite/helpdesk/inbox](https://www.intercom.com/suite/helpdesk/inbox) \
 Intercom’s **Copilot** acts as a **personal AI sidekick** for every support rep, delivering **instant answers** so teams spend less time searching and more time building strong customer relationships.
 
-### Freshdesk
+#### Freshdesk
 
 **Link:** [https://www.freshworks.com/freshdesk/](https://www.freshworks.com/freshdesk/) \
 Freshdesk’s AI bots can resolve up to **80% of everyday queries**, giving customers **24/7 help** without delay. They also **draft on-brand replies** instantly, so agents never start from a blank slate.
 
-## Multilingual
+### Multilingual
 
 **Multilingual** bots understand and reply in **many languages**, removing language barriers, making support **truly global**, and saving companies the time and cost of manual translation.
 
-#### Talkdesk
+##### Talkdesk
 
 **Link:** [https://www.talkdesk.com/cloud-contact-center/self-service-experience/autopilot/#anchor-New%20Feature](https://www.talkdesk.com/cloud-contact-center/self-service-experience/autopilot/#anchor-New%20Feature) \
 Talkdesk’s virtual agents can hold conversations—both voice and text—in up to **59 languages**, adapting to different accents and speech patterns.
 
-# Audio Calls
+## Audio Calls
 
 **Audio Calls** powered by Gen AI provide **human-like voice conversations** without human intervention. These voice bots answer calls **anytime**, **route** customers intelligently, and let people **self-serve** simple requests by phone.
 
-### Talkdesk Autopilot
+#### Talkdesk Autopilot
 
 **Link:** [https://www.talkdesk.com/cloud-contact-center/self-service-experience/autopilot/#anchor-New%20Feature](https://www.talkdesk.com/cloud-contact-center/self-service-experience/autopilot/#anchor-New%20Feature) \
 Talkdesk Autopilot’s **voice AI agents** deliver empathetic, **natural-sounding** interactions that feel like talking to a real person—**24/7**, across voice or digital channels.
 
-### Intercom Omnichannel
+#### Intercom Omnichannel
 
 **Link:** [https://www.intercom.com/suite/helpdesk/omnichannel](https://www.intercom.com/suite/helpdesk/omnichannel) \
 Intercom lets you handle **phone calls**, **video chats**, and **screen shares** in one place. Its **no-code IVR** trees route calls automatically, cutting wait times and boosting team efficiency.
 
-### Zendesk Voice
+#### Zendesk Voice
 
 **Link:** [https://www.zendesk.com/service/voice/](https://www.zendesk.com/service/voice/) \
 Zendesk Voice blends **AI suggestions** with live calls, helping agents deliver **personalized**, **high-quality** support on every phone interaction.
 
-### Freshdesk Omni
+#### Freshdesk Omni
 
 **Link:** [https://www.freshworks.com/freshdesk/](https://www.freshworks.com/freshdesk/) \
 Freshdesk’s voice bots answer routine questions, give agents **real-time call prompts**, and auto-route calls to the right teams for faster problem solving.
 
-### Twilio Programmable Voice
+#### Twilio Programmable Voice
 
 **Link:** [https://www.twilio.com/en-us/voice](https://www.twilio.com/en-us/voice) \
 Twilio’s Programmable Voice API lets you **make**, **receive**, and **track** calls globally. Integrate voice features into your apps with **SDKs** and **APIs** for a reliable, scalable experience.
 
-# Issue Tracking
+## Issue Tracking
 
 **Issue Tracking** uses AI to **capture**, **organize**, and **prioritize** support tickets so that nothing falls through the cracks and every customer issue is addressed in the right order.
 
-### Intercom
+#### Intercom
 
 **Link:** [https://www.intercom.com/suite/helpdesk/tickets](https://www.intercom.com/suite/helpdesk/tickets) \
 Intercom’s ticket system keeps all conversations and notes in one place, making collaboration easy and ensuring no context is ever lost.
 
-### HelpDesk
+#### HelpDesk
 
 **Link:** [https://www.helpdesk.com/?utm_source=livechat.com&utm_medium=referral&utm_campaign=productbarfooter&landing_page=https%3A%2F%2Fwww.livechat.com%2F](https://www.helpdesk.com/?utm_source=livechat.com&utm_medium=referral&utm_campaign=productbarfooter&landing_page=https%3A%2F%2Fwww.livechat.com%2F) \
 HelpDesk’s **similar tickets** feature shows agents past cases like the one they’re working on, so they can apply proven solutions and resolve issues faster.
 
-### Freshchat
+#### Freshchat
 
 **Link:** [https://www.freshworks.com/freshdesk/streamline-admin/](https://www.freshworks.com/freshdesk/streamline-admin/) \
 Freshchat automatically routes and assigns tickets based on an agent’s **skills**, **workload**, and **customer sentiment**, making sure each issue lands with the best person to solve it.
 
-# Proactive Support Triggers
+## Proactive Support Triggers
 
 **Proactive Support Triggers** let AI watch for warning signs in customer data—historical trends or real-time signals—and send **early alerts** or **recommendations** before small problems become big headaches.
 
-### NICE AI Orchestrator
+#### NICE AI Orchestrator
 
 **Link:** [https://www.nice.com/products/ai-orchestrator](https://www.nice.com/products/ai-orchestrator) \
 NICE AI Orchestrator analyzes both past and live data to spot issues early, then suggests the best actions to prevent or fix them, helping teams stay ahead of customer needs.
 
-# Agent Support
+## Agent Support
 
 **Agent Support** equips human agents with **AI-driven guidance**, making it easy to match the right agent to each customer and arm that agent with **live, context-rich information** during interactions.
 
-## Matching the Right Agent
+### Matching the Right Agent
 
 AI looks at **agent skills**, **customer profiles**, and past performance to **route** each query to the team member best suited to resolve it quickly and effectively.
 
-### Genesys Cloud
+#### Genesys Cloud
 
 **Link:** [https://www.genesys.com/capabilities/automated-routing](https://www.genesys.com/capabilities/automated-routing) \
 Genesys Cloud uses AI to personalize each connection, **automatically matching** customers to the right agents instead of relying on fixed routing rules.
 
-### NICE CXone
+#### NICE CXone
 
 **Link:** [https://www.nice.com/products/omnichannel-routing](https://www.nice.com/products/omnichannel-routing) \
 NICE CXone’s Omnichannel Routing ensures every customer is paired with the best available agent, no matter which channel they use.
 
-## Showing Information to the Agent
+### Showing Information to the Agent
 
 During live interactions, AI fetches **relevant articles**, **previous tickets**, and **next-best-action suggestions** right in the agent’s workspace—so they don’t have to hunt for answers.
 
-### Zendesk Voice
+#### Zendesk Voice
 
 **Link:** [https://www.zendesk.com/service/voice/](https://www.zendesk.com/service/voice/) \
 Zendesk’s Agent Copilot for Voice listens in and provides **real-time prompts**, helping agents choose the right response and close calls faster.
 
-### Confluence
+#### Confluence
 
 **Link:** [https://www.atlassian.com/software/confluence/features](https://www.atlassian.com/software/confluence/features) \
 Confluence powers an **intelligent knowledge base**, offering agents up-to-date articles and resources exactly when they need them.
 
-# Knowledge Base
+## Knowledge Base
 
 A **Knowledge Base** is a central hub of articles, FAQs, and guides that customers (and agents) can search instantly, promoting **self-service**, speeding up resolutions, and keeping answers consistent.
 
-### Document360
+#### Document360
 
 **Link:** [https://document360.com/ai/](https://document360.com/ai/) \
 Document360’s AI tools help you **write**, **organize**, and **summarize** content automatically. Agents can pull **precise answers** from articles in conversations, boosting engagement.
 
-### Intercom Knowledge Hub
+#### Intercom Knowledge Hub
 
 **Link:** [https://www.intercom.com/suite/helpdesk/knowledge-hub](https://www.intercom.com/suite/helpdesk/knowledge-hub) \
 Intercom’s Knowledge Hub brings all support content into one system, making it easy to optimize and maintain your entire library of help articles.
 
-### Zendesk Help Center
+#### Zendesk Help Center
 
 **Link:** [https://www.zendesk.com/service/help-center/](https://www.zendesk.com/service/help-center/) \
 Zendesk Help Center structures your knowledge and gives both customers and agents a clear path to the right information.
 
-### Confluence
+#### Confluence
 
 **Link:** [https://www.atlassian.com/software/confluence/features](https://www.atlassian.com/software/confluence/features) \
 Confluence recommends the best resources and keeps your knowledge base **up to date**, so agents always have accurate info.
 
-### Higher Logic Knowledge Base
+#### Higher Logic Knowledge Base
 
 **Link:** [https://www.higherlogic.com/customer-support-features/#knowledge-base](https://www.higherlogic.com/customer-support-features/#knowledge-base) \
 Higher Logic’s searchable repository replaces scattered documents with a single, organized space for everything from product guides to troubleshooting tips.
 
-# Customer Feedback/Satisfaction
+## Customer Feedback/Satisfaction
 
 Collecting and analyzing **customer feedback**—from social media, surveys, chats, and more—helps businesses spot trends, measure sentiment, and continuously improve experiences.
 
-## Tracking Social Media
+### Tracking Social Media
 
 AI monitors mentions on social platforms, applies **sentiment analysis** to understand customer feelings, and alerts teams to emerging issues or opportunities in real time.
 
-### Qualtrics XM Platform
+#### Qualtrics XM Platform
 
 **Link:** [https://www.qualtrics.com/customer-experience/omnichannel](https://www.qualtrics.com/customer-experience/omnichannel)
 
@@ -208,67 +208,67 @@ AI monitors mentions on social platforms, applies **sentiment analysis** to unde
 2. Track engagement metrics and link them to business outcomes like **revenue** and **retention**.
 3. Use AI-driven sentiment analysis to understand how customers feel about every interaction.
 
-## Surveys
+### Surveys
 
 AI helps you **design**, **send**, and **interpret** surveys with smart templates, real-time analytics, and branching logic—so you get the insights you need without manual setup.
 
-### SurveyMonkey
+#### SurveyMonkey
 
 **Link:** [https://www.surveymonkey.com/roles/customer-experience/](https://www.surveymonkey.com/roles/customer-experience/) \
 SurveyMonkey offers **60+ CX templates** and **AI analytics** to turn survey responses into clear insights, helping you make smarter, loyalty-building decisions.
 
-### Influitive
+#### Influitive
 
 **Link:** [https://influitive.com/customer-experience-platform/](https://influitive.com/customer-experience-platform/) \
 Influitive builds **dynamic customer profiles** from survey data—combining demographics, feedback, and experience metrics—to help you personalize every interaction.
 
-# Customer Activity
+## Customer Activity
 
 Tracking what customers **do**—from site visits to feature usage—lets teams spot active or at-risk users and send timely, relevant messages to keep them engaged.
 
-### Sales Activity
+#### Sales Activity
 
 AI analyzes user behavior to flag **at-risk** customers and trigger **re-engagement** campaigns. It also lets you **ask questions in plain language** and get instant analytics reports.
 
-#### Mixpanel
+##### Mixpanel
 
 **Link:** [https://mixpanel.com/use-cases/engage/](https://mixpanel.com/use-cases/engage/) \
 Mixpanel shows you why users return and helps you **re-engage** those who might churn—giving teams **instant insights** without ever writing SQL.
 
-#### Tealium
+##### Tealium
 
 **Link:** [https://tealium.com/solutions-customer-experience-personalization/](https://tealium.com/solutions-customer-experience-personalization/) \
 Tealium unifies customer data into **single profiles**, so you know exactly how and when each person interacts with your brand and can tailor experiences accordingly.
 
-# Customer Outreach
+## Customer Outreach
 
 Gen AI empowers **automated, personalized** outreach via SMS, email, and other channels—helping you **welcome** new users, **recover** abandoned carts, and **win back** customers with the right message at the right time.
 
-### Twilio Programmable Messaging API
+#### Twilio Programmable Messaging API
 
 **Link:** [https://www.twilio.com/en-us/messaging](https://www.twilio.com/en-us/messaging) \
 Twilio’s API sends **personalized alerts**, **reminders**, and **notifications** at scale. Combine it with the OpenAI API to generate **custom SMS content** automatically.
 
-### Mailchimp AI Growth Assistant
+#### Mailchimp AI Growth Assistant
 
 **Link:** [https://mailchimp.com/solutions/ai-tools/](https://mailchimp.com/solutions/ai-tools/) \
 Mailchimp’s AI tools build and send **welcome series**, **cart recovery** emails, and **re-engagement** campaigns—then optimize them with data-driven suggestions.
 
-# Client Onboarding Process Assistant
+## Client Onboarding Process Assistant
 
 Gen AI–powered onboarding tools guide new users through every step—using **in-app tips**, **visual cues**, and **task lists**—so they learn the product quickly and maximize value on their own.
 
-### WalkMe In-App Guidance
+#### WalkMe In-App Guidance
 
 **Link:** [https://www.walkme.com/in-app-guidance/](https://www.walkme.com/in-app-guidance/) \
 WalkMe delivers on-screen **tooltips**, **guides**, and **checklists** that appear at the right moment, helping users complete tasks without leaving the app.
 
-### Higher Logic Vanilla Customer Retention
+#### Higher Logic Vanilla Customer Retention
 
 **Link:** [https://vanilla.higherlogic.com/solutions/customer-retention/](https://vanilla.higherlogic.com/solutions/customer-retention/) \
 Higher Logic centralizes **training materials**—videos, guides, and tutorials—so you can scale onboarding for any number of new customers with ease.
 
-# Conclusion
+## Conclusion
 
 Generative AI is reshaping customer service by automating routine tasks, delivering richer self-service options, and equipping agents with the right information at the right time. From **smart bots** that handle common questions and **voice AI** that carries on natural phone conversations, to **issue-tracking** systems that prioritize tickets and **proactive triggers** that spot problems before they happen, each capability works together to create a smoother experience for customers and support teams alike.
 

--- a/insights-ui/blogs/2026-02-05-block-sq-3-year-stock-price-multiplier.mdx
+++ b/insights-ui/blogs/2026-02-05-block-sq-3-year-stock-price-multiplier.mdx
@@ -28,7 +28,7 @@ seoKeywords:
   ]
 ---
 
-**A) Anchor selection (exactly 3 paragraphs)**
+## A) Anchor selection (exactly 3 paragraphs)
 
 For Block today, the best **PRIMARY value anchor is EV/Gross Profit (enterprise value divided by gross profit), using the latest annual/TTM gross profit as the metric**. The reason is practical: Block’s reported revenue includes large pass-through components (especially around Bitcoin and payment volume) that inflate revenue without reflecting the actual economics, while **gross profit is the cleanest “value-added” measure that captures what Square and Cash App truly earn after direct costs**. Your business summary already frames performance in gross profit terms (Square LTM gross profit **~$3.87B**, Cash App **~$5.88B**), which is how both management teams and sophisticated investors usually discuss Block’s core engine. EV/Gross Profit also fits the business model: payments + software ecosystems typically monetize through a blend of take-rate and software/services, and gross profit is where unit economics and mix improvements show up. By contrast, a simple P/S multiple can be misleading for Block because the “S” is not consistently comparable across periods due to mix, and P/E can be distorted by one-offs (tax items, gains on investments, and period-to-period accounting noise), which your historical statements clearly show.
 
@@ -38,7 +38,7 @@ For **CROSS-CHECK anchor #2**, I use **EV/EBIT (enterprise value divided by oper
 
 ---
 
-**B) The 3–4 driver framework (exactly 4 paragraphs)**
+## B) The 3–4 driver framework (exactly 4 paragraphs)
 
 **Driver 1: Gross profit growth (the core “economic output” of Square + Cash App).** Block’s business is best understood through gross profit because it reflects the net monetization of payments, software, lending-related economics, and consumer financial services after direct costs. Your business summary gives a current picture: Cash App LTM gross profit **~$5.88B** and Square LTM gross profit **~$3.87B**, implying total gross profit around **~$9.8B** with Cash App the larger contributor. This driver matters because it is the direct input to the primary anchor (EV/Gross Profit): if gross profit per share compounds steadily, investors can justify a higher enterprise value even without aggressive multiple expansion. It also connects to business logic: Square gross profit grows with seller GPV, attach of software/services, and lending contribution; Cash App gross profit grows with active users, inflows (direct deposit), card usage, and monetization per active.
 
@@ -50,7 +50,7 @@ For **CROSS-CHECK anchor #2**, I use **EV/EBIT (enterprise value divided by oper
 
 ---
 
-**C) Baseline snapshot (exactly 2 paragraphs; no tables)**
+## C) Baseline snapshot (exactly 2 paragraphs; no tables)
 
 Using the latest available baseline from your snapshot, Block is valued at about **~$36.4B market cap** with **~602.6M shares** and **~$24.0B TTM revenue** that is essentially flat year-over-year (**~+0.5%**). The latest annual (FY 2024) shows revenue **~$24.1B**, gross profit **~$9.0B**, EBIT **~$1.04B** (about **~4.3%** operating margin), and free cash flow **~$1.55B** (about **~6.4%** FCF margin). On the balance sheet, FY 2024 total debt is **~$7.9B** and net cash is only **~$0.65B**, which means Block is not “net-cash optionality” like some software companies; the equity outcome is meaningfully shaped by operating performance and capital allocation. On valuation ratios, the recent “current” snapshot implies P/S about **~1.55×** and P/FCF about **~19.9×**, which is dramatically cheaper than the FY 2021 era but still not “deep value” if cash flow proves cyclical rather than durable.
 
@@ -58,7 +58,7 @@ Over the last 3–5 years, Block’s reported revenue grew from **~$9.5B (FY 202
 
 ---
 
-**D) “2× Hurdle vs Likely Path” (exactly 5 paragraphs — mandatory)**
+## D) “2× Hurdle vs Likely Path” (exactly 5 paragraphs — mandatory)
 
 A **2× return in ~3 years** implies roughly **~26% per year** compounded, which is a high bar in a “similar regime” environment where multiples typically do not expand dramatically without a clear, measurable improvement in fundamentals. For Block, the clean way to think about this is that the stock doubles only if **per-share gross profit/FCF/EBIT grows meaningfully** and/or the market becomes willing to pay a higher multiple on those per-share metrics because the improvement looks durable. Since Block is already a large-cap-ish fintech with meaningful competition and regulation exposure, it is usually unrealistic to rely on “sentiment” alone; the burden of proof is on sustained execution in Cash App monetization, Square upmarket expansion, and tighter cost discipline.
 
@@ -72,7 +72,7 @@ When you compare “required” versus “likely” outcomes, the gap becomes th
 
 ---
 
-**E) Business reality check (exactly 3 paragraphs — mandatory)**
+## E) Business reality check (exactly 3 paragraphs — mandatory)
 
 To hit the base-case driver ranges, Block needs to win in very specific operational ways. On Cash App, the “real” growth comes from deeper primary-financial-relationship behavior—more direct deposits, more Cash Card spend, and higher monetization per active—because that creates stickiness and supports gross profit growth without needing explosive new user adds. On Square, the base case requires steady seller GPV growth and, more importantly, higher software and services attach (payroll, marketing, invoicing, and other tools) because that is where higher-margin gross profit and switching-cost reinforcement come from. Across both ecosystems, the practical path to margin improvement is keeping operating expense growth below gross profit growth, which is plausible because product platforms can scale when mature, but only if the company avoids “growth-at-any-cost” marketing and keeps risk/compliance costs controlled.
 
@@ -82,9 +82,9 @@ Putting the business logic back into the numbers, the base-case trajectory looks
 
 ---
 
-**F) Multi-anchor triangulation (exactly 3 sections; one per anchor)**
+## F) Multi-anchor triangulation (exactly 3 sections; one per anchor)
 
-**1. Primary anchor**
+### 1. Primary anchor
 
 On the primary anchor, the baseline is Block’s enterprise value relative to its gross profit base. FY 2024 gross profit was **~$8.96B**, and your business summary implies current gross profit run-rate is around **~$9.8B** (Square **~$3.87B** plus Cash App **~$5.88B**), which is the right “economic output” measure for a company whose reported revenue includes meaningful pass-through. While your snapshot does not directly give today’s EV, we can reason directionally: with a **~$36.4B** market cap and meaningful debt (FY 2024 total debt **~$7.9B**) offset by cash and investments (FY 2024 cash & short-term investments **~$8.6B**), enterprise value is in the same broad tens-of-billions zone as market cap, not dramatically lower or higher. That means the market is currently paying a mid-single-digit multiple of gross profit, which is far more conservative than the 2020–2021 era.
 
@@ -92,7 +92,7 @@ For the next 3 years, I assume gross profit grows **~8%–12% per year** and the
 
 In plain-English math, **~8%–12%** gross profit growth is about **~1.26×–1.40×** over 3 years. If the EV/Gross Profit multiple stays roughly flat, that alone implies an enterprise value multiplier of **~1.26×–1.40×**; if the multiple rises modestly (say **~1.1×–1.3×**), the combined effect becomes roughly **~1.4×–1.8×** because **1.26×1.1 ≈ 1.39** and **1.40×1.3 ≈ 1.82**. The estimate lands near the low end if gross profit growth stays closer to high single digits and investors keep the multiple compressed due to competition/regulation; it lands near the high end if Cash App monetization and Square attach show consistent improvement and the market becomes more comfortable paying a higher gross-profit multiple for a more integrated ecosystem.
 
-**2. Cross-check anchor #1**
+### 2. Cross-check anchor #1
 
 On P/FCF, the baseline is that Block’s valuation has become much more sensitive to actual cash generation. FY 2024 free cash flow was **~$1.55B**, and the “current” ratios imply a **P/FCF of ~19.9×** and an FCF yield of **~5.0%**, which suggests the market is not pricing Block as a “hyper-growth story” but as a business that needs to prove durable owner cash flow. The complication is the history: FY 2023 FCF was **~-$50M**, FY 2022 was near zero (**~$5M**), and even within 2025 quarters, FCF margins swing widely (**~5.7%** in Q2 vs **~22.9%** in Q3). That volatility is exactly why this is a cross-check rather than the primary anchor: you can’t value Block on one quarter’s cash flow.
 
@@ -100,7 +100,7 @@ For the next 3 years, I use a normalized FCF margin of **~4%–7%** on a revenue
 
 In multiplier terms, if revenue grows **~3%–8% per year** (about **~1.09×–1.26×** over 3 years) and normalized FCF margin is stable, total FCF might grow roughly in that same **~1.1×–1.3×** zone, with some upside if margins drift toward the top of the range as operating leverage improves. If share count falls ~**3%** over three years, FCF per share adds another **~1.03×**, producing a plausible **~1.15×–1.35×** FCF-per-share multiplier in a conservative base case. If the P/FCF multiple stays around ~20×, that implies **~1.2×–1.4×** price upside from fundamentals; reaching the high end requires margins to normalize closer to FY 2024 levels and for buybacks to persist, while the low end occurs if cash conversion slips back toward the weak 2022–2023 pattern and the multiple stays cautious.
 
-**3. Cross-check anchor #2**
+### 3. Cross-check anchor #2
 
 On EV/EBIT, the baseline is that Block is transitioning from “low profitability” to “meaningful operating profit.” FY 2024 EBIT was **~$1.04B** (about **~4.3%** margin), while Q2 2025 and Q3 2025 EBIT margins were **~8.2%** and **~6.9%** respectively, suggesting that the business can operate at materially higher profitability when costs are controlled and gross profit holds up. This matters because a company with ~$24B revenue doesn’t need dramatic revenue growth for EBIT to grow fast; even a few points of margin improvement can produce large absolute EBIT increases, which is what the EV/EBIT anchor captures.
 
@@ -110,7 +110,7 @@ In plain-English math, on a ~$24B revenue base, a move from **~4%** EBIT margin 
 
 ---
 
-**G) Valuation sanity check (exactly 2 paragraphs)**
+## G) Valuation sanity check (exactly 2 paragraphs)
 
 Valuation is **likely a mild tailwind to neutral** rather than a headwind, mainly because Block’s current multiples are far below the 2020–2021 regime and because the market is already discounting meaningful risk. The “current” snapshot shows P/S about **~1.55×** and P/FCF about **~19.9×**, versus FY 2024 ratios that were materially richer (FY 2024 P/S **~2.18×**, P/FCF **~33.9×**) and FY 2021-era multiples that were far higher still. This compression is rational given slower growth and higher rates than the peak era, but it also means the bar for “some rerating” is not extreme: if Block proves that mid-to-high single-digit operating margins and durable gross profit growth are real, the market can justify paying more than today even in a similar regime.
 
@@ -118,7 +118,7 @@ A conservative **valuation multiplier range** over 3 years is **~0.9×–1.3×**
 
 ---
 
-**H) Final answer (exactly 3 paragraphs)**
+## H) Final answer (exactly 3 paragraphs)
 
 Most likely, Block’s 3-year stock price multiplier is about **~1.4× to ~1.8×**, because a conservative combination of **~8%–12% gross profit growth** plus sustained **mid-to-high single-digit operating margins** can compound intrinsic value meaningfully, while today’s valuation leaves room for only modest rerating rather than requiring a return to peak multiples.
 

--- a/insights-ui/blogs/2026-02-10-cf-industries-2x-in-3-years-valuation.mdx
+++ b/insights-ui/blogs/2026-02-10-cf-industries-2x-in-3-years-valuation.mdx
@@ -29,8 +29,6 @@ seoKeywords:
   ]
 ---
 
-# Can CF Industries Stock Double in 3 Years? A 3-Anchor Valuation Breakdown
-
 ## 0) Overall analysis
 
 CF is a high-quality operator in a cyclical business: global nitrogen demand is generally steady (farmers don’t “cancel” nitrogen), but the profit pool is driven by price cycles that swing with global supply, energy economics, and trade flows. Investor interest here is usually pragmatic rather than “hype”: the market tends to pay moderate multiples and heavily discounts peak earnings because fertilizer margins mean-revert. CF’s trajectory is solid in the sense that it can stay on the low-cost end of the global curve and keep returning cash through buybacks, but it does not have a natural multi-year volume growth engine that compounds like a secular grower. The single biggest reason 2x is hard for **this** stock is that CF has already shown it can generate “peak-cycle” profits without the stock re-rating—multiples often compress exactly when EBITDA/earnings spike—so you typically need an unusually strong cycle **and** a “this time is more durable” narrative for the market to pay up.

--- a/insights-ui/src/app/blogs/[blogSlug]/page.tsx
+++ b/insights-ui/src/app/blogs/[blogSlug]/page.tsx
@@ -9,7 +9,7 @@ import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import { Metadata } from 'next';
-import { getRelatedPosts } from '@/util/blog-utils';
+import { DEFAULT_BLOG_AUTHOR, formatBlogDate, getRelatedPosts } from '@/util/blog-utils';
 import RelatedBlogs from '@/components/blogs/RelatedBlogs';
 import { notFound } from 'next/navigation';
 
@@ -25,6 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ blogSlug:
     const title = blogData.title ?? 'Untitled Blog';
     const description = blogData.abstract ?? 'Explore the latest insights on KoalaGains.';
     const canonicalUrl = `https://koalagains.com/blogs/${blogSlug}`;
+    const authorName = blogData.author ?? DEFAULT_BLOG_AUTHOR;
 
     return {
       title: `${title}`,
@@ -38,6 +39,11 @@ export async function generateMetadata({ params }: { params: Promise<{ blogSlug:
         url: canonicalUrl,
         images: ['https://koalagains.com/koalagain_logo.png'],
         type: 'article',
+        publishedTime: blogData.datetime,
+        modifiedTime: blogData.datetime,
+        authors: [authorName],
+        section: blogData.category?.title,
+        tags: blogData.seoKeywords,
       },
       twitter: {
         card: 'summary_large_image',
@@ -45,6 +51,7 @@ export async function generateMetadata({ params }: { params: Promise<{ blogSlug:
         description,
         images: ['https://koalagains.com/koalagain_logo.png'],
       },
+      authors: [{ name: authorName }],
       keywords: blogData.seoKeywords,
     };
   } catch (error) {
@@ -93,6 +100,8 @@ export default async function PostPage({ params }: { params: Promise<{ blogSlug:
 
   const canonicalUrl = `https://koalagains.com/blogs/${slug}`;
   const ogImageUrl = 'https://koalagains.com/koalagain_logo.png';
+  const authorName = data.author ?? DEFAULT_BLOG_AUTHOR;
+  const formattedDate = formatBlogDate(data.datetime);
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
@@ -101,11 +110,7 @@ export default async function PostPage({ params }: { params: Promise<{ blogSlug:
     image: ogImageUrl,
     datePublished: data.datetime,
     dateModified: data.datetime,
-    author: {
-      '@type': 'Organization',
-      name: 'KoalaGains',
-      url: 'https://koalagains.com',
-    },
+    author: data.author ? { '@type': 'Person', name: data.author } : { '@type': 'Organization', name: 'KoalaGains', url: 'https://koalagains.com' },
     publisher: {
       '@type': 'Organization',
       name: 'KoalaGains',
@@ -132,6 +137,11 @@ export default async function PostPage({ params }: { params: Promise<{ blogSlug:
             <span className="relative z-10 rounded-full py-1.5 font-medium">{data.category.title}</span>
           </p>
           <h1 className="mt-2 text-4xl font-semibold tracking-tight text-pretty  sm:text-3xl">{data.title}</h1>
+          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-400">
+            <span>By {authorName}</span>
+            <span aria-hidden="true">·</span>
+            <time dateTime={data.datetime}>{formattedDate}</time>
+          </div>
           <div className="mt-10 max-w-6xl text-md">
             <article className="mx-auto text-color">
               {data.bannerImage && (

--- a/insights-ui/src/app/blogs/[blogSlug]/page.tsx
+++ b/insights-ui/src/app/blogs/[blogSlug]/page.tsx
@@ -91,8 +91,40 @@ export default async function PostPage({ params }: { params: Promise<{ blogSlug:
 
   const relatedPosts = await getRelatedPosts(data.category.slug, slug, 3);
 
+  const canonicalUrl = `https://koalagains.com/blogs/${slug}`;
+  const ogImageUrl = 'https://koalagains.com/koalagain_logo.png';
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: data.title,
+    description: data.abstract,
+    image: ogImageUrl,
+    datePublished: data.datetime,
+    dateModified: data.datetime,
+    author: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      logo: {
+        '@type': 'ImageObject',
+        url: ogImageUrl,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    articleSection: data.category.title,
+    keywords: data.seoKeywords?.join(', '),
+  };
+
   return (
     <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <Breadcrumbs breadcrumbs={breadcrumbs} />
       <div className="px-6 pt-4 lg:px-8 text-color">
         <div className="mx-auto max-w-6xl text-base/7">

--- a/insights-ui/src/components/blogs/RelatedBlogs.tsx
+++ b/insights-ui/src/components/blogs/RelatedBlogs.tsx
@@ -13,7 +13,7 @@ export default function RelatedBlogs({ posts }: RelatedBlogsProps) {
   }
 
   return (
-    <section className="bg-gray-800 pt-12 pb-12 sm:pt-16 sm:pb-16">
+    <section className="mt-8 bg-gray-800 pt-12 pb-12 sm:pt-16 sm:pb-16">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl sm:text-center">
           <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Related Articles</h2>

--- a/insights-ui/src/types/blog.ts
+++ b/insights-ui/src/types/blog.ts
@@ -7,6 +7,7 @@ export interface BlogInterface {
   seoKeywords: string[];
   seoImage?: string;
   bannerImage?: string;
+  author?: string;
 }
 
 export interface BlogInterfaceWithId extends BlogInterface {

--- a/insights-ui/src/util/blog-utils.ts
+++ b/insights-ui/src/util/blog-utils.ts
@@ -3,6 +3,19 @@ import fs from 'fs';
 import matter from 'gray-matter';
 import path from 'path';
 
+const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+export const DEFAULT_BLOG_AUTHOR = 'KoalaGains Team';
+
+export function formatBlogDate(datetime: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(datetime);
+  if (!match) return datetime;
+  const [, yearStr, monthStr, dayStr] = match;
+  const monthIdx = Number(monthStr) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return datetime;
+  return `${MONTH_NAMES[monthIdx]} ${Number(dayStr)}, ${yearStr}`;
+}
+
 export async function getPostsData(length?: number): Promise<BlogInterfaceWithId[]> {
   const postsDirectory = path.join(process.cwd(), 'blogs');
   const fileNames = fs.readdirSync(postsDirectory);
@@ -17,12 +30,14 @@ export async function getPostsData(length?: number): Promise<BlogInterfaceWithId
     const { data } = matter(fileContents);
     const postMetadata = data as BlogInterface;
 
+    const datetime = postMetadata.datetime || postMetadata.date || 'Unknown Date';
+
     return {
       id: id, // using the slug as a unique id
       title: postMetadata.title || 'Untitled Post',
       abstract: postMetadata.abstract || 'No description available.',
-      date: postMetadata.date || 'Unknown Date',
-      datetime: postMetadata.datetime || postMetadata.date || 'Unknown Date',
+      date: formatBlogDate(datetime),
+      datetime,
       category: {
         title: postMetadata.category.title || 'General',
         slug: postMetadata.category.slug || 'general',
@@ -30,6 +45,7 @@ export async function getPostsData(length?: number): Promise<BlogInterfaceWithId
       seoImage: postMetadata.seoImage,
       bannerImage: postMetadata.bannerImage,
       seoKeywords: postMetadata.seoKeywords || [],
+      author: postMetadata.author,
     };
   });
 


### PR DESCRIPTION
## Summary

Three of our blogs (the Akala crowdfunding post, the Gen-AI customer-service post, and the public-vs-private REITs post) were stuck on **Discovered – currently not indexed** in GSC. SEO review pointed at two clear signal-quality issues that are pure code fixes; this PR addresses both.

### Changes

- **Add `BlogPosting` JSON-LD on the blog detail page.** `src/app/blogs/[blogSlug]/page.tsx` now emits a `<script type="application/ld+json">` block with `headline`, `description`, `image`, `datePublished` / `dateModified` (both wired to the front-matter `datetime`), an Organization `author` + `publisher` (KoalaGains), `mainEntityOfPage`, `articleSection`, and `keywords`. Uses the existing logo as the image fallback — we don't have per-post hero images yet and that's intentional.
- **Cascade-demote headings in `2025-07-08-generative-ai-customer-service-capabilities.mdx`.** That post used single-`#` for top-level sections, which `marked` rendered as `<h1>` — combined with the template's own `<h1>{title}</h1>` the page was emitting ~8 H1s. Shifted every heading down one level (`#`→`##`, `##`→`###`, `###`→`####`, `####`→`#####`) so the page has a single H1.
- **Drop the duplicate H1 in `2025-06-23-public-vs-private-reits.mdx`.** The MDX repeated the title as `# **<a name="article-title"></a>...**` near the top of the body; the template already renders the title, so the inner H1 was an extra root heading. Removed it.

### Out of scope

- Per-post body length / "thin content" issues (e.g. the Akala post) are content decisions, not code fixes.
- Per-post hero images / `seoImage` plumbing — fallback to the existing logo is fine for now per request.

## Test plan

- [ ] `yarn lint && yarn prettier-check && yarn compile` (all pass locally)
- [ ] Hit `/blogs/2025-07-08-generative-ai-customer-service-capabilities` in dev — confirm only one `<h1>` in the rendered DOM and that the JSON-LD block validates in Rich Results Test.
- [ ] Hit `/blogs/2025-06-23-public-vs-private-reits` — confirm the body no longer starts with a second `<h1>` and JSON-LD validates.
- [ ] Hit `/blogs/akala-empowering-students-to-navigate-the-college-admissions-journey` — confirm JSON-LD validates (heading structure was already fine).
- [ ] After merge: re-request indexing in GSC for the three URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)