### PR TITLE
Per-ticker section headings + factor intros on stock detail page

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/types/ticker-typesv1';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { getSpiderGraphScorePercentage } from '@/util/radar-chart-utils';
+import { getStockSectionCopy } from '@/utils/stock-section-headings';
 import {
   getCountryByExchange,
   USExchanges,
@@ -604,11 +605,15 @@ const CATEGORY_DETAIL_LINKS: Record<TickerAnalysisCategory, { id: ReportType; hr
 function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCategory; d: TickerV1FastResponse }): JSX.Element {
   const categoryResult: FullTickerV1CategoryAnalysisResult | undefined = d.categoryAnalysisResults?.find((r) => r.categoryKey === categoryKey);
   const link = CATEGORY_DETAIL_LINKS[categoryKey];
+  const factorTitles: string[] = (categoryResult?.factorResults ?? [])
+    .map((fr) => fr.analysisCategoryFactor?.factorAnalysisTitle ?? '')
+    .filter((t) => t.length > 0);
+  const sectionCopy = getStockSectionCopy(categoryKey, d.symbol, d.name, factorTitles);
   return (
     <div id={link.id} className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex flex-wrap items-center gap-2">
-          <h3 className="text-lg font-semibold">{CATEGORY_MAPPINGS[categoryKey]}</h3>
+          <h3 className="text-lg font-semibold">{sectionCopy.heading}</h3>
           {categoryResult && (
             <div
               className="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-xs font-medium"
@@ -628,6 +633,8 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
           {link.label}
         </Link>
       </div>
+      <p className="text-sm text-muted mb-1">{sectionCopy.introLine}</p>
+      {sectionCopy.factorLine && <p className="text-sm text-muted mb-3">{sectionCopy.factorLine}</p>}
       <div
         className="text-body markdown markdown-body"
         dangerouslySetInnerHTML={{ __html: parseMarkdown(categoryResult?.overallAnalysisDetails || 'No summary available.') }}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -608,7 +608,7 @@ function CategorySummaryCard({ categoryKey, d }: { categoryKey: TickerAnalysisCa
   const factorTitles: string[] = (categoryResult?.factorResults ?? [])
     .map((fr) => fr.analysisCategoryFactor?.factorAnalysisTitle ?? '')
     .filter((t) => t.length > 0);
-  const sectionCopy = getStockSectionCopy(categoryKey, d.symbol, d.name, factorTitles);
+  const sectionCopy = getStockSectionCopy(categoryKey, d.symbol, d.name, { factorTitles });
   return (
     <div id={link.id} className="bg-surface p-3 sm:p-4 rounded-md shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 mb-2">

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -1,6 +1,7 @@
 import { computeQuadrantScores, classifyStock, QuadrantDataPoint } from '@/util/quadrant-chart-utils';
 import CompetitionQuadrantChart from '@/components/ticker-reportsv1/CompetitionQuadrantChart';
 import type { CompetitionResponse } from '@/types/ticker-typesv1';
+import { getStockSectionCopy } from '@/utils/stock-section-headings';
 import Link from 'next/link';
 import { use } from 'react';
 
@@ -55,11 +56,13 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
     return null;
   }
 
+  const competitionCopy = getStockSectionCopy('Competition', tickerData.symbol, tickerData.name);
+
   return (
     <section id="competition">
       <div className="bg-surface rounded-lg shadow-sm p-3 sm:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-2 border-b border-border">
-          <h2 className="text-xl font-bold">Competition</h2>
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-2 pb-2 border-b border-border">
+          <h2 className="text-xl font-bold">{competitionCopy.heading}</h2>
           <Link
             href={`/stocks/${exchange}/${ticker}/competition`}
             prefetch={false}
@@ -69,6 +72,7 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
             View Full Analysis →
           </Link>
         </div>
+        <p className="text-sm text-muted mb-4">{competitionCopy.introLine}</p>
 
         <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
           <div className="lg:w-1/2">

--- a/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/CompetitionChartSection.tsx
@@ -56,7 +56,8 @@ export default function CompetitionChartSection({ dataPromise, exchange, ticker 
     return null;
   }
 
-  const competitionCopy = getStockSectionCopy('Competition', tickerData.symbol, tickerData.name);
+  const competitorSymbols: string[] = competitorTickers.filter((c) => c.existsInSystem && c.tickerData?.symbol).map((c) => c.tickerData!.symbol);
+  const competitionCopy = getStockSectionCopy('Competition', tickerData.symbol, tickerData.name, { competitorSymbols });
 
   return (
     <section id="competition">

--- a/insights-ui/src/stock-analysis/stock-section-headings.json
+++ b/insights-ui/src/stock-analysis/stock-section-headings.json
@@ -1,5 +1,5 @@
 {
-  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. Picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Intros are plain English aimed at retail investors. No em dashes, no marketing words, no AI-sounding tropes.",
+  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. Picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Intros are plain English aimed at retail investors. No em dashes, no marketing words, no AI-sounding tropes. Headings reflect what the underlying analysis prompt actually covers (moat sources for Business & Moat; current-quarter health for Financial Statement Analysis; 5-year track record for Past Performance; 3-5 year outlook for Future Growth; price-versus-value for Fair Value; quality-versus-value vs peers for Competition).",
   "placeholders": "{name} = full company name, {symbol} = uppercased ticker symbol, {factorList} = comma-joined factor titles for that ticker's sub-industry, {competitorList} = comma-joined top competitor symbols (Competition section only). Variants that reference {competitorList} are skipped if no competitors are available.",
   "sections": {
     "BusinessAndMoat": {
@@ -13,14 +13,26 @@
         "Is {name} Built to Keep Winning Customers?",
         "How Safe Is {name}'s Position in Its Industry?",
         "What Makes {name} Different From Other Companies?",
-        "Does {symbol} Have Real Advantages Over Competitors?"
+        "Does {symbol} Have Real Advantages Over Competitors?",
+        "How Wide Is {name}'s Moat?",
+        "Does {name} Have a Strong Moat?",
+        "How Durable Is {name}'s Competitive Edge?",
+        "What Is {name}'s Moat Made Of?",
+        "Is {name}'s Moat Getting Wider or Narrower?",
+        "Does {name} Have a Real Moat?",
+        "How Hard Is It to Compete With {name}?",
+        "What Keeps Customers Coming Back to {name}?",
+        "Is {name} Protected From New Competitors?",
+        "What Gives {name} Its Edge Over Other Companies?"
       ],
       "intros": [
         "We look at how strong {name}'s business is and what gives it an edge over other companies.",
         "This section checks whether {name} can keep making good profits for many years to come.",
         "Here we study what makes {symbol} hard for other companies to copy or beat.",
         "We review the parts of {name}'s business that protect it from new and existing competitors.",
-        "Below we check how well placed {name} is to keep its customers and market share."
+        "Below we check how well placed {name} is to keep its customers and market share.",
+        "We check how wide {name}'s moat is and what makes its main products hard for competitors to copy.",
+        "Here we look at the brand, switching costs, scale, and network effects that protect {name}'s long term profits."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -55,16 +67,19 @@
         "How Good Is {name}'s Balance Sheet, Income, and Cash Flow?",
         "Does {symbol} Make Real Money?",
         "How Much Cash Does {name} Generate?",
-        "Is {name} Carrying Too Much Debt?",
         "Are {symbol}'s Profit Margins Healthy?",
-        "What Do {name}'s Financial Statements Show?"
+        "What Do {name}'s Financial Statements Show?",
+        "How Strong Is {name}'s Current Financial Position?",
+        "Is {name}'s Business in Good Financial Shape Right Now?",
+        "How Stable Are {name}'s Profits and Cash Flow?",
+        "What Do the Recent Quarters Say About {name}?"
       ],
       "intros": [
         "We check {name}'s balance sheet, income statement, and cash flow to see how healthy the business is.",
-        "This section looks at whether {symbol} earns real cash and keeps its debt under control.",
+        "This section looks at whether {symbol} earns real cash and keeps its finances under control.",
         "Here we review the numbers behind {name} to see if the business is well run.",
         "Below we check how strong {name}'s profit margins, cash flow, and balance sheet are.",
-        "We look at {symbol}'s reported numbers to see if the business is in good shape."
+        "We look at {symbol}'s reported numbers to see if the business is in good shape today."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -79,7 +94,12 @@
         "How Steady Has {name}'s Growth Been?",
         "Has {symbol} Beaten the Market in the Past?",
         "How Did {name} Perform Through Good and Bad Times?",
-        "What Is {name}'s Long Term Track Record?"
+        "What Is {name}'s Long Term Track Record?",
+        "How Consistent Has {name}'s Growth Been Over the Last 5 Years?",
+        "Has {name} Grown Revenue and Profit Steadily?",
+        "What Do the Last 5 Years Tell Us About {name}?",
+        "How Reliable Has {name}'s Cash Flow Been?",
+        "Has {name} Rewarded Shareholders With Dividends or Buybacks?"
       ],
       "intros": [
         "We look at how {name} has grown its revenue, profits, and shareholder returns over time.",
@@ -101,14 +121,19 @@
         "Is {name} Ready for Long Term Growth?",
         "Can {symbol} Grow Faster Than the Market?",
         "What Could Help or Hurt {name}'s Future Growth?",
-        "How Strong Is {name}'s Future Outlook?"
+        "How Strong Is {name}'s Future Outlook?",
+        "What Could Drive {name}'s Growth Over the Next 3 to 5 Years?",
+        "How Big Could {name}'s Markets Get?",
+        "Are There New Markets {name} Can Expand Into?",
+        "What Outside Factors Will Shape {name}'s Future Growth?",
+        "Where Could {name}'s Next Wave of Revenue Come From?"
       ],
       "intros": [
         "We look at where {name}'s future growth could come from over the next few years.",
         "This section checks if {symbol} can keep growing earnings, cash flow, and revenue.",
         "Here we review the main drivers and risks that will shape {name}'s future growth.",
         "Below we look at how much room {name} still has to grow and what could slow it down.",
-        "We check {symbol}'s future outlook based on its market, products, and plans."
+        "We check {symbol}'s future outlook based on its main products, markets, and industry shifts."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -123,14 +148,19 @@
         "What Is the Fair Price for {name} Stock?",
         "Is Today's Price for {symbol} a Bargain?",
         "Does {name} Offer a Good Margin of Safety?",
-        "Is {symbol} Trading Above or Below Its True Value?"
+        "Is {symbol} Trading Above or Below Its True Value?",
+        "How Does {name}'s P/E Compare to Its Peers?",
+        "Does {name}'s Price Match Its Earnings and Cash Flow?",
+        "Is the Market Pricing {name} Correctly?",
+        "Is {name}'s Dividend Yield Attractive at Today's Price?",
+        "Where Are the Buy, Watch, and Wait Price Zones for {name}?"
       ],
       "intros": [
         "We estimate how much {name} is really worth and compare it to today's market price.",
         "This section checks if {symbol} is cheap, expensive, or fairly priced right now.",
         "Here we look at whether buying {name} at today's price gives investors room for safety.",
         "Below we estimate {name}'s value based on its business and compare it to the stock price.",
-        "We check what {symbol} is worth based on the company's earnings and growth outlook."
+        "We check what {symbol} is worth based on the company's earnings, cash flow, and growth outlook."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     }

--- a/insights-ui/src/stock-analysis/stock-section-headings.json
+++ b/insights-ui/src/stock-analysis/stock-section-headings.json
@@ -1,0 +1,96 @@
+{
+  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. The variant is picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Each section also has line-1 intro variants ('what we evaluate') plus a line-2 factor-list intro ('we evaluated X on: factor 1, factor 2, ...') — the factor names come from the ticker's per-sub-industry factor results, which already vary across ~150 GICS sub-industries.",
+  "placeholders": "{name} = full company name, {symbol} = uppercased ticker symbol.",
+  "sections": {
+    "BusinessAndMoat": {
+      "headings": [
+        "How Wide Is {name}'s Economic Moat?",
+        "Does {name} Have a Durable Competitive Advantage?",
+        "Is {symbol}'s Business Built to Last?",
+        "Can {name} Defend Its Market Position?",
+        "What Makes {name} Hard to Disrupt?"
+      ],
+      "intros": [
+        "This section assesses {name}'s competitive moat — the structural advantages that protect its margins and market share over the long run.",
+        "We dig into how defensible {name}'s business model is and whether {symbol} can keep competitors at bay.",
+        "Below we evaluate the strength and durability of {name}'s business — and what could threaten its position over the next decade."
+      ],
+      "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
+    },
+    "Competition": {
+      "headings": [
+        "How Does {name} Stack Up Against Its Competitors?",
+        "Who Are {symbol}'s Closest Rivals — and Who's Winning?",
+        "{name} vs. Its Peers on Quality and Value",
+        "Where Does {name} Rank Among Industry Peers?",
+        "Is {symbol} a Leader or a Laggard in Its Industry?"
+      ],
+      "intros": [
+        "Here we compare {name} ({symbol}) against its closest sector peers on quality and value scores.",
+        "This view places {name} on a quality-versus-value map alongside its competitors so you can see who leads, who lags, and where {symbol} sits in the mix.",
+        "Below, {name} is benchmarked against direct competitors using our quality and value composite scores."
+      ],
+      "factorIntroTemplate": ""
+    },
+    "FinancialStatementAnalysis": {
+      "headings": [
+        "How Healthy Are {name}'s Financial Statements?",
+        "Inside {symbol}'s Balance Sheet, Cash Flow, and Margins",
+        "What Do {name}'s Books Say About Business Quality?",
+        "Are {symbol}'s Financials Strong Enough to Trust?",
+        "A Statement-by-Statement Look at {name}'s Financials"
+      ],
+      "intros": [
+        "We assess {name}'s financial health across the balance sheet, income statement, and cash-flow statement.",
+        "This section examines whether {symbol}'s financial structure can support its growth plans without straining liquidity or solvency.",
+        "Below we look at how clean and durable {name}'s reported financials are — and what they imply about underlying business quality."
+      ],
+      "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
+    },
+    "PastPerformance": {
+      "headings": [
+        "How Has {name} Performed Over the Past Decade?",
+        "Reviewing {symbol}'s Track Record of Returns",
+        "Has {name} Rewarded Shareholders Historically?",
+        "What Does {symbol}'s Past Performance Tell Us?",
+        "{name}'s Performance Through Cycles: A Historical Review"
+      ],
+      "intros": [
+        "We grade {name}'s historical track record on growth, returns, and capital allocation.",
+        "This section looks back at how {symbol} has compounded value for shareholders through different market environments.",
+        "Below we examine the track record {name} has built — what worked, what didn't, and how consistent the results have been."
+      ],
+      "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
+    },
+    "FutureGrowth": {
+      "headings": [
+        "What's Next for {name}? The Growth Outlook",
+        "Where Will {symbol}'s Future Growth Come From?",
+        "How Big Could {name} Be in 5–10 Years?",
+        "The Growth Drivers Behind {symbol}",
+        "Is {name} Positioned for Long-Term Expansion?"
+      ],
+      "intros": [
+        "We project {name}'s forward growth potential — the drivers that could compound earnings over the next several years.",
+        "This section sizes up where incremental growth for {symbol} is most likely to come from and what could derail it.",
+        "Below we look at the catalysts, runway, and constraints that will shape {name}'s next phase of growth."
+      ],
+      "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
+    },
+    "FairValue": {
+      "headings": [
+        "Is {name} Stock Undervalued, Overvalued, or Fairly Priced?",
+        "What Is {symbol} Really Worth?",
+        "A Fair-Value Take on {name}",
+        "How Does Today's Price Compare to {name}'s Intrinsic Value?",
+        "Putting a Number on {symbol}'s True Worth"
+      ],
+      "intros": [
+        "We model {name}'s intrinsic value to compare it against today's market price.",
+        "This section asks whether buying {symbol} at the current price gives you a meaningful margin of safety.",
+        "Below we estimate what {name} is worth on a fundamentals basis and what kind of return that implies from here."
+      ],
+      "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
+    }
+  }
+}

--- a/insights-ui/src/stock-analysis/stock-section-headings.json
+++ b/insights-ui/src/stock-analysis/stock-section-headings.json
@@ -1,5 +1,5 @@
 {
-  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. Picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Intros are plain English aimed at retail investors. No em dashes, no marketing words, no AI-sounding tropes. Headings reflect what the underlying analysis prompt actually covers (moat sources for Business & Moat; current-quarter health for Financial Statement Analysis; 5-year track record for Past Performance; 3-5 year outlook for Future Growth; price-versus-value for Fair Value; quality-versus-value vs peers for Competition).",
+  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. Picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Intros are plain English aimed at retail investors. No em dashes, no marketing words, no AI-sounding tropes. Every variant must be generic to the section's core question so it works for any ticker (no assumptions about dividend status, buybacks, valuation outcome, score level, etc.) since the picker has no semantic awareness of the company's actual data.",
   "placeholders": "{name} = full company name, {symbol} = uppercased ticker symbol, {factorList} = comma-joined factor titles for that ticker's sub-industry, {competitorList} = comma-joined top competitor symbols (Competition section only). Variants that reference {competitorList} are skipped if no competitors are available.",
   "sections": {
     "BusinessAndMoat": {
@@ -23,7 +23,17 @@
         "How Hard Is It to Compete With {name}?",
         "What Keeps Customers Coming Back to {name}?",
         "Is {name} Protected From New Competitors?",
-        "What Gives {name} Its Edge Over Other Companies?"
+        "What Gives {name} Its Edge Over Other Companies?",
+        "How Easily Can Competitors Replace {name}?",
+        "What Makes {symbol}'s Products Hard to Replace?",
+        "Is {name} a High Quality Business?",
+        "How Strong Are the Walls Around {name}'s Business?",
+        "Does {name} Run a Business That Can Last?",
+        "How Resilient Is {name}'s Business Model?",
+        "What Sets {name} Apart in Its Industry?",
+        "How Big Is {name}'s Long Term Advantage?",
+        "Is {name}'s Business Built on Solid Ground?",
+        "What Makes {name} a Lasting Business?"
       ],
       "intros": [
         "We look at how strong {name}'s business is and what gives it an edge over other companies.",
@@ -32,7 +42,10 @@
         "We review the parts of {name}'s business that protect it from new and existing competitors.",
         "Below we check how well placed {name} is to keep its customers and market share.",
         "We check how wide {name}'s moat is and what makes its main products hard for competitors to copy.",
-        "Here we look at the brand, switching costs, scale, and network effects that protect {name}'s long term profits."
+        "Here we look at the brand, switching costs, scale, and network effects that protect {name}'s long term profits.",
+        "We look at the sources of {name}'s strength and how durable its business really is.",
+        "This section reviews the key reasons {name} stays valuable to its customers year after year.",
+        "Below we check the structural advantages that make {symbol} hard for other companies to match."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -47,14 +60,27 @@
         "Is {name} Doing Better Than Other Companies in Its Industry?",
         "How Does {name} Compare to Its Peers on Quality and Value?",
         "{name} Compared With Its Closest Competitors",
-        "Is {symbol} a Stronger Pick Than Its Peers?"
+        "Is {symbol} a Stronger Pick Than Its Peers?",
+        "How Does {name} Look Next to Its Peers?",
+        "How Does {name} Compare With Other Companies in Its Field?",
+        "How Does {symbol} Rank Among Companies in Its Industry?",
+        "Is {name} the Best Pick Among Similar Companies?",
+        "How Do {name}'s Quality and Value Compare to Other Companies?",
+        "{symbol} Compared to Its Industry Peers",
+        "Is {symbol} a Better Choice Than Its Competitors?",
+        "How Does {name} Score Against Other Companies in Its Industry?",
+        "Where Does {symbol} Sit Among Other Companies in Its Industry?",
+        "How Does {name} Look Compared to Similar Companies?"
       ],
       "intros": [
         "We compare {name} with other companies in the same industry on quality and value scores.",
         "Here we look at how {symbol} performs against its closest competitors on quality and value.",
         "This section places {name} next to other companies in its industry so you can see who is doing well.",
         "Below we check how {name} compares with companies like {competitorList} on quality and value scores.",
-        "We compare {symbol} with companies like {competitorList} to show how it ranks in its industry."
+        "We compare {symbol} with companies like {competitorList} to show how it ranks in its industry.",
+        "We line up {name} with similar companies to see how it scores on quality and value.",
+        "Here we check how {symbol} ranks against the other main companies in its industry.",
+        "This section shows how {name} compares with companies like {competitorList} on the basics that matter for investors."
       ],
       "factorIntroTemplate": ""
     },
@@ -72,14 +98,29 @@
         "How Strong Is {name}'s Current Financial Position?",
         "Is {name}'s Business in Good Financial Shape Right Now?",
         "How Stable Are {name}'s Profits and Cash Flow?",
-        "What Do the Recent Quarters Say About {name}?"
+        "What Do the Recent Quarters Say About {name}?",
+        "Is {name} on Solid Financial Ground?",
+        "How Strong Is {name}'s Income, Cash, and Capital?",
+        "Are {name}'s Financials in Good Shape?",
+        "Does {symbol} Have a Strong Financial Foundation?",
+        "How Healthy Is {name}'s Business Today?",
+        "What Do {name}'s Recent Numbers Tell Us?",
+        "Is {symbol} Financially Sound Right Now?",
+        "How Well Is {name} Managing Its Finances?",
+        "Are the Numbers Behind {name} Solid?",
+        "How Does {name}'s Latest Financial Report Look?",
+        "Is {name}'s Business Running on Healthy Numbers?",
+        "What Do {name}'s Latest Statements Show About the Business?"
       ],
       "intros": [
         "We check {name}'s balance sheet, income statement, and cash flow to see how healthy the business is.",
         "This section looks at whether {symbol} earns real cash and keeps its finances under control.",
         "Here we review the numbers behind {name} to see if the business is well run.",
         "Below we check how strong {name}'s profit margins, cash flow, and balance sheet are.",
-        "We look at {symbol}'s reported numbers to see if the business is in good shape today."
+        "We look at {symbol}'s reported numbers to see if the business is in good shape today.",
+        "This section walks through {name}'s key financial numbers to see how solid the business is right now.",
+        "Here we review the latest income, cash flow, and balance sheet data for {name}.",
+        "Below we look at {symbol}'s reported financials to see how strong the business looks today."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -99,14 +140,27 @@
         "Has {name} Grown Revenue and Profit Steadily?",
         "What Do the Last 5 Years Tell Us About {name}?",
         "How Reliable Has {name}'s Cash Flow Been?",
-        "Has {name} Rewarded Shareholders With Dividends or Buybacks?"
+        "How Did {name} Perform Over the Last Few Years?",
+        "What Does {name}'s History Tell Investors?",
+        "How Has {name} Done Over Time?",
+        "Has {symbol} Built a Solid Track Record?",
+        "What Is {name}'s Past Performance Story?",
+        "How Has {name}'s Business Grown Over Time?",
+        "How Steady Has {name}'s Performance Been?",
+        "Did {name} Hold Up Well Through Different Market Cycles?",
+        "How Has {name} Performed Compared to Its History?",
+        "What Has {name} Delivered to Investors So Far?",
+        "How Has {name}'s Business Evolved Over the Last 5 Years?"
       ],
       "intros": [
         "We look at how {name} has grown its revenue, profits, and shareholder returns over time.",
         "This section checks {symbol}'s track record on growth, returns, and how it handled tough markets.",
         "Here we review what {name} has delivered to shareholders over the past several years.",
         "Below we look at how steady and strong {name}'s growth has been so far.",
-        "We check {symbol}'s past results to see if the company has been a good investment."
+        "We check {symbol}'s past results to see if the company has been a good investment.",
+        "This section reviews how {name} has grown, earned, and held up over the past few years.",
+        "Here we check {name}'s past record to see how the business has performed through different markets.",
+        "Below we look at the past results behind {symbol} to see how steady the business has been."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -126,14 +180,27 @@
         "How Big Could {name}'s Markets Get?",
         "Are There New Markets {name} Can Expand Into?",
         "What Outside Factors Will Shape {name}'s Future Growth?",
-        "Where Could {name}'s Next Wave of Revenue Come From?"
+        "Where Could {name}'s Next Wave of Revenue Come From?",
+        "How Bright Is {name}'s Future?",
+        "What Do the Next Few Years Look Like for {name}?",
+        "Can {symbol} Keep Building Value Over Time?",
+        "How Much Room Does {name} Still Have to Grow?",
+        "What Could Push {name} Higher Over the Next Few Years?",
+        "Is {symbol} Set Up for the Future?",
+        "How Strong Are {name}'s Growth Opportunities?",
+        "What Could Slow Down {name}'s Future Growth?",
+        "Will {name}'s Business Keep Expanding?",
+        "How Promising Is the Future for {name}?"
       ],
       "intros": [
         "We look at where {name}'s future growth could come from over the next few years.",
         "This section checks if {symbol} can keep growing earnings, cash flow, and revenue.",
         "Here we review the main drivers and risks that will shape {name}'s future growth.",
         "Below we look at how much room {name} still has to grow and what could slow it down.",
-        "We check {symbol}'s future outlook based on its main products, markets, and industry shifts."
+        "We check {symbol}'s future outlook based on its main products, markets, and industry shifts.",
+        "This section reviews the main reasons {name}'s business could grow over the next few years.",
+        "Here we look at what could help or slow {name}'s growth in the years ahead.",
+        "Below we check the size of {symbol}'s markets and where its next round of growth could come from."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
@@ -152,15 +219,28 @@
         "How Does {name}'s P/E Compare to Its Peers?",
         "Does {name}'s Price Match Its Earnings and Cash Flow?",
         "Is the Market Pricing {name} Correctly?",
-        "Is {name}'s Dividend Yield Attractive at Today's Price?",
-        "Where Are the Buy, Watch, and Wait Price Zones for {name}?"
+        "Where Are the Buy, Watch, and Wait Price Zones for {name}?",
+        "How Does {name}'s Price Compare to Its Business Value?",
+        "Is {symbol} Trading at a Fair Price?",
+        "What Should {name} Stock Be Worth?",
+        "Is {name}'s Current Price Justified?",
+        "Is {symbol} Priced Right for Today's Business?",
+        "How Does {symbol}'s Price Compare to Its Fundamentals?",
+        "What Does {name} Look Like at Today's Price?",
+        "Is {symbol} Selling for Less Than It Is Worth?",
+        "How Does {symbol}'s Market Price Compare to Its Real Value?",
+        "Is the Price of {name} Stock in the Right Range?",
+        "Are Investors Paying the Right Price for {name}?"
       ],
       "intros": [
         "We estimate how much {name} is really worth and compare it to today's market price.",
         "This section checks if {symbol} is cheap, expensive, or fairly priced right now.",
         "Here we look at whether buying {name} at today's price gives investors room for safety.",
         "Below we estimate {name}'s value based on its business and compare it to the stock price.",
-        "We check what {symbol} is worth based on the company's earnings, cash flow, and growth outlook."
+        "We check what {symbol} is worth based on the company's earnings, cash flow, and growth outlook.",
+        "This section weighs {name}'s current stock price against the value of its business.",
+        "Here we estimate a fair price range for {name} and check where today's price sits.",
+        "Below we check {symbol}'s price against earnings, cash flow, and peer pricing to see if it is fair."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     }

--- a/insights-ui/src/stock-analysis/stock-section-headings.json
+++ b/insights-ui/src/stock-analysis/stock-section-headings.json
@@ -1,94 +1,136 @@
 {
-  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. The variant is picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Each section also has line-1 intro variants ('what we evaluate') plus a line-2 factor-list intro ('we evaluated X on: factor 1, factor 2, ...') — the factor names come from the ticker's per-sub-industry factor results, which already vary across ~150 GICS sub-industries.",
-  "placeholders": "{name} = full company name, {symbol} = uppercased ticker symbol.",
+  "description": "Per-ticker variant copy for the six headline sections on the stock detail page. Picked deterministically from a hash of the ticker symbol so the same ticker always renders the same heading (crawler-stable, cache-friendly) while different tickers across the ~9k stock pages get different headings. Each heading embeds the company name or symbol so every page carries at least one piece of ticker-unique copy in its H2/H3 chrome. Intros are plain English aimed at retail investors. No em dashes, no marketing words, no AI-sounding tropes.",
+  "placeholders": "{name} = full company name, {symbol} = uppercased ticker symbol, {factorList} = comma-joined factor titles for that ticker's sub-industry, {competitorList} = comma-joined top competitor symbols (Competition section only). Variants that reference {competitorList} are skipped if no competitors are available.",
   "sections": {
     "BusinessAndMoat": {
       "headings": [
-        "How Wide Is {name}'s Economic Moat?",
-        "Does {name} Have a Durable Competitive Advantage?",
-        "Is {symbol}'s Business Built to Last?",
-        "Can {name} Defend Its Market Position?",
-        "What Makes {name} Hard to Disrupt?"
+        "Is {name}'s Business Strong?",
+        "How Strong Is {name}'s Business?",
+        "Does {name} Have a Strong Business?",
+        "Why Is {name}'s Business Hard to Beat?",
+        "What Protects {name}'s Profits?",
+        "Can {symbol} Stay Ahead of Other Companies?",
+        "Is {name} Built to Keep Winning Customers?",
+        "How Safe Is {name}'s Position in Its Industry?",
+        "What Makes {name} Different From Other Companies?",
+        "Does {symbol} Have Real Advantages Over Competitors?"
       ],
       "intros": [
-        "This section assesses {name}'s competitive moat — the structural advantages that protect its margins and market share over the long run.",
-        "We dig into how defensible {name}'s business model is and whether {symbol} can keep competitors at bay.",
-        "Below we evaluate the strength and durability of {name}'s business — and what could threaten its position over the next decade."
+        "We look at how strong {name}'s business is and what gives it an edge over other companies.",
+        "This section checks whether {name} can keep making good profits for many years to come.",
+        "Here we study what makes {symbol} hard for other companies to copy or beat.",
+        "We review the parts of {name}'s business that protect it from new and existing competitors.",
+        "Below we check how well placed {name} is to keep its customers and market share."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
     "Competition": {
       "headings": [
-        "How Does {name} Stack Up Against Its Competitors?",
-        "Who Are {symbol}'s Closest Rivals — and Who's Winning?",
-        "{name} vs. Its Peers on Quality and Value",
-        "Where Does {name} Rank Among Industry Peers?",
-        "Is {symbol} a Leader or a Laggard in Its Industry?"
+        "How Does {name} Compare to Other Companies?",
+        "How Does {symbol} Compare to Its Competitors?",
+        "Is {name} Stronger or Weaker Than Its Competitors?",
+        "Where Does {name} Stand Among Other Companies in Its Industry?",
+        "How Strong Is {symbol} Compared to Its Peers?",
+        "Who Are {symbol}'s Main Competitors?",
+        "Is {name} Doing Better Than Other Companies in Its Industry?",
+        "How Does {name} Compare to Its Peers on Quality and Value?",
+        "{name} Compared With Its Closest Competitors",
+        "Is {symbol} a Stronger Pick Than Its Peers?"
       ],
       "intros": [
-        "Here we compare {name} ({symbol}) against its closest sector peers on quality and value scores.",
-        "This view places {name} on a quality-versus-value map alongside its competitors so you can see who leads, who lags, and where {symbol} sits in the mix.",
-        "Below, {name} is benchmarked against direct competitors using our quality and value composite scores."
+        "We compare {name} with other companies in the same industry on quality and value scores.",
+        "Here we look at how {symbol} performs against its closest competitors on quality and value.",
+        "This section places {name} next to other companies in its industry so you can see who is doing well.",
+        "Below we check how {name} compares with companies like {competitorList} on quality and value scores.",
+        "We compare {symbol} with companies like {competitorList} to show how it ranks in its industry."
       ],
       "factorIntroTemplate": ""
     },
     "FinancialStatementAnalysis": {
       "headings": [
         "How Healthy Are {name}'s Financial Statements?",
-        "Inside {symbol}'s Balance Sheet, Cash Flow, and Margins",
-        "What Do {name}'s Books Say About Business Quality?",
+        "Are {name}'s Numbers Strong?",
+        "What Do {name}'s Books Say About the Business?",
         "Are {symbol}'s Financials Strong Enough to Trust?",
-        "A Statement-by-Statement Look at {name}'s Financials"
+        "How Good Is {name}'s Balance Sheet, Income, and Cash Flow?",
+        "Does {symbol} Make Real Money?",
+        "How Much Cash Does {name} Generate?",
+        "Is {name} Carrying Too Much Debt?",
+        "Are {symbol}'s Profit Margins Healthy?",
+        "What Do {name}'s Financial Statements Show?"
       ],
       "intros": [
-        "We assess {name}'s financial health across the balance sheet, income statement, and cash-flow statement.",
-        "This section examines whether {symbol}'s financial structure can support its growth plans without straining liquidity or solvency.",
-        "Below we look at how clean and durable {name}'s reported financials are — and what they imply about underlying business quality."
+        "We check {name}'s balance sheet, income statement, and cash flow to see how healthy the business is.",
+        "This section looks at whether {symbol} earns real cash and keeps its debt under control.",
+        "Here we review the numbers behind {name} to see if the business is well run.",
+        "Below we check how strong {name}'s profit margins, cash flow, and balance sheet are.",
+        "We look at {symbol}'s reported numbers to see if the business is in good shape."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
     "PastPerformance": {
       "headings": [
-        "How Has {name} Performed Over the Past Decade?",
-        "Reviewing {symbol}'s Track Record of Returns",
-        "Has {name} Rewarded Shareholders Historically?",
-        "What Does {symbol}'s Past Performance Tell Us?",
-        "{name}'s Performance Through Cycles: A Historical Review"
+        "How Has {name} Performed in the Past?",
+        "Has {name} Made Money for Shareholders Over Time?",
+        "What Does {symbol}'s Track Record Look Like?",
+        "How Has {name} Grown Over the Years?",
+        "Has {symbol} Delivered Good Returns in the Past?",
+        "What Has {name} Achieved So Far?",
+        "How Steady Has {name}'s Growth Been?",
+        "Has {symbol} Beaten the Market in the Past?",
+        "How Did {name} Perform Through Good and Bad Times?",
+        "What Is {name}'s Long Term Track Record?"
       ],
       "intros": [
-        "We grade {name}'s historical track record on growth, returns, and capital allocation.",
-        "This section looks back at how {symbol} has compounded value for shareholders through different market environments.",
-        "Below we examine the track record {name} has built — what worked, what didn't, and how consistent the results have been."
+        "We look at how {name} has grown its revenue, profits, and shareholder returns over time.",
+        "This section checks {symbol}'s track record on growth, returns, and how it handled tough markets.",
+        "Here we review what {name} has delivered to shareholders over the past several years.",
+        "Below we look at how steady and strong {name}'s growth has been so far.",
+        "We check {symbol}'s past results to see if the company has been a good investment."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
     "FutureGrowth": {
       "headings": [
-        "What's Next for {name}? The Growth Outlook",
-        "Where Will {symbol}'s Future Growth Come From?",
-        "How Big Could {name} Be in 5–10 Years?",
-        "The Growth Drivers Behind {symbol}",
-        "Is {name} Positioned for Long-Term Expansion?"
+        "Can {name} Keep Growing in the Future?",
+        "What Is Next for {name}?",
+        "Where Will {symbol}'s Growth Come From?",
+        "How Big Can {name} Become in the Next Few Years?",
+        "Will {symbol} Keep Growing Earnings?",
+        "What Are the Growth Drivers for {name}?",
+        "Is {name} Ready for Long Term Growth?",
+        "Can {symbol} Grow Faster Than the Market?",
+        "What Could Help or Hurt {name}'s Future Growth?",
+        "How Strong Is {name}'s Future Outlook?"
       ],
       "intros": [
-        "We project {name}'s forward growth potential — the drivers that could compound earnings over the next several years.",
-        "This section sizes up where incremental growth for {symbol} is most likely to come from and what could derail it.",
-        "Below we look at the catalysts, runway, and constraints that will shape {name}'s next phase of growth."
+        "We look at where {name}'s future growth could come from over the next few years.",
+        "This section checks if {symbol} can keep growing earnings, cash flow, and revenue.",
+        "Here we review the main drivers and risks that will shape {name}'s future growth.",
+        "Below we look at how much room {name} still has to grow and what could slow it down.",
+        "We check {symbol}'s future outlook based on its market, products, and plans."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     },
     "FairValue": {
       "headings": [
-        "Is {name} Stock Undervalued, Overvalued, or Fairly Priced?",
+        "Is {name} Cheap or Expensive Right Now?",
+        "Is {name} Stock Worth Buying at Today's Price?",
         "What Is {symbol} Really Worth?",
-        "A Fair-Value Take on {name}",
-        "How Does Today's Price Compare to {name}'s Intrinsic Value?",
-        "Putting a Number on {symbol}'s True Worth"
+        "Is {name} Undervalued, Overvalued, or Fairly Priced?",
+        "How Does {name}'s Price Compare to Its True Value?",
+        "Is {symbol} a Good Buy at Current Levels?",
+        "What Is the Fair Price for {name} Stock?",
+        "Is Today's Price for {symbol} a Bargain?",
+        "Does {name} Offer a Good Margin of Safety?",
+        "Is {symbol} Trading Above or Below Its True Value?"
       ],
       "intros": [
-        "We model {name}'s intrinsic value to compare it against today's market price.",
-        "This section asks whether buying {symbol} at the current price gives you a meaningful margin of safety.",
-        "Below we estimate what {name} is worth on a fundamentals basis and what kind of return that implies from here."
+        "We estimate how much {name} is really worth and compare it to today's market price.",
+        "This section checks if {symbol} is cheap, expensive, or fairly priced right now.",
+        "Here we look at whether buying {name} at today's price gives investors room for safety.",
+        "Below we estimate {name}'s value based on its business and compare it to the stock price.",
+        "We check what {symbol} is worth based on the company's earnings and growth outlook."
       ],
       "factorIntroTemplate": "We evaluated {symbol} on {factorList}."
     }

--- a/insights-ui/src/utils/stock-section-headings.ts
+++ b/insights-ui/src/utils/stock-section-headings.ts
@@ -1,0 +1,84 @@
+import headingsData from '@/stock-analysis/stock-section-headings.json';
+import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
+
+/**
+ * Sections that get a per-ticker dynamic heading + intro. The 5 analysis
+ * categories use the `TickerAnalysisCategory` enum; "Competition" is a special
+ * additional section that lives on the main detail page but isn't part of the
+ * factor-driven analysis result, so we key it separately.
+ */
+export type StockSectionKey = TickerAnalysisCategory | 'Competition';
+
+type SectionContent = Readonly<{
+  headings: readonly string[];
+  intros: readonly string[];
+  factorIntroTemplate: string;
+}>;
+
+const SECTION_CONTENT: Readonly<Record<StockSectionKey, SectionContent>> = headingsData.sections as Readonly<Record<StockSectionKey, SectionContent>>;
+
+/**
+ * Deterministic 32-bit string hash (djb2 variant). Same input → same output
+ * across every server render and every crawl, which is what we want — the goal
+ * is for one specific ticker (e.g. AAPL) to always pick the same heading
+ * variant so Google sees a stable page, while a different ticker (MSFT) picks
+ * a different variant so the corpus of ~9k pages has more headline diversity.
+ */
+function hashString(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function pickVariant<T>(variants: readonly T[], seed: string, salt: string): T {
+  const idx = hashString(`${seed}|${salt}`) % variants.length;
+  return variants[idx];
+}
+
+function fill(template: string, name: string, symbol: string, factorList?: string): string {
+  return template
+    .replace(/\{name\}/g, name)
+    .replace(/\{symbol\}/g, symbol)
+    .replace(/\{factorList\}/g, factorList ?? '');
+}
+
+function joinFactorTitles(factorTitles: readonly string[]): string {
+  const titles = factorTitles.filter((t) => t.trim().length > 0);
+  if (titles.length === 0) return '';
+  if (titles.length === 1) return titles[0];
+  if (titles.length === 2) return `${titles[0]} and ${titles[1]}`;
+  return `${titles.slice(0, -1).join(', ')}, and ${titles[titles.length - 1]}`;
+}
+
+export interface StockSectionCopy {
+  heading: string;
+  introLine: string;
+  factorLine: string | null;
+}
+
+/**
+ * Build per-ticker section copy: a question-style heading that embeds the
+ * company name/symbol, a one-line intro describing what the section evaluates,
+ * and (when factor titles are available) a second line listing the factors
+ * used to score this ticker. Variant pick is seeded by `symbol + sectionKey`
+ * so each ticker carries a consistent set of variants across its sections.
+ */
+export function getStockSectionCopy(sectionKey: StockSectionKey, symbol: string, companyName: string, factorTitles: readonly string[] = []): StockSectionCopy {
+  const content = SECTION_CONTENT[sectionKey];
+  const name = companyName || symbol;
+  const upperSymbol = symbol.toUpperCase();
+
+  const headingTemplate = pickVariant(content.headings, upperSymbol, `${sectionKey}:heading`);
+  const introTemplate = pickVariant(content.intros, upperSymbol, `${sectionKey}:intro`);
+
+  const factorList = joinFactorTitles(factorTitles);
+  const factorLine = content.factorIntroTemplate && factorList ? fill(content.factorIntroTemplate, name, upperSymbol, factorList) : null;
+
+  return {
+    heading: fill(headingTemplate, name, upperSymbol),
+    introLine: fill(introTemplate, name, upperSymbol),
+    factorLine,
+  };
+}

--- a/insights-ui/src/utils/stock-section-headings.ts
+++ b/insights-ui/src/utils/stock-section-headings.ts
@@ -19,10 +19,10 @@ const SECTION_CONTENT: Readonly<Record<StockSectionKey, SectionContent>> = headi
 
 /**
  * Deterministic 32-bit string hash (djb2 variant). Same input → same output
- * across every server render and every crawl, which is what we want — the goal
- * is for one specific ticker (e.g. AAPL) to always pick the same heading
- * variant so Google sees a stable page, while a different ticker (MSFT) picks
- * a different variant so the corpus of ~9k pages has more headline diversity.
+ * across every server render and every crawl, which is what we want: a given
+ * ticker (e.g. AAPL) always picks the same heading variant so Google sees a
+ * stable page, while a different ticker (MSFT) picks a different variant so
+ * the corpus of ~9k pages has more headline diversity.
  */
 function hashString(input: string): number {
   let hash = 5381;
@@ -37,25 +37,48 @@ function pickVariant<T>(variants: readonly T[], seed: string, salt: string): T {
   return variants[idx];
 }
 
-function fill(template: string, name: string, symbol: string, factorList?: string): string {
+function fill(template: string, name: string, symbol: string, factorList?: string, competitorList?: string): string {
   return template
     .replace(/\{name\}/g, name)
     .replace(/\{symbol\}/g, symbol)
-    .replace(/\{factorList\}/g, factorList ?? '');
+    .replace(/\{factorList\}/g, factorList ?? '')
+    .replace(/\{competitorList\}/g, competitorList ?? '');
 }
 
-function joinFactorTitles(factorTitles: readonly string[]): string {
-  const titles = factorTitles.filter((t) => t.trim().length > 0);
-  if (titles.length === 0) return '';
-  if (titles.length === 1) return titles[0];
-  if (titles.length === 2) return `${titles[0]} and ${titles[1]}`;
-  return `${titles.slice(0, -1).join(', ')}, and ${titles[titles.length - 1]}`;
+function joinList(items: readonly string[]): string {
+  const cleaned = items.filter((t) => t.trim().length > 0);
+  if (cleaned.length === 0) return '';
+  if (cleaned.length === 1) return cleaned[0];
+  if (cleaned.length === 2) return `${cleaned[0]} and ${cleaned[1]}`;
+  return `${cleaned.slice(0, -1).join(', ')}, and ${cleaned[cleaned.length - 1]}`;
+}
+
+/**
+ * Pick the deterministic-by-seed intro, but if that variant references a
+ * placeholder we can't fill (e.g. `{competitorList}` when no competitor
+ * symbols are available), walk forward through the list until we find one
+ * whose required placeholders are all satisfied. Falls back to the first
+ * variant if no candidate is fillable (shouldn't happen in practice).
+ */
+function pickFillableIntro(intros: readonly string[], seed: string, salt: string, hasCompetitorList: boolean): string {
+  const start = hashString(`${seed}|${salt}`) % intros.length;
+  for (let i = 0; i < intros.length; i += 1) {
+    const candidate = intros[(start + i) % intros.length];
+    if (!hasCompetitorList && candidate.includes('{competitorList}')) continue;
+    return candidate;
+  }
+  return intros[start];
 }
 
 export interface StockSectionCopy {
   heading: string;
   introLine: string;
   factorLine: string | null;
+}
+
+export interface GetStockSectionCopyOptions {
+  factorTitles?: readonly string[];
+  competitorSymbols?: readonly string[];
 }
 
 /**
@@ -65,20 +88,28 @@ export interface StockSectionCopy {
  * used to score this ticker. Variant pick is seeded by `symbol + sectionKey`
  * so each ticker carries a consistent set of variants across its sections.
  */
-export function getStockSectionCopy(sectionKey: StockSectionKey, symbol: string, companyName: string, factorTitles: readonly string[] = []): StockSectionCopy {
+export function getStockSectionCopy(
+  sectionKey: StockSectionKey,
+  symbol: string,
+  companyName: string,
+  options: GetStockSectionCopyOptions = {}
+): StockSectionCopy {
+  const { factorTitles = [], competitorSymbols = [] } = options;
   const content = SECTION_CONTENT[sectionKey];
   const name = companyName || symbol;
   const upperSymbol = symbol.toUpperCase();
 
   const headingTemplate = pickVariant(content.headings, upperSymbol, `${sectionKey}:heading`);
-  const introTemplate = pickVariant(content.intros, upperSymbol, `${sectionKey}:intro`);
 
-  const factorList = joinFactorTitles(factorTitles);
+  const competitorList = joinList(competitorSymbols.slice(0, 3).map((s) => s.toUpperCase()));
+  const introTemplate = pickFillableIntro(content.intros, upperSymbol, `${sectionKey}:intro`, competitorList.length > 0);
+
+  const factorList = joinList(factorTitles);
   const factorLine = content.factorIntroTemplate && factorList ? fill(content.factorIntroTemplate, name, upperSymbol, factorList) : null;
 
   return {
     heading: fill(headingTemplate, name, upperSymbol),
-    introLine: fill(introTemplate, name, upperSymbol),
+    introLine: fill(introTemplate, name, upperSymbol, undefined, competitorList),
     factorLine,
   };
 }

--- a/insights-ui/src/utils/stock-section-headings.ts
+++ b/insights-ui/src/utils/stock-section-headings.ts
@@ -37,12 +37,18 @@ function pickVariant<T>(variants: readonly T[], seed: string, salt: string): T {
   return variants[idx];
 }
 
+const NAME_PLACEHOLDER = /\{name\}/g;
+const SYMBOL_PLACEHOLDER = /\{symbol\}/g;
+const FACTOR_LIST_PLACEHOLDER = /\{factorList\}/g;
+const COMPETITOR_LIST_PLACEHOLDER = /\{competitorList\}/g;
+const COMPETITOR_LIST_TOKEN = '{competitorList}';
+
 function fill(template: string, name: string, symbol: string, factorList?: string, competitorList?: string): string {
   return template
-    .replace(/\{name\}/g, name)
-    .replace(/\{symbol\}/g, symbol)
-    .replace(/\{factorList\}/g, factorList ?? '')
-    .replace(/\{competitorList\}/g, competitorList ?? '');
+    .replace(NAME_PLACEHOLDER, name)
+    .replace(SYMBOL_PLACEHOLDER, symbol)
+    .replace(FACTOR_LIST_PLACEHOLDER, factorList ?? '')
+    .replace(COMPETITOR_LIST_PLACEHOLDER, competitorList ?? '');
 }
 
 function joinList(items: readonly string[]): string {
@@ -64,7 +70,7 @@ function pickFillableIntro(intros: readonly string[], seed: string, salt: string
   const start = hashString(`${seed}|${salt}`) % intros.length;
   for (let i = 0; i < intros.length; i += 1) {
     const candidate = intros[(start + i) % intros.length];
-    if (!hasCompetitorList && candidate.includes('{competitorList}')) continue;
+    if (!hasCompetitorList && candidate.includes(COMPETITOR_LIST_TOKEN)) continue;
     return candidate;
   }
   return intros[start];


### PR DESCRIPTION
## Summary

- Replaces the static section labels on `/stocks/{exchange}/{ticker}` (Business & Moat Analysis, Competition, Financial Statement Analysis, Past Performance, Future Growth, Fair Value) with **deterministic per-ticker heading variants** that embed the company name/symbol — e.g. "How Wide Is Apple's Economic Moat?" / "Is AAPL's Business Built to Last?".
- Adds a **2-line intro under each heading**:
  - Line 1 — describes what the section evaluates (3 variants per category, picked deterministically).
  - Line 2 — lists the sub-industry-specific analysis factors used to score that ticker (sourced from `categoryResult.factorResults[].analysisCategoryFactor.factorAnalysisTitle`).
- All copy lives in `insights-ui/src/stock-analysis/stock-section-headings.json`; the picker (`insights-ui/src/utils/stock-section-headings.ts`) hashes the ticker symbol so the same ticker always renders the same variant (crawler-stable, edge-cacheable) while different tickers across the ~9k stock pages get different question-style headings.

## Motivation

Of ~9k stock pages, ~5k sit in Google Search Console's *"Crawled — currently not indexed"* bucket. Investigation pointed at the standard cause for programmatic platforms: low per-page unique-content ratio. Every stock detail page used the same 6 boilerplate section labels with the same intro chrome — Google clusters them as near-duplicates and only indexes a handful as representative.

This change is the cheap first lever:

- **Headings**: same wording across 9k → 5 question-style variants per category × name/symbol embed → effectively unique per ticker.
- **Factor list intro**: shared per sub-industry, but factors differ across ~150 GICS sub-industries, so this adds ~150 buckets of distinct copy across the corpus rather than one.

We discussed in the originating Discord thread that this alone won't fix the full 5k gap (the deeper fix is per-ticker unique narrative paragraphs grounded in 10-K / 10-Q / 8-Ks). It's worth shipping as a cheap baseline experiment — re-submit, watch the indexed-URL delta over ~4 weeks, then decide whether to invest in deeper per-ticker substance.

## Test plan

- [ ] Visit a handful of stock detail pages and confirm each section now shows a question-style heading with the company name + a 2-line intro listing the actual factor titles for that ticker's sub-industry.
- [ ] Visit two tickers in the same sub-industry (e.g. two semiconductor names) and confirm:
  - Heading variants differ (deterministic per symbol, not per sub-industry).
  - Factor list intros are identical (factors are sub-industry-scoped).
- [ ] Visit the same ticker twice and confirm heading variants are stable across reloads (deterministic hash, not random).
- [ ] Confirm Competition section heading + intro render even though Competition has no `factorIntroTemplate` (line 2 is correctly suppressed).
- [ ] Confirm a ticker with no `categoryAnalysisResults` (newly added, no reports) renders gracefully — heading + line 1 only, no broken factor-list line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)