### PR TITLE
feat(etfs): list only populated ETFs in listings; admins still see all

### DIFF
--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -21,6 +21,7 @@ import {
   EtfSortField,
   MOR_ADVANCED_FILTERS,
 } from '@/utils/etf-filter-utils';
+import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { getEtfExchangesByCountry, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { Prisma } from '@prisma/client';
@@ -153,7 +154,13 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const cachedScoreFilter = createEtfCachedScoreFilter(filters);
   const hasCachedScoreFilter = Object.keys(cachedScoreFilter).length > 0;
   if (hasCachedScoreFilter) {
+    // A score filter (`{ is: ... }`) already requires the row to exist, so it
+    // implicitly restricts to populated ETFs.
     etfWhere.cachedScore = { is: cachedScoreFilter };
+  } else if (!(await shouldIncludeUnpopulatedForRequest(req))) {
+    // Default: only list ETFs that have a generated report (an EtfCachedScore
+    // row). Admins requesting includeUnpopulated=true bypass this and see all.
+    etfWhere.cachedScore = { isNot: null };
   }
 
   const futureReturnsFilter = createEtfFutureReturnsFilter(filters);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route.ts
@@ -1,5 +1,6 @@
 import { EtfGroupingPreview, fetchEtfsForGroupings } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
@@ -14,13 +15,14 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const { searchParams } = new URL(req.url);
   const countryParam = searchParams.get('country')?.trim();
   const country = countryParam && isEtfSupportedCountry(countryParam) ? countryParam : undefined;
+  const includeUnpopulated = await shouldIncludeUnpopulatedForRequest(req);
 
   const valueToKey = new Map<string, string>();
   for (const opt of ETF_ASSET_CLASS_OPTIONS) {
     if (opt.value !== '') valueToKey.set(opt.value, opt.value);
   }
 
-  return fetchEtfsForGroupings(spaceId, 'assetClass', valueToKey, country);
+  return fetchEtfsForGroupings(spaceId, 'assetClass', valueToKey, country, includeUnpopulated);
 }
 
 export const GET = withErrorHandlingV2<EtfAssetClassesIndexResponse>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/group/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/group/route.ts
@@ -5,6 +5,7 @@ import {
   fetchUncategorizedEtfPreview,
 } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { ETF_OTHERS_GROUP_KEY, getCategoriesForGroupKey, getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
@@ -24,6 +25,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const countryParam = searchParams.get('country')?.trim();
   const country = countryParam && isEtfSupportedCountry(countryParam) ? countryParam : undefined;
   const groupKey = searchParams.get('groupKey')?.trim();
+  const includeUnpopulated = await shouldIncludeUnpopulatedForRequest(req);
 
   if (!groupKey) {
     return { found: false, values: {}, counts: {}, others: null };
@@ -35,13 +37,13 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   }
 
   if (groupObj.key === ETF_OTHERS_GROUP_KEY) {
-    const others = await fetchUncategorizedEtfPreview(spaceId, country);
+    const others = await fetchUncategorizedEtfPreview(spaceId, country, includeUnpopulated);
     return { found: true, values: {}, counts: {}, others };
   }
 
   const categories = getCategoriesForGroupKey(groupObj.key);
   const categoryNames = categories.map((c) => c.name);
-  const { values, counts } = await fetchAllEtfsByCategory(spaceId, categoryNames, country);
+  const { values, counts } = await fetchAllEtfsByCategory(spaceId, categoryNames, country, includeUnpopulated);
 
   return { found: true, values, counts, others: null };
 }

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/groups-index/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/groups-index/route.ts
@@ -5,6 +5,7 @@ import {
   fetchUncategorizedEtfPreview,
 } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { getCategoriesForGroupKey, getAllEtfGroups } from '@/utils/etf-categorization-utils';
+import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
@@ -21,6 +22,7 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const { searchParams } = new URL(req.url);
   const countryParam = searchParams.get('country')?.trim();
   const country = countryParam && isEtfSupportedCountry(countryParam) ? countryParam : undefined;
+  const includeUnpopulated = await shouldIncludeUnpopulatedForRequest(req);
 
   const groups = getAllEtfGroups();
 
