### PR TITLE
ETF favourites listing page + visible related-section pills

### DIFF
--- a/insights-ui/src/app/etf-favourites/page.tsx
+++ b/insights-ui/src/app/etf-favourites/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import AddEditEtfFavouriteModal from '@/app/etfs/[exchange]/[etf]/AddEditEtfFavouriteModal';
+import DeleteConfirmationModal from '@/app/admin-v1/industry-management/DeleteConfirmationModal';
+import EtfFavouriteItem from '@/components/etf-favourites/EtfFavouriteItem';
+import EtfFavouritesPageHeader from '@/components/etf-favourites/EtfFavouritesPageHeader';
+import FavouritesEmptyState from '@/components/favourites/FavouritesEmptyState';
+import FavouritesLoadingSkeleton from '@/components/favourites/FavouritesLoadingSkeleton';
+import { KoalaGainsSession } from '@/types/auth';
+import { FavouriteEtfResponse, FavouriteEtfsResponse } from '@/types/etf-user';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
+import { useDeleteData } from '@dodao/web-core/ui/hooks/fetch/useDeleteData';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
+
+export default function EtfFavouritesPage() {
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+  const router = useRouter();
+
+  const [editingFavourite, setEditingFavourite] = useState<FavouriteEtfResponse | null>(null);
+  const [deletingFavourite, setDeletingFavourite] = useState<FavouriteEtfResponse | null>(null);
+
+  // Redirect to login if not authenticated.
+  useEffect(() => {
+    if (koalaSession === null) {
+      router.push('/login');
+    }
+  }, [koalaSession, router]);
+
+  const {
+    data: favouritesData,
+    loading: favouritesLoading,
+    reFetchData: refetchFavourites,
+  } = useFetchData<FavouriteEtfsResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-etfs`,
+    { skipInitialFetch: !session },
+    'Failed to fetch ETF favourites'
+  );
+
+  const { deleteData: deleteFavourite, loading: isDeleting } = useDeleteData({
+    successMessage: 'Favourite deleted successfully!',
+    errorMessage: 'Failed to delete favourite.',
+  });
+
+  // Sort by myScore desc, nulls last — matches the stock favourites page within each list.
+  const favourites = useMemo<FavouriteEtfResponse[]>(() => {
+    const items = favouritesData?.favouriteEtfs ?? [];
+    return [...items].sort((a, b) => {
+      const scoreA = a.myScore ?? -Infinity;
+      const scoreB = b.myScore ?? -Infinity;
+      return scoreB - scoreA;
+    });
+  }, [favouritesData]);
+
+  if (favouritesLoading) {
+    return (
+      <PageWrapper>
+        <FavouritesLoadingSkeleton />
+      </PageWrapper>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  const handleDelete = async () => {
+    if (!deletingFavourite) return;
+
+    const result = await deleteFavourite(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-etfs/${deletingFavourite.id}`);
+    if (result) {
+      await refetchFavourites();
+      setDeletingFavourite(null);
+    }
+  };
+
+  const handleEditFavourite = (e: React.MouseEvent, fav: FavouriteEtfResponse) => {
+    e.stopPropagation();
+    setEditingFavourite(fav);
+  };
+
+  const handleDeleteFavourite = (e: React.MouseEvent, fav: FavouriteEtfResponse) => {
+    e.stopPropagation();
+    setDeletingFavourite(fav);
+  };
+
+  return (
+    <PageWrapper>
+      <div className="max-w-7xl mx-auto px-1 sm:px-2">
+        <div className="py-6">
+          <div className="mb-8">
+            <EtfFavouritesPageHeader favouritesCount={favourites.length} />
+          </div>
+
+          {favourites.length === 0 ? (
+            <FavouritesEmptyState browseHref="/etfs" browseLabel="Browse ETFs" description="Start adding ETFs to your favourites and they'll show up here." />
+          ) : (
+            <div className="space-y-2 pb-12">
+              {favourites.map((fav) => (
+                <EtfFavouriteItem key={fav.id} favourite={fav} onEdit={handleEditFavourite} onDelete={handleDeleteFavourite} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {editingFavourite && (
+          <AddEditEtfFavouriteModal
+            isOpen={!!editingFavourite}
+            onClose={() => setEditingFavourite(null)}
+            etfId={editingFavourite.etfId}
+            etfSymbol={editingFavourite.etf.symbol}
+            etfName={editingFavourite.etf.name}
+            favouriteEtf={editingFavourite}
+            onUpsert={async () => {
+              await refetchFavourites();
+              setEditingFavourite(null);
+            }}
+          />
+        )}
+
+        {deletingFavourite && (
+          <DeleteConfirmationModal
+            open={!!deletingFavourite}
+            onClose={() => setDeletingFavourite(null)}
+            onDelete={handleDelete}
+            deleting={isDeleting}
+            title={`Delete ${deletingFavourite.etf.symbol} from favourites?`}
+            deleteButtonText="Delete Favourite"
+            confirmationText="DELETE"
+          />
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -91,7 +91,17 @@ export default function TopNav() {
                   </Link>
                 </PopoverGroup>
               )}
-              {!isStocksRoute && (
+              {isEtfsRoute && session && (
+                <PopoverGroup className="flex gap-x-6">
+                  <Link
+                    href="/etf-favourites"
+                    className="text-sm/6 font-semibold text-gray-900 dark:text-white hover:text-indigo-600 dark:hover:text-indigo-400"
+                  >
+                    My Favourite ETFs
+                  </Link>
+                </PopoverGroup>
+              )}
+              {!isStocksRoute && !isEtfsRoute && (
                 <PopoverGroup className="hidden lg:flex lg:gap-x-6">
                   <Popover className="relative">
                     {({ close }) => (

--- a/insights-ui/src/components/core/UserProfile/UserProfile.tsx
+++ b/insights-ui/src/components/core/UserProfile/UserProfile.tsx
@@ -118,6 +118,13 @@ export function UserProfile({ isMobile = false, onMenuToggle }: UserProfileProps
             >
               My Favourite Stocks
             </Link>
+            <Link
+              href="/etf-favourites"
+              className="-mx-3 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-gray-300 hover:bg-gray-700 w-full text-left"
+              onClick={onMenuToggle}
+            >
+              My Favourite ETFs
+            </Link>
             <div className="border-t border-gray-700 my-1"></div>
             {portfolioProfile?.id && (
               <Link
@@ -186,6 +193,9 @@ export function UserProfile({ isMobile = false, onMenuToggle }: UserProfileProps
               )}
               <Link href="/favourites" className="block w-full px-4 py-2 text-sm font-semibold text-color cursor-pointer text-left hover:bg-gray-700">
                 My Favourite Stocks
+              </Link>
+              <Link href="/etf-favourites" className="block w-full px-4 py-2 text-sm font-semibold text-color cursor-pointer text-left hover:bg-gray-700">
+                My Favourite ETFs
               </Link>
               <div className="border-t border-gray-700 my-1"></div>
               {portfolioProfile?.id && (

--- a/insights-ui/src/components/etf-favourites/EtfFavouriteItem.tsx
+++ b/insights-ui/src/components/etf-favourites/EtfFavouriteItem.tsx
@@ -1,0 +1,61 @@
+import FavouriteNotes from '@/components/favourites/FavouriteNotes';
+import { FavouriteEtfResponse } from '@/types/etf-user';
+import { getEtfScoreColorClasses } from '@/utils/score-utils';
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import React from 'react';
+
+interface EtfFavouriteItemProps {
+  favourite: FavouriteEtfResponse;
+  onEdit: (e: React.MouseEvent, favourite: FavouriteEtfResponse) => void;
+  onDelete: (e: React.MouseEvent, favourite: FavouriteEtfResponse) => void;
+}
+
+export default function EtfFavouriteItem({ favourite, onEdit, onDelete }: EtfFavouriteItemProps) {
+  const cachedScore = favourite.etf.cachedScore;
+
+  return (
+    <div className="bg-gray-900 rounded-lg p-3 border border-gray-700 hover:border-gray-600 transition-colors">
+      <div className="flex justify-between items-center gap-2 mb-2">
+        <div className="flex-1 flex items-center gap-x-2 gap-y-1 flex-wrap">
+          <Link
+            href={`/etfs/${favourite.etf.exchange}/${favourite.etf.symbol}`}
+            prefetch={false}
+            className="hover:text-blue-400"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h4 className="text-sm font-semibold tracking-tight text-gray-100 leading-tight">
+              {favourite.etf.name} ({favourite.etf.symbol})
+            </h4>
+          </Link>
+          {cachedScore &&
+            (() => {
+              const { textColorClass, bgColorClass } = getEtfScoreColorClasses(cachedScore.finalScore);
+              return (
+                <span className={`${textColorClass} px-1.5 rounded ${bgColorClass} bg-opacity-15 font-semibold text-xs leading-5`}>
+                  {cachedScore.finalScore}/20
+                </span>
+              );
+            })()}
+          {favourite.myScore !== null && favourite.myScore !== undefined && (
+            <span className="font-semibold text-xs tracking-tight" style={{ color: 'var(--primary-color, #3B82F6)' }}>
+              My Score: {favourite.myScore % 1 === 0 ? favourite.myScore.toString() : favourite.myScore.toFixed(1)}
+            </span>
+          )}
+        </div>
+        <div className="flex gap-0.5">
+          <button onClick={(e) => onEdit(e, favourite)} className="text-blue-400 hover:text-blue-300 p-0.5" title="Edit">
+            <PencilIcon className="w-4 h-4" />
+          </button>
+          <button onClick={(e) => onDelete(e, favourite)} className="text-red-400 hover:text-red-300 p-0.5" title="Delete">
+            <TrashIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <FavouriteNotes notes={favourite.myNotes} />
+    </div>
+  );
+}

--- a/insights-ui/src/components/etf-favourites/EtfFavouritesPageHeader.tsx
+++ b/insights-ui/src/components/etf-favourites/EtfFavouritesPageHeader.tsx
@@ -1,0 +1,20 @@
+import { HeartIcon } from '@heroicons/react/24/solid';
+import React from 'react';
+
+interface EtfFavouritesPageHeaderProps {
+  favouritesCount: number;
+}
+
+export default function EtfFavouritesPageHeader({ favouritesCount }: EtfFavouritesPageHeaderProps) {
+  return (
+    <div>
+      <h1 className="text-2xl sm:text-3xl font-bold text-white flex items-center gap-2 tracking-tight">
+        <HeartIcon className="w-6 h-6 sm:w-7 sm:h-7 text-red-500 shrink-0" />
+        My Favourite ETFs
+      </h1>
+      <p className="text-sm text-gray-400 mt-1">
+        <span className="font-semibold text-gray-100">{favouritesCount}</span> favourite {favouritesCount === 1 ? 'ETF' : 'ETFs'}
+      </p>
+    </div>
+  );
+}

--- a/insights-ui/src/components/favourites/FavouritesEmptyState.tsx
+++ b/insights-ui/src/components/favourites/FavouritesEmptyState.tsx
@@ -6,19 +6,23 @@ interface FavouritesEmptyStateProps {
   /** Where the call-to-action button links to. Defaults to the stocks listing. */
   browseHref?: string;
   browseLabel?: string;
+  /** Body copy under the title. Defaults to the stock-favourites wording. */
+  description?: React.ReactNode;
 }
 
 /**
  * Empty state shown when the user has no favourites yet.
  */
-export default function FavouritesEmptyState({ browseHref = '/stocks', browseLabel = 'Browse Stocks' }: FavouritesEmptyStateProps) {
+export default function FavouritesEmptyState({
+  browseHref = '/stocks',
+  browseLabel = 'Browse Stocks',
+  description = "Start adding stocks to your favourites and they'll show up here, grouped by your lists.",
+}: FavouritesEmptyStateProps) {
   return (
     <div className="bg-gray-800/60 border border-gray-700 rounded-xl px-6 py-12 sm:py-16 text-center">
       <HeartIcon className="w-14 h-14 sm:w-16 sm:h-16 text-gray-600 mx-auto mb-5" />
       <h3 className="text-lg sm:text-xl font-semibold text-white mb-2">No favourites yet</h3>
-      <p className="text-sm text-gray-400 mb-6 max-w-md mx-auto">
-        Start adding stocks to your favourites and they&apos;ll show up here, grouped by your lists.
-      </p>
+      <p className="text-sm text-gray-400 mb-6 max-w-md mx-auto">{description}</p>
       <Link
         href={browseHref}
         className="inline-flex items-center px-5 py-2.5 bg-blue-600 hover:bg-blue-700 transition-colors rounded-lg text-white text-sm font-semibold"

--- a/insights-ui/src/components/ui/sections/RelatedSectionsNav.tsx
+++ b/insights-ui/src/components/ui/sections/RelatedSectionsNav.tsx
@@ -34,7 +34,7 @@ export default function RelatedSectionsNav({ ariaLabel, heading, items, classNam
             <Link
               href={item.href}
               prefetch={false}
-              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface hover:bg-surface-2 text-body hover:text-heading transition-colors"
+              className="flex h-full items-center rounded-md px-3 py-2 text-sm bg-surface-2 hover:bg-surface-3 text-body hover:text-heading transition-colors"
             >
               {item.label}
             </Link>


### PR DESCRIPTION
## Summary

This PR bundles two ETF-side polish/feature commits on the `etf-favourites` branch.

### 1. ETF favourites listing page (new)

Mirrors the stocks-side `/favourites` page for ETFs, scoped down to what the `FavouriteEtf` model carries today (notes + score; **no** lists, tags, or bulk actions — those exist only on the stocks side).

- **New route:** `/etf-favourites` (client page) — fetches `/api/[spaceId]/users/favourite-etfs`, sorts by `myScore` desc, opens the existing `AddEditEtfFavouriteModal` for edit, uses the shared `DeleteConfirmationModal` for delete. Falls back to a login redirect if the user is unauthenticated. Reuses `FavouritesLoadingSkeleton`.
- **New components** under `src/components/etf-favourites/`: `EtfFavouritesPageHeader` (HeartIcon + "My Favourite ETFs" + count), `EtfFavouriteItem` (card with ETF name+symbol link, cached `finalScore`/20 badge, `My Score`, and the shared `FavouriteNotes` leaf). Card chrome and typography match the stocks-side `FavouriteItem` for visual parity.
- **`FavouritesEmptyState`:** added an optional `description` prop with a default that preserves the existing stock-favourites wording — `/favourites` is byte-identical UX.
- **`TopNav`:** new "My Favourite ETFs" link visible when `isEtfsRoute && session`, parallel to the existing stocks branch. The reports/Gen-AI dropdowns are now gated on `!isStocksRoute && !isEtfsRoute` so ETF detail pages stay uncluttered like stock pages already do.
- **`UserProfile`:** added "My Favourite ETFs" entries beneath "My Favourite Stocks" in both the desktop user-icon dropdown and the mobile menu.
- **No API changes needed** — the existing `/api/[spaceId]/users/favourite-etfs[/[favouriteId]]` routes already cover GET / POST / PUT / DELETE.

### 2. Visible related-section pills on ETF sub-reports

The shared `RelatedSectionsNav` leaf (used by `EtfRelatedSections` for the per-sub-report "More <ETF> analyses" footer) rendered pills with `bg-surface` inside a `bg-surface` report shell, so the buttons effectively had no background. Bumped to `bg-surface-2 hover:bg-surface-3`, matching the stock-side `TickerRelatedSections` exactly.

## Test plan
- [ ] Mark an ETF as favourite from `/etfs/[exchange]/[etf]`; navigate to `/etf-favourites` and confirm it shows with name, symbol, final-score badge, your score, and notes.
- [ ] Edit a favourite via the pencil icon → modal opens prefilled; save and confirm the card updates.
- [ ] Delete a favourite via the trash icon → confirmation modal, then card disappears and refetch runs.
- [ ] Visit `/etf-favourites` while logged out → redirected to `/login`.
- [ ] Empty state appears when the user has zero favourite ETFs and "Browse ETFs" button links to `/etfs`.
- [ ] On `/etfs/*` routes, the desktop navbar shows "My Favourite ETFs" (only when logged in).
- [ ] User-icon dropdown (desktop and mobile) shows both "My Favourite Stocks" and "My Favourite ETFs".
- [ ] `/favourites` (stocks) still renders identically — no regressions in the empty state or layout.
- [ ] Any ETF sub-report (e.g. `/etfs/[exchange]/[etf]/performance-returns`) — "More <ETF> analyses" links render as visible dark pills on the report card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)