### PR TITLE
feat(stocks): in-process background generation of stock reports (USE_LAMBDA_FOR_LLM_RESPONSE)

### DIFF
--- a/deployments/insights-ui/variables.tf
+++ b/deployments/insights-ui/variables.tf
@@ -149,6 +149,11 @@ variable "app_env" {
     CLOUDFRONT_DISTRIBUTION_ID = "EZI5H8FKNE9R1"
     # Lambda report-generation callbacks should return to this AWS host in Phase A.
     REPORT_GENERATION_CALLBACK_BASE_URL = "https://prod.koalagains.com"
+    # "true" runs stock report generation in-process in the background on this
+    # Lightsail server (no AWS Lambda hop, no CloudFront-origin timeout); the LLM
+    # call is detached and saves directly. unset/"false" keeps offloading to the
+    # llm-call-with-callback Lambda. See src/utils/analysis-reports/llm-callback-lambda-utils.ts.
+    USE_LAMBDA_FOR_LLM_RESPONSE = "true"
     # The app's pino→CloudWatch transport ships structured JSON logs here (§17).
     CLOUDWATCH_LOG_GROUP = "/insights-ui/app"
     AWS_REGION_LOGS      = "us-east-1"

--- a/insights-ui/.env.example
+++ b/insights-ui/.env.example
@@ -39,6 +39,8 @@ GEMINI_MODEL=
 LLM_PROVIDER=
 ## Tariff generation: "true" runs each section in the background (returns fast, no 504); unset/false runs it synchronously (old behavior).
 USE_LAMBDA_FOR_TARIFF_LLM_RESPONSE=
+## Stock report generation: "true" runs the LLM call in-process in the background on this server (Lightsail); unset/false offloads to the AWS Lambda (old behavior).
+USE_LAMBDA_FOR_LLM_RESPONSE=
 ## fetching information lambdas:
 STOCK_ANALYZER_LAMBDA_URL=
 SCREENER_API_URL=

--- a/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-report-callback/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-report-callback/route.ts
@@ -1,18 +1,4 @@
-import { prisma } from '@/prisma';
-import { InvestorTypes, ReportType, TickerAnalysisCategory } from '@/types/ticker-typesv1';
-import { triggerGenerationOfAReportSimplified } from '@/utils/analysis-reports/generation-report-utils';
-import { calculatePendingSteps } from '@/utils/analysis-reports/report-steps-statuses';
-import {
-  saveBusinessAndMoatFactorAnalysisResponse,
-  saveCompetitionAnalysisResponse,
-  saveFairValueFactorAnalysisResponse,
-  saveFinalSummaryResponse,
-  saveFinancialAnalysisFactorAnalysisResponse,
-  saveFutureGrowthFactorAnalysisResponse,
-  saveInvestorAnalysisResponse,
-  saveManagementTeamResponse,
-  savePastPerformanceFactorAnalysisResponse,
-} from '@/utils/analysis-reports/save-report-utils';
+import { saveTickerReportAndAdvanceGeneration } from '@/utils/analysis-reports/save-report-callback-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
@@ -29,81 +15,16 @@ async function postHandler(req: NextRequest, { params }: { params: Promise<{ spa
     ticker,
   });
 
-  // When this save is part of an ongoing generation request, only revalidate the
-  // page cache when this is the LAST pending step. Intermediate steps skip the
-  // revalidation so a full generation produces a single cache invalidation
-  // instead of one per step.
-  let skipRevalidation = false;
-  if (generationRequestId) {
-    const currentRequest = await prisma.tickerV1GenerationRequest.findUniqueOrThrow({
-      where: { id: generationRequestId },
-    });
-    const projectedCompletedSteps = currentRequest.completedSteps.includes(reportType)
-      ? currentRequest.completedSteps
-      : [...currentRequest.completedSteps, reportType];
-    const remainingPendingSteps = calculatePendingSteps({
-      ...currentRequest,
-      completedSteps: projectedCompletedSteps,
-    });
-    skipRevalidation = remainingPendingSteps.length > 0;
-  }
-
-  // Save the report based on the report type
-  switch (reportType) {
-    case ReportType.BUSINESS_AND_MOAT:
-      await saveBusinessAndMoatFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.BusinessAndMoat, { skipRevalidation });
-      break;
-    case ReportType.PAST_PERFORMANCE:
-      await savePastPerformanceFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.PastPerformance, { skipRevalidation });
-      break;
-    case ReportType.FUTURE_GROWTH:
-      await saveFutureGrowthFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FutureGrowth, { skipRevalidation });
-      break;
-    case ReportType.FINANCIAL_ANALYSIS:
-      await saveFinancialAnalysisFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FinancialStatementAnalysis, { skipRevalidation });
-      break;
-    case ReportType.COMPETITION:
-      await saveCompetitionAnalysisResponse(ticker, exchange, llmResponse, { skipRevalidation });
-      break;
-    case ReportType.FAIR_VALUE:
-      await saveFairValueFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FairValue, { skipRevalidation });
-      break;
-    case ReportType.MANAGEMENT_TEAM:
-      await saveManagementTeamResponse(ticker, exchange, llmResponse, { skipRevalidation });
-      break;
-    case ReportType.FINAL_SUMMARY:
-      await saveFinalSummaryResponse(ticker, exchange, llmResponse.finalSummary, llmResponse.metaDescription, llmResponse.aboutReport, { skipRevalidation });
-      break;
-    default:
-      throw new Error(`Unsupported report type: ${reportType}`);
-  }
-
-  // If we have a generation request ID, update the generation request to mark this report as completed
-  if (generationRequestId) {
-    // Get the current generation request
-    const generationRequest = await prisma.tickerV1GenerationRequest.findUniqueOrThrow({
-      where: { id: generationRequestId },
-    });
-
-    // Add the current report to completedSteps if it's not already there
-    const updatedCompletedSteps = [...generationRequest.completedSteps];
-    if (!updatedCompletedSteps.includes(reportType)) {
-      updatedCompletedSteps.push(reportType);
-    }
-
-    // Update the generation request
-    await prisma.tickerV1GenerationRequest.update({
-      where: { id: generationRequestId },
-      data: {
-        completedSteps: updatedCompletedSteps,
-        inProgressStep: null,
-        lastInvocationTime: null,
-      },
-    });
-
-    // Trigger generation of the next report
-    await triggerGenerationOfAReportSimplified(ticker, exchange, generationRequestId);
-  }
+  // All the save + generation-request advancement logic lives in a shared util
+  // so the in-process background path (processStockReportLLMResponseInBackground)
+  // runs the exact same code without going back over HTTP.
+  await saveTickerReportAndAdvanceGeneration({
+    exchange,
+    ticker,
+    reportType,
+    llmResponse,
+    generationRequestId,
+  });
 
   return {
     success: true,

--- a/insights-ui/src/utils/analysis-reports/background-llm-generation-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/background-llm-generation-utils.ts
@@ -1,0 +1,74 @@
+import { GeminiModel, LLMProvider } from '@/types/llmConstants';
+import { ReportType } from '@/types/ticker-typesv1';
+import { saveTickerReportAndAdvanceGeneration } from '@/utils/analysis-reports/save-report-callback-utils';
+import { getLLMResponse } from '@/util/get-llm-response';
+
+export interface BackgroundStockReportArgs {
+  symbol: string;
+  exchange: string;
+  reportType: ReportType;
+  generationRequestId: string;
+  invocationId: string;
+  llmProvider: LLMProvider;
+  model: GeminiModel;
+  /** The fully-compiled prompt string (already built by the caller). */
+  prompt: string;
+  /** The parsed output JSON schema object the response is validated against. */
+  outputSchema: object;
+}
+
+/**
+ * In-process, fire-and-forget replacement for the AWS Lambda
+ * (`lambdas/llm-call-with-callback`) for STOCK report generation.
+ *
+ * It does exactly what the lambda + callback did, just in this process:
+ *  1. Run the LLM via the same `getLLMResponse` core runner, with the same
+ *     invocation row / prompt / provider / model / output schema the lambda
+ *     would have received.
+ *  2. Persist the report and advance the generation request by calling
+ *     `saveTickerReportAndAdvanceGeneration` DIRECTLY — the same function the
+ *     `save-report-callback` route runs — instead of POSTing back to that route
+ *     over HTTP. So revalidation, storage, `completedSteps`, and the next-step
+ *     trigger are byte-for-byte the same; only the call mechanism changes (a
+ *     function call instead of a network round-trip).
+ *
+ * Call this detached (`void`) so the triggering request returns immediately,
+ * mirroring the lambda's instant ack. The try/catch is mandatory: an unhandled
+ * rejection in a detached promise can take down the Node process. On failure
+ * `getLLMResponse` has already marked the PromptInvocation `Failed`; we
+ * deliberately leave the generation request's `inProgressStep` /
+ * `lastInvocationTime` untouched so the 5-minute stale-step guard in
+ * `triggerGenerationOfAReportSimplified` reclaims the step on the next tick.
+ *
+ * Caveat (same as the tariff background path): an in-process task lives only in
+ * this process's memory, so a redeploy/crash mid-run leaves the step
+ * `InProgress` until the stale-step guard reclaims it.
+ */
+export async function processStockReportLLMResponseInBackground(args: BackgroundStockReportArgs): Promise<void> {
+  const { symbol, exchange, reportType, generationRequestId, invocationId, llmProvider, model, prompt, outputSchema } = args;
+
+  try {
+    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Running stock report LLM in background (in-process), skipping lambda`);
+
+    const { result } = await getLLMResponse({
+      invocationId,
+      llmProvider,
+      modelName: model,
+      prompt,
+      outputSchema,
+      maxRetries: 2,
+    });
+
+    await saveTickerReportAndAdvanceGeneration({
+      exchange,
+      ticker: symbol,
+      reportType,
+      llmResponse: result,
+      generationRequestId,
+    });
+
+    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Background stock report saved and next step triggered`);
+  } catch (error) {
+    console.error(`[${reportType}] [${symbol}] [${generationRequestId}] Background stock report generation failed:`, error);
+  }
+}

