### PR TITLE
ETF mobile view: 3-dot menu for Favourite/Notes + back-only breadcrumbs

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -158,6 +158,14 @@ Remaining:
 
 - [ ] **Audit + fix UI issues across the ETF listing surfaces** — `/etfs` (index), `/etfs/categories` (+ `[category]`), `/etfs/countries` (+ `[country]`), `/etfs/asset-classes` (+ `[assetClass]`), `/etfs/groups` (+ `[group]`), `/etfs/providers` (+ `[provider]`). Walk each page on desktop + mobile and capture concrete issues here as sub-bullets before scheduling fixes: layout/spacing, card alignment, header + breadcrumb consistency across the sub-listing variants, empty/loading/error states, sort + filter UX, pagination, and dark/light theme rendering. Cross-check against the `isComplete` filter behavior once that lands.
 
+### Mobile view support for ETF screens
+
+- [ ] **Mobile layout audit across every ETF surface** — detail page (`/etfs/[exchange]/[etf]`) + all sub-pages (`analysis`, `mor-info`, `portfolio-holdings`, per-category analysis pages: `risk-analysis`, `cost-efficiency-team`, `performance-returns`, `future-performance-outlook`, `index-strategy`, `final-summary`, `competition`, `scenarios`) and the listing surfaces (`/etfs`, `/etfs/categories[/...]`, `/etfs/countries[/...]`, `/etfs/asset-classes[/...]`, `/etfs/groups[/...]`, `/etfs/providers[/...]`). Capture concrete issues — overflow tables, cut-off charts (radar, price/returns/CAGR tabs, competition quadrant), font sizes, spacing, sticky-header behavior, tap-target sizing, breadcrumb + section-nav usability, image/holding row wrapping — as sub-bullets before scheduling fixes.
+- [ ] **Charts must render on phones** — verify the lazy-loaded chart.js components (`EtfRadarChart`, `EtfChartTabs`, `EtfCompetitionQuadrantChart`) size correctly inside narrow viewports, legend doesn't push the canvas off-screen, and the viewport-gated `useInView` trigger still fires on first scroll on mobile.
+- [ ] **Tables → mobile-friendly layouts** — holdings list, performance/returns metrics, sibling-ETF comparison, and competition rankings switch to card or stacked-row layouts under the mobile breakpoint instead of horizontal scroll where readability suffers.
+- [ ] **Verify after each per-slice streaming change** — re-test mobile every time a `<Suspense>` boundary in the detail page is re-cut (see ETF performance optimization tasks), since shell-vs-body splits can land different content above the fold on mobile vs desktop.
+- [ ] Cross-link with the stocks-side **Mobile layout audit** task — share patterns where the two surfaces converge (sticky headers, tap targets, chart sizing) and reuse leaf components rather than forking per-surface mobile styles.
+
 ### Known limitations in the new 8-group taxonomy (follow-up cleanups)
 
 - [ ] **Split strategy funds back out of `derivative-income`** — managed-futures / market-neutral / long-short (~50 funds) don't share a decision framework with the ~600 option-engineered payoff funds; prompt has to branch internally. Highest-impact follow-up.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -158,14 +158,6 @@ Remaining:
 
 - [ ] **Audit + fix UI issues across the ETF listing surfaces** — `/etfs` (index), `/etfs/categories` (+ `[category]`), `/etfs/countries` (+ `[country]`), `/etfs/asset-classes` (+ `[assetClass]`), `/etfs/groups` (+ `[group]`), `/etfs/providers` (+ `[provider]`). Walk each page on desktop + mobile and capture concrete issues here as sub-bullets before scheduling fixes: layout/spacing, card alignment, header + breadcrumb consistency across the sub-listing variants, empty/loading/error states, sort + filter UX, pagination, and dark/light theme rendering. Cross-check against the `isComplete` filter behavior once that lands.
 
