### PR TITLE
etf-prompts: mark factorAnalysisArray section mandatory

### DIFF
--- a/insights-ui/etf-prompts/cost-efficiency-team.md
+++ b/insights-ui/etf-prompts/cost-efficiency-team.md
@@ -82,7 +82,7 @@ The per-factor description carries the generic measurement principle and Pass/Fa
 
 If a factor's core metric is absent, first try the "Factor-metric lookup" rule. If still unavailable, judge from the closest related evidence — do not Fail on one missing secondary data point.
 
-## 4. For each item in `factorAnalysisArray` produce
+## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
 - `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: expense_ratio_vs_competition). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway.

--- a/insights-ui/etf-prompts/future-performance-outlook.md
+++ b/insights-ui/etf-prompts/future-performance-outlook.md
@@ -115,7 +115,7 @@ Cross-cutting rules:
 
 If a factor’s core metric is missing, use the lookup rule first; otherwise judge conservatively using the closest related evidence.
 
-## 4. For each item in `factorAnalysisArray` produce
+## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
 - `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: short_term_hold_outlook). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
 - `oneLineExplanation` — one sentence with the clearest investor takeaway.

--- a/insights-ui/etf-prompts/past-returns.md
+++ b/insights-ui/etf-prompts/past-returns.md
@@ -72,7 +72,7 @@ Two cross-cutting reminders that apply on top of every factor:
 - **Missing-data discipline**: if a factor's core metric is absent, first try the “Factor-metric lookup” section. If still unavailable, make a conservative call using the closest related evidence from the provided data blocks. Do not Fail a factor only because one secondary data point is missing.
 - **Young funds (< 3 years)**: only judge on the periods actually available; don't Fail for missing long-window metrics.
 
-## 4. For each item in `factorAnalysisArray` produce
+## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
 - `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: historical_long_term_returns). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway.

--- a/insights-ui/etf-prompts/risk-analysis.md
+++ b/insights-ui/etf-prompts/risk-analysis.md
@@ -81,7 +81,7 @@ The per-factor description carries the generic measurement principle and Pass/Fa
 
 If a factor's core metric is absent, first try the "Factor-metric lookup" rule. If still unavailable, judge from the closest related evidence — do not Fail on one missing secondary data point.
 
-## 4. For each item in `factorAnalysisArray` produce
+## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
 - `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: risk_adjusted_return). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
 - `oneLineExplanation` — one sentence with the clearest takeaway, stated in terms a retail reader can act on (not a metric definition).


### PR DESCRIPTION
## Problem

Some ETF generation requests fail at DB-save time, most often for the **FuturePerformanceOutlook** report type. Example error:

```
ETF SH (NYSEARCA) FuturePerformanceOutlook: expected 5 factor result(s) but got 0 valid (LLM returned 3). Aborting save to avoid persisting an incomplete report.
```

Even though the correct analysis factors are passed in the prompt, the LLM sometimes returns fewer factor results than requested and/or generic factor keys, so the save validation rejects the report.

## Change

Append `(VERY IMPORTANT AND MANDATORY)` to the `## 4. For each item in \`factorAnalysisArray\` produce` heading in all four affected prompts to push the model to return a result for **every** input factor using the **exact** input keys:

- `insights-ui/etf-prompts/cost-efficiency-team.md`
- `insights-ui/etf-prompts/future-performance-outlook.md`
- `insights-ui/etf-prompts/past-returns.md`
- `insights-ui/etf-prompts/risk-analysis.md`

Markdown-only change; no TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)