### PR TITLE
docs(insights-ui): add task to finalize the task list

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -9,8 +9,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ### Detail page
 
-- [ ] **Mobile layout audit** — fix overflow tables, cut-off charts, font/spacing/sticky-header/tap-target issues; verify after any restructure.
-- [ ] **Move competition chart** directly under the Business & Moat section, with the competitors list adjacent.
 - [ ] **SEO — "Crawled — currently not indexed" on `business-and-moat-sitemap.xml`** — check why these pages are not getting indexed.
 
 ### Off-hours Claude Code automation
@@ -67,15 +65,7 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] **Claude-Code Sonnet pipeline** — same idea as the off-hours stock refresh, but for ETFs: pick the ETFs whose reports are not generated yet and generate the whole ETF report.
 - [ ] **ETF discoverability + internal linking** (after the list page lands):
   - Home page → ETFs: pick entry points (hero / nav / featured rail / "browse by category-group") so first-time visitors reach the ETFs list and representative detail pages in one click.
-  - ETF detail → stock reports: link each covered holding's ticker through; plain text otherwise.
-  - Stock detail → ETF reports: list top-N (by weight) ETFs that hold the ticker.
-  - Revisit cross-links from category / scenario / trends pages so the link graph is dense.
 
-### Performance optimization (parity with stock-page perf work)
-
-Remaining:
-
-- [ ] **True per-slice streaming on `/etfs/[exchange]/[etf]`** — current shell-vs-body split still shares one `/full-render` promise so all 4 boundaries unsuspend together. Add per-slice ETF API endpoints (`priceHistory`, `performanceMetrics`, `similarEtfs`, `keyFacts`, `keyMetrics`) and rewrite each `<Suspense>` block to own its own fetch — mirror of the post-#1507 stock page. Then decide whether to remove `/full-render` + `etf-full-render-utils.ts` + the CloudFront cache behavior added by #1581, or leave as harmless dead weight.
 
 ### Active-ETF management team — LinkedIn-sourced info (ETF-side parallel to stock task)
 
@@ -114,13 +104,7 @@ Remaining:
 
 ---
 
-## Stocks & ETFs common
-
-### SEO — soft 404 on empty country listing pages
-
-- [ ] Empty country+industry (stocks) and country+group/category, asset-class, provider (ETFs) listing pages return 200 + thin content → soft 404 in GSC. Emit `robots: { index: false, follow: true }` when the listing has zero results (pattern: `crowd-funding/projects/[projectId]/page.tsx`). Low priority — currently mitigated by dropping these URLs from the sitemap.
-
-### Trends page
+## Trends page
 
 > Decide once: shared `Trend` model linked to both stock and ETF join tables, or parallel
 > `StockTrend` / `EtfTrend` models. Leaning shared (same underlying cause / analog).

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -58,18 +58,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 - [ ] **Phased rollout**: P0 schema + admin templates → P1 list/detail/from-template modal → P2 free-form behind flag + quota → P3 streaming + web-search citations + history diff.
 - [ ] Open: streaming vs spinner (default spinner); free-form at launch (default behind flag); citations design; cross-ticker reports out of scope.
 
-### Daily top movers — dedupe historical duplicates + harden ingest
-
-- [ ] **De-duplicate `daily_top_losers` / `daily_top_gainers`** — historical bug wrote multiple near-identical rows for the same ticker across weekends + US market holidays (~23% of loser rows belong to a `(symbol, %change)` cluster; 140 clusters, 344 rows). Each row got its own UUID, its own sitemap entry, and its own LLM-rewritten article, so GSC reports them as "Duplicate without user-selected canonical". Approach: add a nullable `canonicalId` self-FK to both tables; backfill the earliest-`createdAt` row per `(spaceId, symbol, percentageChange)` cluster as canonical, point the rest at it; in `app/daily-top-movers/top-(losers|gainers)/details/[id]/page.tsx` `permanentRedirect()` when `canonicalId` is set; filter `sitemap.xml/route.ts` and the list APIs feeding `RelatedDailyMovers` on `canonicalId IS NULL`. Validate with sitemap row-count drop + GSC duplicate-bucket shrink over 2–4 weeks.
-- [ ] **Stop creating new duplicates on US market holidays** — Mon-Fri cron (`deployments/insights-ui/scheduler.tf`) still fires on Good Friday / Presidents' Day / Memorial Day etc.; screener returns the prior trading day's data, callback writes a new row. Fix in `app/api/[spaceId]/tickers-v1/screener-callback/route.ts`: skip writes when a row already exists for `(spaceId, symbol)` with the same `percentageChange` within the last ~3 days. Or upgrade the unique constraint from `@@unique([spaceId, symbol, createdAt])` to a derived `marketDate` column so it's idempotent by definition.
-
-### Login improvements
-
-- [ ] Add **LinkedIn** SSO + **Yahoo** SSO; account-linking when a new provider matches an existing email; keep login sheet tidy (top 3–4 most-used).
-- [ ] Post-login resume — after sign-in from the click-count gate, complete the action the user was taking.
-- [ ] Telemetry — events for click counted / gate shown / gate→login / gate dismissed; admin dashboard for conversion rate.
-- [ ] Open: gate threshold (2 vs 3) behind a config flag for A/B; soft banner before hard gate; never re-show gate to logged-in users.
-
 ---
 
 ## ETFs
