### PR TITLE
Dedup tasks + 308 legacy industry-areas/final-conclusion to chapter URLs

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -59,6 +59,11 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] **Phased rollout**: P0 schema + admin templates → P1 list/detail/from-template modal → P2 free-form behind flag + quota → P3 streaming + web-search citations + history diff.
 - [ ] Open: streaming vs spinner (default spinner); free-form at launch (default behind flag); citations design; cross-ticker reports out of scope.
 
+### Daily top movers — dedupe historical duplicates + harden ingest
+
+- [ ] **De-duplicate `daily_top_losers` / `daily_top_gainers`** — historical bug wrote multiple near-identical rows for the same ticker across weekends + US market holidays (~23% of loser rows belong to a `(symbol, %change)` cluster; 140 clusters, 344 rows). Each row got its own UUID, its own sitemap entry, and its own LLM-rewritten article, so GSC reports them as "Duplicate without user-selected canonical". Approach: add a nullable `canonicalId` self-FK to both tables; backfill the earliest-`createdAt` row per `(spaceId, symbol, percentageChange)` cluster as canonical, point the rest at it; in `app/daily-top-movers/top-(losers|gainers)/details/[id]/page.tsx` `permanentRedirect()` when `canonicalId` is set; filter `sitemap.xml/route.ts` and the list APIs feeding `RelatedDailyMovers` on `canonicalId IS NULL`. Validate with sitemap row-count drop + GSC duplicate-bucket shrink over 2–4 weeks.
+- [ ] **Stop creating new duplicates on US market holidays** — Mon-Fri cron (`deployments/insights-ui/scheduler.tf`) still fires on Good Friday / Presidents' Day / Memorial Day etc.; screener returns the prior trading day's data, callback writes a new row. Fix in `app/api/[spaceId]/tickers-v1/screener-callback/route.ts`: skip writes when a row already exists for `(spaceId, symbol)` with the same `percentageChange` within the last ~3 days. Or upgrade the unique constraint from `@@unique([spaceId, symbol, createdAt])` to a derived `marketDate` column so it's idempotent by definition.
+
 ### Login improvements
 
 - [ ] Add **LinkedIn** SSO + **Yahoo** SSO; account-linking when a new provider matches an existing email; keep login sheet tidy (top 3–4 most-used).

--- a/insights-ui/src/app/industry-tariff-report/[industryId]/final-conclusion/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/final-conclusion/page.tsx
@@ -3,10 +3,13 @@ import FinalConclusionActions from '@/components/industry-tariff/section-actions
 import { FinalConclusionRenderer } from '@/components/industry-tariff/renderers/FinalConclusionRenderer';
 
 import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
