### PR TITLE
feat(etfs): add sitemaps for ETF pages

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -45,4 +45,25 @@
   <sitemap>
     <loc>https://koalagains.com/stock-scenarios/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/competition-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/risk-analysis-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/performance-returns-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/cost-efficiency-team-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/holdings-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://koalagains.com/etfs/future-performance-outlook-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/insights-ui/src/app/etfs/competition-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/competition-sitemap.xml/route.ts
@@ -1,0 +1,15 @@
+import { buildEtfCompetitionSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfCompetitionSitemap();
+  } catch (error) {
+    console.error('Error generating ETF competition sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/cost-efficiency-team-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/cost-efficiency-team-sitemap.xml/route.ts
@@ -1,0 +1,16 @@
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import { buildEtfCategoryReportSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfCategoryReportSitemap(EtfAnalysisCategory.CostEfficiencyAndTeam);
+  } catch (error) {
+    console.error('Error generating ETF cost-efficiency-team sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/future-performance-outlook-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/future-performance-outlook-sitemap.xml/route.ts
@@ -1,0 +1,16 @@
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import { buildEtfCategoryReportSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfCategoryReportSitemap(EtfAnalysisCategory.FuturePerformanceOutlook);
+  } catch (error) {
+    console.error('Error generating ETF future-performance-outlook sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/holdings-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/holdings-sitemap.xml/route.ts
@@ -1,0 +1,15 @@
+import { buildEtfHoldingsSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfHoldingsSitemap();
+  } catch (error) {
+    console.error('Error generating ETF holdings sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/performance-returns-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/performance-returns-sitemap.xml/route.ts
@@ -1,0 +1,16 @@
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import { buildEtfCategoryReportSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfCategoryReportSitemap(EtfAnalysisCategory.PerformanceAndReturns);
+  } catch (error) {
+    console.error('Error generating ETF performance-returns sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/risk-analysis-sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/risk-analysis-sitemap.xml/route.ts
@@ -1,0 +1,16 @@
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import { buildEtfCategoryReportSitemap } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+async function GET(): Promise<NextResponse> {
+  try {
+    return await buildEtfCategoryReportSitemap(EtfAnalysisCategory.RiskAnalysis);
+  } catch (error) {
+    console.error('Error generating ETF risk-analysis sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/etfs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/sitemap.xml/route.ts
@@ -1,0 +1,113 @@
+import { fetchEtfProvidersForCountry, fetchEtfsForGroupings } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import { prisma } from '@/prisma';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
+import { etfBrowseDetailPath, etfBrowsePath, etfGroupCategoryPath, etfSectionIndexPath } from '@/utils/etf-country-route-utils';
+import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
+import { slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
+import { ETF_SUPPORTED_COUNTRIES } from '@/utils/etfCountryExchangeUtils';
+import { buildEtfSitemapResponse, SiteMapUrl } from '@/utils/etfSitemapUtils';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// Build the listing/browse URLs (/etfs root, group/category/asset-class/provider pages) plus every
+// individual ETF report page (/etfs/{exchange}/{symbol}). Per-ETF analysis sub-pages
+// (risk-analysis, competition, …) live in their own sitemaps under /etfs/*-sitemap.xml.
+async function generateEtfUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  // Category → group / category buckets, mirroring the groups-index API route so the sitemap's
+  // notion of "which group/category has ETFs" matches what the listing pages actually render.
+  const groups = getAllEtfGroups();
+  const categoryValueToKey = new Map<string, string>();
+  const groupValueToKey = new Map<string, string>();
+  for (const group of groups) {
+    for (const category of getCategoriesForGroupKey(group.key)) {
+      categoryValueToKey.set(category.name, category.name);
+      groupValueToKey.set(category.name, group.key);
+    }
+  }
+
+  const assetClassValueToKey = new Map<string, string>();
+  for (const option of ETF_ASSET_CLASS_OPTIONS) {
+    if (option.value !== '') assetClassValueToKey.set(option.value, option.value);
+  }
+
+  for (const country of ETF_SUPPORTED_COUNTRIES) {
+    // Section index pages. The groups index collapses onto the country root (/etfs for US,
+    // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it.
+    urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
+    urls.push({ url: etfBrowsePath(country, 'asset-classes'), changefreq: 'weekly', priority: 0.7 });
+    urls.push({ url: etfBrowsePath(country, 'providers'), changefreq: 'weekly', priority: 0.7 });
+
+    // Counts come from the same bucketing the index pages use, so a group/category/asset-class page
+    // only enters the sitemap when at least one populated ETF lands in it. Providers are already
+    // populated-only and content-derived.
+    const [byGroup, byCategory, byAssetClass, providers] = await Promise.all([
+      fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', groupValueToKey, country),
+      fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', categoryValueToKey, country),
+      fetchEtfsForGroupings(KoalaGainsSpaceId, 'assetClass', assetClassValueToKey, country),
+      fetchEtfProvidersForCountry(KoalaGainsSpaceId, country),
+    ]);
+
+    for (const group of groups) {
+      if ((byGroup.counts[group.key] ?? 0) > 0) {
+        urls.push({ url: etfBrowseDetailPath(country, 'groups', group.key), changefreq: 'weekly', priority: 0.6 });
+      }
+      for (const category of getCategoriesForGroupKey(group.key)) {
+        if ((byCategory.counts[category.name] ?? 0) > 0) {
+          urls.push({ url: etfGroupCategoryPath(country, group.key, category.name), changefreq: 'weekly', priority: 0.6 });
+        }
+      }
+    }
+
+    for (const option of ETF_ASSET_CLASS_OPTIONS) {
+      if (option.value !== '' && (byAssetClass.counts[option.value] ?? 0) > 0) {
+        urls.push({ url: etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(option.value)), changefreq: 'weekly', priority: 0.6 });
+      }
+    }
+
+    for (const provider of providers.providers) {
+      urls.push({ url: etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider)), changefreq: 'weekly', priority: 0.6 });
+    }
+  }
+
+  // Individual ETF report pages — only populated ETFs (cachedScore present), matching the listing
+  // pages' POPULATED_ETF_WHERE filter. Unpopulated ETFs render thin pages that Google flags as
+  // "Crawled — currently not indexed".
+  const etfs = await prisma.etf.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      cachedScore: { isNot: null },
+    },
+    select: {
+      symbol: true,
+      exchange: true,
+      updatedAt: true,
+    },
+  });
+
+  for (const etf of etfs) {
+    urls.push({
+      url: `/etfs/${etf.exchange}/${etf.symbol}`,
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod: etf.updatedAt ? etf.updatedAt.toISOString().split('T')[0] : undefined,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(): Promise<NextResponse> {
+  try {
+    const urls = await generateEtfUrls();
+    return await buildEtfSitemapResponse(urls);
+  } catch (error) {
+    console.error('Error generating ETFs sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/utils/etfSitemapUtils.ts
+++ b/insights-ui/src/utils/etfSitemapUtils.ts
@@ -1,0 +1,132 @@
+import { prisma } from '@/prisma';
+import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
+import { Prisma } from '@prisma/client';
+import { NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+
+export interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+/** Stream a list of URLs into an XML sitemap response — shared by every ETF sitemap route. */
+export async function buildEtfSitemapResponse(urls: SiteMapUrl[]): Promise<NextResponse<Buffer>> {
+  const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
+
+  for (const url of urls) {
+    smStream.write(url);
+  }
+
+  smStream.end();
+  const response: Buffer = await streamToPromise(smStream);
+
+  return new NextResponse(response as BodyInit, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}
+
+// Per-ETF analysis sub-page URL slug for each category. Must match CATEGORY_DISPLAY in
+// EtfAnalysisSections.tsx — these are the same routes the on-page report nav links to.
+const CATEGORY_PATH_SLUG: Record<EtfAnalysisCategory, string> = {
+  [EtfAnalysisCategory.PerformanceAndReturns]: 'performance-returns',
+  [EtfAnalysisCategory.CostEfficiencyAndTeam]: 'cost-efficiency-team',
+  [EtfAnalysisCategory.RiskAnalysis]: 'risk-analysis',
+  [EtfAnalysisCategory.FuturePerformanceOutlook]: 'future-performance-outlook',
+};
+
+/**
+ * Sitemap for one ETF analysis category's sub-pages (e.g. /etfs/{exchange}/{symbol}/risk-analysis).
+ * Mirrors the per-category stock sitemaps: only ETFs that actually have a written report for the
+ * category are emitted. The sub-page calls notFound() when the category result is missing, so an
+ * ETF without a report would otherwise seed the sitemap with a 404.
+ */
+export async function buildEtfCategoryReportSitemap(categoryKey: EtfAnalysisCategory): Promise<NextResponse<Buffer>> {
+  const results = await prisma.etfCategoryAnalysisResult.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      categoryKey,
+      // The sub-page renders overallAnalysisDetails; an empty body is a thin page.
+      overallAnalysisDetails: { not: '' },
+    },
+    select: {
+      updatedAt: true,
+      etf: { select: { symbol: true, exchange: true } },
+    },
+  });
+
+  const slug = CATEGORY_PATH_SLUG[categoryKey];
+  const urls: SiteMapUrl[] = results.map((result) => ({
+    url: `/etfs/${result.etf.exchange}/${result.etf.symbol}/${slug}`,
+    changefreq: 'weekly',
+    priority: 0.6,
+    lastmod: result.updatedAt ? new Date(result.updatedAt).toISOString().split('T')[0] : undefined,
+  }));
+
+  return buildEtfSitemapResponse(urls);
+}
+
+/**
+ * Sitemap for the ETF competition sub-pages (/etfs/{exchange}/{symbol}/competition). Only ETFs with
+ * a competition report are included — the page calls notFound() when EtfVsCompetition is missing.
+ */
+export async function buildEtfCompetitionSitemap(): Promise<NextResponse<Buffer>> {
+  const records = await prisma.etfVsCompetition.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      overallAnalysisDetails: { not: '' },
+    },
+    select: {
+      updatedAt: true,
+      etf: { select: { symbol: true, exchange: true } },
+    },
+  });
+
+  const urls: SiteMapUrl[] = records.map((record) => ({
+    url: `/etfs/${record.etf.exchange}/${record.etf.symbol}/competition`,
+    changefreq: 'weekly',
+    priority: 0.6,
+    lastmod: record.updatedAt ? new Date(record.updatedAt).toISOString().split('T')[0] : undefined,
+  }));
+
+  return buildEtfSitemapResponse(urls);
+}
+
+/**
+ * Sitemap for the ETF holdings sub-pages (/etfs/{exchange}/{symbol}/holdings). Unlike the analysis
+ * sub-pages, the holdings page does not call notFound() when data is missing — it renders an empty
+ * table — so gate on the backing EtfMorPortfolioInfo.holdings JSON being present to avoid thin pages.
+ */
+export async function buildEtfHoldingsSitemap(): Promise<NextResponse<Buffer>> {
+  const etfs = await prisma.etf.findMany({
+    where: {
+      spaceId: KoalaGainsSpaceId,
+      morPortfolioInfo: { is: { holdings: { not: Prisma.DbNull } } },
+    },
+    select: {
+      symbol: true,
+      exchange: true,
+      updatedAt: true,
+      // Prefer the portfolio refresh time for lastmod, fall back to the ETF row's updatedAt.
+      morPortfolioInfo: { select: { updatedAt: true } },
+    },
+  });
+
+  const urls: SiteMapUrl[] = etfs.map((etf) => {
+    const lastmodDate = etf.morPortfolioInfo?.updatedAt ?? etf.updatedAt;
+    return {
+      url: `/etfs/${etf.exchange}/${etf.symbol}/holdings`,
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod: lastmodDate ? lastmodDate.toISOString().split('T')[0] : undefined,
+    };
+  });
+
+  return buildEtfSitemapResponse(urls);
+}


### PR DESCRIPTION
## Summary

Adds sitemaps for ETF pages in insights-ui (KoalaGains), mirroring the existing stock sitemap structure, and registers them in \`public/sitemap_index.xml\`.

## What's included

- **\`/etfs/sitemap.xml\`** — listing/browse pages (per-country section index, groups, group categories, asset classes, providers) plus every populated individual ETF report page (\`/etfs/{exchange}/{symbol}\`).
  - Group / category / asset-class pages are emitted only when ≥1 populated ETF buckets into them, reusing the same enumeration (\`fetchEtfsForGroupings\`, \`fetchEtfProvidersForCountry\`) the listing index pages use — so no thin/empty pages enter the sitemap.
  - URLs are built with the canonical route helpers (\`etfBasePath\`/\`etfBrowseDetailPath\`/\`etfGroupCategoryPath\`/\`slugifyEtfTag\`) so they match the app's internal links exactly.
  - Individual ETF pages filter on \`cachedScore\` present (the listing pages' "populated" filter).
- **Per-category sub-page sitemaps** — \`risk-analysis\`, \`performance-returns\`, \`cost-efficiency-team\`, \`future-performance-outlook\`, and \`competition\`. Each includes only ETFs that actually have a written report (the sub-pages call \`notFound()\` otherwise).
- **\`holdings-sitemap.xml\`** — gated on portfolio holdings data being present (the holdings page renders empty rather than 404ing when data is missing).

Shared streaming + query helpers live in \`src/utils/etfSitemapUtils.ts\` to avoid duplicating the boilerplate across routes.

## Verification

- \`yarn prettier-check\` ✅
- \`yarn lint\` ✅
- \`yarn compile\` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)