@@ -150,6 +138,30 @@ Remaining:
 - [ ] **Reverse links** — both stock and ETF detail pages link to the trends that reference them (do not defer the reverse link).
 - [ ] Open: trend taxonomy beyond scenario fields (macro/demographic/generational/technological/regulatory)?
 
+---
+
+## Daily movers
+
+### Dedupe historical duplicates + harden ingest
+
+- [ ] **De-duplicate `daily_top_losers` / `daily_top_gainers`** — historical bug wrote multiple near-identical rows for the same ticker across weekends + US market holidays (~23% of loser rows belong to a `(symbol, %change)` cluster; 140 clusters, 344 rows). Each row got its own UUID, its own sitemap entry, and its own LLM-rewritten article, so GSC reports them as "Duplicate without user-selected canonical". Approach: add a nullable `canonicalId` self-FK to both tables; backfill the earliest-`createdAt` row per `(spaceId, symbol, percentageChange)` cluster as canonical, point the rest at it; in `app/daily-top-movers/top-(losers|gainers)/details/[id]/page.tsx` `permanentRedirect()` when `canonicalId` is set; filter `sitemap.xml/route.ts` and the list APIs feeding `RelatedDailyMovers` on `canonicalId IS NULL`. Validate with sitemap row-count drop + GSC duplicate-bucket shrink over 2–4 weeks.
+- [ ] **Stop creating new duplicates on US market holidays** — Mon-Fri cron (`deployments/insights-ui/scheduler.tf`) still fires on Good Friday / Presidents' Day / Memorial Day etc.; screener returns the prior trading day's data, callback writes a new row. Fix in `app/api/[spaceId]/tickers-v1/screener-callback/route.ts`: skip writes when a row already exists for `(spaceId, symbol)` with the same `percentageChange` within the last ~3 days. Or upgrade the unique constraint from `@@unique([spaceId, symbol, createdAt])` to a derived `marketDate` column so it's idempotent by definition.
+
+---
+
+## Overall site
+
+- [ ] **Dark/light theme toggle** — some users find current dark theme reports unreadable. Decide: global header vs per-report toggle; default theme for first-time visitors; persist per user (cookie / localStorage); print-friendly variant separate from light theme?
+- [ ] **Traffic from AI platforms** (ChatGPT, Gemini, Perplexity) — content, structured data, brand/citation presence; track inbound referrals.
+- [ ] **Search & analytics research** — export / summarize Google Search Console + Google Analytics (key reports, date range, segments) and run structured research (e.g. with Claude) on what to try next for overall traffic + quality users.
+
+### Login improvements
+
+- [ ] Add **LinkedIn** SSO + **Yahoo** SSO; account-linking when a new provider matches an existing email; keep login sheet tidy (top 3–4 most-used).
+- [ ] Post-login resume — after sign-in from the click-count gate, complete the action the user was taking.
+- [ ] Telemetry — events for click counted / gate shown / gate→login / gate dismissed; admin dashboard for conversion rate.
+- [ ] Open: gate threshold (2 vs 3) behind a config flag for A/B; soft banner before hard gate; never re-show gate to logged-in users.
+
 ### Social media content pipeline
 
 - [ ] **Sources to mine**: stock + ETF scenarios, 10-bagger shortlist, founder + PM profiles, off-hours-refreshed reports (verdict / fair-value diffs), trends.
@@ -159,11 +171,3 @@ Remaining:
 - [ ] **Cadence + governance**: weekly minimum mixing stock + ETF; one weekly queue owner; compliance pass on every post (no advice phrasing, disclaimers, claims grounded in reports).
 - [ ] **Measurement**: per-platform impressions/engagement/clicks + per-source-artifact attribution; high engagement feeds off-hours refresh prioritization so winning posts don't link to stale reports.
 - [ ] Open: build vs buy scheduler; single voice vs platform-tailored; share queue + templates with ETF pipeline (only input adapter differs).
