### PR TITLE
Lazy-fetch industries in MobileTopNav (only on /stocks when menu opens)

### DIFF
--- a/insights-ui/src/app/layout.tsx
+++ b/insights-ui/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import TopNav from '@/components/core/TopNav/TopNav';
 import { themeColors } from '@/util/theme-colors';
-import 'tailwindcss/tailwind.css';
 import './globals.scss';
 import type { Metadata } from 'next';
 import Script from 'next/script';

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/MobileStockActionsMenu.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/MobileStockActionsMenu.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { TickerNotesResponse } from '@/app/api/[spaceId]/users/ticker-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { FavouriteTickerResponse, UserListResponse, UserTickerTagResponse } from '@/types/ticker-user';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { TickerV1Notes } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+// Same dynamic chunks used by the desktop buttons — Next.js only fetches each
+// once, so loading them here adds no bundle cost when desktop buttons render.
+const AddEditFavouriteModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditFavouriteModal'), { ssr: false });
+const ManageListsModal = dynamic(() => import('@/components/favourites/ManageListsModal'), { ssr: false });
+const ManageTagsModal = dynamic(() => import('@/components/favourites/ManageTagsModal'), { ssr: false });
+const AddEditNotesModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditNotesModal'), { ssr: false });
+const ComparisonModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/ComparisonModal'), { ssr: false });
+
+export interface MobileStockActionsMenuProps {
+  tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
+  tickerIndustryKey: string;
+  tickerSubIndustryKey: string;
+  tickerIndustryName: string;
+  tickerSubIndustryName: string;
+}
+
+type FavouriteManageView = 'manage-lists' | 'manage-tags' | null;
+
+export default function MobileStockActionsMenu({
+  tickerId,
+  tickerSymbol,
+  tickerName,
+  tickerIndustryKey,
+  tickerSubIndustryKey,
+  tickerIndustryName,
+  tickerSubIndustryName,
+}: MobileStockActionsMenuProps): JSX.Element {
+  const router = useRouter();
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+  const [favouriteManageView, setFavouriteManageView] = useState<FavouriteManageView>(null);
+
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+
+  const [isComparisonOpen, setIsComparisonOpen] = useState(false);
+  const [comparisonMounted, setComparisonMounted] = useState(false);
+
+  const { data: listsData, reFetchData: refetchLists } = useFetchData<{ lists: UserListResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-lists`,
+    { skipInitialFetch: !session },
+    'Failed to fetch lists'
+  );
+
+  const { data: tagsData, reFetchData: refetchTags } = useFetchData<{ tags: UserTickerTagResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-ticker-tags`,
+    { skipInitialFetch: !session },
+    'Failed to fetch tags'
+  );
+
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<{ favouriteTickers: FavouriteTickerResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-tickers`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<TickerNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/ticker-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+
+  const lists = listsData?.lists || [];
+  const tags = tagsData?.tags || [];
+  const favouriteTicker = favouritesData?.favouriteTickers.find((f) => f.tickerId === tickerId) || null;
+  const existingNote: TickerV1Notes | null = notesData?.tickerNotes.find((n) => n.tickerId === tickerId) || null;
+
+  const items: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteTicker ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+    { key: 'compare', label: 'Compare with others' },
+  ];
+
+  const handleSelect = (key: string) => {
+    if (key === 'favourite' || key === 'notes') {
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+    }
+    if (key === 'favourite') {
+      setFavouriteMounted(true);
+      setIsFavouriteOpen(true);
+    } else if (key === 'notes') {
+      setNotesMounted(true);
+      setIsNotesOpen(true);
+    } else if (key === 'compare') {
+      setComparisonMounted(true);
+      setIsComparisonOpen(true);
+    }
+  };
+
+  return (
+    <div className="relative z-10">
+      <EllipsisDropdown items={items} onSelect={handleSelect} className="px-2 py-2" />
+
+      {session && favouriteMounted && (
+        <>
+          <AddEditFavouriteModal
+            isOpen={isFavouriteOpen}
+            onClose={() => setIsFavouriteOpen(false)}
+            tickerId={tickerId}
+            tickerSymbol={tickerSymbol}
+            tickerName={tickerName}
+            lists={lists}
+            tags={tags}
+            onManageLists={() => setFavouriteManageView('manage-lists')}
+            onManageTags={() => setFavouriteManageView('manage-tags')}
+            onSuccess={() => setIsFavouriteOpen(false)}
+            favouriteTicker={favouriteTicker}
+            onUpsert={refetchFavourites}
+          />
+
+          <ManageListsModal
+            isOpen={favouriteManageView === 'manage-lists'}
+            onClose={() => setFavouriteManageView(null)}
+            lists={lists}
+            onListsChange={refetchLists}
+          />
+
+          <ManageTagsModal isOpen={favouriteManageView === 'manage-tags'} onClose={() => setFavouriteManageView(null)} tags={tags} onTagsChange={refetchTags} />
+        </>
+      )}
+
+      {session && notesMounted && (
+        <AddEditNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          tickerId={tickerId}
+          tickerSymbol={tickerSymbol}
+          tickerName={tickerName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+
+      {comparisonMounted && (
+        <ComparisonModal
+          isOpen={isComparisonOpen}
+          onClose={() => setIsComparisonOpen(false)}
+          currentTicker={{
+            symbol: tickerSymbol,
+            name: tickerName,
+            industryKey: tickerIndustryKey,
+            subIndustryKey: tickerSubIndustryKey,
+            industryName: tickerIndustryName,
+            subIndustryName: tickerSubIndustryName,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/StockActions.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/StockActions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { TickerIdentifier } from '@/app/api/[spaceId]/tickers-v1/generation-requests/route';
+import MobileStockActionsMenu, { MobileStockActionsMenuProps } from '@/app/stocks/[exchange]/[ticker]/MobileStockActionsMenu';
 import PrivateWrapper from '@/components/auth/PrivateWrapper';
 import { KoalaGainsSession } from '@/types/auth';
 import dynamic from 'next/dynamic';
@@ -16,16 +17,29 @@ interface StockActionsProps {
   ticker: TickerIdentifier;
   session?: KoalaGainsSession;
   children?: ReactNode;
+  mobileActions: MobileStockActionsMenuProps;
   movedExchange?: string | null;
   movedSymbol?: string | null;
   isDeleted?: boolean;
   websiteUrl?: string | null;
 }
 
-export default function StockActions({ ticker, children, session, movedExchange, movedSymbol, isDeleted, websiteUrl }: StockActionsProps): JSX.Element {
+export default function StockActions({
+  ticker,
+  children,
+  session,
+  mobileActions,
+  movedExchange,
+  movedSymbol,
+  isDeleted,
+  websiteUrl,
+}: StockActionsProps): JSX.Element {
   return (
-    <div className="flex flex-wrap items-center gap-2 z-10">
-      {children}
+    <div className="flex items-center gap-2 z-10">
+      <div className="hidden sm:flex flex-wrap items-center gap-2">{children}</div>
+      <div className="sm:hidden">
+        <MobileStockActionsMenu {...mobileActions} />
+      </div>
       <PrivateWrapper session={session}>
         <StockActionsAdminPanel ticker={ticker} movedExchange={movedExchange} movedSymbol={movedSymbol} isDeleted={isDeleted} websiteUrl={websiteUrl} />
       </PrivateWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/StockActions.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/StockActions.tsx
@@ -35,7 +35,7 @@ export default function StockActions({
   websiteUrl,
 }: StockActionsProps): JSX.Element {
   return (
-    <div className="flex items-center gap-2 z-10">
+    <div className="flex flex-wrap items-center gap-2 z-10">
       <div className="hidden sm:flex flex-wrap items-center gap-2">{children}</div>
       <div className="sm:hidden">
         <MobileStockActionsMenu {...mobileActions} />

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -439,6 +439,15 @@ function BreadcrumbsFromData({ data }: { data: Promise<TickerV1FastResponse> }):
           movedSymbol={d.movedSymbol ?? null}
           isDeleted={d.isDeleted ?? false}
           websiteUrl={d.websiteUrl ?? null}
+          mobileActions={{
+            tickerId: d.id,
+            tickerSymbol: d.symbol,
+            tickerName: d.name,
+            tickerIndustryKey: d.industryKey,
+            tickerSubIndustryKey: d.subIndustryKey,
+            tickerIndustryName: industryName,
+            tickerSubIndustryName: subIndustryName,
+          }}
         >
           <FavouriteButton tickerId={d.id} tickerSymbol={d.symbol} tickerName={d.name} />
           <NotesButton tickerId={d.id} tickerSymbol={d.symbol} tickerName={d.name} />
@@ -453,6 +462,7 @@ function BreadcrumbsFromData({ data }: { data: Promise<TickerV1FastResponse> }):
         </StockActions>
       }
       hideHomeIcon={true}
+      mobileBackOnly={true}
     />
   );
 }

--- a/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
@@ -10,6 +10,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 
 interface MobileTopNavProps {
   mobileMenuOpen: boolean;
@@ -32,8 +33,19 @@ export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, report
   const isStocksRoute = pathname.startsWith('/stocks');
   const isEtfsRoute = pathname.startsWith('/etfs');
 
-  // Fetch industries data when on stocks page
-  const { data: industries, loading } = useFetchData<IndustryWithSubIndustriesAndCounts[]>(`${getBaseUrl()}/api/industries`, {}, 'Failed to load industries');
+  // Lazily fetch industries: only when the mobile menu is opened on a /stocks route,
+  // so non-stocks pages and unopened menus don't trigger the network call.
+  const {
+    data: industries,
+    loading,
+    reFetchData: fetchIndustries,
+  } = useFetchData<IndustryWithSubIndustriesAndCounts[]>(`${getBaseUrl()}/api/industries`, { skipInitialFetch: true }, 'Failed to load industries');
+
+  useEffect(() => {
+    if (mobileMenuOpen && isStocksRoute && !industries && !loading) {
+      fetchIndustries();
+    }
+  }, [mobileMenuOpen, isStocksRoute, industries, loading, fetchIndustries]);
 
   return (
     <Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} className="lg:hidden">

--- a/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/MobileTopNav.tsx
@@ -2,19 +2,18 @@
 
 import SearchBar from '@/components/core/SearchBar';
 import { IndustryWithSubIndustriesAndCounts } from '@/types/ticker-typesv1';
-import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
-import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { Dialog, DialogPanel, Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
 
 interface MobileTopNavProps {
   mobileMenuOpen: boolean;
   setMobileMenuOpen: (open: boolean) => void;
+  industries: IndustryWithSubIndustriesAndCounts[] | undefined;
+  industriesLoading: boolean;
   reportsDropdown: Array<{
     name: string;
     href: string;
@@ -28,24 +27,10 @@ interface MobileTopNavProps {
   }>;
 }
 
-export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, reportsDropdown, genaiDropdown }: MobileTopNavProps) {
+export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, industries, industriesLoading, reportsDropdown, genaiDropdown }: MobileTopNavProps) {
   const pathname = usePathname() ?? '';
   const isStocksRoute = pathname.startsWith('/stocks');
   const isEtfsRoute = pathname.startsWith('/etfs');
-
-  // Lazily fetch industries: only when the mobile menu is opened on a /stocks route,
-  // so non-stocks pages and unopened menus don't trigger the network call.
-  const {
-    data: industries,
-    loading,
-    reFetchData: fetchIndustries,
-  } = useFetchData<IndustryWithSubIndustriesAndCounts[]>(`${getBaseUrl()}/api/industries`, { skipInitialFetch: true }, 'Failed to load industries');
-
-  useEffect(() => {
-    if (mobileMenuOpen && isStocksRoute && !industries && !loading) {
-      fetchIndustries();
-    }
-  }, [mobileMenuOpen, isStocksRoute, industries, loading, fetchIndustries]);
 
   return (
     <Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} className="lg:hidden">
@@ -74,7 +59,7 @@ export default function MobileTopNav({ mobileMenuOpen, setMobileMenuOpen, report
                 <div>
                   <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-3">Industries</h3>
 
-                  {loading ? (
+                  {industriesLoading ? (
                     <div className="text-center">
                       <div
                         className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-solid border-current border-r-transparent motion-reduce:animate-[spin_1.5s_linear_infinite] text-gray-500 dark:text-gray-400"

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -3,6 +3,9 @@
 import SearchBar from '@/components/core/SearchBar';
 import { UserProfile } from '@/components/core/UserProfile/UserProfile';
 import MobileTopNav from '@/components/core/TopNav/MobileTopNav';
+import { IndustryWithSubIndustriesAndCounts } from '@/types/ticker-typesv1';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { Popover, PopoverButton, PopoverGroup, PopoverPanel } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Bars3Icon } from '@heroicons/react/24/outline';
@@ -49,6 +52,23 @@ export default function TopNav() {
   const isEtfsRoute = pathname.startsWith('/etfs');
   const isHomeRoute = pathname === '/';
 
+  // Lazily fetch industries: only when the mobile menu is actually opened on a
+  // /stocks route. Firing from the click handler (instead of a useEffect that
+  // reacts to `mobileMenuOpen`) avoids re-firing during render churn — see
+  // useFetchData's setLoading(false)→setData(...) gap.
+  const {
+    data: industries,
+    loading: industriesLoading,
+    reFetchData: fetchIndustries,
+  } = useFetchData<IndustryWithSubIndustriesAndCounts[]>(`${getBaseUrl()}/api/industries`, { skipInitialFetch: true }, 'Failed to load industries');
+
+  const openMobileMenu = () => {
+    setMobileMenuOpen(true);
+    if (isStocksRoute && !industries && !industriesLoading) {
+      fetchIndustries();
+    }
+  };
+
   // Wrap the whole header in a parent with className="dark" to force dark mode here
   return (
     <div className="dark">
@@ -74,7 +94,7 @@ export default function TopNav() {
           <div className="flex lg:hidden">
             <button
               type="button"
-              onClick={() => setMobileMenuOpen(true)}
+              onClick={openMobileMenu}
               className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700 dark:text-gray-400"
             >
               <span className="sr-only">Open main menu</span>
@@ -171,7 +191,14 @@ export default function TopNav() {
           </div>
         </nav>
 
-        <MobileTopNav mobileMenuOpen={mobileMenuOpen} setMobileMenuOpen={setMobileMenuOpen} reportsDropdown={reportsDropdown} genaiDropdown={genaiDropdown} />
+        <MobileTopNav
+          mobileMenuOpen={mobileMenuOpen}
+          setMobileMenuOpen={setMobileMenuOpen}
+          industries={industries}
+          industriesLoading={industriesLoading}
+          reportsDropdown={reportsDropdown}
+          genaiDropdown={genaiDropdown}
+        />
       </header>
     </div>
   );

--- a/insights-ui/src/components/ui/Breadcrumbs.tsx
+++ b/insights-ui/src/components/ui/Breadcrumbs.tsx
@@ -5,12 +5,13 @@ interface BreadcrumbsProps {
   breadcrumbs: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
+  mobileBackOnly?: boolean;
 }
 
-export default function Breadcrumbs({ breadcrumbs, rightButton, hideHomeIcon }: BreadcrumbsProps) {
+export default function Breadcrumbs({ breadcrumbs, rightButton, hideHomeIcon, mobileBackOnly }: BreadcrumbsProps) {
   return (
     <div className="my-4 text-color">
-      <BreadcrumbsWithChevrons breadcrumbs={breadcrumbs} rightButton={rightButton} hideHomeIcon={hideHomeIcon} />
+      <BreadcrumbsWithChevrons breadcrumbs={breadcrumbs} rightButton={rightButton} hideHomeIcon={hideHomeIcon} mobileBackOnly={mobileBackOnly} />
     </div>
   );
 }

--- a/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
+++ b/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import Link from 'next/link';
 import ChevronLeftIcon from '@heroicons/react/20/solid/ChevronLeftIcon';
 import ChevronRightIcon from '@heroicons/react/20/solid/ChevronRightIcon';
+import EllipsisHorizontalIcon from '@heroicons/react/20/solid/EllipsisHorizontalIcon';
 import HomeIcon from '@heroicons/react/24/solid/HomeIcon';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 export interface BreadcrumbsOjbect {
   name: string;
@@ -15,29 +18,86 @@ interface BreadcrumbsWithChevronsProps {
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
   /**
-   * On mobile, collapse the chain to a single "← {parent}" back link instead
-   * of wrapping the full trail. Opt-in so existing pages keep their behavior;
-   * pages with long crumb names (e.g. the stock detail page) should enable it.
+   * On mobile, collapse the chain to a single "← {parent}" back link plus a
+   * `⋯` toggle that expands the full chain inline. Opt-in so existing pages
+   * keep their behavior; pages with long crumb names (e.g. the stock detail
+   * page) should enable it. No effect at `sm` and above.
    */
   mobileBackOnly?: boolean;
 }
 
 export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false, mobileBackOnly = false }: BreadcrumbsWithChevronsProps) {
+  const [mobileExpanded, setMobileExpanded] = useState(false);
+
   if (breadcrumbs.length === 0) return null;
 
   // Second-to-last crumb. When there's only one crumb there's no parent to
   // navigate back to, so the mobile row simply omits the back link.
   const parentCrumb: BreadcrumbsOjbect | null = mobileBackOnly && breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2] : null;
+  // Only show the ⋯ toggle when there's actually more chain to reveal than the
+  // single back link already shows (i.e. 3+ crumbs, or 2+ crumbs with the home
+  // icon).
+  const showMobileExpander: boolean = mobileBackOnly && (breadcrumbs.length >= 3 || (breadcrumbs.length >= 2 && !hideHomeIcon));
 
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
-      {parentCrumb && (
-        <nav className="flex sm:hidden min-w-0 w-full" aria-label="Back">
-          <Link href={parentCrumb.href} className="flex items-center text-sm font-medium link-color min-w-0">
-            <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
-            <span className="truncate">{parentCrumb.name}</span>
-          </Link>
-        </nav>
+      {mobileBackOnly && (
+        <div className="flex sm:hidden flex-col min-w-0 w-full gap-2">
+          <div className="flex items-center justify-between min-w-0 w-full gap-2">
+            {parentCrumb ? (
+              <Link href={parentCrumb.href} className="flex items-center text-sm font-medium link-color min-w-0 flex-1">
+                <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
+                <span className="truncate">{parentCrumb.name}</span>
+              </Link>
+            ) : (
+              <span className="flex-1" />
+            )}
+            {showMobileExpander && (
+              <button
+                type="button"
+                onClick={() => setMobileExpanded((v) => !v)}
+                aria-expanded={mobileExpanded}
+                aria-label={mobileExpanded ? 'Hide full breadcrumb' : 'Show full breadcrumb'}
+                className="flex-shrink-0 inline-flex items-center justify-center rounded-md p-1 text-color hover:bg-white/5"
+              >
+                <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+          {mobileExpanded && (
+            <nav className="min-w-0 w-full" aria-label="Breadcrumb">
+              <ol role="list" className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+                {!hideHomeIcon && (
+                  <li>
+                    <Link className="cursor-pointer inline-flex items-center" href={'/'}>
+                      <HomeIcon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                      <span className="sr-only">Home</span>
+                    </Link>
+                  </li>
+                )}
+                {breadcrumbs.map((breadcrumb, index) => {
+                  const isFirstBreadcrumb = index === 0;
+                  return (
+                    <li key={breadcrumb.name} className="min-w-0">
+                      <div className="flex items-center min-w-0">
+                        {(!hideHomeIcon || !isFirstBreadcrumb) && (
+                          <ChevronRightIcon className="h-4 w-4 flex-shrink-0 mr-1" aria-hidden="true" />
+                        )}
+                        <Link
+                          href={breadcrumb.href}
+                          className={`text-xs font-medium break-words ${breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'}`}
+                          aria-current={breadcrumb.current ? 'page' : undefined}
+                        >
+                          {breadcrumb.name}
+                        </Link>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            </nav>
+          )}
+        </div>
       )}
 
       <nav className={`${mobileBackOnly ? 'hidden sm:flex' : 'flex'} min-w-0`} aria-label="Breadcrumb">