@@ -34,9 +36,9 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   }
 
   const [byCategory, byGroup, others] = await Promise.all([
-    fetchEtfsForGroupings(spaceId, 'category', categoryValueToKey, country),
-    fetchEtfsForGroupings(spaceId, 'category', groupValueToKey, country),
-    fetchUncategorizedEtfPreview(spaceId, country),
+    fetchEtfsForGroupings(spaceId, 'category', categoryValueToKey, country, includeUnpopulated),
+    fetchEtfsForGroupings(spaceId, 'category', groupValueToKey, country, includeUnpopulated),
+    fetchUncategorizedEtfPreview(spaceId, country, includeUnpopulated),
   ]);
 
   return {

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/listings-prisma.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/listings-prisma.ts
@@ -14,6 +14,14 @@ export type { EtfGroupingPreview, EtfGroupingPreviewItem, EtfProvidersPreview, E
 
 const TOP_N_PER_GROUPING = 5;
 
+/**
+ * A "populated" ETF has a generated report, signalled by the presence of an
+ * `EtfCachedScore` row (the score is the last artifact the generation pipeline
+ * writes). AND-ed into every listing query unless the caller is an admin asking
+ * to include unpopulated ETFs. See `etf-listing-visibility.ts`.
+ */
+const POPULATED_ETF_WHERE = { cachedScore: { isNot: null } } as const;
+
 type GroupingMode = 'category' | 'assetClass';
 
 interface RawEtfRow {
@@ -27,7 +35,13 @@ interface RawEtfRow {
   aum: string | null;
 }
 
-async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: string[], country?: EtfSupportedCountry): Promise<RawEtfRow[]> {
+async function loadRawEtfRows(
+  spaceId: string,
+  mode: GroupingMode,
+  dbValues: string[],
+  country?: EtfSupportedCountry,
+  includeUnpopulated = false
+): Promise<RawEtfRow[]> {
   if (dbValues.length === 0) return [];
 
   const baseWhere =
@@ -35,7 +49,11 @@ async function loadRawEtfRows(spaceId: string, mode: GroupingMode, dbValues: str
       ? { spaceId, stockAnalyzerInfo: { is: { category: { in: dbValues } } } }
       : { spaceId, stockAnalyzerInfo: { is: { assetClass: { in: dbValues } } } };
 
-  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
+  const where = {
+    ...baseWhere,
+    ...(country ? { exchange: { in: getEtfExchangesByCountry(country) } } : {}),
+    ...(includeUnpopulated ? {} : POPULATED_ETF_WHERE),
+  };
 
   const etfs = await prisma.etf.findMany({
     where,
@@ -93,7 +111,8 @@ export async function fetchEtfsForGroupings(
   spaceId: string,
   mode: GroupingMode,
   valueToKey: Map<string, string>,
-  country?: EtfSupportedCountry
+  country?: EtfSupportedCountry,
+  includeUnpopulated = false
 ): Promise<EtfGroupingPreview> {
   if (mode === 'category') {
     const canonicalToBucket = new Map(valueToKey);
@@ -106,7 +125,7 @@ export async function fetchEtfsForGroupings(
   }
 
   const dbValues = Array.from(valueToKey.keys());
-  const rawRows = await loadRawEtfRows(spaceId, mode, dbValues, country);
+  const rawRows = await loadRawEtfRows(spaceId, mode, dbValues, country, includeUnpopulated);
 
   const rowsByKey = new Map<string, RawEtfRow[]>();
   const counts: Record<string, number> = {};
@@ -135,7 +154,12 @@ export async function fetchEtfsForGroupings(
  * Every ETF (no top-N cap) bucketed by category. Used by the group detail page,
  * which lists every ETF in each category packed into columns.
  */
-export async function fetchAllEtfsByCategory(spaceId: string, categoryNames: string[], country?: EtfSupportedCountry): Promise<EtfGroupingPreview> {
+export async function fetchAllEtfsByCategory(
+  spaceId: string,
+  categoryNames: string[],
+  country?: EtfSupportedCountry,
+  includeUnpopulated = false
+): Promise<EtfGroupingPreview> {
   const valueToKey = new Map<string, string>();
   for (const name of categoryNames) valueToKey.set(name, name);
 
@@ -148,7 +172,7 @@ export async function fetchAllEtfsByCategory(spaceId: string, categoryNames: str
   }
 
   const dbValues = Array.from(valueToKey.keys());
-  const rawRows = await loadRawEtfRows(spaceId, 'category', dbValues, country);
+  const rawRows = await loadRawEtfRows(spaceId, 'category', dbValues, country, includeUnpopulated);
 
   const rowsByKey = new Map<string, RawEtfRow[]>();
   const counts: Record<string, number> = {};
@@ -173,12 +197,20 @@ export async function fetchAllEtfsByCategory(spaceId: string, categoryNames: str
 }
 
 /** ETFs whose category is null or whose stockAnalyzerInfo row is missing entirely. */
-export async function fetchUncategorizedEtfPreview(spaceId: string, country?: EtfSupportedCountry): Promise<EtfUncategorizedPreview> {
+export async function fetchUncategorizedEtfPreview(
+  spaceId: string,
+  country?: EtfSupportedCountry,
+  includeUnpopulated = false
+): Promise<EtfUncategorizedPreview> {
   const baseWhere = {
     spaceId,
     OR: [{ stockAnalyzerInfo: { is: null } }, { stockAnalyzerInfo: { is: { category: null } } }],
   };
-  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
+  const where = {
+    ...baseWhere,
+    ...(country ? { exchange: { in: getEtfExchangesByCountry(country) } } : {}),
+    ...(includeUnpopulated ? {} : POPULATED_ETF_WHERE),
+  };
 
   const etfs = await prisma.etf.findMany({
     where,
@@ -208,9 +240,13 @@ export async function fetchUncategorizedEtfPreview(spaceId: string, country?: Et
 }
 
 /** Bucketed by issuer (provider). */
-export async function fetchEtfProvidersForCountry(spaceId: string, country?: EtfSupportedCountry): Promise<EtfProvidersPreview> {
+export async function fetchEtfProvidersForCountry(spaceId: string, country?: EtfSupportedCountry, includeUnpopulated = false): Promise<EtfProvidersPreview> {
   const baseWhere = { spaceId, stockAnalyzerInfo: { is: { issuer: { not: null } } } };
-  const where = country ? { ...baseWhere, exchange: { in: getEtfExchangesByCountry(country) } } : baseWhere;
+  const where = {
+    ...baseWhere,
+    ...(country ? { exchange: { in: getEtfExchangesByCountry(country) } } : {}),
+    ...(includeUnpopulated ? {} : POPULATED_ETF_WHERE),
+  };
 
   const etfs = await prisma.etf.findMany({
     where,

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/providers-index/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/providers-index/route.ts
@@ -1,4 +1,5 @@
 import { EtfProvidersPreview, fetchEtfProvidersForCountry } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
@@ -10,8 +11,9 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const { searchParams } = new URL(req.url);
   const countryParam = searchParams.get('country')?.trim();
   const country = countryParam && isEtfSupportedCountry(countryParam) ? countryParam : undefined;
+  const includeUnpopulated = await shouldIncludeUnpopulatedForRequest(req);
 
-  return fetchEtfProvidersForCountry(spaceId, country);
+  return fetchEtfProvidersForCountry(spaceId, country, includeUnpopulated);
 }
 
 export const GET = withErrorHandlingV2<EtfProvidersIndexResponse>(getHandler);

--- a/insights-ui/src/app/etfs/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/page.tsx
@@ -2,7 +2,8 @@ import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/l
 import EtfAssetClassesIndex from '@/components/etfs/EtfAssetClassesIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfAssetClassesIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfAssetClassesIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
@@ -18,7 +19,7 @@ const EMPTY_ASSET_CLASSES: EtfAssetClassesIndexResponse = { values: {}, counts: 
 async function fetchAssetClassesIndex(country: SupportedCountries): Promise<EtfAssetClassesIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/asset-classes-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfAssetClassesIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfAssetClassesIndexTag(country));
     if (!res.ok) {
       console.error(`fetchAssetClassesIndex failed (${res.status}): ${url}`);
       return EMPTY_ASSET_CLASSES;

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
@@ -1,7 +1,8 @@
 import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
 import EtfAssetClassesIndex from '@/components/etfs/EtfAssetClassesIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfAssetClassesIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfAssetClassesIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
@@ -22,7 +23,7 @@ const EMPTY_ASSET_CLASSES: EtfAssetClassesIndexResponse = { values: {}, counts: 
 async function fetchAssetClassesIndex(country: EtfSupportedCountry): Promise<EtfAssetClassesIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/asset-classes-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfAssetClassesIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfAssetClassesIndexTag(country));
     if (!res.ok) {
       console.error(`fetchAssetClassesIndex failed (${res.status}): ${url}`);
       return EMPTY_ASSET_CLASSES;

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -1,7 +1,8 @@
 import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listings/group/route';
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfGroupDetailTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfGroupDetailTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
@@ -25,7 +26,7 @@ async function fetchGroupDetail(country: EtfSupportedCountry, groupKey: string):
     country
   )}&groupKey=${encodeURIComponent(groupKey)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfGroupDetailTag(country, groupKey)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfGroupDetailTag(country, groupKey));
     if (!res.ok) {
       console.error(`fetchGroupDetail failed (${res.status}): ${url}`);
       return EMPTY_GROUP_DETAIL;

--- a/insights-ui/src/app/etfs/countries/[country]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/page.tsx
@@ -1,7 +1,8 @@
 import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
 import EtfGroupsIndex from '@/components/etfs/EtfGroupsIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfGroupsIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfGroupsIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { generateEtfCountryListingBreadcrumbJsonLd, generateEtfCountryListingMetadata } from '@/utils/etf-metadata-generators';
@@ -27,7 +28,7 @@ const EMPTY_GROUPS_INDEX: EtfGroupsIndexResponse = {
 async function fetchGroupsIndex(country: EtfSupportedCountry): Promise<EtfGroupsIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/groups-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfGroupsIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfGroupsIndexTag(country));
     if (!res.ok) {
       console.error(`fetchGroupsIndex failed (${res.status}): ${url}`);
       return EMPTY_GROUPS_INDEX;

--- a/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
@@ -1,7 +1,8 @@
 import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
 import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfProvidersIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfProvidersIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
@@ -22,7 +23,7 @@ const EMPTY_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values
 async function fetchProvidersIndex(country: EtfSupportedCountry): Promise<EtfProvidersIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/providers-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfProvidersIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfProvidersIndexTag(country));
     if (!res.ok) {
       console.error(`fetchProvidersIndex failed (${res.status}): ${url}`);
       return EMPTY_PROVIDERS_INDEX;

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -2,7 +2,8 @@ import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listing
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfGroupDetailTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfGroupDetailTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
@@ -24,7 +25,7 @@ async function fetchGroupDetail(country: SupportedCountries, groupKey: string): 
     country
   )}&groupKey=${encodeURIComponent(groupKey)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfGroupDetailTag(country, groupKey)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfGroupDetailTag(country, groupKey));
     if (!res.ok) {
       console.error(`fetchGroupDetail failed (${res.status}): ${url}`);
       return EMPTY_GROUP_DETAIL;

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -2,7 +2,8 @@ import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listing
 import EtfGroupsIndex from '@/components/etfs/EtfGroupsIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfGroupsIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfGroupsIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { generateEtfListingBreadcrumbJsonLd, generateEtfListingJsonLd, generateEtfListingMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
@@ -23,7 +24,7 @@ const EMPTY_GROUPS_INDEX: EtfGroupsIndexResponse = {
 async function fetchGroupsIndex(country: SupportedCountries): Promise<EtfGroupsIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/groups-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfGroupsIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfGroupsIndexTag(country));
     if (!res.ok) {
       console.error(`fetchGroupsIndex failed (${res.status}): ${url}`);
       return EMPTY_GROUPS_INDEX;

--- a/insights-ui/src/app/etfs/providers/page.tsx
+++ b/insights-ui/src/app/etfs/providers/page.tsx
@@ -2,7 +2,8 @@ import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/list
 import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfProvidersIndexTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getEtfProvidersIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 
@@ -18,7 +19,7 @@ const EMPTY_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values
 async function fetchProvidersIndex(country: SupportedCountries): Promise<EtfProvidersIndexResponse> {
   const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/providers-index?country=${encodeURIComponent(country)}`;
   try {
-    const res = await fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfProvidersIndexTag(country)] } });
+    const res = await fetchEtfListingsIndex(url, getEtfProvidersIndexTag(country));
     if (!res.ok) {
       console.error(`fetchProvidersIndex failed (${res.status}): ${url}`);
       return EMPTY_PROVIDERS_INDEX;

--- a/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
+++ b/insights-ui/src/components/etfs/CompactEtfGroupingCard.tsx
@@ -1,5 +1,5 @@
+import EtfScoreBadge from '@/components/ui/badges/EtfScoreBadge';
 import type { EtfGroupingPreviewItem } from '@/types/etf/etf-listings-types';
-import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import Link from 'next/link';
 import React from 'react';
 
@@ -28,26 +28,19 @@ export default function CompactEtfGroupingCard({ title, href, totalCount, etfs, 
       {displayedEtfs.length > 0 ? (
         <div className="px-3 py-1">
           <ul className="space-y-1">
-            {displayedEtfs.map((etf) => {
-              const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
-              const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
-
-              return (
-                <li key={etf.id}>
-                  <Link
-                    href={`/etfs/${etf.exchange}/${etf.symbol}`}
-                    prefetch={false}
-                    className="flex items-center gap-1.5 py-1 hover:bg-surface-3 transition-colors rounded px-1 -mx-1"
-                  >
-                    <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
-                      <span className={`${textColorClass} text-xs font-mono`}>{scoreLabel}</span>
-                    </p>
-                    <span className="text-xs font-medium bg-primary text-primary-text ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>
-                    <span className="text-xs text-heading truncate">{etf.name}</span>
-                  </Link>
-                </li>
-              );
-            })}
+            {displayedEtfs.map((etf) => (
+              <li key={etf.id}>
+                <Link
+                  href={`/etfs/${etf.exchange}/${etf.symbol}`}
+                  prefetch={false}
+                  className="flex items-center gap-1.5 py-1 hover:bg-surface-3 transition-colors rounded px-1 -mx-1"
+                >
+                  <EtfScoreBadge score={etf.finalScore} />
+                  <span className="text-xs font-medium bg-primary text-primary-text ml-1.5 px-1.5 py-0.5 rounded">{etf.symbol}</span>
+                  <span className="text-xs text-heading truncate">{etf.name}</span>
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       ) : (

--- a/insights-ui/src/components/etfs/EtfAssetClassesIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfAssetClassesIndex.tsx
@@ -1,5 +1,5 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import EtfGroupingCardGrid from '@/components/etfs/EtfGroupingCardGrid';
 import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
@@ -24,17 +24,16 @@ export default function EtfAssetClassesIndex({ country, data }: EtfAssetClassesI
       switcherSection="asset-classes"
       extraBreadcrumbs={[{ name: 'Asset Classes', href: assetClassesPath, current: true }]}
     >
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
-        {assetClasses.map((opt) => (
-          <CompactEtfGroupingCard
-            key={opt.value}
-            title={opt.label}
-            href={etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(opt.value))}
-            totalCount={data.counts[opt.value] ?? 0}
-            etfs={data.values[opt.value] ?? []}
-          />
-        ))}
-      </div>
+      <EtfGroupingCardGrid
+        columns={3}
+        items={assetClasses.map((opt) => ({
+          key: opt.value,
+          title: opt.label,
+          href: etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(opt.value)),
+          totalCount: data.counts[opt.value] ?? 0,
+          etfs: data.values[opt.value] ?? [],
+        }))}
+      />
     </EtfPageLayout>
   );
 }

--- a/insights-ui/src/components/etfs/EtfCategoryCard.tsx
+++ b/insights-ui/src/components/etfs/EtfCategoryCard.tsx
@@ -1,5 +1,5 @@
+import EtfScoreBadge from '@/components/ui/badges/EtfScoreBadge';
 import type { EtfGroupingPreviewItem } from '@/types/etf/etf-listings-types';
-import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import Link from 'next/link';
 import React from 'react';
 
@@ -29,29 +29,23 @@ export default function EtfCategoryCard({ categoryName, href, etfs, total }: Etf
         {etfLabel}
       </div>
       <ul className="divide-y divide-color flex-1">
-        {etfs.map((etf) => {
-          const { textColorClass, bgColorClass } = getEtfScoreColorClasses(etf.finalScore);
-          const scoreLabel = etf.finalScore !== null ? `${etf.finalScore}/20` : '—';
-          return (
-            <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-surface-3 transition-colors">
-              <Link
-                href={`/etfs/${etf.exchange}/${etf.symbol}`}
-                prefetch={false}
-                className="flex gap-1.5 items-center min-w-0 w-full"
-                aria-label={`View ${etf.name}`}
-                title={etf.name}
-              >
-                <p className={`${textColorClass} px-1 rounded-md ${bgColorClass} bg-opacity-15 hover:bg-opacity-25 w-[46px] text-right shrink-0`}>
-                  <span className={`${textColorClass} font-mono tabular-nums text-right text-xs`}>{scoreLabel}</span>
-                </p>
-                <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-primary text-primary-text self-center shadow-sm shrink-0">
-                  {etf.symbol}
-                </p>
-                <p className="text-sm font-medium text-break break-words text-heading truncate min-w-0 flex-1">{etf.name}</p>
-              </Link>
-            </li>
-          );
-        })}
+        {etfs.map((etf) => (
+          <li key={etf.id} className="px-3 sm:px-4 py-1.5 hover:bg-surface-3 transition-colors">
+            <Link
+              href={`/etfs/${etf.exchange}/${etf.symbol}`}
+              prefetch={false}
+              className="flex gap-1.5 items-center min-w-0 w-full"
+              aria-label={`View ${etf.name}`}
+              title={etf.name}
+            >
+              <EtfScoreBadge score={etf.finalScore} />
+              <p className="whitespace-nowrap rounded-md px-2 py-0.5 text-sm font-medium bg-primary text-primary-text self-center shadow-sm shrink-0">
+                {etf.symbol}
+              </p>
+              <p className="text-sm font-medium text-break break-words text-heading truncate min-w-0 flex-1">{etf.name}</p>
+            </Link>
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/insights-ui/src/components/etfs/EtfGroupingCardGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupingCardGrid.tsx
@@ -1,0 +1,31 @@
+import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import type { EtfGroupingPreviewItem } from '@/types/etf/etf-listings-types';
+import React from 'react';
+
+export interface EtfGroupingCardSpec {
+  key: string;
+  title: string;
+  href: string;
+  totalCount?: number;
+  etfs: EtfGroupingPreviewItem[];
+}
+
+interface EtfGroupingCardGridProps {
+  items: EtfGroupingCardSpec[];
+  /** Max columns at the largest breakpoint: 3 (asset-class / provider indexes) or 4 (groups index). */
+  columns?: 3 | 4;
+}
+
+/** Responsive grid of {@link CompactEtfGroupingCard} preview cards, shared by every ETF grouping index. */
+export default function EtfGroupingCardGrid({ items, columns = 4 }: EtfGroupingCardGridProps): React.JSX.Element {
+  const gridClass =
+    columns === 3 ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6' : 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6';
+
+  return (
+    <div className={gridClass}>
+      {items.map((item) => (
+        <CompactEtfGroupingCard key={item.key} title={item.title} href={item.href} totalCount={item.totalCount} etfs={item.etfs} />
+      ))}
+    </div>
+  );
+}

--- a/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupsIndex.tsx
@@ -1,5 +1,5 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import EtfGroupingCardGrid from '@/components/etfs/EtfGroupingCardGrid';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
 import { ETF_OTHERS_GROUP, getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
@@ -59,17 +59,16 @@ export default function EtfGroupsIndex({ country, data, title, description, swit
               </Link>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6">
-              {categoriesWithEtfs.map((cat) => (
-                <CompactEtfGroupingCard
-                  key={cat.name}
-                  title={cat.name}
-                  href={etfGroupCategoryPath(country, group.key, cat.name)}
-                  totalCount={categoryCounts[cat.name] ?? 0}
-                  etfs={categoryValues[cat.name] ?? []}
-                />
-              ))}
-            </div>
+            <EtfGroupingCardGrid
+              columns={4}
+              items={categoriesWithEtfs.map((cat) => ({
+                key: cat.name,
+                title: cat.name,
+                href: etfGroupCategoryPath(country, group.key, cat.name),
+                totalCount: categoryCounts[cat.name] ?? 0,
+                etfs: categoryValues[cat.name] ?? [],
+              }))}
+            />
           </div>
         );
       })}
@@ -87,15 +86,18 @@ export default function EtfGroupsIndex({ country, data, title, description, swit
               <span className="ml-1">→</span>
             </Link>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6">
-            <CompactEtfGroupingCard
-              key={ETF_OTHERS_GROUP.key}
-              title={ETF_OTHERS_GROUP.name}
-              href={etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key)}
-              totalCount={others.count}
-              etfs={others.items}
-            />
-          </div>
+          <EtfGroupingCardGrid
+            columns={4}
+            items={[
+              {
+                key: ETF_OTHERS_GROUP.key,
+                title: ETF_OTHERS_GROUP.name,
+                href: etfBrowseDetailPath(country, 'groups', ETF_OTHERS_GROUP.key),
+                totalCount: others.count,
+                etfs: others.items,
+              },
+            ]}
+          />
         </div>
       )}
     </EtfPageLayout>

--- a/insights-ui/src/components/etfs/EtfListingGrid.tsx
+++ b/insights-ui/src/components/etfs/EtfListingGrid.tsx
@@ -1,8 +1,8 @@
 import { EtfListingResponse, EtfListingItem } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import { formatPercentageDecimal } from '@/components/reportsv1/financialFormatters';
 import EmptyStateCard from '@/components/ui/EmptyStateCard';
+import EtfScoreBadge from '@/components/ui/badges/EtfScoreBadge';
 import { getEtfGroupKey } from '@/utils/etf-categorization-utils';
-import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import Link from 'next/link';
 import React, { use } from 'react';
 import EtfPagination from './EtfPagination';
@@ -60,8 +60,6 @@ function pickThirdMetric(etf: EtfListingItem): ThirdMetric {
 function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
   const third = pickThirdMetric(etf);
   const score = etf.finalScore;
-  const { textColorClass, bgColorClass } = getEtfScoreColorClasses(score);
-  const showScore = score !== null;
 
   return (
     <Link
@@ -75,14 +73,7 @@ function EtfCard({ etf }: { etf: EtfListingItem }): JSX.Element {
           <span className="text-xs text-muted">{etf.exchange}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {showScore && (
-            <span
-              className={`${textColorClass} px-1.5 rounded-md ${bgColorClass} bg-opacity-15 text-xs font-mono tabular-nums`}
-              title={`KoalaGains score: ${score}/20`}
-            >
-              {score}/20
-            </span>
-          )}
+          {score !== null && <EtfScoreBadge score={score} variant="inline" />}
           {etf.payoutFrequency && <span className="text-xs text-muted bg-surface-2 px-2 py-0.5 rounded">{etf.payoutFrequency}</span>}
         </div>
       </div>

--- a/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
@@ -1,5 +1,5 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import CompactEtfGroupingCard from '@/components/etfs/CompactEtfGroupingCard';
+import EtfGroupingCardGrid from '@/components/etfs/EtfGroupingCardGrid';
 import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
@@ -26,17 +26,16 @@ export default function EtfProvidersIndex({ country, data }: EtfProvidersIndexPr
       {providers.length === 0 ? (
         <p className="text-[#E5E7EB] text-md">No providers available for {displayName} ETFs.</p>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
-          {providers.map((provider) => (
-            <CompactEtfGroupingCard
-              key={provider}
-              title={provider}
-              href={etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider))}
-              totalCount={counts[provider] ?? 0}
-              etfs={values[provider] ?? []}
-            />
-          ))}
-        </div>
+        <EtfGroupingCardGrid
+          columns={3}
+          items={providers.map((provider) => ({
+            key: provider,
+            title: provider,
+            href: etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider)),
+            totalCount: counts[provider] ?? 0,
+            etfs: values[provider] ?? [],
+          }))}
+        />
       )}
     </EtfPageLayout>
   );

--- a/insights-ui/src/components/ui/badges/EtfScoreBadge.tsx
+++ b/insights-ui/src/components/ui/badges/EtfScoreBadge.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+import { getEtfScoreColorClasses } from '@/utils/score-utils';
+import { cva } from 'class-variance-authority';
+import React from 'react';
+
+interface EtfScoreBadgeProps {
+  /** KoalaGains final score (0–20); `null` renders a neutral em-dash. */
+  score: number | null;
+  /** `row` = fixed-width right-aligned pill (grouping-card lists); `inline` = compact pill (filterable grid header). */
+  variant?: 'row' | 'inline';
+  className?: string;
+}
+
+const etfScoreBadge = cva('rounded-md bg-opacity-15 font-mono tabular-nums text-xs', {
+  variants: {
+    variant: {
+      row: 'px-1 w-[46px] text-right shrink-0 hover:bg-opacity-25',
+      inline: 'px-1.5',
+    },
+  },
+  defaultVariants: { variant: 'row' },
+});
+
+/** Single source of truth for the per-ETF score pill (color + label). */
+export default function EtfScoreBadge({ score, variant = 'row', className }: EtfScoreBadgeProps): React.JSX.Element {
+  const { textColorClass, bgColorClass } = getEtfScoreColorClasses(score);
+  const label = score !== null ? `${score}/20` : '—';
+  const title = score !== null ? `KoalaGains score: ${score}/20` : undefined;
+
+  return (
+    <span title={title} className={cn(etfScoreBadge({ variant }), textColorClass, bgColorClass, className)}>
+      {label}
+    </span>
+  );
+}

--- a/insights-ui/src/components/ui/badges/EtfScoreBadge.tsx
+++ b/insights-ui/src/components/ui/badges/EtfScoreBadge.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@/lib/utils';
 import { getEtfScoreColorClasses } from '@/utils/score-utils';
 import { cva } from 'class-variance-authority';
 import React from 'react';
@@ -27,8 +26,15 @@ export default function EtfScoreBadge({ score, variant = 'row', className }: Etf
   const label = score !== null ? `${score}/20` : '—';
   const title = score !== null ? `KoalaGains score: ${score}/20` : undefined;
 
+  // NOTE: do NOT route these classes through `cn`/tailwind-merge. The faint-pill
+  // look relies on `bg-opacity-15` sitting alongside a dynamic `bg-{color}`;
+  // tailwind-merge treats them as conflicting and drops `bg-opacity-15`, which
+  // makes the pill fully opaque and hides the same-colored text until hover.
+  // Plain concatenation preserves the original (and JIT-safe) class pairing.
+  const classes = [etfScoreBadge({ variant }), textColorClass, bgColorClass, className].filter(Boolean).join(' ');
+
   return (
-    <span title={title} className={cn(etfScoreBadge({ variant }), textColorClass, bgColorClass, className)}>
+    <span title={title} className={classes}>
       {label}
     </span>
   );

--- a/insights-ui/src/utils/etf-data-utils.ts
+++ b/insights-ui/src/utils/etf-data-utils.ts
@@ -2,9 +2,11 @@ import { EtfListingResponse } from '@/app/api/[spaceId]/etfs-v1/listing/route';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { hasEtfFiltersApplied, hasEtfSortApplied, etfToSortedQueryString, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfListingFilterableTag, TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { INCLUDE_UNPOPULATED_PARAM, isEtfAdminViewer } from '@/utils/etf-listing-visibility';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { headers } from 'next/headers';
 
 /**
  * Fetch the filter-aware listing data for category/asset-class/provider/country-root
@@ -18,17 +20,29 @@ export async function fetchEtfListingData(searchParams?: EtfSearchParams, countr
   const sortApplied = hasEtfSortApplied(searchParams);
   const hasPageOrFilters = filters || sortApplied || (searchParams?.page && searchParams.page !== '1');
 
+  // Admins see every ETF (including ones without a generated report); everyone
+  // else sees only populated ETFs. The admin path is cookie-authenticated and
+  // uncached so the full set is never cached under the public key.
+  const isAdmin = await isEtfAdminViewer();
+
   const baseUrlPath = `${baseUrl}/api/${KoalaGainsSpaceId}/etfs-v1/listing`;
   const qsParts: string[] = [];
   if (hasPageOrFilters && searchParams) qsParts.push(etfToSortedQueryString(searchParams));
   if (country) qsParts.push(`country=${encodeURIComponent(country)}`);
+  if (isAdmin) qsParts.push(`${INCLUDE_UNPOPULATED_PARAM}=true`);
   const qs = qsParts.filter(Boolean).join('&');
   const url = qs ? `${baseUrlPath}?${qs}` : baseUrlPath;
 
   const tagCountry = country ?? SupportedCountries.US;
-  const cacheConfig = hasPageOrFilters
-    ? { next: { revalidate: 0 as const } }
-    : { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfListingFilterableTag(tagCountry)] } };
+  let cacheConfig: RequestInit & { next?: { revalidate?: number; tags?: string[] } };
+  if (isAdmin) {
+    const cookieHeader = (await headers()).get('cookie');
+    cacheConfig = { cache: 'no-store', headers: cookieHeader ? { cookie: cookieHeader } : {} };
+  } else if (hasPageOrFilters) {
+    cacheConfig = { next: { revalidate: 0 } };
+  } else {
+    cacheConfig = { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [getEtfListingFilterableTag(tagCountry)] } };
+  }
 
   try {
     const res = await fetch(url, cacheConfig);

--- a/insights-ui/src/utils/etf-listing-visibility.ts
+++ b/insights-ui/src/utils/etf-listing-visibility.ts
@@ -1,0 +1,65 @@
+import { authOptions } from '@/app/api/auth/[...nextauth]/authOptions';
+import { KoalaGainsSession } from '@/types/auth';
+import { TWO_WEEKS_IN_SECONDS } from '@/utils/etf-cache-utils';
+import { getServerSession } from 'next-auth/next';
+import { headers } from 'next/headers';
+import { NextRequest } from 'next/server';
+
+/**
+ * ETF listing visibility rule (shared across every listing surface).
+ *
+ * A "populated" ETF is one that has a generated report — i.e. an `EtfCachedScore`
+ * row exists. The score is the last thing the generation pipeline writes (it is
+ * derived from the per-category `EtfCategoryAnalysisResult` rows), so its presence
+ * is the single most efficient and accurate signal that an ETF has real data.
+ *
+ * - Default (logged-out + non-admin users): only populated ETFs are listed.
+ * - Admins: see every ETF, including ones without a generated report — same as the
+ *   listing behaved before this filter was introduced.
+ *
+ * Unpopulated ETFs stay reachable by direct URL; this only filters the listings.
+ *
+ * The `includeUnpopulated=true` request flag is honored ONLY for admins. The page
+ * (a Server Component that can read the session cookie) decides admin-ness and
+ * forwards the cookie so the API route can independently re-verify. If that
+ * re-verification ever fails, admins simply fall back to the populated-only view —
+ * a safe default that never leaks unpopulated ETFs to non-admins.
+ */
+export const INCLUDE_UNPOPULATED_PARAM = 'includeUnpopulated';
+
+/** True when the current request's session belongs to an Admin. Safe in both
+ *  Server Components and Route Handlers (reads cookies from the ambient request). */
+export async function isEtfAdminViewer(): Promise<boolean> {
+  const session = (await getServerSession(authOptions)) as KoalaGainsSession | null;
+  return session?.role === 'Admin';
+}
+
+/**
+ * Admin-aware fetch for the cached ETF listings index/grouping endpoints.
+ * - Non-admin: the existing cached fetch (2-week revalidate + cache tag), which
+ *   returns populated-only data.
+ * - Admin: an uncached, cookie-authenticated fetch with `includeUnpopulated=true`
+ *   so the full set is never cached under the public key.
+ */
+export async function fetchEtfListingsIndex(url: string, tag: string): Promise<Response> {
+  if (await isEtfAdminViewer()) {
+    const cookieHeader = (await headers()).get('cookie');
+    const sep = url.includes('?') ? '&' : '?';
+    return fetch(`${url}${sep}${INCLUDE_UNPOPULATED_PARAM}=true`, {
+      cache: 'no-store',
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+  }
+  return fetch(url, { next: { revalidate: TWO_WEEKS_IN_SECONDS, tags: [tag] } });
+}
+
+/**
+ * Route-side check: returns true only when the request asked for unpopulated ETFs
+ * (`includeUnpopulated=true`) AND the session is an admin. Anything else resolves
+ * to false, so the populated-only filter is applied.
+ */
+export async function shouldIncludeUnpopulatedForRequest(req: NextRequest): Promise<boolean> {
+  const { searchParams } = new URL(req.url);
+  if (searchParams.get(INCLUDE_UNPOPULATED_PARAM) !== 'true') return false;
+  return isEtfAdminViewer();
+}


### PR DESCRIPTION
## What

ETF listing surfaces now show only **populated** ETFs — those that have a generated report — for logged-out and non-admin users. **Admins still see every ETF** (including ones without a report), exactly as the listings behaved before.

## "Populated" = has an `EtfCachedScore`

The final score is the last artifact the generation pipeline writes (derived from the per-category `EtfCategoryAnalysisResult` rows), so its presence is the single most efficient + accurate "has real data" signal. The filter is one indexed relation-existence check: `cachedScore: { isNot: null }`. No multi-table fan-out.

## How (centralized in `src/utils/etf-listing-visibility.ts`)

- `isEtfAdminViewer()` — `session.role === 'Admin'` via `getServerSession` (works in Server Components + Route Handlers).
- `fetchEtfListingsIndex(url, tag)` — admin-aware fetch for the cached index/grouping endpoints. Non-admins keep the existing cached fetch (2-week revalidate + tag, populated-only). Admins get an **uncached, cookie-authenticated** request with `includeUnpopulated=true` so the full set is never cached under the public key.
- `shouldIncludeUnpopulatedForRequest(req)` — route-side guard: honors `includeUnpopulated` **only** when the (cookie-forwarded) session is an admin; otherwise falls back to populated-only. Safe by default — never leaks unpopulated ETFs to non-admins.

The `cachedScore` predicate is applied at the **data layer**:
- `listings-prisma.ts` — `fetchEtfsForGroupings`, `fetchAllEtfsByCategory`, `fetchUncategorizedEtfPreview`, `fetchEtfProvidersForCountry` (so counts match rendered rows).
- `listing/route.ts` — the filterable table (when no explicit score filter is already applied).

The 4 `/listings/*` routes parse the admin flag; the 8 index pages call `fetchEtfListingsIndex`; `fetchEtfListingData` is admin-aware internally so all detail/`etfs-filtered` pages inherit the behavior without per-page changes.

## Notes
- Unpopulated ETFs stay reachable by **direct URL** (no 404) — this only filters the listings/counts.
- The "others"/uncategorized bucket naturally collapses to ~empty for non-admins (those ETFs rarely have a score), which is the desired effect.

## Verification
`pnpm tsc` (typecheck), `next lint`, and `prettier --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)