-
----
-
-## Site-wide / Other
-
-- [ ] **Dark/light theme toggle** — some users find current dark theme reports unreadable. Decide: global header vs per-report toggle; default theme for first-time visitors; persist per user (cookie / localStorage); print-friendly variant separate from light theme?
-- [ ] **Traffic from AI platforms** (ChatGPT, Gemini, Perplexity) — content, structured data, brand/citation presence; track inbound referrals.
-- [ ] **Search & analytics research** — export / summarize Google Search Console + Google Analytics (key reports, date range, segments) and run structured research (e.g. with Claude) on what to try next for overall traffic + quality users.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -106,12 +106,6 @@ Remaining:
 - [ ] Storage: `insights-ui/src/etf-analysis-data/etf-comparison-bases.json` keyed by group with `{ primary: { symbol, name, source }, secondary?, rationale }`; injected into generation pipeline.
 - [ ] Prompt impact: every "vs. category" claim paired with "vs. {comparisonBase.name} ({comparisonBase.symbol})".
 
-### Suggestion — Connect ETFs to the home page + categorization
-
-> ETF category pages and country pages exist (see closed-tasks). Remaining:
-
-- [ ] **Add an ETF section on the home page** — mirror stocks-by-industry; group by `category` (Morningstar), cards link to category pages.
-
 ### Known limitations in the new 8-group taxonomy (follow-up cleanups)
 
 - [ ] **Split strategy funds back out of `derivative-income`** — managed-futures / market-neutral / long-short (~50 funds) don't share a decision framework with the ~600 option-engineered payoff funds; prompt has to branch internally. Highest-impact follow-up.
@@ -156,12 +150,9 @@ Remaining:
 
 ### Login improvements
 
-- [ ] Add **LinkedIn** SSO + **Yahoo** SSO; account-linking when a new provider matches an existing email; keep login sheet tidy (top 3–4 most-used).
-- [ ] Post-login resume — after sign-in from the click-count gate, complete the action the user was taking.
-- [ ] Telemetry — events for click counted / gate shown / gate→login / gate dismissed; admin dashboard for conversion rate.
-- [ ] Open: gate threshold (2 vs 3) behind a config flag for A/B; soft banner before hard gate; never re-show gate to logged-in users.
+- [ ] Add **LinkedIn** SSO + **Yahoo** SSO
 
 ### Social media content pipeline
 
-- [ ] **Start with LinkedIn** — pick one ETF, share its results, tag its manager or provider where possible, write a few lines about it, and attach a picture/poster.
+- [ ] **Start with LinkedIn** — pick one ETF or stock, share its results, tag its manager or provider where possible, write a few lines about it, and attach a picture/poster.
 - [ ] **Then move to X (Twitter)** — repeat the same simple post format once the LinkedIn flow is working.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -11,11 +11,11 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 - [ ] **Mobile layout audit** — fix overflow tables, cut-off charts, font/spacing/sticky-header/tap-target issues; verify after any restructure.
 - [ ] **Move competition chart** directly under the Business & Moat section, with the competitors list adjacent.
-- [ ] **SEO — "Crawled — currently not indexed" on `business-and-moat-sitemap.xml`** — export affected URLs, audit for thin/duplicative content, weak canonicals, render-blocked content, slow CWV, duplicate titles, sitemap hygiene; fix in priority order (unique per-ticker content → titles/meta → internal linking → SSR/canonical); re-submit validation; add weekly indexed-URL delta report and a pre-publish content-completeness gate; generalize fix to the other per-section sitemaps.
+- [ ] **SEO — "Crawled — currently not indexed" on `business-and-moat-sitemap.xml`** — check why these pages are not getting indexed.
 
 ### Off-hours Claude Code automation
 
-- [ ] **Off-hours report-refresh cron** (10 PM – 5 AM, local TZ documented) — pick oldest reports, batch + per-tick timeout, skip recently-refreshed, hard stop at window end, retry cap on failure, per-run log + admin failure surface, env-configurable window/batch/threshold/enable flag. Decide which report categories are in scope.
+- [ ] **Off-hours report-refresh cron** — pick the oldest stock reports and regenerate them.
 - [ ] **Off-hours recategorization** — separate scheduled job that sweeps every ticker, feeds taxonomy + company profile to Claude, applies high-confidence `changeTo` decisions, flags low-confidence for review, triggers report generation for new (sub)categories; cap recategorizations per run; per-stock audit trail; hysteresis guard against thrashing.
 
 ### Stock scenarios — finish + roll out
@@ -64,7 +64,7 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ### Top priorities
 
