### PR TITLE
Stock sub-pages: Favourite/Notes actions (desktop + mobile)

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/StockSubPageActions.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/StockSubPageActions.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { TickerNotesResponse } from '@/app/api/[spaceId]/users/ticker-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { FavouriteTickerResponse, UserListResponse, UserTickerTagResponse } from '@/types/ticker-user';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { DocumentTextIcon as DocumentTextOutline, HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
+import { DocumentTextIcon as DocumentTextSolid, HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+import { TickerV1Notes } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+
+// Heavy modal chunks are dynamic-imported — they only download/mount after the
+// user actually opens a modal (or, for `ManageListsModal` / `ManageTagsModal`,
+// only after they click the "Manage" sub-action). Keeps the sub-page initial
+// JS unchanged for crawlers and first paint.
+const AddEditFavouriteModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditFavouriteModal'), { ssr: false });
+const AddEditNotesModal = dynamic(() => import('@/app/stocks/[exchange]/[ticker]/AddEditNotesModal'), { ssr: false });
+const ManageListsModal = dynamic(() => import('@/components/favourites/ManageListsModal'), { ssr: false });
+const ManageTagsModal = dynamic(() => import('@/components/favourites/ManageTagsModal'), { ssr: false });
+const LoginPopup = dynamic(() => import('@/components/login/login-popup').then((m) => ({ default: m.LoginPopup })), { ssr: false });
+
+export interface StockSubPageActionsProps {
+  tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
+}
+
+type ManageModalView = 'manage-lists' | 'manage-tags';
+
+export default function StockSubPageActions({ tickerId, tickerSymbol, tickerName }: StockSubPageActionsProps): JSX.Element {
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+  const [manageModalView, setManageModalView] = useState<ManageModalView | null>(null);
+  const [isLoginPopupOpen, setIsLoginPopupOpen] = useState(false);
+
+  // De-duplicated fetches: the desktop buttons and the mobile dropdown share
+  // the same data. Rendering both layouts in the DOM (one hidden via CSS)
+  // would otherwise double the API calls on every load.
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<{ favouriteTickers: FavouriteTickerResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-tickers`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<TickerNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/ticker-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+  const { data: listsData, reFetchData: refetchLists } = useFetchData<{ lists: UserListResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-lists`,
+    { skipInitialFetch: !session },
+    'Failed to fetch lists'
+  );
+  const { data: tagsData, reFetchData: refetchTags } = useFetchData<{ tags: UserTickerTagResponse[] }>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/user-ticker-tags`,
+    { skipInitialFetch: !session },
+    'Failed to fetch tags'
+  );
+
+  const favouriteTicker: FavouriteTickerResponse | null = favouritesData?.favouriteTickers.find((f) => f.tickerId === tickerId) || null;
+  const existingNote: TickerV1Notes | null = notesData?.tickerNotes.find((n) => n.tickerId === tickerId) || null;
+  const lists: UserListResponse[] = listsData?.lists || [];
+  const tags: UserTickerTagResponse[] = tagsData?.tags || [];
+
+  const openFavourite = () => {
+    if (!session) {
+      setIsLoginPopupOpen(true);
+      return;
+    }
+    setFavouriteMounted(true);
+    setIsFavouriteOpen(true);
+  };
+
+  const openNotes = () => {
+    if (!session) {
+      setIsLoginPopupOpen(true);
+      return;
+    }
+    setNotesMounted(true);
+    setIsNotesOpen(true);
+  };
+
+  const mobileItems: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteTicker ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+  ];
+
+  const handleMobileSelect = (key: string) => {
+    if (key === 'favourite') openFavourite();
+    else if (key === 'notes') openNotes();
+  };
+
+  return (
+    <div className="flex items-center gap-2 relative z-10">
+      <div className="hidden sm:flex flex-wrap items-center gap-2">
+        <button
+          onClick={openFavourite}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            favouriteTicker ? 'bg-blue-700 hover:bg-blue-600 border-blue-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add to favourites' : favouriteTicker ? 'Edit favourite' : 'Add to favourites'}
+        >
+          {favouriteTicker ? (
+            <HeartSolid className="w-5 h-5 mr-2 text-red-400" aria-hidden="true" />
+          ) : (
+            <HeartOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Favourite</span>
+        </button>
+        <button
+          onClick={openNotes}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            existingNote ? 'bg-green-700 hover:bg-green-600 border-green-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add notes' : existingNote ? 'Edit note' : 'Add note'}
+        >
+          {existingNote ? (
+            <DocumentTextSolid className="w-5 h-5 mr-2 text-green-300" aria-hidden="true" />
+          ) : (
+            <DocumentTextOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Notes</span>
+        </button>
+      </div>
+
+      <div className="sm:hidden">
+        <EllipsisDropdown items={mobileItems} onSelect={handleMobileSelect} className="px-2 py-2" />
+      </div>
+
+      {session && favouriteMounted && (
+        <>
+          <AddEditFavouriteModal
+            isOpen={isFavouriteOpen}
+            onClose={() => setIsFavouriteOpen(false)}
+            tickerId={tickerId}
+            tickerSymbol={tickerSymbol}
+            tickerName={tickerName}
+            lists={lists}
+            tags={tags}
+            onManageLists={() => setManageModalView('manage-lists')}
+            onManageTags={() => setManageModalView('manage-tags')}
+            onSuccess={() => setIsFavouriteOpen(false)}
+            favouriteTicker={favouriteTicker}
+            onUpsert={refetchFavourites}
+          />
+          <ManageListsModal isOpen={manageModalView === 'manage-lists'} onClose={() => setManageModalView(null)} lists={lists} onListsChange={refetchLists} />
+          <ManageTagsModal isOpen={manageModalView === 'manage-tags'} onClose={() => setManageModalView(null)} tags={tags} onTagsChange={refetchTags} />
+        </>
+      )}
+
+      {session && notesMounted && (
+        <AddEditNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          tickerId={tickerId}
+          tickerSymbol={tickerSymbol}
+          tickerName={tickerName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+
+      {!session && <LoginPopup open={isLoginPopupOpen} onClose={() => setIsLoginPopupOpen(false)} />}
+    </div>
+  );
+}

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import BusinessAndMoat from '@/components/ticker-reportsv1/BusinessAndMoat';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -123,7 +124,12 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <BusinessAndMoat tickerData={tickerData} data={bmData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import Competition from '@/components/ticker-reportsv1/Competition';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
@@ -212,7 +213,12 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <Competition tickerData={tickerData} data={competitionData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FairValue from '@/components/ticker-reportsv1/FairValue';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function FairValuePage({ params }: { params: RouteParams })
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FairValue tickerData={tickerData} data={fairValueData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FinancialStatementAnalysis from '@/components/ticker-reportsv1/FinancialStatementAnalysis';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -128,7 +129,12 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import FuturePerformance from '@/components/ticker-reportsv1/FuturePerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <FuturePerformance tickerData={tickerData} data={futurePerformanceData} />
     </PageWrapper>

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import AdminTimestamp from '@/components/auth/AdminTimestamp';
 import TickerRelatedSections, { getAvailableSiblingSlugs } from '@/components/ticker-reportsv1/TickerRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -216,7 +217,12 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <article className="bg-surface rounded-lg shadow-sm border border-color p-3 sm:p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         <section className="mb-6">

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -1,3 +1,4 @@
+import StockSubPageActions from '@/app/stocks/[exchange]/[ticker]/StockSubPageActions';
 import PastPerformance from '@/components/ticker-reportsv1/PastPerformance';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { TickerAnalysisCategory } from '@/types/ticker-typesv1';
@@ -127,7 +128,12 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
         }}
       />
 
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<StockSubPageActions tickerId={tickerData.id} tickerSymbol={tickerData.symbol} tickerName={tickerData.name} />}
+      />
 
       <PastPerformance tickerData={tickerData} data={pastPerformanceData} />
     </PageWrapper>


### PR DESCRIPTION
## Summary

Adds Favourite + Notes actions to all seven stock report sub-pages, so users who land directly via Google can act on the company without backing out to the main stock page.

- **Desktop (\`sm+\`)**: Favourite + Notes buttons render inline next to the breadcrumb chain (same look as the main stock page).
- **Mobile (\`<sm\`)**: actions collapse into a 3-dot dropdown next to the back link (mirrors the ETF main-page pattern from PR #1620).

Covered routes:
- \`/stocks/[exchange]/[ticker]/business-and-moat\`
- \`/stocks/[exchange]/[ticker]/competition\`
- \`/stocks/[exchange]/[ticker]/fair-value\`
- \`/stocks/[exchange]/[ticker]/financial-statement-analysis\`
- \`/stocks/[exchange]/[ticker]/future-performance\`
- \`/stocks/[exchange]/[ticker]/past-performance\`
- \`/stocks/[exchange]/[ticker]/management-team\`

## How this avoids perf / SEO impact

- The new \`StockSubPageActions.tsx\` is a single \`'use client'\` component wired through the \`<Breadcrumbs rightButton={...}>\` slot. Server HTML for the route is unchanged for crawlers — no \`getServerSession()\` blocks SSR.
- Both layouts (desktop buttons + mobile dropdown) share **one** set of \`useFetchData\` calls (favourites, notes, lists, tags). No duplicate API calls when both layouts are rendered in the DOM.
- All hooks use \`skipInitialFetch: !session\` — logged-out users (including Googlebot) trigger zero data fetches.
- Heavy modal chunks (\`AddEditFavouriteModal\`, \`AddEditNotesModal\`, \`ManageListsModal\`, \`ManageTagsModal\`, \`LoginPopup\`) stay \`dynamic()\`-imported and are only mounted/downloaded after the user actually clicks. Initial route JS for the sub-pages should remain very close to the current ~108 kB First Load JS.

## Stacking

This PR is based on \`etf-mobile-view-task-entry\` (PR #1620), which adds the \`mobileBackOnly\` Breadcrumbs prop these pages rely on. Once #1620 lands, GitHub will auto-rebase this PR onto \`main\`.

## Follow-up

ETF sub-pages will get the same treatment in a separate PR once this lands.

## Test plan
- [ ] Logged-out: visit a sub-page on desktop — Favourite/Notes show as Login popup on click; no extra network calls in DevTools.
- [ ] Logged-out on mobile width (<640px) — 3-dot menu appears next to the back link; tapping an item routes to login.
- [ ] Logged-in desktop: clicking Favourite/Notes opens the same modals as the main stock page; saved state reflects on the buttons.
- [ ] Logged-in mobile: 3-dot menu opens favourite + notes modals; saving updates the dropdown labels.
- [ ] No new TypeScript errors (\`yarn compile\` clean).
- [ ] No new Prettier issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)