--- a/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
@@ -5,12 +5,12 @@ import { ReportType } from '@/types/ticker-typesv1';
 import {
   compileTemplate,
   createPromptInvocation,
-  getLLMResponse,
   LLMResponseViaInvocationRequest,
   loadSchema,
   updateInvocationStatus,
   validateData,
 } from '@/util/get-llm-response';
+import { processStockReportLLMResponseInBackground } from '@/utils/analysis-reports/background-llm-generation-utils';
 import path from 'path';
 import { PromptInvocationStatus } from '@prisma/client';
 import { DailyMoverType } from '@/types/daily-mover-constants';
@@ -90,63 +90,6 @@ export async function callLambdaForLLMResponseViaCallback<Input>(request: LLMRes
  */
 function isBackgroundLLMGenerationEnabled(): boolean {
   return process.env.USE_LAMBDA_FOR_LLM_RESPONSE === 'true';
-}
-
-/**
- * In-process, fire-and-forget equivalent of the AWS Lambda
- * (`lambdas/llm-call-with-callback`): runs the LLM with the SAME invocation row,
- * prompt, provider/model, and output schema the lambda would have received, then
- * POSTs `{ llmResponse, additionalData }` to the SAME `callbackUrl`
- * (`save-report-callback`). That callback persists the report and chains the
- * next step exactly as before — so generation-request, prompt/invocation, and
- * storage logic are all reused untouched; only the execution location changes.
- *
- * The heavy work is detached from the request (`void` at the call site) so the
- * triggering route returns immediately, just like the lambda's instant ack. The
- * `.catch`-equivalent try/catch here is mandatory — an unhandled rejection in a
- * detached promise can take down the Node process.
- *
- * On failure `getLLMResponse` already marks the PromptInvocation `Failed`; we
- * deliberately leave the generation request's `inProgressStep`/`lastInvocationTime`
- * as-is so the existing 5-minute stale-step guard in
- * `triggerGenerationOfAReportSimplified` recovers the step on the next tick.
- *
- * Caveat (same as the tariff background path): an in-process task lives only in
- * this process's memory, so a redeploy/crash mid-run leaves the step
- * `InProgress` until the stale-step guard reclaims it.
- */
-export async function processLLMResponseInBackgroundViaCallback<Input>(request: LLMResponseViaLambdaRequest<Input>): Promise<void> {
-  const { invocationId, callbackUrl, promptStringToSendToLLM, outputSchemaString, llmProvider, model, additionalData } = request;
-  const reportType = additionalData?.reportType || 'unknown';
-  const symbol = additionalData?.symbol || 'unknown';
-  const generationRequestId = additionalData?.generationRequestId || 'unknown';
-
-  try {
-    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Running LLM in background (in-process), skipping lambda`);
-
-    const { result } = await getLLMResponse({
-      invocationId,
-      llmProvider,
-      modelName: model,
-      prompt: promptStringToSendToLLM,
-      outputSchema: JSON.parse(outputSchemaString),
-      maxRetries: 2,
-    });
-
-    const response = await fetch(callbackUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ llmResponse: result, additionalData }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Callback POST failed with status ${response.status}: ${errorText}`);
-    }
-    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Background LLM response saved via callback`);
-  } catch (error) {
-    console.error(`[${reportType}] [${symbol}] [${generationRequestId}] Background LLM processing failed:`, error);
-  }
 }
 
 export interface LLMResponseForPromptViaInvocationViaLambda<Input> {
@@ -269,13 +212,25 @@ export async function getLLMResponseForPromptViaInvocationViaLambda<Input>(args:
     };
 
     // Background generation is currently limited to stock (ticker V1) report
-    // generation, which always carries a `reportType`. Daily movers (no
-    // `reportType`) continue to go through the lambda regardless of the flag.
-    if (reportType && isBackgroundLLMGenerationEnabled()) {
+    // generation, which always carries both a `reportType` and an `exchange`.
+    // Daily movers (no `reportType`) continue to go through the lambda
+    // regardless of the flag.
+    if (reportType && exchange && isBackgroundLLMGenerationEnabled()) {
       // Detach the heavy LLM call from the request so this returns immediately,
-      // mirroring the lambda's instant ack. The background task saves via the
-      // same callback and chains the next step.
-      void processLLMResponseInBackgroundViaCallback<Input>(lambdaRequest);
+      // mirroring the lambda's instant ack. The background task runs the LLM
+      // in-process and then saves + chains the next step directly (no callback
+      // round-trip).
+      void processStockReportLLMResponseInBackground({
+        symbol,
+        exchange,
+        reportType,
+        generationRequestId,
+        invocationId: invocation.id,
+        llmProvider,
+        model,
+        prompt: finalPrompt,
+        outputSchema,
+      });
     } else {
       await callLambdaForLLMResponseViaCallback<Input>(lambdaRequest);
     }

--- a/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
@@ -5,6 +5,7 @@ import { ReportType } from '@/types/ticker-typesv1';
 import {
   compileTemplate,
   createPromptInvocation,
+  getLLMResponse,
   LLMResponseViaInvocationRequest,
   loadSchema,
   updateInvocationStatus,
@@ -71,6 +72,80 @@ export async function callLambdaForLLMResponseViaCallback<Input>(request: LLMRes
   } catch (error) {
     console.error('Error calling lambda:', error);
     throw error;
+  }
+}
+
+/**
+ * Master switch for HOW a stock report's LLM call is run, read from the
+ * `USE_LAMBDA_FOR_LLM_RESPONSE` env var (mirrors the tariff side's
+ * `USE_LAMBDA_FOR_TARIFF_LLM_RESPONSE` convention):
+ *   - `true`        → run the LLM call in-process in the BACKGROUND on this
+ *                     server (no AWS Lambda hop). Now safe because we run on a
+ *                     long-lived Lightsail server instead of time-limited Vercel.
+ *   - unset/`false` → call the AWS Lambda (the original behavior).
+ *
+ * NOTE: deliberately NOT named `use…` — ESLint's `react-hooks/rules-of-hooks`
+ * treats any `use`-prefixed function as a React hook and errors when it's
+ * called outside a component/hook.
+ */
+function isBackgroundLLMGenerationEnabled(): boolean {
+  return process.env.USE_LAMBDA_FOR_LLM_RESPONSE === 'true';
+}
+
+/**
+ * In-process, fire-and-forget equivalent of the AWS Lambda
+ * (`lambdas/llm-call-with-callback`): runs the LLM with the SAME invocation row,
+ * prompt, provider/model, and output schema the lambda would have received, then
+ * POSTs `{ llmResponse, additionalData }` to the SAME `callbackUrl`
+ * (`save-report-callback`). That callback persists the report and chains the
+ * next step exactly as before — so generation-request, prompt/invocation, and
+ * storage logic are all reused untouched; only the execution location changes.
+ *
+ * The heavy work is detached from the request (`void` at the call site) so the
+ * triggering route returns immediately, just like the lambda's instant ack. The
+ * `.catch`-equivalent try/catch here is mandatory — an unhandled rejection in a
+ * detached promise can take down the Node process.
+ *
+ * On failure `getLLMResponse` already marks the PromptInvocation `Failed`; we
+ * deliberately leave the generation request's `inProgressStep`/`lastInvocationTime`
+ * as-is so the existing 5-minute stale-step guard in
+ * `triggerGenerationOfAReportSimplified` recovers the step on the next tick.
+ *
+ * Caveat (same as the tariff background path): an in-process task lives only in
+ * this process's memory, so a redeploy/crash mid-run leaves the step
+ * `InProgress` until the stale-step guard reclaims it.
+ */
+export async function processLLMResponseInBackgroundViaCallback<Input>(request: LLMResponseViaLambdaRequest<Input>): Promise<void> {
+  const { invocationId, callbackUrl, promptStringToSendToLLM, outputSchemaString, llmProvider, model, additionalData } = request;
+  const reportType = additionalData?.reportType || 'unknown';
+  const symbol = additionalData?.symbol || 'unknown';
+  const generationRequestId = additionalData?.generationRequestId || 'unknown';
+
+  try {
+    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Running LLM in background (in-process), skipping lambda`);
+
+    const { result } = await getLLMResponse({
+      invocationId,
+      llmProvider,
+      modelName: model,
+      prompt: promptStringToSendToLLM,
+      outputSchema: JSON.parse(outputSchemaString),
+      maxRetries: 2,
+    });
+
+    const response = await fetch(callbackUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ llmResponse: result, additionalData }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Callback POST failed with status ${response.status}: ${errorText}`);
+    }
+    console.log(`[${reportType}] [${symbol}] [${generationRequestId}] Background LLM response saved via callback`);
+  } catch (error) {
+    console.error(`[${reportType}] [${symbol}] [${generationRequestId}] Background LLM processing failed:`, error);
   }
 }
 
@@ -193,7 +268,17 @@ export async function getLLMResponseForPromptViaInvocationViaLambda<Input>(args:
       additionalData,
     };
 
-    await callLambdaForLLMResponseViaCallback<Input>(lambdaRequest);
+    // Background generation is currently limited to stock (ticker V1) report
+    // generation, which always carries a `reportType`. Daily movers (no
+    // `reportType`) continue to go through the lambda regardless of the flag.
+    if (reportType && isBackgroundLLMGenerationEnabled()) {
+      // Detach the heavy LLM call from the request so this returns immediately,
+      // mirroring the lambda's instant ack. The background task saves via the
+      // same callback and chains the next step.
+      void processLLMResponseInBackgroundViaCallback<Input>(lambdaRequest);
+    } else {
+      await callLambdaForLLMResponseViaCallback<Input>(lambdaRequest);
+    }
 
     // Update lastInvocationTime only for ticker V1 generation requests (when reportType is provided)
     if (reportType) {

--- a/insights-ui/src/utils/analysis-reports/save-report-callback-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/save-report-callback-utils.ts
@@ -1,0 +1,125 @@
+import { prisma } from '@/prisma';
+import { ReportType, TickerAnalysisCategory } from '@/types/ticker-typesv1';
+import { triggerGenerationOfAReportSimplified } from '@/utils/analysis-reports/generation-report-utils';
+import { calculatePendingSteps } from '@/utils/analysis-reports/report-steps-statuses';
+import {
+  saveBusinessAndMoatFactorAnalysisResponse,
+  saveCompetitionAnalysisResponse,
+  saveFairValueFactorAnalysisResponse,
+  saveFinalSummaryResponse,
+  saveFinancialAnalysisFactorAnalysisResponse,
+  saveFutureGrowthFactorAnalysisResponse,
+  saveManagementTeamResponse,
+  savePastPerformanceFactorAnalysisResponse,
+} from '@/utils/analysis-reports/save-report-utils';
+
+export interface SaveTickerReportAndAdvanceArgs {
+  exchange: string;
+  ticker: string;
+  reportType: ReportType;
+  /**
+   * The raw LLM JSON. Untyped on purpose — the same object is dispatched to each
+   * strongly-typed `save*` function below, exactly as the `save-report-callback`
+   * route did when it read this straight off the request body.
+   */
+  llmResponse: any;
+  generationRequestId?: string;
+}
+
+/**
+ * Persists one stock (ticker V1) report and advances its generation request.
+ *
+ * This is the exact logic the `save-report-callback` route used to run inline,
+ * extracted into a single shared function so BOTH execution paths run identical
+ * code:
+ *  - the HTTP callback (AWS Lambda path) — the route awaits this, and
+ *  - the in-process background path (`processStockReportLLMResponseInBackground`),
+ *    which calls this directly instead of POSTing back over HTTP.
+ *
+ * Steps (unchanged from the original route):
+ *  1. Compute `skipRevalidation` — only the LAST pending step revalidates the
+ *     page cache, so a full generation invalidates the cache once instead of
+ *     once per step.
+ *  2. Save the report for `reportType`.
+ *  3. If this save is part of a generation request: mark the step completed,
+ *     clear `inProgressStep`/`lastInvocationTime`, then trigger the next step.
+ */
+export async function saveTickerReportAndAdvanceGeneration(args: SaveTickerReportAndAdvanceArgs): Promise<void> {
+  const { exchange, ticker, reportType, llmResponse, generationRequestId } = args;
+
+  // When this save is part of an ongoing generation request, only revalidate the
+  // page cache when this is the LAST pending step. Intermediate steps skip the
+  // revalidation so a full generation produces a single cache invalidation
+  // instead of one per step.
+  let skipRevalidation = false;
+  if (generationRequestId) {
+    const currentRequest = await prisma.tickerV1GenerationRequest.findUniqueOrThrow({
+      where: { id: generationRequestId },
+    });
+    const projectedCompletedSteps = currentRequest.completedSteps.includes(reportType)
+      ? currentRequest.completedSteps
+      : [...currentRequest.completedSteps, reportType];
+    const remainingPendingSteps = calculatePendingSteps({
+      ...currentRequest,
+      completedSteps: projectedCompletedSteps,
+    });
+    skipRevalidation = remainingPendingSteps.length > 0;
+  }
+
+  // Save the report based on the report type
+  switch (reportType) {
+    case ReportType.BUSINESS_AND_MOAT:
+      await saveBusinessAndMoatFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.BusinessAndMoat, { skipRevalidation });
+      break;
+    case ReportType.PAST_PERFORMANCE:
+      await savePastPerformanceFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.PastPerformance, { skipRevalidation });
+      break;
+    case ReportType.FUTURE_GROWTH:
+      await saveFutureGrowthFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FutureGrowth, { skipRevalidation });
+      break;
+    case ReportType.FINANCIAL_ANALYSIS:
+      await saveFinancialAnalysisFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FinancialStatementAnalysis, { skipRevalidation });
+      break;
+    case ReportType.COMPETITION:
+      await saveCompetitionAnalysisResponse(ticker, exchange, llmResponse, { skipRevalidation });
+      break;
+    case ReportType.FAIR_VALUE:
+      await saveFairValueFactorAnalysisResponse(ticker, exchange, llmResponse, TickerAnalysisCategory.FairValue, { skipRevalidation });
+      break;
+    case ReportType.MANAGEMENT_TEAM:
+      await saveManagementTeamResponse(ticker, exchange, llmResponse, { skipRevalidation });
+      break;
+    case ReportType.FINAL_SUMMARY:
+      await saveFinalSummaryResponse(ticker, exchange, llmResponse.finalSummary, llmResponse.metaDescription, llmResponse.aboutReport, { skipRevalidation });
+      break;
+    default:
+      throw new Error(`Unsupported report type: ${reportType}`);
+  }
+
+  // If we have a generation request ID, update the generation request to mark this report as completed
+  if (generationRequestId) {
+    // Get the current generation request
+    const generationRequest = await prisma.tickerV1GenerationRequest.findUniqueOrThrow({
+      where: { id: generationRequestId },
+    });
+
+    // Add the current report to completedSteps if it's not already there
+    const updatedCompletedSteps = [...generationRequest.completedSteps];
+    if (!updatedCompletedSteps.includes(reportType)) {
+      updatedCompletedSteps.push(reportType);
+    }
+
+    // Update the generation request
+    await prisma.tickerV1GenerationRequest.update({
+      where: { id: generationRequestId },
+      data: {
+        completedSteps: updatedCompletedSteps,
+        inProgressStep: null,
+        lastInvocationTime: null,
+      },
+    });
+
+    // Trigger generation of the next report
+    await triggerGenerationOfAReportSimplified(ticker, exchange, generationRequestId);
+  }
+}


### PR DESCRIPTION
## What

Stock report LLM calls were always offloaded to the AWS Lambda (`lambdas/llm-call-with-callback`) because Vercel capped request execution time. On Lightsail there is no such cap, so we run the LLM call **in-process in the background** instead of paying the Lambda hop.

A new env flag `USE_LAMBDA_FOR_LLM_RESPONSE` gates the choice, mirroring the existing tariff convention (`USE_LAMBDA_FOR_TARIFF_LLM_RESPONSE`):

- `'true'` → run the LLM in-process in the background on this server
- unset / `'false'` → call the AWS Lambda (**unchanged** behavior)

**Production is enabled**: `USE_LAMBDA_FOR_LLM_RESPONSE = "true"` is set in the Lightsail `app_env` map (`deployments/insights-ui/variables.tf`), which `container.tf` merges into the container environment.

## How — identical save logic, no HTTP round-trip

The dispatch branch lives inside `getLLMResponseForPromptViaInvocationViaLambda`, the single point every stock `generate*` function already funnels through. Everything up to building the request is shared; only the final dispatch changes.

**Background path runs the same save logic the callback route runs — directly, in-process:**

1. The entire `save-report-callback` route body was extracted into a shared util `saveTickerReportAndAdvanceGeneration` (`save-report-callback-utils.ts`): revalidation decision → switch/store per report type → mark step completed + clear `inProgressStep`/`lastInvocationTime` → `triggerGenerationOfAReportSimplified`. The HTTP route now just parses the request and calls it, so **the Lambda path and the background path execute byte-for-byte identical save + chaining logic**.
2. The background processor (`processStockReportLLMResponseInBackground` in its own file `background-llm-generation-utils.ts`) runs the **same** `getLLMResponse` core runner with the **same** invocation row / prompt / provider / model / output schema the Lambda would have used, then calls `saveTickerReportAndAdvanceGeneration` **directly** — no POST back to the callback URL over HTTP.

The call is detached (`void`) so the triggering request returns immediately, like the Lambda's instant ack. On failure `getLLMResponse` marks the `PromptInvocation` `Failed` and the existing 5-minute stale-step guard reclaims the step on the next tick.

## Scope

Limited to **stocks**: the background branch is taken only when both `reportType` and `exchange` are present, so daily-mover generation keeps using the Lambda regardless of the flag.

## Triggering the queue

The `NotStarted` generation requests are drained by `GET /api/koala_gains/tickers-v1/generate-ticker-v1-request` (the prod EventBridge cron in `scheduler.tf` hits it every 3 min, unauthenticated). In background mode, one call kicks off up to 10 requests and each self-chains through all report steps in-process.

## Files

- `insights-ui/src/utils/analysis-reports/save-report-callback-utils.ts` — **new**, shared save + generation-advance logic (extracted from the route)
- `insights-ui/src/utils/analysis-reports/background-llm-generation-utils.ts` — **new**, in-process background processor
- `insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts` — flag helper + dispatch branch
- `insights-ui/src/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/save-report-callback/route.ts` — thinned to parse + delegate
- `insights-ui/.env.example` — document `USE_LAMBDA_FOR_LLM_RESPONSE`
- `deployments/insights-ui/variables.tf` — enable the flag in production (`app_env`)

## Checks

`yarn compile`, `yarn prettier-check`, `yarn lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