--- a/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
+++ b/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
@@ -1,11 +1,8 @@
-'use client';
-
 import Link from 'next/link';
 import ChevronLeftIcon from '@heroicons/react/20/solid/ChevronLeftIcon';
 import ChevronRightIcon from '@heroicons/react/20/solid/ChevronRightIcon';
-import EllipsisHorizontalIcon from '@heroicons/react/20/solid/EllipsisHorizontalIcon';
 import HomeIcon from '@heroicons/react/24/solid/HomeIcon';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 
 export interface BreadcrumbsOjbect {
   name: string;
@@ -18,117 +15,81 @@ interface BreadcrumbsWithChevronsProps {
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
   /**
-   * On mobile, collapse the chain to a single "← {parent}" back link plus a
-   * `⋯` toggle that expands the full chain inline. Opt-in so existing pages
-   * keep their behavior; pages with long crumb names (e.g. the stock detail
-   * page) should enable it. No effect at `sm` and above.
+   * On mobile, collapse the chain to a single truncated "← {parent}" back
+   * link inline with `rightButton`. The full chain still renders at `sm` and
+   * above. Opt-in so existing pages keep their behavior — pages with long
+   * crumb names should enable it. No effect at `sm` and above.
    */
   mobileBackOnly?: boolean;
 }
 
-export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false, mobileBackOnly = false }: BreadcrumbsWithChevronsProps) {
-  const [mobileExpanded, setMobileExpanded] = useState(false);
+function FullBreadcrumbChain({ breadcrumbs, hideHomeIcon }: { breadcrumbs: BreadcrumbsOjbect[]; hideHomeIcon: boolean }) {
+  return (
+    <ol role="list" className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      {/* Home icon - hidden only on mobile */}
+      <li className={hideHomeIcon ? 'hidden sm:block' : ''}>
+        <Link className="cursor-pointer" href={'/'}>
+          <HomeIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <span className="sr-only">Home</span>
+        </Link>
+      </li>
+      {breadcrumbs.map((breadcrumb, index) => {
+        const isFirstBreadcrumb = index === 0;
+        return (
+          <li key={breadcrumb.name} className="min-w-0">
+            <div className="flex items-center min-w-0">
+              {/* Show chevron on desktop always, on mobile only if not first breadcrumb when home is hidden */}
+              <ChevronRightIcon className={`h-5 w-5 flex-shrink-0 ${hideHomeIcon && isFirstBreadcrumb ? 'hidden sm:block' : ''}`} aria-hidden="true" />
+              <Link
+                href={breadcrumb.href}
+                className={`${hideHomeIcon && isFirstBreadcrumb ? 'sm:ml-4' : 'ml-4'} text-sm font-medium break-words ${
+                  breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'
+                }`}
+                aria-current={breadcrumb.current ? 'page' : undefined}
+              >
+                {breadcrumb.name}
+              </Link>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
 
+export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false, mobileBackOnly = false }: BreadcrumbsWithChevronsProps) {
   if (breadcrumbs.length === 0) return null;
 
-  // Second-to-last crumb. When there's only one crumb there's no parent to
-  // navigate back to, so the mobile row simply omits the back link.
-  const parentCrumb: BreadcrumbsOjbect | null = mobileBackOnly && breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2] : null;
-  // Only show the ⋯ toggle when there's actually more chain to reveal than the
-  // single back link already shows (i.e. 3+ crumbs, or 2+ crumbs with the home
-  // icon).
-  const showMobileExpander: boolean = mobileBackOnly && (breadcrumbs.length >= 3 || (breadcrumbs.length >= 2 && !hideHomeIcon));
+  // Opt-in mobile layout: back link inline with rightButton on one row.
+  // `sm:contents` flattens the wrapper at `sm+` so the full-chain nav and
+  // rightButton become direct children of the outer flex-row again — that
+  // way rightButton is rendered exactly once and the desktop spacing
+  // (`justify-between`) is preserved.
+  if (mobileBackOnly) {
+    const parentCrumb: BreadcrumbsOjbect | null = breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2] : null;
+
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
+        <div className="flex sm:contents items-center justify-between min-w-0 w-full gap-2">
+          {parentCrumb && (
+            <Link href={parentCrumb.href} className="flex sm:hidden items-center text-sm font-medium link-color min-w-0 flex-1">
+              <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
+              <span className="truncate">{parentCrumb.name}</span>
+            </Link>
+          )}
+          <nav className="hidden sm:flex min-w-0" aria-label="Breadcrumb">
+            <FullBreadcrumbChain breadcrumbs={breadcrumbs} hideHomeIcon={hideHomeIcon} />
+          </nav>
+          {rightButton && <div className="flex-shrink-0">{rightButton}</div>}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
-      {mobileBackOnly && (
-        <div className="flex sm:hidden flex-col min-w-0 w-full gap-2">
-          <div className="flex items-center justify-between min-w-0 w-full gap-2">
-            {parentCrumb ? (
-              <Link href={parentCrumb.href} className="flex items-center text-sm font-medium link-color min-w-0 flex-1">
-                <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
-                <span className="truncate">{parentCrumb.name}</span>
-              </Link>
-            ) : (
-              <span className="flex-1" />
-            )}
-            {showMobileExpander && (
-              <button
-                type="button"
-                onClick={() => setMobileExpanded((v) => !v)}
-                aria-expanded={mobileExpanded}
-                aria-label={mobileExpanded ? 'Hide full breadcrumb' : 'Show full breadcrumb'}
-                className="flex-shrink-0 inline-flex items-center justify-center rounded-md p-1 text-color hover:bg-white/5"
-              >
-                <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
-              </button>
-            )}
-          </div>
-          {mobileExpanded && (
-            <nav className="min-w-0 w-full" aria-label="Breadcrumb">
-              <ol role="list" className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-                {!hideHomeIcon && (
-                  <li>
-                    <Link className="cursor-pointer inline-flex items-center" href={'/'}>
-                      <HomeIcon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-                      <span className="sr-only">Home</span>
-                    </Link>
-                  </li>
-                )}
-                {breadcrumbs.map((breadcrumb, index) => {
-                  const isFirstBreadcrumb = index === 0;
-                  return (
-                    <li key={breadcrumb.name} className="min-w-0">
-                      <div className="flex items-center min-w-0">
-                        {(!hideHomeIcon || !isFirstBreadcrumb) && <ChevronRightIcon className="h-4 w-4 flex-shrink-0 mr-1" aria-hidden="true" />}
-                        <Link
-                          href={breadcrumb.href}
-                          className={`text-xs font-medium break-words ${breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'}`}
-                          aria-current={breadcrumb.current ? 'page' : undefined}
-                        >
-                          {breadcrumb.name}
-                        </Link>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ol>
-            </nav>
-          )}
-        </div>
-      )}
-
-      <nav className={`${mobileBackOnly ? 'hidden sm:flex' : 'flex'} min-w-0`} aria-label="Breadcrumb">
-        <ol role="list" className="flex flex-wrap items-center gap-x-4 gap-y-2">
-          {/* Home icon - hidden only on mobile */}
-          <li className={hideHomeIcon ? 'hidden sm:block' : ''}>
-            <Link className="cursor-pointer" href={'/'}>
-              <HomeIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
-              <span className="sr-only">Home</span>
-            </Link>
-          </li>
-          {breadcrumbs.map((breadcrumb, index) => {
-            const isFirstBreadcrumb = index === 0;
-
-            return (
-              <li key={breadcrumb.name} className="min-w-0">
-                <div className="flex items-center min-w-0">
-                  {/* Show chevron on desktop always, on mobile only if not first breadcrumb when home is hidden */}
-                  <ChevronRightIcon className={`h-5 w-5 flex-shrink-0 ${hideHomeIcon && isFirstBreadcrumb ? 'hidden sm:block' : ''}`} aria-hidden="true" />
-                  <Link
-                    href={breadcrumb.href}
-                    className={`${hideHomeIcon && isFirstBreadcrumb ? 'sm:ml-4' : 'ml-4'} text-sm font-medium break-words ${
-                      breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'
-                    }`}
-                    aria-current={breadcrumb.current ? 'page' : undefined}
-                  >
-                    {breadcrumb.name}
-                  </Link>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
+      <nav className="flex min-w-0" aria-label="Breadcrumb">
+        <FullBreadcrumbChain breadcrumbs={breadcrumbs} hideHomeIcon={hideHomeIcon} />
       </nav>
       {rightButton && <div className="flex-shrink-0 w-full sm:w-auto">{rightButton}</div>}
     </div>

--- a/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
+++ b/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ChevronLeftIcon from '@heroicons/react/20/solid/ChevronLeftIcon';
 import ChevronRightIcon from '@heroicons/react/20/solid/ChevronRightIcon';
 import HomeIcon from '@heroicons/react/24/solid/HomeIcon';
 import { ReactNode } from 'react';
@@ -13,12 +14,33 @@ interface BreadcrumbsWithChevronsProps {
   breadcrumbs: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
+  /**
+   * On mobile, collapse the chain to a single "← {parent}" back link instead
+   * of wrapping the full trail. Opt-in so existing pages keep their behavior;
+   * pages with long crumb names (e.g. the stock detail page) should enable it.
+   */
+  mobileBackOnly?: boolean;
 }
 
-export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false }: BreadcrumbsWithChevronsProps) {
-  return breadcrumbs.length === 0 ? null : (
+export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false, mobileBackOnly = false }: BreadcrumbsWithChevronsProps) {
+  if (breadcrumbs.length === 0) return null;
+
+  // Second-to-last crumb. When there's only one crumb there's no parent to
+  // navigate back to, so the mobile row simply omits the back link.
+  const parentCrumb: BreadcrumbsOjbect | null = mobileBackOnly && breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2] : null;
+
+  return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
-      <nav className="flex min-w-0" aria-label="Breadcrumb">
+      {parentCrumb && (
+        <nav className="flex sm:hidden min-w-0 w-full" aria-label="Back">
+          <Link href={parentCrumb.href} className="flex items-center text-sm font-medium link-color min-w-0">
+            <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
+            <span className="truncate">{parentCrumb.name}</span>
+          </Link>
+        </nav>
+      )}
+
+      <nav className={`${mobileBackOnly ? 'hidden sm:flex' : 'flex'} min-w-0`} aria-label="Breadcrumb">
         <ol role="list" className="flex flex-wrap items-center gap-x-4 gap-y-2">
           {/* Home icon - hidden only on mobile */}
           <li className={hideHomeIcon ? 'hidden sm:block' : ''}>

--- a/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
+++ b/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
@@ -80,9 +80,7 @@ export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hide
                   return (
                     <li key={breadcrumb.name} className="min-w-0">
                       <div className="flex items-center min-w-0">
-                        {(!hideHomeIcon || !isFirstBreadcrumb) && (
-                          <ChevronRightIcon className="h-4 w-4 flex-shrink-0 mr-1" aria-hidden="true" />
-                        )}
+                        {(!hideHomeIcon || !isFirstBreadcrumb) && <ChevronRightIcon className="h-4 w-4 flex-shrink-0 mr-1" aria-hidden="true" />}
                         <Link
                           href={breadcrumb.href}
                           className={`text-xs font-medium break-words ${breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'}`}


### PR DESCRIPTION
## Summary
- MobileTopNav was firing `GET /api/industries` on every page render (it's mounted by `TopNav` on every route), even when the user never tapped the hamburger and when not on a `/stocks` route.
- Switched the call to `skipInitialFetch: true` and added a `useEffect` that triggers `reFetchData()` only when the menu is opened, the route is `/stocks*`, and we don't already have data.
- Existing loading state in the menu body now does the work it was already wired for.

## Test plan
- [ ] On `/` (non-stocks route), open DevTools Network → load page → confirm no `/api/industries` request.
- [ ] On `/stocks`, load page without tapping the menu → confirm no `/api/industries` request.
- [ ] On `/stocks`, tap the menu → confirm one `/api/industries` request fires and the loading spinner shows briefly before the industries list renders.
- [ ] On `/stocks`, close and reopen the menu → confirm no extra request (data is cached on the hook).
- [ ] On a non-stocks route, open the menu → confirm no `/api/industries` request (Reports/GenAI disclosures still work).