+import { chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
 import { fetchIndustryFinalConclusionMetadata } from '@/utils/tariff-reports/industry-metadata';
+import { getChapterSlugForOldUrl } from '@/utils/tariff-reports/seeded-chapter-reports';
 import { tariffReportTag } from '@/utils/tariff-report-tags';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 
 export async function generateMetadata({ params }: { params: Promise<{ industryId: string }> }): Promise<Metadata> {
   const { industryId } = await params;
@@ -15,6 +18,15 @@ export async function generateMetadata({ params }: { params: Promise<{ industryI
 
 export default async function FinalConclusionPage({ params }: { params: Promise<{ industryId: string }> }) {
   const { industryId } = await params;
+
+  // Industry-areas and final-conclusion legacy URLs were the two sections GSC kept flagging as
+  // duplicates of the chapter route — the canonical-only consolidation wasn't strong enough. 308 to
+  // the chapter URL when a mapping exists; non-mapped industries (rare; usually new ones) still
+  // render the legacy page until they get a chapter row.
+  const chapterSlug = await getChapterSlugForOldUrl(industryId);
+  if (chapterSlug) {
+    permanentRedirect(chapterSectionHref(chapterSlug, 'final-conclusion'));
+  }
 
   // Fetch the report data
   const reportResponse = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/${industryId}`, {

--- a/insights-ui/src/app/industry-tariff-report/[industryId]/industry-areas/page.tsx
+++ b/insights-ui/src/app/industry-tariff-report/[industryId]/industry-areas/page.tsx
@@ -5,9 +5,12 @@ import { getMarkdownContentForIndustryAreas } from '@/scripts/industry-tariff-re
 import type { IndustryTariffReport } from '@/scripts/industry-tariff-reports/tariff-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { chapterSectionHref } from '@/utils/tariff-reports/chapter-route-helpers';
 import { fetchIndustryAreasMetadata } from '@/utils/tariff-reports/industry-metadata';
+import { getChapterSlugForOldUrl } from '@/utils/tariff-reports/seeded-chapter-reports';
 import { tariffReportTag } from '@/utils/tariff-report-tags';
 import { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 
 export async function generateMetadata({ params }: { params: Promise<{ industryId: string }> }): Promise<Metadata> {
   const { industryId } = await params;
@@ -16,6 +19,15 @@ export async function generateMetadata({ params }: { params: Promise<{ industryI
 
 export default async function IndustryAreasPage({ params }: { params: Promise<{ industryId: string }> }) {
   const { industryId } = await params;
+
+  // Industry-areas and final-conclusion legacy URLs were the two sections GSC kept flagging as
+  // duplicates of the chapter route — the canonical-only consolidation wasn't strong enough. 308 to
+  // the chapter URL when a mapping exists; non-mapped industries (rare; usually new ones) still
+  // render the legacy page until they get a chapter row.
+  const chapterSlug = await getChapterSlugForOldUrl(industryId);
+  if (chapterSlug) {
+    permanentRedirect(chapterSectionHref(chapterSlug, 'industry-areas'));
+  }
 
   // Fetch the report data
   const reportResponse = await fetch(`${getBaseUrlForServerSidePages()}/api/industry-tariff-reports/${industryId}`, {


### PR DESCRIPTION
## Summary

Two changes for the GSC-indexing investigation thread:

1. **Track daily-top-movers dedup follow-ups** — adds two bullets to `docs/insights-ui/tasks/todo-tasks.md` under a new "Daily top movers" subsection (backfill historical `(symbol, %change)` duplicate clusters via a `canonicalId` self-FK + `permanentRedirect()`; close the US-market-holiday hole in the `Mon-Fri` AWS EventBridge cron).
2. **308 redirect the two GSC-flagged legacy section URLs to their chapter equivalents** — `app/industry-tariff-report/[industryId]/industry-areas/page.tsx` and `app/industry-tariff-report/[industryId]/final-conclusion/page.tsx`. These were the two sections in the GSC report:
   - 27 in "Duplicate without user-selected canonical" (source: Website)
   - 4 in "Duplicate, Google chose different canonical than user" (source: Google systems)

   Earlier we had set `<link rel="canonical">` on the legacy pages to point at the chapter URL, removed internal links, and dropped the legacy URLs from the sitemap — but both URLs still serving content-identical pages as HTTP 200 with `index, follow` was too symmetric for Google to confidently consolidate on the chapter URL. `permanentRedirect()` returns 308; Google treats it as 301 for canonicalization. External backlinks and bookmarks keep working (browser follows the redirect).

Scope is intentionally limited to the two flagged section types — the cover, `tariff-updates`, `understand-industry`, etc. stay on the canonical-only setup since they aren't in the duplicate buckets. Industries without a `chapter_slug` mapping in `tariff_chapter_reports.old_url` fall through and continue to render the legacy page.

## Test plan

- [ ] After deploy, `curl -I https://koalagains.com/industry-tariff-report/constructionMaterials/industry-areas` returns `HTTP/2 308` with `Location:` pointing at `.../chapters/25-salt-sulfur-and-cements/industry-areas`.
- [ ] Same for `.../oilAndGasRefiningAndMarketing/final-conclusion → .../chapters/27-mineral-fuels-and-oils/final-conclusion`.
- [ ] Visit `.../industry-tariff-report/constructionMaterials/tariff-updates` (NOT redirected) and confirm it still renders the legacy page with canonical pointing at the chapter URL.
- [ ] Re-submit affected URLs in GSC URL Inspection; expect "Duplicate" buckets to drain over 2-4 weeks as Google re-crawls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)