### PR TITLE
Crowd-funding SEO: indexable metadata, JSON-LD, sibling links, sitemap completeness filter

### DIFF
--- a/insights-ui/src/app/crowd-funding/projects/[projectId]/page.tsx
+++ b/insights-ui/src/app/crowd-funding/projects/[projectId]/page.tsx
@@ -1,11 +1,14 @@
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
-import { ProjectDetails, REPORT_TYPES_TO_DISPLAY, ReportInterfaceWithType, SpiderGraph } from '@/types/project/project';
+import { ProcessingStatus, ProjectDetails, REPORT_TYPES_TO_DISPLAY, SpiderGraph } from '@/types/project/project';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import { Metadata } from 'next';
 import React from 'react';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import ProjectDetailPage from '@/components/projects/ProductDetailsPage';
+import { formatProjectName, truncateDescription } from '@/util/report-utils';
+
+const DEFAULT_OG_IMAGE = 'https://koalagains.com/koalagain_logo.png';
 
 export async function generateMetadata({ params }: { params: Promise<{ projectId: string }> }): Promise<Metadata> {
   const { projectId } = await params;
@@ -13,37 +16,35 @@ export async function generateMetadata({ params }: { params: Promise<{ projectId
   const res = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`);
   const data: { projectDetails: ProjectDetails } = await res.json();
 
+  const projectName = data.projectDetails?.name || formatProjectName(projectId);
+  const startupSummary = data.projectDetails?.processedProjectInfo?.startupSummary?.trim();
+  const hasAnyCompletedReport = REPORT_TYPES_TO_DISPLAY.some((rt) => data.projectDetails?.reports?.[rt]?.status === ProcessingStatus.COMPLETED);
+
+  const description =
+    truncateDescription(startupSummary) ??
+    `Independent crowdfunding analysis for ${projectName}: founder & team, traction, market opportunity, execution, valuation, and financial-health checklists for retail investors.`;
+
+  const canonicalUrl = `https://koalagains.com/crowd-funding/projects/${projectId}`;
+  const ogImage = data.projectDetails?.imgUrl || DEFAULT_OG_IMAGE;
+
   return {
-    title: `${data.projectDetails.name} - Crowdfunding Project`,
-    description: `KoalaGains provides detailed analysis and insights for "${data.projectDetails.name}" with graphs, reports and metrics like growth,financial health ,traction, valuation ,Execution and speed.`,
-    keywords: [
-      'Crowdfunding',
-      'Traction',
-      'Investment',
-      'Market Opportunity',
-      'Execution and Speed',
-      'Team',
-      'Valuation',
-      data.projectDetails.name,
-      'Wefunder',
-      'Kickstarter',
-      'Start Engine',
-      'Insights',
-    ],
-    robots: {
-      index: true,
-      follow: true,
-    },
-    alternates: {
-      canonical: `https://koalagains.com/crowd-funding/projects/${projectId}`,
-    },
+    title: `${projectName} — Crowdfunding Analysis | KoalaGains`,
+    description,
+    robots: hasAnyCompletedReport ? { index: true, follow: true } : { index: false, follow: true },
+    alternates: { canonical: canonicalUrl },
     openGraph: {
-      title: `${data.projectDetails.name} - Crowdfunding Project`,
-      description: `KoalaGains provides detailed analysis and insights for "${data.projectDetails.name}" with graphs, reports and metrics like growth,financial health ,traction, valuation ,Execution and speed.`,
-      url: `https://koalagains.com/crowd-funding/projects/${projectId}`,
-      type: 'website',
-      images: [data.projectDetails.imgUrl || ''],
+      title: `${projectName} — Crowdfunding Analysis`,
+      description,
+      url: canonicalUrl,
+      type: 'article',
+      images: [ogImage],
       siteName: 'KoalaGains',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${projectName} — Crowdfunding Analysis`,
+      description,
+      images: [ogImage],
     },
   };
 }
@@ -54,6 +55,11 @@ export default async function ProjectDetailPageWrapper({ params }: { params: Pro
   const res = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`);
   const data: { projectDetails: ProjectDetails; spiderGraph: SpiderGraph | {} } = await res.json();
 
+  const projectName = data.projectDetails?.name || formatProjectName(projectId);
+  const startupSummary = data.projectDetails?.processedProjectInfo?.startupSummary?.trim();
+  const canonicalUrl = `https://koalagains.com/crowd-funding/projects/${projectId}`;
+  const ogImage = data.projectDetails?.imgUrl || DEFAULT_OG_IMAGE;
+
   const breadcrumbs: BreadcrumbsOjbect[] = [
     {
       name: 'Crowd Funding Projects',
@@ -61,14 +67,50 @@ export default async function ProjectDetailPageWrapper({ params }: { params: Pro
       current: false,
     },
     {
-      name: projectId,
+      name: projectName,
       href: `/crowd-funding/projects/${projectId}`,
       current: true,
     },
   ];
 
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${projectName} — Crowdfunding Analysis`,
+    description: truncateDescription(startupSummary) ?? `Independent crowdfunding analysis for ${projectName}.`,
+    image: [ogImage],
+    author: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: DEFAULT_OG_IMAGE,
+      },
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: DEFAULT_OG_IMAGE,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    about: {
+      '@type': 'Organization',
+      name: projectName,
+      url: data.projectDetails?.projectInfoInput?.websiteUrl,
+    },
+  };
+
   return (
     <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
       <Breadcrumbs breadcrumbs={breadcrumbs} />
       {data.projectDetails && <ProjectDetailPage projectId={projectId} initialProjectDetails={data.projectDetails} projectDetails={data.projectDetails} />}
     </PageWrapper>

--- a/insights-ui/src/app/crowd-funding/projects/[projectId]/reports/[reportType]/page.tsx
+++ b/insights-ui/src/app/crowd-funding/projects/[projectId]/reports/[reportType]/page.tsx
@@ -1,10 +1,29 @@
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import Link from 'next/link';
 import { Metadata } from 'next';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
-import { ProjectDetails, ReportType, SpiderGraph } from '@/types/project/project';
+import { ProcessingStatus, ProjectDetails, REPORT_TYPES_TO_DISPLAY, ReportType, SpiderGraph } from '@/types/project/project';
 import { parseMarkdown } from '@/util/parse-markdown';
+import { formatProjectName, getReportName, truncateDescription } from '@/util/report-utils';
+
+const DEFAULT_OG_IMAGE = 'https://koalagains.com/koalagain_logo.png';
+
+const REPORT_TITLES: Record<string, string> = {
+  [ReportType.GENERAL_INFO]: 'General Information',
+  [ReportType.FOUNDER_AND_TEAM]: 'Founder and Team',
+  [ReportType.TRACTION]: 'Traction',
+  [ReportType.MARKET_OPPORTUNITY]: 'Market Opportunity',
+  [ReportType.VALUATION]: 'Valuation',
+  [ReportType.EXECUTION_AND_SPEED]: 'Execution and Speed',
+  [ReportType.FINANCIAL_HEALTH]: 'Financial Health',
+  [ReportType.RELEVANT_LINKS]: 'Relevant Links',
+};
+
+function getReadableReportType(reportType: string): string {
+  return REPORT_TITLES[reportType] ?? getReportName(reportType);
+}
 
 export async function generateMetadata({ params }: { params: Promise<{ projectId: string; reportType: string }> }): Promise<Metadata> {
   const { projectId, reportType } = await params;
@@ -12,51 +31,39 @@ export async function generateMetadata({ params }: { params: Promise<{ projectId
   const projectResponse = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`);
   const projectData: { projectDetails: ProjectDetails; spiderGraph: SpiderGraph | {} } = await projectResponse.json();
 
-  const report = projectData.projectDetails.reports[reportType];
+  const projectName = projectData.projectDetails?.name || formatProjectName(projectId);
+  const report = projectData.projectDetails?.reports?.[reportType];
+  const readableReportType = getReadableReportType(reportType);
+  const summary = report?.summary?.trim();
+  const isReportReady = report?.status === ProcessingStatus.COMPLETED && (summary?.length ?? 0) > 0;
 
-  // Map report types to better human-readable titles
-  const reportTitles: Record<string, string> = {
-    [ReportType.GENERAL_INFO]: 'General Information',
-    [ReportType.FOUNDER_AND_TEAM]: 'Founder and Team',
-    [ReportType.TRACTION]: 'Traction',
-    [ReportType.MARKET_OPPORTUNITY]: 'Market Opportunity',
-    [ReportType.VALUATION]: 'Valuation',
-    [ReportType.EXECUTION_AND_SPEED]: 'Execution and Speed',
-    [ReportType.FINANCIAL_HEALTH]: 'Financial Health',
-    [ReportType.RELEVANT_LINKS]: 'Relevant Links',
-  };
+  const description =
+    truncateDescription(summary) ??
+    `Independent ${readableReportType.toLowerCase()} analysis for ${projectName}: checklist scoring, calculation logic, and key findings for crowdfunding investors.`;
 
-  // Default title if the report type is unknown
-  const readableReportType = reportTitles[reportType] || 'Project Report';
+  const canonicalUrl = `https://koalagains.com/crowd-funding/projects/${projectId}/reports/${reportType}`;
+  const ogImage = projectData.projectDetails?.imgUrl || DEFAULT_OG_IMAGE;
 
   return {
-    title: `${readableReportType} - ${projectData.projectDetails.name}`,
-    description: `Explore the ${readableReportType} for the crowdfunding project "${projectData.projectDetails.name}". ${report.summary || ''}`,
-    keywords: [
-      projectData.projectDetails.name,
-      'crowdfunding insights',
-      'investment analysis',
-      'investor reports',
-      'analysis',
-      'risk analysis',
-      'investment risks',
-      'funding health',
-      projectId,
-      readableReportType, // Dynamic keyword from report type
-    ],
-    robots: {
-      index: true,
-      follow: true,
-    },
-    alternates: {
-      canonical: `https://koalagains.com/crowd-funding/projects/${projectId}/reports/${reportType}`,
-    },
+    title: `${projectName} — ${readableReportType} Report | KoalaGains`,
+    description,
+    robots: isReportReady ? { index: true, follow: true } : { index: false, follow: true },
+    alternates: { canonical: canonicalUrl },
     openGraph: {
-      title: `${readableReportType} - ${projectId}`,
-      description: `View the ${readableReportType} for project "${projectId}". Detailed analysis of investment risks, funding health, and team assessment.`,
-      url: `https://koalagains.com/crowd-funding/projects/${projectId}/reports/${reportType}`,
+      title: `${projectName} — ${readableReportType} Report`,
+      description,
+      url: canonicalUrl,
       type: 'article',
       siteName: 'KoalaGains',
+      images: [ogImage],
+      publishedTime: report?.startTime,
+      modifiedTime: report?.endTime ?? report?.startTime,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${projectName} — ${readableReportType}`,
+      description,
+      images: [ogImage],
     },
   };
 }
@@ -64,13 +71,18 @@ export async function generateMetadata({ params }: { params: Promise<{ projectId
 export default async function ReportDetailPage({ params }: { params: Promise<{ projectId: string; reportType: string }> }) {
   const { projectId, reportType } = await params;
 
-  const reportResponse = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}/reports/${reportType}`);
+  const [reportResponse, projectResponse] = await Promise.all([
+    fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}/reports/${reportType}`),
+    fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`),
+  ]);
   const reportData: { reportDetail: string } = await reportResponse.json();
-
-  const projectResponse = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`);
   const projectData: { projectDetails: ProjectDetails; spiderGraph: SpiderGraph | {} } = await projectResponse.json();
 
-  const report = projectData.projectDetails.reports[reportType];
+  const projectName = projectData.projectDetails?.name || formatProjectName(projectId);
+  const report = projectData.projectDetails?.reports?.[reportType];
+  const readableReportType = getReadableReportType(reportType);
+  const summary = report?.summary?.trim();
+
   const breadcrumbs: BreadcrumbsOjbect[] = [
     {
       name: 'Crowd Funding Projects',
@@ -78,30 +90,85 @@ export default async function ReportDetailPage({ params }: { params: Promise<{ p
       current: false,
     },
     {
-      name: projectId,
+      name: projectName,
       href: `/crowd-funding/projects/${projectId}`,
       current: false,
     },
     {
-      name: reportType,
+      name: readableReportType,
       href: `/crowd-funding/projects/${projectId}/reports/${reportType}`,
       current: true,
     },
   ];
 
   const reportDetailContents = reportData.reportDetail && parseMarkdown(reportData.reportDetail);
+  const canonicalUrl = `https://koalagains.com/crowd-funding/projects/${projectId}/reports/${reportType}`;
+  const ogImage = projectData.projectDetails?.imgUrl || DEFAULT_OG_IMAGE;
+  const headlineDescription =
+    summary ??
+    `Independent ${readableReportType.toLowerCase()} analysis for ${projectName}: checklist scoring, calculation logic, and key findings for crowdfunding investors.`;
+
+  const siblingReports = REPORT_TYPES_TO_DISPLAY.filter((rt) => rt !== reportType).filter(
+    (rt) => (projectData.projectDetails?.reports?.[rt]?.summary?.trim()?.length ?? 0) > 0
+  );
+
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${projectName} — ${readableReportType} Report`,
+    description: truncateDescription(headlineDescription) ?? headlineDescription,
+    image: [ogImage],
+    datePublished: report?.startTime,
+    dateModified: report?.endTime ?? report?.startTime,
+    author: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: DEFAULT_OG_IMAGE,
+      },
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'KoalaGains',
+      url: 'https://koalagains.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: DEFAULT_OG_IMAGE,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+    articleSection: readableReportType,
+    about: {
+      '@type': 'Organization',
+      name: projectName,
+      url: projectData.projectDetails?.projectInfoInput?.websiteUrl,
+    },
+  };
 
   return (
     <PageWrapper>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
       <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
       <div className="mx-auto text-color">
-        <div className="text-center text-color my-5">
-          <h1 className="font-semibold leading-6 text-2xl">Project: {projectId}</h1>
-          <div className="my-5">Report: {reportType}</div>
-        </div>
-        <div className="block-bg-color p-8">
+        <header className="text-center my-5">
+          <h1 className="font-semibold text-3xl sm:text-4xl">
+            {projectName} — {readableReportType}
+          </h1>
+          <p className="mt-3 text-sm opacity-80">
+            Crowdfunding analysis ·{' '}
+            <Link href={`/crowd-funding/projects/${projectId}`} className="link-color">
+              View {projectName} overview
+            </Link>
+          </p>
+        </header>
+        <article className="block-bg-color p-8" itemScope itemType="https://schema.org/Article">
           <div className="overflow-x-auto">
-            {report.performanceChecklist?.length && (
+            {report?.performanceChecklist?.length ? (
               <ul className="list-disc mt-2">
                 {report.performanceChecklist.map((item, index) => (
                   <li key={index} className="mb-1 flex items-start">
@@ -110,16 +177,28 @@ export default async function ReportDetailPage({ params }: { params: Promise<{ p
                   </li>
                 ))}
               </ul>
-            )}
+            ) : null}
             {reportDetailContents ? (
               <div className="markdown-body text-md" dangerouslySetInnerHTML={{ __html: reportDetailContents }} />
             ) : (
-              <>
-                <div className="text-center">Empty</div>
-              </>
+              <div className="text-center">Empty</div>
             )}
           </div>
-        </div>
+        </article>
+        {siblingReports.length > 0 && (
+          <nav aria-label="Other sections of this project" className="my-8 text-color">
+            <h2 className="font-semibold text-lg mb-3">Other sections of {projectName}</h2>
+            <ul className="flex flex-wrap gap-3">
+              {siblingReports.map((rt) => (
+                <li key={rt}>
+                  <Link href={`/crowd-funding/projects/${projectId}/reports/${rt}`} className="link-color underline underline-offset-2">
+                    {getReadableReportType(rt)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
       </div>
     </PageWrapper>
   );

--- a/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
+++ b/insights-ui/src/app/crowd-funding/sitemap.xml/route.ts
@@ -1,4 +1,4 @@
-import { REPORT_TYPES_TO_DISPLAY } from '@/types/project/project';
+import { ProcessingStatus, ProjectDetails, REPORT_TYPES_TO_DISPLAY } from '@/types/project/project';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { NextResponse } from 'next/server';
@@ -21,7 +21,29 @@ async function getAllProjects(): Promise<string[]> {
   return data.projectIds || [];
 }
 
-// Generate sitemap URLs
+async function getProjectDetails(projectId: string): Promise<ProjectDetails | undefined> {
+  try {
+    const response = await fetch(`${getBaseUrl()}/api/crowd-funding/projects/${projectId}`);
+    if (!response.ok) return undefined;
+    const data: { projectDetails: ProjectDetails } = await response.json();
+    return data.projectDetails;
+  } catch (error) {
+    console.warn(`Failed to fetch details for project ${projectId} while building sitemap:`, error);
+    return undefined;
+  }
+}
+
+function isReportIndexable(details: ProjectDetails | undefined, reportType: string): boolean {
+  const report = details?.reports?.[reportType];
+  if (!report) return false;
+  if (report.status !== ProcessingStatus.COMPLETED) return false;
+  return (report.summary?.trim()?.length ?? 0) > 0;
+}
+
+// Generate sitemap URLs — only include URLs whose reports are complete + non-empty.
+// Incomplete URLs still resolve, but are emitted with `robots: noindex` from the pages
+// themselves and are kept out of the sitemap so Google doesn't churn crawl budget on
+// thin/"Empty" report pages (the main driver of the "Discovered — currently not indexed" bucket).
 async function generateCrowdFundingUrls(): Promise<SiteMapUrl[]> {
   const projectIds = await getAllProjects();
   const urls: SiteMapUrl[] = [];
@@ -37,7 +59,16 @@ async function generateCrowdFundingUrls(): Promise<SiteMapUrl[]> {
     return urls; // Return at least the home page URL
   }
 
-  for (const projectId of projectIds) {
+  const projectDetailsList = await Promise.all(projectIds.map(async (projectId) => ({ projectId, details: await getProjectDetails(projectId) })));
+
+  for (const { projectId, details } of projectDetailsList) {
+    const indexableReportTypes = REPORT_TYPES_TO_DISPLAY.filter((reportType) => isReportIndexable(details, reportType));
+    if (indexableReportTypes.length === 0) {
+      // Skip projects with no indexable reports — pages still resolve via direct URL,
+      // and `generateMetadata` flips them to `noindex` so Google can drop them.
+      continue;
+    }
+
     const lastmod = (crowdFundingLastmod as Record<string, string>)[projectId] || undefined;
     urls.push({
       url: `/crowd-funding/projects/${projectId}`,
@@ -46,7 +77,7 @@ async function generateCrowdFundingUrls(): Promise<SiteMapUrl[]> {
       lastmod,
     });
 
-    for (const reportType of REPORT_TYPES_TO_DISPLAY) {
+    for (const reportType of indexableReportTypes) {
       urls.push({
         url: `/crowd-funding/projects/${projectId}/reports/${reportType}`,
         changefreq: 'weekly',

--- a/insights-ui/src/components/projects/ProjectSummaryCard.tsx
+++ b/insights-ui/src/components/projects/ProjectSummaryCard.tsx
@@ -4,6 +4,7 @@ import { shorten } from '@dodao/web-core/utils/utils';
 import Link from 'next/link';
 import React from 'react';
 import { InsightsConstants } from '@/util/insights-constants';
+import { formatProjectName } from '@/util/report-utils';
 import ProjectActionsDropdown from './ProjectActionsDropdown';
 import PrivateWrapper from '../auth/PrivateWrapper';
 
@@ -12,13 +13,6 @@ interface ProjectSummaryCardProps {
 }
 
 const ProjectSummaryCard: React.FC<ProjectSummaryCardProps> = ({ projectId }) => {
-  function formatProjectName(projectId: string): string {
-    return projectId
-      .trim() // Remove extra spaces
-      .replace(/_/g, ' ') // Replace underscores with spaces
-      .replace(/\b\w/g, (char) => char.toUpperCase()); // Capitalize each word
-  }
-
   return (
     <Card>
       <Link href={`/crowd-funding/projects/${projectId}`} className="card blog-card w-inline-block h-full w-full">

--- a/insights-ui/src/util/report-utils.ts
+++ b/insights-ui/src/util/report-utils.ts
@@ -8,3 +8,22 @@ export function getReportName(key: string) {
 export function getReportKey(name: string) {
   return name.toLowerCase().replace(/\s+/g, '_');
 }
+
+/** Turn a project id slug ("hah_parking") into a display name ("HAH Parking"). */
+export function formatProjectName(projectId: string): string {
+  return projectId
+    .trim()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/** Trim a string to a target length on a word boundary, with no trailing whitespace or stray punctuation. */
+export function truncateDescription(text: string | undefined, maxLength = 155): string | undefined {
+  if (!text) return undefined;
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  const slice = cleaned.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(' ');
+  const cut = lastSpace > 80 ? slice.slice(0, lastSpace) : slice;
+  return cut.replace(/[\s,;:.\-–—]+$/, '') + '…';
+}


### PR DESCRIPTION
## Summary
- Fixes the on-page signal weaknesses driving the GSC "Discovered/Crawled — currently not indexed" buckets on `/crowd-funding/sitemap.xml` (200 of 309 URLs not indexed at the time of investigation).
- Rewrites metadata + adds JSON-LD on both the project page and the report sub-page, swaps the slug-based H1 (`Project: akala`) for a real one (`{Project Name} — {Readable Report Type}`), and adds a sibling-report rail at the bottom of each report page for stronger internal linking between the six sub-reports of the same project.
- Filters the crowd-funding sitemap to projects that have at least one completed + non-empty report, and per-project only emits the report URLs whose `status === 'completed'` with a non-empty `summary`. Incomplete URLs still resolve but are `noindex`'d from the page itself so Google can drop them from the index.

## What changed by file
- `insights-ui/src/app/crowd-funding/projects/[projectId]/reports/[reportType]/page.tsx`: title/OG title/twitter all use the project name (was slug); description from `report.summary` truncated to ~155 chars (no more `". "` tails); drops the always-identical `keywords` array; OG image falls back to the KoalaGains logo when `imgUrl` is empty; `<article>` + Article JSON-LD with `KoalaGains` Organization as publisher/author (matches the pattern in `app/blogs/[blogSlug]/page.tsx` and the stock pages); `robots: noindex` when the report isn't ready; H1 changed to `{projectName} — {readableReportType}`; breadcrumbs use formatted names; new `Other sections of {projectName}` rail at the bottom.
- `insights-ui/src/app/crowd-funding/projects/[projectId]/page.tsx`: description sourced from `processedProjectInfo.startupSummary` (truncated) with a non-boilerplate fallback; OG image falls back to the KoalaGains logo; Article JSON-LD added; breadcrumb name formatted; `noindex` if no completed reports.
- `insights-ui/src/app/crowd-funding/sitemap.xml/route.ts`: per-project `getProjectDetails` (parallelised) feeds an `isReportIndexable` filter; project URL only emitted if at least one report is indexable; `lastmod` continues to read from the static `crowd-funding-lastmod.json` (reports aren't being regenerated right now).
- `insights-ui/src/util/report-utils.ts`: adds shared `formatProjectName` and `truncateDescription` helpers used by all the above.
- `insights-ui/src/components/projects/ProjectSummaryCard.tsx`: drops the local copy of `formatProjectName` and reuses the shared one.

## Deliberately not in this PR (per latest user direction)
- Caching headers / ISR / cache-tag revalidation — coupled to the upcoming Vercel → CloudFront migration and will be handled then.
- Regenerating `crowd-funding-lastmod.json` — reports aren't being regenerated, so the static file is still correct.

## Test plan
- [ ] On a deploy preview, run `View Source` on `/crowd-funding/projects/akala/reports/financial_health`: confirm `<title>` is `Akala — Financial Health Report | KoalaGains`, the `og:title` matches (NAME not slug), `og:image` is present (logo fallback works for projects without `imgUrl` like `hah_parking`), the page emits an Article JSON-LD block, and the on-page `<h1>` reads `Akala — Financial Health`.
- [ ] `curl -s <preview>/crowd-funding/sitemap.xml | grep -c "/reports/"` — count should be lower than the live (200) count once incomplete reports are filtered.
- [ ] Visit a report whose `status !== 'completed'` and confirm `<meta name="robots" content="noindex,follow">`.
- [ ] Search Console URL Inspection → Live Test on `/crowd-funding/projects/akala/reports/financial_health` and confirm the rendered HTML matches and the Rich Results test parses the Article JSON-LD.
- [ ] After merge, "Validate Fix" on the `Crawled — currently not indexed` and `Discovered — currently not indexed` groups in GSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)