### PR TITLE
ETF sub-pages: Favourite/Notes actions (desktop + mobile)

### DIFF
--- a/insights-ui/src/app/etfs/[exchange]/[etf]/EtfSubPageActions.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/EtfSubPageActions.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { EtfNotesResponse } from '@/app/api/[spaceId]/users/etf-notes/route';
+import { KoalaGainsSession } from '@/types/auth';
+import { FavouriteEtfResponse, FavouriteEtfsResponse } from '@/types/etf-user';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import EllipsisDropdown, { EllipsisDropdownItem } from '@dodao/web-core/components/core/dropdowns/EllipsisDropdown';
+import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { DocumentTextIcon as DocumentTextOutline, HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
+import { DocumentTextIcon as DocumentTextSolid, HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+import { EtfNote } from '@prisma/client';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+// Heavy modal chunks are dynamic-imported — they only download/mount after the
+// user actually opens a modal. Keeps the sub-page initial JS unchanged for
+// crawlers and first paint.
+const AddEditEtfFavouriteModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfFavouriteModal'), { ssr: false });
+const AddEditEtfNotesModal = dynamic(() => import('@/app/etfs/[exchange]/[etf]/AddEditEtfNotesModal'), { ssr: false });
+
+export interface EtfSubPageActionsProps {
+  etfId: string;
+  etfSymbol: string;
+  etfName: string;
+}
+
+export default function EtfSubPageActions({ etfId, etfSymbol, etfName }: EtfSubPageActionsProps): JSX.Element {
+  const { data: koalaSession } = useSession();
+  const session: KoalaGainsSession | null = koalaSession as KoalaGainsSession | null;
+  const router = useRouter();
+
+  const [isFavouriteOpen, setIsFavouriteOpen] = useState(false);
+  const [favouriteMounted, setFavouriteMounted] = useState(false);
+  const [isNotesOpen, setIsNotesOpen] = useState(false);
+  const [notesMounted, setNotesMounted] = useState(false);
+
+  // De-duplicated fetches: the desktop buttons and the mobile dropdown share
+  // the same data. Rendering both layouts in the DOM (one hidden via CSS)
+  // would otherwise double the API calls on every load.
+  const { data: favouritesData, reFetchData: refetchFavourites } = useFetchData<FavouriteEtfsResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/favourite-etfs`,
+    { skipInitialFetch: !session },
+    'Failed to fetch favourites'
+  );
+  const { data: notesData, reFetchData: refetchNotes } = useFetchData<EtfNotesResponse>(
+    `${getBaseUrl()}/api/${KoalaGainsSpaceId}/users/etf-notes`,
+    { skipInitialFetch: !session },
+    'Failed to fetch notes'
+  );
+
+  const favouriteEtf: FavouriteEtfResponse | null = favouritesData?.favouriteEtfs.find((f) => f.etfId === etfId) || null;
+  const existingNote: EtfNote | null = notesData?.etfNotes.find((n) => n.etfId === etfId) || null;
+
+  const openFavourite = () => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    setFavouriteMounted(true);
+    setIsFavouriteOpen(true);
+  };
+
+  const openNotes = () => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    setNotesMounted(true);
+    setIsNotesOpen(true);
+  };
+
+  const mobileItems: EllipsisDropdownItem[] = [
+    { key: 'favourite', label: favouriteEtf ? 'Edit favourite' : 'Add to favourites' },
+    { key: 'notes', label: existingNote ? 'Edit note' : 'Add note' },
+  ];
+
+  const handleMobileSelect = (key: string) => {
+    if (key === 'favourite') openFavourite();
+    else if (key === 'notes') openNotes();
+  };
+
+  return (
+    <div className="flex items-center gap-2 relative z-10">
+      <div className="hidden sm:flex flex-wrap items-center gap-2">
+        <button
+          onClick={openFavourite}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            favouriteEtf ? 'bg-blue-700 hover:bg-blue-600 border-blue-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add to favourites' : favouriteEtf ? 'Edit favourite' : 'Add to favourites'}
+        >
+          {favouriteEtf ? (
+            <HeartSolid className="w-5 h-5 mr-2 text-red-400" aria-hidden="true" />
+          ) : (
+            <HeartOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Favourite</span>
+        </button>
+        <button
+          onClick={openNotes}
+          className={`inline-flex items-center px-4 py-2 text-sm font-medium text-white ${
+            existingNote ? 'bg-green-700 hover:bg-green-600 border-green-600' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'
+          } border rounded-lg shadow-md`}
+          title={!session ? 'Login to add notes' : existingNote ? 'Edit note' : 'Add note'}
+        >
+          {existingNote ? (
+            <DocumentTextSolid className="w-5 h-5 mr-2 text-green-300" aria-hidden="true" />
+          ) : (
+            <DocumentTextOutline className="w-5 h-5 mr-2" aria-hidden="true" />
+          )}
+          <span>Notes</span>
+        </button>
+      </div>
+
+      <div className="sm:hidden">
+        <EllipsisDropdown items={mobileItems} onSelect={handleMobileSelect} className="px-2 py-2" />
+      </div>
+
+      {session && favouriteMounted && (
+        <AddEditEtfFavouriteModal
+          isOpen={isFavouriteOpen}
+          onClose={() => setIsFavouriteOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsFavouriteOpen(false)}
+          favouriteEtf={favouriteEtf}
+          onUpsert={refetchFavourites}
+        />
+      )}
+
+      {session && notesMounted && (
+        <AddEditEtfNotesModal
+          isOpen={isNotesOpen}
+          onClose={() => setIsNotesOpen(false)}
+          etfId={etfId}
+          etfSymbol={etfSymbol}
+          etfName={etfName}
+          onSuccess={() => setIsNotesOpen(false)}
+          existingNote={existingNote}
+          onUpsert={refetchNotes}
+        />
+      )}
+    </div>
+  );
+}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -1,4 +1,5 @@
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCompetitionFullView from '@/components/etf-reportsv1/EtfCompetitionFullView';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -97,7 +98,12 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleJsonLd, breadcrumbJsonLd]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={data.etf.id} etfSymbol={data.etf.symbol} etfName={data.etf.name} />}
+      />
       <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} />
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/cost-efficiency-team/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -111,7 +112,12 @@ export default async function CostEfficiencyTeamPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/future-performance-outlook/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -111,7 +112,12 @@ export default async function FuturePerformanceOutlookPage({ params }: { params:
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -1,5 +1,6 @@
 import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
 import EtfRelatedSections, { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -110,7 +111,12 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etfData.id} etfSymbol={etfData.symbol} etfName={etfData.name} />}
+      />
 
       <article className="py-4" itemScope itemType="https://schema.org/Article">
         <meta itemProp="datePublished" content={lastUpdatedDate.toISOString()} />

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/performance-returns/page.tsx
@@ -1,4 +1,5 @@
 import { EtfMorInfoOptionalWrapper } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/mor-info/route';
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import EtfReturnsTable from '@/components/etf-reportsv1/EtfReturnsTable';
@@ -128,7 +129,12 @@ export default async function PerformanceReturnsPage({ params }: { params: Route
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/risk-analysis/page.tsx
@@ -1,3 +1,4 @@
+import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCategoryReport from '@/components/etf-reportsv1/analysis/EtfCategoryReport';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -114,7 +115,12 @@ export default async function RiskAnalysisPage({ params }: { params: RouteParams
   return (
     <PageWrapper>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([articleSchema, breadcrumbSchema]) }} />
-      <Breadcrumbs breadcrumbs={breadcrumbs} hideHomeIcon={true} mobileBackOnly={true} />
+      <Breadcrumbs
+        breadcrumbs={breadcrumbs}
+        hideHomeIcon={true}
+        mobileBackOnly={true}
+        rightButton={<EtfSubPageActions etfId={etf.id} etfSymbol={etf.symbol} etfName={etf.name} />}
+      />
       <EtfCategoryReport
         etfName={etf.name}
         symbol={symbol}


### PR DESCRIPTION
## Summary

Mirrors PR #1621 for the ETF tree. Adds Favourite + Notes actions to all six user-facing ETF report sub-pages so a user who lands directly via Google can act on the fund without backing out to the main ETF page.

- **Desktop (\`sm+\`)**: Favourite + Notes buttons render inline next to the breadcrumb chain (same look as the main ETF page).
- **Mobile (\`<sm\`)**: actions collapse into a 3-dot dropdown next to the back link (matches the main ETF page pattern from PR #1620).

Covered routes:
- \`/etfs/[exchange]/[etf]/competition\`
- \`/etfs/[exchange]/[etf]/cost-efficiency-team\`
- \`/etfs/[exchange]/[etf]/future-performance-outlook\`
- \`/etfs/[exchange]/[etf]/holdings\`
- \`/etfs/[exchange]/[etf]/performance-returns\`
- \`/etfs/[exchange]/[etf]/risk-analysis\`

\`/etfs/[exchange]/[etf]/financial-data\` is intentionally **not** included — it's a raw-JSON debug page, not a user-facing report.

## How this avoids perf / SEO impact

- The new \`EtfSubPageActions.tsx\` is a single \`'use client'\` component wired through the \`<Breadcrumbs rightButton={...}>\` slot. Server HTML for the route is unchanged for crawlers — no \`getServerSession()\` blocks SSR.
- Both layouts (desktop buttons + mobile dropdown) share **one** set of \`useFetchData\` calls (favourites, notes). No duplicate API calls when both layouts are rendered in the DOM.
- Both hooks use \`skipInitialFetch: !session\` — logged-out users (including Googlebot) trigger zero data fetches.
- Heavy modal chunks (\`AddEditEtfFavouriteModal\`, \`AddEditEtfNotesModal\`) stay \`dynamic()\`-imported and are only mounted/downloaded after the user actually clicks. Initial route JS for the sub-pages should remain very close to the current ~108 kB First Load JS reported on main.

## Stacking

This PR is based on \`etf-mobile-view-task-entry\` (PR #1620), which adds the \`mobileBackOnly\` Breadcrumbs prop these pages rely on. Once #1620 lands, GitHub will auto-rebase this PR onto \`main\`. Independent of PR #1621 (stocks side).

## Test plan
- [ ] Logged-out: visit an ETF sub-page on desktop — clicking Favourite/Notes routes to \`/login\`; no extra network calls in DevTools.
- [ ] Logged-out on mobile width (<640px) — 3-dot menu appears next to the back link; tapping an item routes to login.
- [ ] Logged-in desktop: clicking Favourite/Notes opens the same modals as the main ETF page; saved state reflects on the buttons.
- [ ] Logged-in mobile: 3-dot menu opens favourite + notes modals; saving updates the dropdown labels.
- [ ] No new TypeScript errors (\`yarn compile\` clean).
- [ ] No new Prettier issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)