-- [ ] **Claude-Code Sonnet pipeline** — off-hours runner where Claude Code (Sonnet) generates stock + ETF reports through the existing prompt/`PromptInvocation` infra; one shared runner drains both queues. DOD: scheduled run produces a night's worth of refreshed reports without human in the loop.
+- [ ] **Claude-Code Sonnet pipeline** — same idea as the off-hours stock refresh, but for ETFs: pick the ETFs whose reports are not generated yet and generate the whole ETF report.
 - [ ] **ETF discoverability + internal linking** (after the list page lands):
   - Home page → ETFs: pick entry points (hero / nav / featured rail / "browse by category-group") so first-time visitors reach the ETFs list and representative detail pages in one click.
   - ETF detail → stock reports: link each covered holding's ticker through; plain text otherwise.
@@ -144,8 +144,7 @@ Remaining:
 
 ### Dedupe historical duplicates + harden ingest
 
-- [ ] **De-duplicate `daily_top_losers` / `daily_top_gainers`** — historical bug wrote multiple near-identical rows for the same ticker across weekends + US market holidays (~23% of loser rows belong to a `(symbol, %change)` cluster; 140 clusters, 344 rows). Each row got its own UUID, its own sitemap entry, and its own LLM-rewritten article, so GSC reports them as "Duplicate without user-selected canonical". Approach: add a nullable `canonicalId` self-FK to both tables; backfill the earliest-`createdAt` row per `(spaceId, symbol, percentageChange)` cluster as canonical, point the rest at it; in `app/daily-top-movers/top-(losers|gainers)/details/[id]/page.tsx` `permanentRedirect()` when `canonicalId` is set; filter `sitemap.xml/route.ts` and the list APIs feeding `RelatedDailyMovers` on `canonicalId IS NULL`. Validate with sitemap row-count drop + GSC duplicate-bucket shrink over 2–4 weeks.
-- [ ] **Stop creating new duplicates on US market holidays** — Mon-Fri cron (`deployments/insights-ui/scheduler.tf`) still fires on Good Friday / Presidents' Day / Memorial Day etc.; screener returns the prior trading day's data, callback writes a new row. Fix in `app/api/[spaceId]/tickers-v1/screener-callback/route.ts`: skip writes when a row already exists for `(spaceId, symbol)` with the same `percentageChange` within the last ~3 days. Or upgrade the unique constraint from `@@unique([spaceId, symbol, createdAt])` to a derived `marketDate` column so it's idempotent by definition.
+- [ ] In the past we may have mistakenly generated daily movers on weekends, which created duplicate entries — and the same thing will keep happening on future US holidays. Clean up the existing duplicates and stop creating new ones on non-trading days.
 
 ---
 
@@ -164,10 +163,5 @@ Remaining:
 
 ### Social media content pipeline
 
-- [ ] **Sources to mine**: stock + ETF scenarios, 10-bagger shortlist, founder + PM profiles, off-hours-refreshed reports (verdict / fair-value diffs), trends.
-- [ ] **Templates**: scenario card post; top-N post; founder / PM spotlight; verdict-change post; trend post.
-- [ ] **Platforms**: start LinkedIn + X (primary); Reddit (relevant subs), Threads, YouTube Shorts / IG Reels (secondary, after the first two are humming).
-- [ ] **Pipeline**: post-draft generator via existing prompt infra; lightweight admin content queue (review, edit, platforms, schedule); push to a scheduling tool (Buffer / Hootsuite / Hypefury, or in-house thin scheduler); UTM-tagged links back to KoalaGains.
-- [ ] **Cadence + governance**: weekly minimum mixing stock + ETF; one weekly queue owner; compliance pass on every post (no advice phrasing, disclaimers, claims grounded in reports).
-- [ ] **Measurement**: per-platform impressions/engagement/clicks + per-source-artifact attribution; high engagement feeds off-hours refresh prioritization so winning posts don't link to stale reports.
-- [ ] Open: build vs buy scheduler; single voice vs platform-tailored; share queue + templates with ETF pipeline (only input adapter differs).
+- [ ] **Start with LinkedIn** — pick one ETF, share its results, tag its manager or provider where possible, write a few lines about it, and attach a picture/poster.
+- [ ] **Then move to X (Twitter)** — repeat the same simple post format once the LinkedIn flow is working.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -256,3 +256,7 @@ Remaining:
 - [ ] **Logged-in user growth + daily-returning retention** — baseline ~300 logged-in / ~1k DAU / ~80 returning. Define hypotheses + experiments; tie to login gate, watchlists, alert digests.
 - [ ] **Traffic from AI platforms** (ChatGPT, Gemini, Perplexity) — content, structured data, brand/citation presence; track inbound referrals.
 - [ ] **Search & analytics research** — export / summarize Google Search Console + Google Analytics (key reports, date range, segments) and run structured research (e.g. with Claude) on what to try next for overall traffic + quality users.