-### Mobile view support for ETF screens
-
-- [ ] **Mobile layout audit across every ETF surface** — detail page (`/etfs/[exchange]/[etf]`) + all sub-pages (`analysis`, `mor-info`, `portfolio-holdings`, per-category analysis pages: `risk-analysis`, `cost-efficiency-team`, `performance-returns`, `future-performance-outlook`, `index-strategy`, `final-summary`, `competition`, `scenarios`) and the listing surfaces (`/etfs`, `/etfs/categories[/...]`, `/etfs/countries[/...]`, `/etfs/asset-classes[/...]`, `/etfs/groups[/...]`, `/etfs/providers[/...]`). Capture concrete issues — overflow tables, cut-off charts (radar, price/returns/CAGR tabs, competition quadrant), font sizes, spacing, sticky-header behavior, tap-target sizing, breadcrumb + section-nav usability, image/holding row wrapping — as sub-bullets before scheduling fixes.
-- [ ] **Charts must render on phones** — verify the lazy-loaded chart.js components (`EtfRadarChart`, `EtfChartTabs`, `EtfCompetitionQuadrantChart`) size correctly inside narrow viewports, legend doesn't push the canvas off-screen, and the viewport-gated `useInView` trigger still fires on first scroll on mobile.
-- [ ] **Tables → mobile-friendly layouts** — holdings list, performance/returns metrics, sibling-ETF comparison, and competition rankings switch to card or stacked-row layouts under the mobile breakpoint instead of horizontal scroll where readability suffers.
-- [ ] **Verify after each per-slice streaming change** — re-test mobile every time a `<Suspense>` boundary in the detail page is re-cut (see ETF performance optimization tasks), since shell-vs-body splits can land different content above the fold on mobile vs desktop.
-- [ ] Cross-link with the stocks-side **Mobile layout audit** task — share patterns where the two surfaces converge (sticky headers, tap targets, chart sizing) and reuse leaf components rather than forking per-surface mobile styles.
-
 ### Known limitations in the new 8-group taxonomy (follow-up cleanups)
 
 - [ ] **Split strategy funds back out of `derivative-income`** — managed-futures / market-neutral / long-short (~50 funds) don't share a decision framework with the ~600 option-engineered payoff funds; prompt has to branch internally. Highest-impact follow-up.

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/EtfSubPageActions.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/EtfSubPageActions.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { EtfNotesResponse } from '@/app/api/[spaceId]/users/etf-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { FavouriteEtfResponse, FavouriteEtfsResponse } from '@/types/etf-user';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { DocumentTextIcon as DocumentTextOutline, HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
+import { DocumentTextIcon as DocumentTextSolid, HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+import { EtfNote } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+// Heavy modal chunks are dynamic-imported — they only download/mount after the
+// user actually opens a modal. Keeps the sub-page initial JS unchanged for
+// crawlers and first paint.
+const AddEditEtfFavouriteModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfFavouriteModal'), { ssr: false });
+const AddEditEtfNotesModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfNotesModal'), { ssr: false });
+
+export interface EtfSubPageActionsProps {
+  etfId: string;
+  etfSymbol: string;
+  etfName: string;
+}
+
+export default function EtfSubPageActions({ etfId, etfSymbol, etfName }: EtfSubPageActionsProps): JSX.Element {
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+  const router = useRouter();
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+
+  // De-duplicated fetches: the desktop buttons and the mobile dropdown share
+  // the same data. Rendering both layouts in the DOM (one hidden via CSS)
+  // would otherwise double the API calls on every load.
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<FavouriteEtfsResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-etfs`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<EtfNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/etf-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+
+  const favouriteEtf: FavouriteEtfResponse | null = favouritesData?.favouriteEtfs.find((f) => f.etfId === etfId) || null;
+  const existingNote: EtfNote | null = notesData?.etfNotes.find((n) => n.etfId === etfId) || null;
+
+  const openFavourite = () => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    setFavouriteMounted(true);
+    setIsFavouriteOpen(true);
+  };
+
+  const openNotes = () => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    setNotesMounted(true);
+    setIsNotesOpen(true);
+  };
+
+  const mobileItems: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteEtf ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+  ];
+
+  const handleMobileSelect = (key: string) => {
+    if (key === 'favourite') openFavourite();
+    else if (key === 'notes') openNotes();
+  };
+
+  return (
+    <div className="flex items-center gap-2 relative z-10">
+      <div className="hidden sm:flex flex-wrap items-center gap-2">
+        <button
+          onClick={openFavourite}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            favouriteEtf ? 'bg-blue-700 hover:bg-blue-600 border-blue-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add to favourites' : favouriteEtf ? 'Edit favourite' : 'Add to favourites'}
+        >
+          {favouriteEtf ? (
+            <HeartSolid className="w-5 h-5 mr-2 text-red-400" aria-hidden="true" />
+          ) : (
+            <HeartOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Favourite</span>
+        </button>
+        <button
+          onClick={openNotes}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            existingNote ? 'bg-green-700 hover:bg-green-600 border-green-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add notes' : existingNote ? 'Edit note' : 'Add note'}
+        >
+          {existingNote ? (
+            <DocumentTextSolid className="w-5 h-5 mr-2 text-green-300" aria-hidden="true" />
+          ) : (
+            <DocumentTextOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Notes</span>
+        </button>
+      </div>
+
+      <div className="sm:hidden">
+        <EllipsisDropdown items={mobileItems} onSelect={handleMobileSelect} className="px-2 py-2" />
+      </div>
+
+      {session && favouriteMounted && (
+        <AddEditEtfFavouriteModal
+          isOpen={isFavouriteOpen}
+          onClose={() => setIsFavouriteOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsFavouriteOpen(false)}
+          favouriteEtf={favouriteEtf}
+          onUpsert={refetchFavourites}
+        />
+      )}
+
+      {session && notesMounted && (
+        <AddEditEtfNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/MobileEtfActionsMenu.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/MobileEtfActionsMenu.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { EtfNotesResponse } from '@/app/api/[spaceId]/users/etf-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { FavouriteEtfResponse, FavouriteEtfsResponse } from '@/types/etf-user';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { EtfNote } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+// Same dynamic chunks used by the desktop buttons — Next.js dedupes the
+// chunk, so loading them here adds no bundle cost when desktop buttons render.
+const AddEditEtfFavouriteModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfFavouriteModal'), { ssr: false });
+const AddEditEtfNotesModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfNotesModal'), { ssr: false });
+
+export interface MobileEtfActionsMenuProps {
+  etfId: string;
+  etfSymbol: string;
+  etfName: string;
+}
+
+export default function MobileEtfActionsMenu({ etfId, etfSymbol, etfName }: MobileEtfActionsMenuProps): JSX.Element {
+  const router = useRouter();
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<FavouriteEtfsResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-etfs`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<EtfNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/etf-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+
+  const favouriteEtf: FavouriteEtfResponse | null = favouritesData?.favouriteEtfs.find((f) => f.etfId === etfId) || null;
+  const existingNote: EtfNote | null = notesData?.etfNotes.find((n) => n.etfId === etfId) || null;
+
+  const items: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteEtf ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+  ];
+
+  const handleSelect = (key: string) => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    if (key === 'favourite') {
+      setFavouriteMounted(true);
+      setIsFavouriteOpen(true);
+    } else if (key === 'notes') {
+      setNotesMounted(true);
+      setIsNotesOpen(true);
+    }
+  };
+
+  return (
+    <div className="relative z-10">
+      <EllipsisDropdown items={items} onSelect={handleSelect} className="px-2 py-2" />
+
+      {session && favouriteMounted && (
+        <AddEditEtfFavouriteModal
+          isOpen={isFavouriteOpen}
+          onClose={() => setIsFavouriteOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsFavouriteOpen(false)}
+          favouriteEtf={favouriteEtf}
+          onUpsert={refetchFavourites}
+        />
+      )}
+
+      {session && notesMounted && (
+        <AddEditEtfNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -97,7 +97,7 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleJsonLd, breadcrumbJsonLd]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
       <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -1,4 +1,5 @@
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCompetitionFullView from '@/components/etf-reportsv1/EtfCompetitionFullView';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -97,7 +98,12 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleJsonLd, breadcrumbJsonLd]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={data.etf.id} etfSymbol={data.etf.symbol} etfName={data.etf.name} />}
+      />
       <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -111,7 +112,12 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -111,7 +111,7 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
