### PR TITLE
fix(etfs): keep active listing when switching countries on ETF listing pages

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -178,6 +178,10 @@ Remaining:
 
 ## Stocks & ETFs common
 
+### SEO — soft 404 on empty country listing pages
+
+- [ ] Empty country+industry (stocks) and country+group/category, asset-class, provider (ETFs) listing pages return 200 + thin content → soft 404 in GSC. Emit `robots: { index: false, follow: true }` when the listing has zero results (pattern: `crowd-funding/projects/[projectId]/page.tsx`). Low priority — currently mitigated by dropping these URLs from the sitemap.
+
 ### Trends page
 
 > Decide once: shared `Trend` model linked to both stock and ETF join tables, or parallel

--- a/insights-ui/src/components/etfs/EtfAssetClassDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfAssetClassDetail.tsx
@@ -32,6 +32,7 @@ export default async function EtfAssetClassDetail({ country, assetClass, searchP
       description={`Explore ${displayCountry} ETFs in the ${displayAssetClass} asset class with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
       currentCountry={country}
       switcherSection="asset-classes"
+      switcherHref={(c) => etfBrowseDetailPath(c, 'asset-classes', slugifyEtfTag(filterValue))}
       extraBreadcrumbs={[
         { name: 'All Asset Classes', href: etfBrowsePath(country, 'asset-classes'), current: false },
         { name: displayAssetClass, href: etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(filterValue)), current: true },

--- a/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
+++ b/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
@@ -6,10 +6,17 @@ import { ALL_ETF_COUNTRIES, EtfBrowseSection, etfBasePath, etfCountryDisplayName
 interface EtfCountryAlternativesProps {
   currentCountry: EtfSupportedCountry;
   section?: EtfBrowseSection;
+  /**
+   * Builds the destination path for a given country. Detail listing pages (a specific group,
+   * category, asset class, or provider) pass this so the switcher links to the *same* listing in
+   * the other country (e.g. `/etfs/countries/Canada/groups/broad-equity/categories/large-value`)
+   * instead of just the section index. When omitted we fall back to the section index path.
+   */
+  buildHref?: (country: EtfSupportedCountry) => string;
   className?: string;
 }
 
-export default function EtfCountryAlternatives({ currentCountry, section, className = '' }: EtfCountryAlternativesProps) {
+export default function EtfCountryAlternatives({ currentCountry, section, buildHref, className = '' }: EtfCountryAlternativesProps) {
   const alternatives = ALL_ETF_COUNTRIES.filter((c) => c !== currentCountry);
   if (alternatives.length === 0) return null;
 
@@ -21,7 +28,7 @@ export default function EtfCountryAlternatives({ currentCountry, section, classN
       </div>
       <div className="flex flex-wrap gap-2 sm:ml-2">
         {alternatives.map((country, index) => {
-          const href = section ? etfSectionIndexPath(country, section) : etfBasePath(country);
+          const href = buildHref ? buildHref(country) : section ? etfSectionIndexPath(country, section) : etfBasePath(country);
           return (
             <span key={country} className="inline-flex items-center">
               <Link href={href} prefetch={false} className="text-blue-400 hover:text-blue-300 transition-colors duration-200 font-semibold">

--- a/insights-ui/src/components/etfs/EtfGroupCategoryDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupCategoryDetail.tsx
@@ -43,6 +43,7 @@ export default async function EtfGroupCategoryDetail({ country, groupKey, catego
       description={`Explore ${displayCountry} ETFs in the ${knownCategory.name} category (part of ${groupObj.name}) with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
       currentCountry={country}
       switcherSection="groups"
+      switcherHref={(c) => etfGroupCategoryPath(c, groupObj.key, knownCategory.name)}
       extraBreadcrumbs={[
         { name: groupObj.name, href: etfBrowseDetailPath(country, 'groups', groupObj.key), current: false },
         { name: knownCategory.name, href: etfGroupCategoryPath(country, groupObj.key, knownCategory.name), current: true },

--- a/insights-ui/src/components/etfs/EtfGroupDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfGroupDetail.tsx
@@ -53,6 +53,7 @@ export default function EtfGroupDetail({ country, groupKey, data }: EtfGroupDeta
       description={groupObj.description}
       currentCountry={country}
       switcherSection="groups"
+      switcherHref={(c) => etfBrowseDetailPath(c, 'groups', groupObj.key)}
       extraBreadcrumbs={[{ name: groupObj.name, href: etfBrowseDetailPath(country, 'groups', groupObj.key), current: true }]}
     >
       <EtfCategoriesGrid categories={cardSpecs} emptyMessage={`No ${displayCountry} ETFs found in the ${groupObj.name} group.`} />

--- a/insights-ui/src/components/etfs/EtfPageLayout.tsx
+++ b/insights-ui/src/components/etfs/EtfPageLayout.tsx
@@ -18,6 +18,8 @@ interface EtfPageLayoutProps {
   extraBreadcrumbs?: BreadcrumbsOjbect[];
   currentCountry?: EtfSupportedCountry;
   switcherSection?: EtfBrowseSection;
+  /** Builds the country-switcher href for a given country; lets detail pages keep the active listing when switching countries. */
+  switcherHref?: (country: EtfSupportedCountry) => string;
   children: ReactNode;
 }
 
@@ -37,6 +39,7 @@ export default function EtfPageLayout({
   extraBreadcrumbs,
   currentCountry = SupportedCountries.US,
   switcherSection,
+  switcherHref,
   children,
 }: EtfPageLayoutProps) {
   const breadcrumbs = buildBreadcrumbs(currentCountry, extraBreadcrumbs);
@@ -64,7 +67,7 @@ export default function EtfPageLayout({
         <h1 className="text-2xl font-bold text-white mb-4">{title}</h1>
         <p className="text-[#E5E7EB] text-md mb-4">{description}</p>
         <div className="mt-2 mb-2">
-          <EtfCountryAlternatives currentCountry={currentCountry} section={switcherSection} className="text-sm" />
+          <EtfCountryAlternatives currentCountry={currentCountry} section={switcherSection} buildHref={switcherHref} className="text-sm" />
         </div>
       </div>
 

--- a/insights-ui/src/components/etfs/EtfProviderDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfProviderDetail.tsx
@@ -29,6 +29,7 @@ export default async function EtfProviderDetail({ country, provider, searchParam
       description={`Explore ${displayCountry} ETFs issued by ${provider} with detailed financial metrics, expense ratios, dividend analysis, and AI-driven insights.`}
       currentCountry={country}
       switcherSection="providers"
+      switcherHref={(c) => etfBrowseDetailPath(c, 'providers', slugifyEtfTag(provider))}
       extraBreadcrumbs={[
         { name: 'All Providers', href: etfBrowsePath(country, 'providers'), current: false },
         { name: provider, href: etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider)), current: true },


### PR DESCRIPTION
## Problem

On ETF *detail* listing pages, the **"Also view"** country switcher dropped the active filter when switching countries:

| Page | Old destination | Expected |
|------|-----------------|----------|
| `/etfs/groups/broad-equity/categories/large-value` | `/etfs/countries/Canada` | `/etfs/countries/Canada/groups/broad-equity/categories/large-value` |
| `/etfs/asset-classes/fixed-income` | `/etfs/countries/Canada/asset-classes` | `/etfs/countries/Canada/asset-classes/fixed-income` |
| `/etfs/providers/blackrock` | `/etfs/countries/Canada/providers` | `/etfs/countries/Canada/providers/blackrock` |

`EtfCountryAlternatives` only knew the *section* (groups / asset-classes / providers), so it could only link to that section's index in the other country.

## Fix

Added an optional `switcherHref(country) => string` builder threaded through `EtfPageLayout` → `EtfCountryAlternatives`. Each detail page now supplies it using the existing country-aware route utils:

- **EtfGroupCategoryDetail** → `etfGroupCategoryPath(c, group, category)`
- **EtfGroupDetail** → `etfBrowseDetailPath(c, 'groups', group)`
- **EtfAssetClassDetail** → `etfBrowseDetailPath(c, 'asset-classes', slug)`
- **EtfProviderDetail** → `etfBrowseDetailPath(c, 'providers', slug)`

Index pages keep the existing section-index fallback (unchanged). All four target country routes already exist, so the links resolve to the corresponding country-scoped listing (which may be empty where that country has no matching ETFs — sitemap handling to be done separately).

## Checks
`yarn lint` ✅ · `yarn prettier-check` ✅ · `yarn compile` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)