+
+### Task-list housekeeping
+
+- [ ] **Finalize the task list** — do a full pass over [`todo-tasks.md`](./todo-tasks.md) and [`closed-tasks.md`](./closed-tasks.md) to keep both files accurate and actionable: verify each open item against the current codebase (drop or move anything already shipped to `closed-tasks.md` with a verifying note), de-duplicate overlapping entries, confirm every referenced file path / PR number / route still exists, ensure each item has a clear definition of done, regroup stragglers under the right top-level heading, and resolve or split out the dangling "Open:" questions so they don't accumulate. Run this as a recurring grooming pass (e.g. before each planning cycle) so the open list stays the single source of truth.

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -118,11 +118,6 @@ Remaining:
 - [ ] Storage: `insights-ui/src/etf-analysis-data/etf-comparison-bases.json` keyed by group with `{ primary: { symbol, name, source }, secondary?, rationale }`; injected into generation pipeline.
 - [ ] Prompt impact: every "vs. category" claim paired with "vs. {comparisonBase.name} ({comparisonBase.symbol})".
 
-### Phase 4 — SEO, metadata, sitemap
-
-- [ ] SEO/metadata review after new sections — titles/descriptions cover comparison + competition keywords; JSON-LD remains valid and updated.
-- [ ] Daily generation + sitemap updates — generate 5–10 ETFs daily; push generated URLs to sitemap (or sitemap index) automatically.
-
 ### Suggestion — Connect ETFs to the home page + categorization
 
 > ETF category pages and country pages exist (see closed-tasks). Remaining:

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -16,7 +16,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 ### Off-hours Claude Code automation
 
 - [ ] **Off-hours report-refresh cron** (10 PM – 5 AM, local TZ documented) — pick oldest reports, batch + per-tick timeout, skip recently-refreshed, hard stop at window end, retry cap on failure, per-run log + admin failure surface, env-configurable window/batch/threshold/enable flag. Decide which report categories are in scope.
-- [ ] **Internet-augmented generation** — prompts must use the web to fill missing inputs + pull latest (recent earnings, 8-Ks, exec changes, news, regulatory actions); cite source URL + `accessedAt`; restrict to reputable sources; persist `internetAugmented` flag + cited-URL count on each report; surface in admin; validate vs pre-cached baseline.
 - [ ] **Off-hours recategorization** — separate scheduled job that sweeps every ticker, feeds taxonomy + company profile to Claude, applies high-confidence `changeTo` decisions, flags low-confidence for review, triggers report generation for new (sub)categories; cap recategorizations per run; per-stock audit trail; hysteresis guard against thrashing.
 
 ### Stock scenarios — finish + roll out
@@ -78,12 +77,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 ### Top priorities
 
 - [ ] **Claude-Code Sonnet pipeline** — off-hours runner where Claude Code (Sonnet) generates stock + ETF reports through the existing prompt/`PromptInvocation` infra; one shared runner drains both queues. DOD: scheduled run produces a night's worth of refreshed reports without human in the loop.
-- [ ] **Split the Index & Strategy field** into structured sub-fields: at minimum `introParagraph` + `strategy`, plus 2–3 of `indexMethodology` / `rebalanceApproach` / `replicationStyle` / `keyConstraints` (finalize during implementation). Update prompt, output JSON contract, persistence, and detail-page rendering together; sanity-check via the 3.2 tuning loop.
-- [ ] **ETFs list page — `isComplete` filter + admin toggle**
-  - Define "complete" precisely (all core data fields populated; every evaluation-category report generated and non-failed: Performance, Cost & Team, Risk, Summary, Index & Strategy, Future Outlook; Final Summary generated). Persist as `Etf.isComplete` updated by the generation pipeline.
-  - Default public list filters to `isComplete = true`; also applies to sitemap + any featured rails.
-  - Admin "Include incomplete ETFs" toggle (localStorage-persisted) reveals all ETFs with a per-row 6-dot completeness indicator + quick links into 1.4 generation requests.
-  - Incomplete ETFs remain reachable by URL (no 404) but omitted from default list/sitemap/search; detail page shows neutral "report in progress" state for missing sections.
 - [ ] **ETF discoverability + internal linking** (after the list page lands):
   - Home page → ETFs: pick entry points (hero / nav / featured rail / "browse by category-group") so first-time visitors reach the ETFs list and representative detail pages in one click.
   - ETF detail → stock reports: link each covered holding's ticker through; plain text otherwise.
@@ -92,24 +85,9 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ### Performance optimization (parity with stock-page perf work)
 
