### PR TITLE
Send X-Robots-Tag: noindex on /_next/static/* from Next server

### DIFF
--- a/insights-ui/next.config.ts
+++ b/insights-ui/next.config.ts
@@ -39,6 +39,22 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // Tell Googlebot it can fetch /_next/static/* (it needs them to render pages) but should
+  // not index the assets themselves. Mirrors the legacy vercel.json rule for the Lightsail/
+  // CloudFront prod path, which doesn't pick up vercel.json headers. Without this, CSS/JS
+  // URLs end up in Search Console's "Crawled — currently not indexed" bucket.
+  async headers() {
+    return [
+      {
+        source: '/_next/static/:path*',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex' }],
+      },
+      {
+        source: '/_next/image',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex' }],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary

Mirrors the existing rule in `insights-ui/vercel.json:15-18` (`/_next/static/(.*)` → `X-Robots-Tag: noindex`), but emits it from the Next standalone server so it fires under the current CloudFront → Lightsail prod path. `vercel.json` no longer applies to live traffic — prod moved off Vercel in the 6/4 cutover (`d2d266747 Set insights-ui NEXTAUTH_URL to https://koalagains.com for CloudFront cut-over`) — and the live response on `koalagains.com/_next/static/*.css` had no robots header at all, letting CSS/JS URLs drift into Search Console's "Crawled — currently not indexed" bucket whenever Googlebot's renderer followed a `<link rel=stylesheet>` from a page.

We can't `Disallow` `/_next/` in robots.txt because Googlebot needs to fetch CSS/JS to render pages (that's already documented in `src/app/robots.ts:10-12`). `X-Robots-Tag: noindex` is the surgical fix — fetch allowed, page-indexing not.

Same rule also added for `/_next/image` since the optimized-image responses have the same property (browser-only resource, not a page).

## Test plan

- [ ] Before merge: `curl -sI https://koalagains.com/_next/static/css/<any-hash>.css` shows **no** `X-Robots-Tag` header (current bug).
- [ ] After deploy: same curl shows `x-robots-tag: noindex`.
- [ ] Page-Inspection on a real content URL in Search Console still passes rendering (CSS/JS still fetched, only `noindex` on the asset response itself).
- [ ] No `next lint` regressions (clean — only pre-existing tailwind warnings unrelated to this change).
- [ ] No new `next build` / `tsc` errors (the existing `@/images/*` "Cannot find module" errors are pre-existing on main, unrelated).

## Follow-ups (not in this PR)

- Validate per-sitemap in GSC (clean) rather than "All known pages" (inherently noisy with resource URLs).
- Stuck Vercel-era `?dpl=dpl_…` ghost CSS URLs will age out of GSC on their own over ~6 months; no fix exists for those.