### PR TITLE
SEO Playground

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -248,6 +248,12 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
   let metaDescription: string = '';
   let createdTime: string | undefined;
   let updatedTime: string | undefined;
+  // A page is "thin" until it has genuinely unique prose (the AI `summary` or a
+  // curated `metaDescription`). Without it the page is just chrome + the generic
+  // fallback description, which GSC clusters as a near-duplicate ("Crawled -
+  // currently not indexed" / "Duplicate, Google chose a different canonical").
+  // Gate indexing on real content; the page flips to indexable once populated.
+  let hasUniqueContent = false;
 
   try {
     const data = await fetchTickerByExchange(exchange, ticker);
@@ -257,6 +263,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
       metaDescription = data.metaDescription ?? '';
       createdTime = data.createdAt?.toISOString();
       updatedTime = data.updatedAt?.toISOString() ?? createdTime;
+      hasUniqueContent = Boolean(data.summary?.trim()) || Boolean(data.metaDescription?.trim());
     }
   } catch {
     /* keep generic */
@@ -282,6 +289,7 @@ export async function generateMetadata({ params }: { params: RouteParams }): Pro
     title: `${companyName} (${ticker}) Stock Analysis & Key Metrics (${year})`,
     description: shortDesc,
     alternates: { canonical: canonicalUrl },
+    robots: { index: hasUniqueContent, follow: true },
     openGraph: {
       title: `${companyName} (${ticker}) Stock Analysis & Key Metrics | KoalaGains`,
       description: shortDesc,

--- a/insights-ui/src/app/stocks/sitemap.xml/route.ts
+++ b/insights-ui/src/app/stocks/sitemap.xml/route.ts
@@ -57,6 +57,11 @@ interface SitemapTicker {
 // 404, and tickers with movedExchange/movedSymbol set 308 away — neither
 // should appear in the sitemap. The destination of a move is a separate row
 // (created when the move is applied) and lands in the sitemap on its own.
+//
+// Also require genuinely unique content (`summary` OR `metaDescription`). The
+// detail page sets `robots: noindex` until one of these is populated, so a
+// thin ticker in the sitemap would be a conflicting signal (sitemap says
+// "index" while the page says "don't"). Gating here keeps the two aligned.
 async function getAllTickers(): Promise<SitemapTicker[]> {
   return prisma.tickerV1.findMany({
     where: {
@@ -64,6 +69,7 @@ async function getAllTickers(): Promise<SitemapTicker[]> {
       isDeleted: false,
       movedExchange: null,
       movedSymbol: null,
+      OR: [{ summary: { not: null, notIn: [''] } }, { metaDescription: { not: null, notIn: [''] } }],
     },
     select: {
       symbol: true,


### PR DESCRIPTION
## Summary

Implements SEO improvements for ETF and stock detail pages by:
1. Creating a new ETF sitemap endpoint (`/etfs/sitemap.xml`)
2. Gating page indexing on the presence of unique content (AI-generated summaries or curated descriptions)
3. Updating the sitemap index to include the new ETF sitemap

## Changes

### New Files
- **`insights-ui/src/app/etfs/sitemap.xml/route.ts`** — Dynamic sitemap generation for ETF detail pages
  - Only includes ETFs with populated AI summaries (avoids indexing thin template-only pages)
  - Includes the `/etfs` listing page with daily change frequency
  - Sets appropriate priority and lastmod dates for each ETF

### Modified Files

**`insights-ui/src/utils/etf-metadata-generators.ts`**
- Extended `EtfDetailMetadataInput` to include `summary`, `assetClass`, `issuer`, and `indexName`
- Added `buildEtfDetailDescription()` helper that prefers AI summary but falls back to a templated description using ETF-specific metadata (asset class, issuer, index name) to ensure uniqueness
- Updated `generateEtfDetailMetadata()` to set `robots: { index: hasUniqueContent }` — pages remain noindex until summary is populated

**`insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx`**
- Updated `generateMetadata()` to fetch and pass `summary`, `assetClass`, `issuer`, and `indexName` to the metadata generator

**`insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx`**
- Updated `generateMetadata()` to compute `hasUniqueContent` based on presence of `summary` or `metaDescription`
- Set `robots: { index: hasUniqueContent }` to gate indexing on unique content

**`insights-ui/src/app/stocks/sitemap.xml/route.ts`**
- Updated `getAllTickers()` query to require either `summary` or `metaDescription` (non-empty)
- Ensures sitemap and page-level robots directives remain aligned

**`insights-ui/public/sitemap_index.xml`**
- Added entry for `/etfs/sitemap.xml`

## Rationale

**Problem:** Template-only pages (chrome + injected name/symbol) without unique content are clustered by Google as near-duplicates and marked "Crawled — currently not indexed." This creates a conflicting signal when the page is in the sitemap but marked noindex.

**Solution:** 
- Gate indexing on the presence of genuinely unique content (AI summary for ETFs, summary or metaDescription for stocks)
- Only include pages in sitemaps once they have unique content
- This keeps the sitemap and page-level robots directives aligned and prevents Google from clustering thin pages

## Testing

- Verified ETF sitemap generation filters correctly (only includes ETFs with non-empty summaries)
- Confirmed metadata generation uses AI summary when available, falls back to templated description with ETF-specific fields
- Validated robots directives are set based on content uniqueness
- Confirmed sitemap index includes new ETF sitemap entry

## Notes

- ETF pages will automatically flip to indexable once the AI summary is generated and the site is rebuilt
- Stock pages follow the same pattern (already implemented in this change)
- The fallback description for ETFs without summaries still includes unique metadata (asset class, issuer, index name) to minimize near-duplicate clustering

https://claude.ai/code/session_01PdNkBRHcpphasmd8f9mVmA