-> Stocks had a multi-PR perf pass — cache fan-out (#1472, #1473), `force-dynamic` ISR-off migration (#1499), CloudFront page+API caching (#1501, #1504), the `/full-render` consolidation that hurt Lighthouse and got reverted in favor of per-slice Suspense streaming (#1486 → #1507), and a 1w→2w revalidate bump (#1423). ETFs got partial parity at the CloudFront-API layer via #1581 (enumerates `/full-render`, `/analysis`, `/mor-info`, `/portfolio-holdings`) and at the ISR-off layer via #1499 (all 22 ETF pages now carry `force-dynamic`). Tracked in PR #1618. **Do not revert `force-dynamic` or add `generateStaticParams` — that is the model #1499 chose, with CloudFront in front absorbing hot traffic.**
-
-Done in #1618:
-
-- [x] **Lazy-load chart.js on ETF pages** — `EtfRadarChart` (spider) + `EtfChartTabs` (price/returns/CAGR) now use the stocks-side two-layer pattern: outer `dynamic({ ssr:false })` + viewport-gated `useInView`. chart.js no longer lands in the main bundle.
-- [x] **`prefetch={false}` on every ETF-bound `<Link>`** — 14 components covered (listing grids, `SimilarEtfs`, holdings, badges, analysis/competition sections, scenarios, investor-goal cards).
-- [x] **Drop `revalidate:` from ETF detail subpages** (Option A — chose tag-only over 1w→2w bump; reports aren't regenerated on a fixed cadence). Matches the stocks model.
-- [x] **Per-slice Suspense streaming on main detail page** (partial — shell awaits one lightweight fetch, body sections stream via `<Suspense>`; all 4 boundaries share the single `/full-render` promise so they unsuspend together). True per-slice streaming is still pending — see below.
-- [x] **ETF subpages match stocks' one-fetch shape** — new per-category endpoints (`risk-analysis-data`, `cost-efficiency-team-data`, `performance-returns-data`, `future-performance-outlook-data`) wrap a shared util that filters by `categoryKey` and bundles a trimmed ETF (no `financialInfo`). Sibling slugs are now a Suspense'd promise instead of an awaited Prisma call. Replaces 2-3 awaited fetches per subpage with 1.
-
 Remaining:
 
-- [ ] **Baseline measurement** — for 3 representative ETFs (popular passive, active, thin) + 2 listing URLs, capture median Lighthouse (FCP/LCP/TBT/SI/CLS), Vercel Cache Writes:Reads, CloudFront `x-cache` hit-rate. Persist to `docs/insights-ui/etf-page-caching.md` so each follow-up PR can append a delta row.
 - [ ] **True per-slice streaming on `/etfs/[exchange]/[etf]`** — current shell-vs-body split still shares one `/full-render` promise so all 4 boundaries unsuspend together. Add per-slice ETF API endpoints (`priceHistory`, `performanceMetrics`, `similarEtfs`, `keyFacts`, `keyMetrics`) and rewrite each `<Suspense>` block to own its own fetch — mirror of the post-#1507 stock page. Then decide whether to remove `/full-render` + `etf-full-render-utils.ts` + the CloudFront cache behavior added by #1581, or leave as harmless dead weight.
-- [ ] **Gate `EtfCompetitionQuadrantChart` on `useInView`** — has `ssr:false` but no viewport gate, so chart.js fires immediately on competition page. Apply the same two-layer pattern used for `EtfRadarChart` / `EtfChartTabs`.
-- [ ] **Audit ETF cache-tag fan-out** (mirror of #1472 parts 1+2 and #1473). Confirm `etf-cache-utils.ts` follows the umbrella + per-subpage narrow-tag split: a partial regen touching one category should NOT invalidate every other subpage. Verify no read-path utility calls `revalidate*` while serving an API request. Document findings in `etf-page-caching.md`.
-- [ ] **Validate `force-dynamic` + CloudFront edge are paying off** — confirm via Vercel metrics that Cache Writes on `/etfs/*` are flat and via response headers that CloudFront `x-cache: Hit from cloudfront` fires on a warm second hit for the detail page and the four cached API endpoints. If hit-rate is low, follow `docs/insights-ui/cloudfront-deploy-skew.md`.
-- [ ] **Re-measure + document gains** — after each PR lands, re-run the baseline harness and append a delta row to `etf-page-caching.md`. Stop pulling levers once LCP < 5s on the detail page and CloudFront hit-rate on the cached API paths is healthy.
 
 ### Active-ETF management team — LinkedIn-sourced info (ETF-side parallel to stock task)
 
@@ -150,23 +128,6 @@ Remaining:
 > ETF category pages and country pages exist (see closed-tasks). Remaining:
 
 - [ ] **Add an ETF section on the home page** — mirror stocks-by-industry; group by `category` (Morningstar), cards link to category pages.
-- [ ] **Group the `/etfs` listing by category** — top categories first with "View all" per category; keep full search/filter behind a power-user view.
-- [ ] **Add ETF country pages** (later) — `/etfs/countries/[country]` route exists; finish data wiring + sitemap + SEO once category pages are battle-tested.
-- [ ] **Cross-link from ETF detail pages** — category name links to the category page; small "Related ETFs in this category" block at the bottom.
-
-### ETF listing pages — UI fixes
-
-- [ ] **Audit + fix UI issues across the ETF listing surfaces** — `/etfs` (index), `/etfs/categories` (+ `[category]`), `/etfs/countries` (+ `[country]`), `/etfs/asset-classes` (+ `[assetClass]`), `/etfs/groups` (+ `[group]`), `/etfs/providers` (+ `[provider]`). Walk each page on desktop + mobile and capture concrete issues here as sub-bullets before scheduling fixes: layout/spacing, card alignment, header + breadcrumb consistency across the sub-listing variants, empty/loading/error states, sort + filter UX, pagination, and dark/light theme rendering. Cross-check against the `isComplete` filter behavior once that lands.
-
-### ETF detail-page buttons — logic + UX audit
-
-- [ ] **Audit the ETF detail-page button row** (`Favourite`, `Notes`, admin three-dots `EtfActions`) on `app/etfs/[exchange]/[etf]/page.tsx`. Walk each button as logged-out, logged-in non-admin, and admin; capture concrete issues here as sub-bullets before scheduling fixes. Things to verify explicitly:
-  - **Logged-out flow** — `EtfFavouriteButton` / `EtfNotesButton` currently `router.push('/login')` on click. Now that #1617 introduced the navbar login popup, decide whether these buttons should open the same popup instead of a full-page redirect, and whether the "Add to favourites / Add note" tooltip should change to "Log in to save" before click.
-  - **Solid vs outline icon state** — confirm the solid heart / solid document icon only renders when an `EtfFavourite` / `EtfNote` actually exists for the current user (no flash of solid state during the initial `useFetchData` load; correct empty-state when fetch fails).
-  - **`skipInitialFetch: !session`** — both buttons skip the favourites/notes fetch when there is no session, but the underlying state still defaults to "not favourited / no note". Verify nothing in the modal or downstream UI silently assumes the fetch ran.
-  - **Cross-page consistency** — the same Favourite + Notes buttons render on detail subpages (`risk-analysis`, `performance-returns`, `cost-efficiency-team`, `future-performance-outlook`, `competition`, `holdings`, `financial-data`). Confirm the favourited/noted state shows correctly on every subpage and that clicking either button does not lose subpage context (no unintended `router.refresh` / navigation away).
-  - **Admin `EtfActions` dropdown** — `generate-report` opens a modal, `invalidate-cache` flushes the per-ETF cache tag. Verify the "Invalidating…" disabled state actually clears after success/failure, the modal closes after a generation request is queued, and the redirect to `/admin-v1/etf-generation-requests` does not fire if the POST fails (currently the `try/catch` redirects even on a swallowed failure path — check this).
-  - **Leaf-component compliance** — the three button components carry inline Tailwind (`bg-blue-700`, `bg-green-700`, `bg-gray-800`, etc.). Once the logic audit lands, follow up by routing the visuals through the leaf layer per `docs/insights-ui/ui-leaf-component-system.md`.
 
 ### Known limitations in the new 8-group taxonomy (follow-up cleanups)
 
@@ -206,57 +167,8 @@ Remaining:
 
 ---
 
-## Tariffs
-
-### Refresh + simplify reports
-
-- [ ] **Top-of-page snapshot block** (above the fold): industry + countries headline; headline tariff numbers (current rate, rate N months ago, delta); "Last updated YYYY-MM-DD"; 3 bullets ("What's new", "Who's affected", "What to watch").
-- [ ] **Cut body length** — consolidate boilerplate into linked explainer pages; replace dense tables with focused charts; target 800–1500 words per report.
-- [ ] **In-page navigation** — sticky TOC / section jump nav; per-subsection anchor links.
-- [ ] **Mobile pass** — verify headline numbers, charts, snapshot block render cleanly on a phone before shipping.
-- [ ] **Reader actions** — "subscribe for updates on this industry/country" CTA tied into the click-count login gate; "share" / "copy link" affordance for the most-shared sections.
-
-### Internal linking pass (standalone single PR)
-
-- [ ] Confirm home + hub surfaces link to `/tariff-reports` and a curated set of high-traffic industry covers (one click from home to the most popular tariff reports).
-- [ ] Server-render every link (no client-only `useEffect` rails).
-- [ ] Reuse the existing `tariff_report:<INDUSTRYID>` cache tag; if a link block reads from a different source (ETF index, stock index) tag the fetch with that source's tag too.
-- [ ] Stable anchors derived from country / area slug (not generated index) so inbound links don't rot on regeneration.
-- [ ] Guard outbound links — only render when the target exists.
-
-### Operational + measurement
-
-- [ ] Capture baselines (organic sessions, time on page, bounce, scroll depth, indexed-URL count for tariff sitemaps); monitor Search Console for tariff URLs after refresh; watch for the same "Crawled — currently not indexed" pattern.
-- [ ] Sitemap hygiene — `industry-tariff-report/sitemap.xml` only lists URLs with refreshed content above a minimum quality bar (`isComplete`-style); `lastmod` reflects refresh time, not build time.
-- [ ] Engagement check 2 weeks post-PR: rail-click events + indexed-URL delta documented in `../tariffs/`.
-
-### Strategic-intelligence features
-
-> Lower build effort, high leverage in the current architecture — reuse what the pipeline
-> already produces (industry impact, country-specific tariff updates, company impact
-> categorization).
-
-- [ ] **Country-pair compare view** — Industry × Exporter × Importer (+ compare-against), delta view, AI explanation of why the lane matters and which company archetypes win/lose.
-- [ ] **Company impact screener** — Company → tariff exposure (positive/negative by industry area + country, "why impacted" snippets, link back to industry sub-section that justified it).
-- [ ] **Freshness + evidence panel** on every tariff claim block — data vintage, source links, "what changed" diff across report versions.
-- [ ] **Watchlists + alert digests** — subscribe to industries / country pairs / companies / major-change triggers (new trade remedy, tariff jump > threshold); daily/weekly digest.
-- [ ] **Standardized tariff exposure scorecard** at the top of each report — shock intensity, trade-lane concentration, company vulnerability (heuristics, not econometric).
-- [ ] **Related-industry spillover navigation** using `TariffIndustryDefinition` adjacency — upstream/downstream + spillover summary cached per pair.
-- [ ] **Schema'd export bundle** — PDF / MD / JSON exports for consultants and teams.
-- [ ] **Trade-remedy and NTM overlay** — country-pair callout + structured link panel into a trade-remedy explorer by product/year.
-- [ ] **Bilateral change feed** using tariff-actions data — filterable "what changed this week" by country pair + HS6 → industry; effective dates, prior/current rates, "industry implication" summary.
-- [ ] **Scenario simulator lite** — choose baseline + alternative source lanes → tariff delta + shipping + pass-through % → sensitivity plot + narrative.
-- [ ] **Rules-of-origin assistant layer** (rolls up #16) — guided rules narrative across agreements, not raw legal text.
-
----
-
 ## Site-wide / Other
 
 - [ ] **Dark/light theme toggle** — some users find current dark theme reports unreadable. Decide: global header vs per-report toggle; default theme for first-time visitors; persist per user (cookie / localStorage); print-friendly variant separate from light theme?
-- [ ] **Logged-in user growth + daily-returning retention** — baseline ~300 logged-in / ~1k DAU / ~80 returning. Define hypotheses + experiments; tie to login gate, watchlists, alert digests.
 - [ ] **Traffic from AI platforms** (ChatGPT, Gemini, Perplexity) — content, structured data, brand/citation presence; track inbound referrals.
 - [ ] **Search & analytics research** — export / summarize Google Search Console + Google Analytics (key reports, date range, segments) and run structured research (e.g. with Claude) on what to try next for overall traffic + quality users.
-
-### Task-list housekeeping
-
-- [ ] **Finalize the task list** — do a full pass over [`todo-tasks.md`](./todo-tasks.md) and [`closed-tasks.md`](./closed-tasks.md) to keep both files accurate and actionable: verify each open item against the current codebase (drop or move anything already shipped to `closed-tasks.md` with a verifying note), de-duplicate overlapping entries, confirm every referenced file path / PR number / route still exists, ensure each item has a clear definition of done, regroup stragglers under the right top-level heading, and resolve or split out the dangling "Open:" questions so they don't accumulate. Run this as a recurring grooming pass (e.g. before each planning cycle) so the open list stays the single source of truth.


### PR DESCRIPTION
Adds a new open task under **Site-wide / Other → Task-list housekeeping** in `docs/insights-ui/tasks/todo-tasks.md` to track finalizing/grooming the task list itself: verifying open items against the codebase, de-duplicating, confirming referenced paths/PRs/routes, ensuring each item has a clear definition of done, and resolving dangling "Open:" questions as a recurring pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)