@@ -111,7 +111,7 @@ export default async function FuturePerformanceOutlookPage({ params }: { params:
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -111,7 +112,12 @@ export default async function FuturePerformanceOutlookPage({ params }: { params:
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -110,7 +110,7 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <article className="py-4" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={lastUpdatedDate.toISOString()} />

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -1,5 +1,6 @@
 import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
 import EtfRelatedSections, { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -110,7 +111,12 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />}
+      />
 
       <article className="py-4" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={lastUpdatedDate.toISOString()} />

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -3,6 +3,7 @@ import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]
 import EtfActions from '@/app/etfs/[exchange]/[etf]/EtfActions';
 import EtfFavouriteButton from '@/app/etfs/[exchange]/[etf]/EtfFavouriteButton';
 import EtfNotesButton from '@/app/etfs/[exchange]/[etf]/EtfNotesButton';
+import MobileEtfActionsMenu from '@/app/etfs/[exchange]/[etf]/MobileEtfActionsMenu';
 import { getEtfFundCategoryHierarchy } from '@/utils/etf-categorization-utils';
 import EtfAnalysisSections from '@/components/etf-reportsv1/analysis/EtfAnalysisSections';
 import EtfRadarChart from '@/components/etf-reportsv1/analysis/EtfRadarChart';
@@ -321,10 +322,16 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
       <Breadcrumbs
         breadcrumbs={breadcrumbs}
         hideHomeIcon={true}
+        mobileBackOnly={true}
         rightButton={
           <div className="flex flex-wrap items-center gap-2">
-            <EtfFavouriteButton etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />
-            <EtfNotesButton etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />
+            <div className="hidden sm:flex flex-wrap items-center gap-2">
+              <EtfFavouriteButton etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />
+              <EtfNotesButton etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />
+            </div>
+            <div className="sm:hidden">
+              <MobileEtfActionsMenu etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />
+            </div>
             <EtfActions etf={{ symbol: etf, exchange }} />
           </div>
         }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -128,7 +128,7 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -1,4 +1,5 @@
 import { EtfMorInfoOptionalWrapper } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/mor-info/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import EtfReturnsTable from '@/components/etf-reportsv1/EtfReturnsTable';
@@ -128,7 +129,12 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -114,7 +114,7 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -114,7 +115,12 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/StockSubPageActions.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/StockSubPageActions.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { TickerNotesResponse } from '@/app/api/[spaceId]/users/ticker-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { FavouriteTickerResponse, UserListResponse, UserTickerTagResponse } from '@/types/ticker-user';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { DocumentTextIcon as DocumentTextOutline, HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
+import { DocumentTextIcon as DocumentTextSolid, HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+import { TickerV1Notes } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+
+// Heavy modal chunks are dynamic-imported — they only download/mount after the
+// user actually opens a modal (or, for `ManageListsModal` / `ManageTagsModal`,
+// only after they click the "Manage" sub-action). Keeps the sub-page initial
+// JS unchanged for crawlers and first paint.
+const AddEditFavouriteModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditFavouriteModal'), { ssr: false });
+const AddEditNotesModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditNotesModal'), { ssr: false });
+const ManageListsModal = dynamic(() => import('@/components/favourites/ManageListsModal'), { ssr: false });
+const ManageTagsModal = dynamic(() => import('@/components/favourites/ManageTagsModal'), { ssr: false });
+const LoginPopup = dynamic(() => import('@/components/login/login-popup').then((m) => ({ default: m.LoginPopup })), { ssr: false });
+
+export interface StockSubPageActionsProps {
+  tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
+}
+
+type ManageModalView = 'manage-lists' | 'manage-tags';
+
+export default function StockSubPageActions({ tickerId, tickerSymbol, tickerName }: StockSubPageActionsProps): JSX.Element {
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+  const [manageModalView, setManageModalView] = useState<ManageModalView | null>(null);
+  const [isLoginPopupOpen, setIsLoginPopupOpen] = useState(false);
+
+  // De-duplicated fetches: the desktop buttons and the mobile dropdown share
+  // the same data. Rendering both layouts in the DOM (one hidden via CSS)
+  // would otherwise double the API calls on every load.
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<{ favouriteTickers: FavouriteTickerResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-tickers`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<TickerNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/ticker-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+  const { data: listsData, reFetchData: refetchLists } = useFetchData<{ lists: UserListResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-lists`,
+    { skipInitialFetch: !session },
+    'Failed to fetch lists'
+  );
+  const { data: tagsData, reFetchData: refetchTags } = useFetchData<{ tags: UserTickerTagResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-ticker-tags`,
+    { skipInitialFetch: !session },
+    'Failed to fetch tags'
+  );
+
+  const favouriteTicker: FavouriteTickerResponse | null = favouritesData?.favouriteTickers.find((f) => f.tickerId === tickerId) || null;
+  const existingNote: TickerV1Notes | null = notesData?.tickerNotes.find((n) => n.tickerId === tickerId) || null;
+  const lists: UserListResponse[] = listsData?.lists || [];
+  const tags: UserTickerTagResponse[] = tagsData?.tags || [];
+
+  const openFavourite = () => {
+    if (!session) {
+      setIsLoginPopupOpen(true);
+      return;
+    }
+    setFavouriteMounted(true);
+    setIsFavouriteOpen(true);
+  };
+
+  const openNotes = () => {
+    if (!session) {
+      setIsLoginPopupOpen(true);
+      return;
+    }
+    setNotesMounted(true);
+    setIsNotesOpen(true);
+  };
+
+  const mobileItems: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteTicker ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+  ];
+
+  const handleMobileSelect = (key: string) => {
+    if (key === 'favourite') openFavourite();
+    else if (key === 'notes') openNotes();
+  };
+
+  return (
+    <div className="flex items-center gap-2 relative z-10">
+      <div className="hidden sm:flex flex-wrap items-center gap-2">
+        <button
+          onClick={openFavourite}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            favouriteTicker ? 'bg-blue-700 hover:bg-blue-600 border-blue-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add to favourites' : favouriteTicker ? 'Edit favourite' : 'Add to favourites'}
+        >
+          {favouriteTicker ? (
+            <HeartSolid className="w-5 h-5 mr-2 text-red-400" aria-hidden="true" />
+          ) : (
+            <HeartOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Favourite</span>
+        </button>
+        <button
+          onClick={openNotes}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            existingNote ? 'bg-green-700 hover:bg-green-600 border-green-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add notes' : existingNote ? 'Edit note' : 'Add note'}
+        >
+          {existingNote ? (
+            <DocumentTextSolid className="w-5 h-5 mr-2 text-green-300" aria-hidden="true" />
+          ) : (
+            <DocumentTextOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Notes</span>
+        </button>
+      </div>
+
+      <div className="sm:hidden">
+        <EllipsisDropdown items={mobileItems} onSelect={handleMobileSelect} className="px-2 py-2" />
+      </div>
+
+      {session && favouriteMounted && (
+        <>
+          <AddEditFavouriteModal
+            isOpen={isFavouriteOpen}
+            onClose={() => setIsFavouriteOpen(false)}
+            tickerId={tickerId}
+            tickerSymbol={tickerSymbol}
+            tickerName={tickerName}
+            lists={lists}
+            tags={tags}
+            onManageLists={() => setManageModalView('manage-lists')}
+            onManageTags={() => setManageModalView('manage-tags')}
+            onSuccess={() => setIsFavouriteOpen(false)}
+            favouriteTicker={favouriteTicker}
+            onUpsert={refetchFavourites}
+          />
+          <ManageListsModal isOpen={manageModalView === 'manage-lists'} onClose={() => setManageModalView(null)} lists={lists} onListsChange={refetchLists} />
+          <ManageTagsModal isOpen={manageModalView === 'manage-tags'} onClose={() => setManageModalView(null)} tags={tags} onTagsChange={refetchTags} />
+        </>
+      )}
+
+      {session && notesMounted && (
+        <AddEditNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          tickerId={tickerId}
+          tickerSymbol={tickerSymbol}
+          tickerName={tickerName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+
+      {!session && <LoginPopup open={isLoginPopupOpen} onClose={() => setIsLoginPopupOpen(false)} />}
+    </div>
+  );
+}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import BusinessAndMoat from '@/components/ticker-reportsv1/BusinessAndMoat';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -123,7 +124,12 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <BusinessAndMoat tickerData={tickerData} data={bmData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -123,7 +123,7 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <BusinessAndMoat tickerData={tickerData} data={bmData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import Competition from '@/components/ticker-reportsv1/Competition';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
@@ -212,7 +213,12 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <Competition tickerData={tickerData} data={competitionData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -212,7 +212,7 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <Competition tickerData={tickerData} data={competitionData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -127,7 +127,7 @@ export default async function FairValuePage({ params }: { params: RouteParams })
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <FairValue tickerData={tickerData} data={fairValueData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FairValue from '@/components/ticker-reportsv1/FairValue';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function FairValuePage({ params }: { params: RouteParams })
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FairValue tickerData={tickerData} data={fairValueData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FinancialStatementAnalysis from '@/components/ticker-reportsv1/FinancialStatementAnalysis';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -128,7 +129,12 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -128,7 +128,7 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FuturePerformance from '@/components/ticker-reportsv1/FuturePerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FuturePerformance tickerData={tickerData} data={futurePerformanceData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -127,7 +127,7 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <FuturePerformance tickerData={tickerData} data={futurePerformanceData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -216,7 +216,7 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <article className="bg-surface rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <section className="mb-6">

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import AdminTimestamp from '@/components/auth/AdminTimestamp';
 import TickerRelatedSections, { getAvailableSiblingSlugs } from '@/components/ticker-reportsv1/TickerRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -216,7 +217,12 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <article className="bg-surface rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <section className="mb-6">

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import PastPerformance from '@/components/ticker-reportsv1/PastPerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <PastPerformance tickerData={tickerData} data={pastPerformanceData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -127,7 +127,7 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
 
       <PastPerformance tickerData={tickerData} data={pastPerformanceData} />
     </PageWrapper>

--- a/insights-ui/src/components/ui/Breadcrumbs.tsx
+++ b/insights-ui/src/components/ui/Breadcrumbs.tsx
@@ -5,12 +5,13 @@ interface BreadcrumbsProps {
   breadcrumbs: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
+  mobileBackOnly?: boolean;
 }
 
-export default function Breadcrumbs({ breadcrumbs, rightButton, hideHomeIcon }: BreadcrumbsProps) {
+export default function Breadcrumbs({ breadcrumbs, rightButton, hideHomeIcon, mobileBackOnly }: BreadcrumbsProps) {
   return (
     <div className="my-4 text-color">
-      <BreadcrumbsWithChevrons breadcrumbs={breadcrumbs} rightButton={rightButton} hideHomeIcon={hideHomeIcon} />
+      <BreadcrumbsWithChevrons breadcrumbs={breadcrumbs} rightButton={rightButton} hideHomeIcon={hideHomeIcon} mobileBackOnly={mobileBackOnly} />
     </div>
   );
 }

--- a/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
+++ b/shared/web-core/src/components/core/breadcrumbs/BreadcrumbsWithChevrons.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ChevronLeftIcon from '@heroicons/react/20/solid/ChevronLeftIcon';
 import ChevronRightIcon from '@heroicons/react/20/solid/ChevronRightIcon';
 import HomeIcon from '@heroicons/react/24/solid/HomeIcon';
 import { ReactNode } from 'react';
@@ -13,42 +14,82 @@ interface BreadcrumbsWithChevronsProps {
   breadcrumbs: BreadcrumbsOjbect[];
   rightButton?: ReactNode;
   hideHomeIcon?: boolean;
+  /**
+   * On mobile, collapse the chain to a single truncated "← {parent}" back
+   * link inline with `rightButton`. The full chain still renders at `sm` and
+   * above. Opt-in so existing pages keep their behavior — pages with long
+   * crumb names should enable it. No effect at `sm` and above.
+   */
+  mobileBackOnly?: boolean;
 }
 
-export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false }: BreadcrumbsWithChevronsProps) {
-  return breadcrumbs.length === 0 ? null : (
+function FullBreadcrumbChain({ breadcrumbs, hideHomeIcon }: { breadcrumbs: BreadcrumbsOjbect[]; hideHomeIcon: boolean }) {
+  return (
+    <ol role="list" className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      {/* Home icon - hidden only on mobile */}
+      <li className={hideHomeIcon ? 'hidden sm:block' : ''}>
+        <Link className="cursor-pointer" href={'/'}>
+          <HomeIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <span className="sr-only">Home</span>
+        </Link>
+      </li>
+      {breadcrumbs.map((breadcrumb, index) => {
+        const isFirstBreadcrumb = index === 0;
+        return (
+          <li key={breadcrumb.name} className="min-w-0">
+            <div className="flex items-center min-w-0">
+              {/* Show chevron on desktop always, on mobile only if not first breadcrumb when home is hidden */}
+              <ChevronRightIcon className={`h-5 w-5 flex-shrink-0 ${hideHomeIcon && isFirstBreadcrumb ? 'hidden sm:block' : ''}`} aria-hidden="true" />
+              <Link
+                href={breadcrumb.href}
+                className={`${hideHomeIcon && isFirstBreadcrumb ? 'sm:ml-4' : 'ml-4'} text-sm font-medium break-words ${
+                  breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'
+                }`}
+                aria-current={breadcrumb.current ? 'page' : undefined}
+              >
+                {breadcrumb.name}
+              </Link>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export default function BreadcrumbsWithChevrons({ breadcrumbs, rightButton, hideHomeIcon = false, mobileBackOnly = false }: BreadcrumbsWithChevronsProps) {
+  if (breadcrumbs.length === 0) return null;
+
+  // Opt-in mobile layout: back link inline with rightButton on one row.
+  // `sm:contents` flattens the wrapper at `sm+` so the full-chain nav and
+  // rightButton become direct children of the outer flex-row again — that
+  // way rightButton is rendered exactly once and the desktop spacing
+  // (`justify-between`) is preserved.
+  if (mobileBackOnly) {
+    const parentCrumb: BreadcrumbsOjbect | null = breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2] : null;
+
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
+        <div className="flex sm:contents items-center justify-between min-w-0 w-full gap-2">
+          {parentCrumb && (
+            <Link href={parentCrumb.href} className="flex sm:hidden items-center text-sm font-medium link-color min-w-0 flex-1">
+              <ChevronLeftIcon className="h-5 w-5 flex-shrink-0 mr-1" aria-hidden="true" />
+              <span className="truncate">{parentCrumb.name}</span>
+            </Link>
+          )}
+          <nav className="hidden sm:flex min-w-0" aria-label="Breadcrumb">
+            <FullBreadcrumbChain breadcrumbs={breadcrumbs} hideHomeIcon={hideHomeIcon} />
+          </nav>
+          {rightButton && <div className="flex-shrink-0">{rightButton}</div>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between w-full gap-4">
       <nav className="flex min-w-0" aria-label="Breadcrumb">
-        <ol role="list" className="flex flex-wrap items-center gap-x-4 gap-y-2">
-          {/* Home icon - hidden only on mobile */}
-          <li className={hideHomeIcon ? 'hidden sm:block' : ''}>
-            <Link className="cursor-pointer" href={'/'}>
-              <HomeIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
-              <span className="sr-only">Home</span>
-            </Link>
-          </li>
-          {breadcrumbs.map((breadcrumb, index) => {
-            const isFirstBreadcrumb = index === 0;
-
-            return (
-              <li key={breadcrumb.name} className="min-w-0">
-                <div className="flex items-center min-w-0">
-                  {/* Show chevron on desktop always, on mobile only if not first breadcrumb when home is hidden */}
-                  <ChevronRightIcon className={`h-5 w-5 flex-shrink-0 ${hideHomeIcon && isFirstBreadcrumb ? 'hidden sm:block' : ''}`} aria-hidden="true" />
-                  <Link
-                    href={breadcrumb.href}
-                    className={`${hideHomeIcon && isFirstBreadcrumb ? 'sm:ml-4' : 'ml-4'} text-sm font-medium break-words ${
-                      breadcrumb.current ? 'cursor-default' : 'cursor-pointer link-color'
-                    }`}
-                    aria-current={breadcrumb.current ? 'page' : undefined}
-                  >
-                    {breadcrumb.name}
-                  </Link>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
+        <FullBreadcrumbChain breadcrumbs={breadcrumbs} hideHomeIcon={hideHomeIcon} />
       </nav>
       {rightButton && <div className="flex-shrink-0 w-full sm:w-auto">{rightButton}</div>}
     </div>


### PR DESCRIPTION
## Summary

Mirror of the stocks-side mobile fix from #1616 for ETF screens only. On phones, the ETF detail page's Favourite + Notes text buttons wrap to a second row and the breadcrumb chain runs across multiple lines.

### Changes

- **`Breadcrumbs` / `BreadcrumbsWithChevrons`** — add an opt-in `mobileBackOnly` prop. When set, the mobile layout collapses the chain to a single truncated "← {parent}" back link inline with `rightButton`; the full chain still renders at `sm+`. Existing consumers are unchanged. *(Same prop added by #1616 — only one of the two PRs needs to land this; the other will rebase to drop the duplicate.)*
- **New `MobileEtfActionsMenu`** — single ellipsis dropdown with "Add to favourites / Edit favourite" and "Add note / Edit note". Reuses the existing `AddEditEtfFavouriteModal` + `AddEditEtfNotesModal` chunks (Next.js dedupes), so zero extra bundle cost when desktop buttons render.
- **ETF detail `page.tsx`** — desktop Favourite + Notes buttons wrapped in `hidden sm:flex`; the new mobile menu wrapped in `sm:hidden`. Admin `EtfActions` ellipsis is left untouched (separate concern — admins operate from desktop). `Breadcrumbs` flagged with `mobileBackOnly`.
- **Six ETF sub-pages** (`performance-returns`, `cost-efficiency-team`, `risk-analysis`, `future-performance-outlook`, `competition`, `holdings`) — each gets `mobileBackOnly={true}` on its `Breadcrumbs`. None of these have Favourite/Notes buttons so they don't need the menu.
- Also includes the previously-committed docs task entry (`docs/insights-ui/tasks/todo-tasks.md`).

### Surfaces covered

- `/etfs/NASDAQ/QQQ` — mobile 3-dot + back-only breadcrumb
- `/etfs/NASDAQ/QQQ/performance-returns` — back-only breadcrumb
- `/etfs/NASDAQ/QQQ/cost-efficiency-team` — back-only breadcrumb
- `/etfs/NASDAQ/QQQ/risk-analysis` — back-only breadcrumb
- `/etfs/NASDAQ/QQQ/future-performance-outlook` — back-only breadcrumb
- `/etfs/NASDAQ/QQQ/competition` — back-only breadcrumb
- `/etfs/NASDAQ/QQQ/holdings` — back-only breadcrumb

Desktop layout and non-ETF pages are unchanged.

## Test plan

- [ ] Mobile: visit `/etfs/NASDAQ/QQQ` — breadcrumb shows "← Large Growth" (parent crumb) only; 3-dot menu replaces Favourite/Notes buttons; tapping it shows the two options; logged-out tap routes to `/login`; logged-in tap opens the existing modals.
- [ ] Mobile: visit each of the six sub-pages — breadcrumb shows only the parent back link.
- [ ] Desktop (≥ sm): full breadcrumb chain renders on all 7 pages; Favourite + Notes text buttons render on the detail page; admin ⋯ unchanged.
- [ ] Non-ETF pages (stocks, ETF listings, tariffs) — visually unchanged (no `mobileBackOnly` passed → no behavior change).