### PR TITLE
etf-prompts: mark factorAnalysisKey mandatory in input factor block

### DIFF
--- a/insights-ui/etf-prompts/cost-efficiency-team.md
+++ b/insights-ui/etf-prompts/cost-efficiency-team.md
@@ -84,7 +84,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 ## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
-- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: expense_ratio_vs_competition). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
+- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: expense_ratio_vs_competition). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form. (VERY IMPORTANT AND MANDATORY)
 - `oneLineExplanation` — one sentence with the clearest takeaway.
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per the factor's own description and Section 3.

--- a/insights-ui/etf-prompts/cost-efficiency-team.md
+++ b/insights-ui/etf-prompts/cost-efficiency-team.md
@@ -103,7 +103,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 {{#each factorAnalysisArray}}
 
 #### Title: {{factorAnalysisTitle}}
-- Key: {{factorAnalysisKey}}
+- Key: {{factorAnalysisKey}} (VERY IMPORTANT AND MANDATORY)
 - Description: {{factorAnalysisDescription}}
 {{#if factorAnalysisGroupInstructions}}- Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
 {{/if}}- Metrics (if available): {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/future-performance-outlook.md
+++ b/insights-ui/etf-prompts/future-performance-outlook.md
@@ -117,7 +117,7 @@ If a factor’s core metric is missing, use the lookup rule first; otherwise jud
 
 ## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
-- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: short_term_hold_outlook). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
+- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: short_term_hold_outlook). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form. (VERY IMPORTANT AND MANDATORY)
 - `oneLineExplanation` — one sentence with the clearest investor takeaway.
 - `detailedExplanation` — one short paragraph that applies the factor’s bar to THIS ETF. Use the listed metrics and any strongly relevant input field or lookup result. Anchor conclusions with at least one concrete detail.
 - `result` — `"Pass"` or `"Fail"` per Section 3 and the factor’s own description.

--- a/insights-ui/etf-prompts/future-performance-outlook.md
+++ b/insights-ui/etf-prompts/future-performance-outlook.md
@@ -155,7 +155,7 @@ Shorter horizons are inherently less certain than the 5-year figure — be more 
 {{#each factorAnalysisArray}}
 
 #### Title: {{factorAnalysisTitle}}
-- Key: {{factorAnalysisKey}}
+- Key: {{factorAnalysisKey}} (VERY IMPORTANT AND MANDATORY)
 - Description: {{factorAnalysisDescription}}
 {{#if factorAnalysisGroupInstructions}}- Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
 {{/if}}- Metrics (if available): {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/past-returns.md
+++ b/insights-ui/etf-prompts/past-returns.md
@@ -116,7 +116,7 @@ When the factor carries a `factorAnalysisGroupInstructions` string, treat it as 
 {{#each factorAnalysisArray}}
 
 #### Title: {{factorAnalysisTitle}}
-- Key: {{factorAnalysisKey}}
+- Key: {{factorAnalysisKey}} (VERY IMPORTANT AND MANDATORY)
 - Description: {{factorAnalysisDescription}}
 {{#if factorAnalysisGroupInstructions}}- Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
 {{/if}}- Metrics (if available): {{factorAnalysisMetrics}}

--- a/insights-ui/etf-prompts/past-returns.md
+++ b/insights-ui/etf-prompts/past-returns.md
@@ -74,7 +74,7 @@ Two cross-cutting reminders that apply on top of every factor:
 
 ## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
-- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: historical_long_term_returns). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
+- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: historical_long_term_returns). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form. (VERY IMPORTANT AND MANDATORY)
 - `oneLineExplanation` — one sentence with the clearest takeaway.
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per Section 3.

--- a/insights-ui/etf-prompts/risk-analysis.md
+++ b/insights-ui/etf-prompts/risk-analysis.md
@@ -83,7 +83,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 
 ## 4. For each item in `factorAnalysisArray` produce (VERY IMPORTANT AND MANDATORY)
 
-- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: risk_adjusted_return). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form.
+- `factorAnalysisKey` — use the exact snake_case key from the matching input factor block (for example: risk_adjusted_return). Output the raw key as plain text — no backticks or other markdown, and never the bolded title or a rephrased form. (VERY IMPORTANT AND MANDATORY)
 - `oneLineExplanation` — one sentence with the clearest takeaway, stated in terms a retail reader can act on (not a metric definition).
 - `detailedExplanation` — one short paragraph. Use the metrics listed in `factorAnalysisMetrics` and any other strongly relevant input field. Every conclusion needs a numeric anchor. Every cited metric must sit next to a peer / category / benchmark comparison number plus a plain-English direction word (`better than`, `in line with`, `worse than`, `above`, `below`) — never leave a Sharpe, drawdown, capture, or risk score stranded. Close with one clause translating the `Pass` / `Fail` into what it means for an investor holding this fund (e.g. "Pass here means the fund is delivering the promised decorrelation", "Fail here means the fund's fate is tethered to a handful of mega-cap names"). If the factor is a weak fit for this ETF, say so and judge on the closest relevant evidence rather than forcing a Fail.
 - `result` — `"Pass"` or `"Fail"` per the factor's own description and Section 3.

--- a/insights-ui/etf-prompts/risk-analysis.md
+++ b/insights-ui/etf-prompts/risk-analysis.md
@@ -107,7 +107,7 @@ If a factor's core metric is absent, first try the "Factor-metric lookup" rule. 
 {{#each factorAnalysisArray}}
 
 #### Title: {{factorAnalysisTitle}}
-- Key: {{factorAnalysisKey}}
+- Key: {{factorAnalysisKey}} (VERY IMPORTANT AND MANDATORY)
 - Description: {{factorAnalysisDescription}}
 {{#if factorAnalysisGroupInstructions}}- Group-specific perspective ({{../groupKey}}): {{factorAnalysisGroupInstructions}}
 {{/if}}- Metrics (if available): {{factorAnalysisMetrics}}


### PR DESCRIPTION
Follow-up to #1634 (already merged).

## Change

Append `(VERY IMPORTANT AND MANDATORY)` after `{{factorAnalysisKey}}` on the `- Key:` line of the per-factor input block in all four ETF analysis prompts, reinforcing that the LLM must echo the exact input key for **every** factor (the same failure mode #1634 addressed in the output-section heading).

Files:
- `insights-ui/etf-prompts/cost-efficiency-team.md`
- `insights-ui/etf-prompts/future-performance-outlook.md`
- `insights-ui/etf-prompts/past-returns.md`
- `insights-ui/etf-prompts/risk-analysis.md`

Markdown-only change; no TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)