### PR TITLE
fix(tariffs): stop full page reload on admin Gen click

### DIFF
--- a/insights-ui/src/app/admin-v1/tariff-reports/TariffReportsAdminTable.tsx
+++ b/insights-ui/src/app/admin-v1/tariff-reports/TariffReportsAdminTable.tsx
@@ -197,7 +197,11 @@ export default function TariffReportsAdminTable(): JSX.Element {
 
   // Generate a single section via its own route — the "generate one, then wait"
   // flow. Same per-mode behavior as a step inside `generateAll`: background mode
-  // returns immediately (refresh later to see it land), synchronous mode waits.
+  // returns immediately, synchronous mode waits. We intentionally do NOT
+  // re-fetch afterward: re-fetching flips `loading` back on and re-renders the
+  // whole table (resetting the admin's scroll position), which is jarring after
+  // a single "Gen" click. The admin clicks "Refresh" when they want to pull the
+  // latest generation status.
   const generateSection = async (slug: string, step: ChapterGenerateStep, idx: number): Promise<void> => {
     updateRun(slug, { currentStep: idx, error: null });
     try {
@@ -212,7 +216,6 @@ export default function TariffReportsAdminTable(): JSX.Element {
         }
       }
       updateRun(slug, { currentStep: null });
-      await reFetchData();
     } catch (err) {
       updateRun(slug, { currentStep: null, error: err instanceof Error ? err.message : 'Generation failed' });
     }


### PR DESCRIPTION
## Problem

On the admin tariff reports page (`admin-v1/tariff-reports`), clicking a per-section **Gen** button caused the whole page to reload — replacing the table with the "Loading…" state and resetting the admin's scroll position. With many chapters, the admin had to scroll back down after every single click, making the flow slow and frustrating.

## Cause

`generateSection` called `await reFetchData()` after each Gen click. That refetch flips `useFetchData`'s `loading` flag back on, which hits the early `if (loading) return <Loading… />` return and re-renders the entire table from scratch.

## Fix

Remove the automatic refetch from `generateSection`. Generation is already async (the POST returns immediately), and the page already has a **Refresh** button admins can use to pull the latest generation status whenever they want. The "Generate all" flow is unchanged.

Files: `insights-ui/src/app/admin-v1/tariff-reports/TariffReportsAdminTable.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)