### PR TITLE
fix(etfs): real 404 / noindex for empty ETF listing pages (soft-404 fix)

### DIFF
--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-uti
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { etfBrowseDetailPath } from '@/utils/etf-country-route-utils';
+import { fetchEtfAssetClassesIndex } from '@/utils/etf-listing-fetchers';
+import { assetClassDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfAssetClassDetailBreadcrumbJsonLd, generateEtfAssetClassDetailMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -29,11 +31,15 @@ export async function generateMetadata(props: { params: Promise<{ assetClass: st
   const resolved = resolveAssetClass(assetClass);
   const canonical = resolved?.canonical ?? decodeURIComponent(assetClass);
   const slug = resolved?.slug ?? slugifyEtfTag(canonical);
-  return generateEtfAssetClassDetailMetadata({
+  const base = generateEtfAssetClassDetailMetadata({
     country: SupportedCountries.US,
     assetClass: canonical,
     assetClassSlug: slug,
   });
+  // Unknown asset class → the page 404s, so there's nothing to index either way.
+  if (!resolved) return base;
+  const index = await fetchEtfAssetClassesIndex(SupportedCountries.US);
+  return { ...base, ...assetClassDetailRobots(index, resolved.slug) };
 }
 
 export default async function EtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/page.tsx
@@ -1,38 +1,19 @@
-import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
 import EtfAssetClassesIndex from '@/components/etfs/EtfAssetClassesIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfAssetClassesIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
+import { EMPTY_ETF_ASSET_CLASSES_INDEX, fetchEtfAssetClassesIndex } from '@/utils/etf-listing-fetchers';
+import { assetClassesIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = generateEtfAssetClassesIndexMetadata(SupportedCountries.US);
-
-const EMPTY_ASSET_CLASSES: EtfAssetClassesIndexResponse = { values: {}, counts: {} };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchAssetClassesIndex(country: SupportedCountries): Promise<EtfAssetClassesIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/asset-classes-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfAssetClassesIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchAssetClassesIndex failed (${res.status}): ${url}`);
-      return EMPTY_ASSET_CLASSES;
-    }
-    return (await res.json()) as EtfAssetClassesIndexResponse;
-  } catch (e) {
-    console.error('fetchAssetClassesIndex error:', e);
-    return EMPTY_ASSET_CLASSES;
-  }
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchEtfAssetClassesIndex(SupportedCountries.US);
+  return { ...generateEtfAssetClassesIndexMetadata(SupportedCountries.US), ...assetClassesIndexRobots(data) };
 }
 
 export default async function EtfsAssetClassesIndexPage() {
-  const data = await fetchAssetClassesIndex(SupportedCountries.US);
+  const data = (await fetchEtfAssetClassesIndex(SupportedCountries.US)) ?? EMPTY_ETF_ASSET_CLASSES_INDEX;
   return (
     <>
       <script

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-uti
 import { etfBrowseDetailPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { fetchEtfAssetClassesIndex } from '@/utils/etf-listing-fetchers';
+import { assetClassDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfAssetClassDetailBreadcrumbJsonLd, generateEtfAssetClassDetailMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -30,11 +32,15 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
   const canonical = resolved?.canonical ?? decodeURIComponent(assetClass);
   const slug = resolved?.slug ?? slugifyEtfTag(canonical);
   const decodedCountry = resolveEtfCountryParam(country, etfBrowseDetailPath(SupportedCountries.US, 'asset-classes', slug));
-  return generateEtfAssetClassDetailMetadata({
+  const base = generateEtfAssetClassDetailMetadata({
     country: decodedCountry,
     assetClass: canonical,
     assetClassSlug: slug,
   });
+  // Unknown asset class → the page 404s, so there's nothing to index either way.
+  if (!resolved) return base;
+  const index = await fetchEtfAssetClassesIndex(decodedCountry);
+  return { ...base, ...assetClassDetailRobots(index, resolved.slug) };
 }
 
 export default async function CountryEtfsByAssetClassPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/page.tsx
@@ -1,12 +1,8 @@
-import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
 import EtfAssetClassesIndex from '@/components/etfs/EtfAssetClassesIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfAssetClassesIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
-import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { EMPTY_ETF_ASSET_CLASSES_INDEX, fetchEtfAssetClassesIndex } from '@/utils/etf-listing-fetchers';
+import { assetClassesIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfAssetClassesIndexBreadcrumbJsonLd, generateEtfAssetClassesIndexMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -15,36 +11,17 @@ type PageProps = {
   params: Promise<{ country: string }>;
 };
 
-const EMPTY_ASSET_CLASSES: EtfAssetClassesIndexResponse = { values: {}, counts: {} };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchAssetClassesIndex(country: EtfSupportedCountry): Promise<EtfAssetClassesIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/asset-classes-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfAssetClassesIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchAssetClassesIndex failed (${res.status}): ${url}`);
-      return EMPTY_ASSET_CLASSES;
-    }
-    return (await res.json()) as EtfAssetClassesIndexResponse;
-  } catch (e) {
-    console.error('fetchAssetClassesIndex error:', e);
-    return EMPTY_ASSET_CLASSES;
-  }
-}
-
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { country } = await props.params;
   const decoded = resolveEtfCountryParam(country, '/etfs/asset-classes');
-  return generateEtfAssetClassesIndexMetadata(decoded);
+  const data = await fetchEtfAssetClassesIndex(decoded);
+  return { ...generateEtfAssetClassesIndexMetadata(decoded), ...assetClassesIndexRobots(data) };
 }
 
 export default async function CountryEtfsAssetClassesIndexPage({ params }: PageProps) {
   const { country } = await params;
   const decoded = resolveEtfCountryParam(country, '/etfs/asset-classes');
-  const data = await fetchAssetClassesIndex(decoded);
+  const data = (await fetchEtfAssetClassesIndex(decoded)) ?? EMPTY_ETF_ASSET_CLASSES_INDEX;
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfAssetClassesIndexBreadcrumbJsonLd(decoded)) }} />

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/categories/[category]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfCategoryByName, getEtfCategoryBySlug, getEtfGroupByKey, slugifyEtfCategory } from '@/utils/etf-categorization-utils';
 import { etfGroupCategoryPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { fetchEtfGroupDetail } from '@/utils/etf-listing-fetchers';
+import { groupCategoryDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfGroupCategoryListingBreadcrumbJsonLd, generateEtfGroupCategoryListingMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -21,12 +23,16 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
   const cat = getEtfCategoryBySlug(decodedCategory) ?? getEtfCategoryByName(decodedCategory);
   const decodedCountry = resolveEtfCountryParam(country, etfGroupCategoryPath(SupportedCountries.US, cat?.group ?? decodedGroup, cat?.name ?? decodedCategory));
   const groupObj = getEtfGroupByKey(decodedGroup);
-  return generateEtfGroupCategoryListingMetadata({
+  const base = generateEtfGroupCategoryListingMetadata({
     country: decodedCountry,
     groupKey: cat?.group ?? decodedGroup,
     groupName: groupObj?.name ?? decodedGroup,
     categoryName: cat?.name ?? decodedCategory,
   });
+  // Unknown category → the page 404s, so there's nothing to index either way.
+  if (!cat) return base;
+  const groupData = await fetchEtfGroupDetail(decodedCountry, cat.group);
+  return { ...base, ...groupCategoryDetailRobots(groupData, cat.name) };
 }
 
 export default async function CountryEtfsByGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -9,6 +9,7 @@ import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -54,12 +55,16 @@ export default async function CountryEtfsByGroupPage({ params }: PageProps) {
   const { country, group } = await params;
   const decodedGroupKey = decodeURIComponent(group);
   const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
-  const data = await fetchGroupDetail(decodedCountry, decodedGroupKey);
+  // Reject unknown group keys with a real 404 instead of rendering an empty
+  // listing (a soft 404). Uses the local category config so transient API
+  // failures on a valid key still fail-soft via EMPTY_GROUP_DETAIL.
   const groupObj = getEtfGroupByKey(decodedGroupKey);
+  if (!groupObj) notFound();
+  const data = await fetchGroupDetail(decodedCountry, decodedGroupKey);
   const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
     country: decodedCountry,
     groupKey: decodedGroupKey,
-    groupName: groupObj?.name ?? decodedGroupKey,
+    groupName: groupObj.name,
   });
   return (
     <>

--- a/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/groups/[group]/page.tsx
@@ -1,13 +1,9 @@
-import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listings/group/route';
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfGroupDetailTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
-import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { EMPTY_ETF_GROUP_DETAIL, fetchEtfGroupDetail } from '@/utils/etf-listing-fetchers';
+import { groupDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
@@ -17,38 +13,20 @@ type PageProps = {
   params: Promise<{ country: string; group: string }>;
 };
 
-const EMPTY_GROUP_DETAIL: EtfGroupDetailResponse = { found: false, values: {}, counts: {}, others: null };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchGroupDetail(country: EtfSupportedCountry, groupKey: string): Promise<EtfGroupDetailResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/group?country=${encodeURIComponent(
-    country
-  )}&groupKey=${encodeURIComponent(groupKey)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfGroupDetailTag(country, groupKey));
-    if (!res.ok) {
-      console.error(`fetchGroupDetail failed (${res.status}): ${url}`);
-      return EMPTY_GROUP_DETAIL;
-    }
-    return (await res.json()) as EtfGroupDetailResponse;
-  } catch (e) {
-    console.error('fetchGroupDetail error:', e);
-    return EMPTY_GROUP_DETAIL;
-  }
-}
-
 export async function generateMetadata(props: { params: Promise<{ country: string; group: string }> }): Promise<Metadata> {
   const { country, group } = await props.params;
   const decodedGroup = decodeURIComponent(group);
   const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroup)}`);
   const groupObj = getEtfGroupByKey(decodedGroup);
-  return generateEtfGroupDetailMetadata({
+  const base = generateEtfGroupDetailMetadata({
     country: decodedCountry,
     groupKey: decodedGroup,
     groupName: groupObj?.name ?? decodedGroup,
   });
+  // Unknown key → the page 404s, so there's nothing to index either way.
+  if (!groupObj) return base;
+  const data = await fetchEtfGroupDetail(decodedCountry, decodedGroup);
+  return { ...base, ...groupDetailRobots(data) };
 }
 
 export default async function CountryEtfsByGroupPage({ params }: PageProps) {
@@ -57,10 +35,10 @@ export default async function CountryEtfsByGroupPage({ params }: PageProps) {
   const decodedCountry = resolveEtfCountryParam(country, `/etfs/groups/${encodeURIComponent(decodedGroupKey)}`);
   // Reject unknown group keys with a real 404 instead of rendering an empty
   // listing (a soft 404). Uses the local category config so transient API
-  // failures on a valid key still fail-soft via EMPTY_GROUP_DETAIL.
+  // failures on a valid key still fail-soft via EMPTY_ETF_GROUP_DETAIL.
   const groupObj = getEtfGroupByKey(decodedGroupKey);
   if (!groupObj) notFound();
-  const data = await fetchGroupDetail(decodedCountry, decodedGroupKey);
+  const data = (await fetchEtfGroupDetail(decodedCountry, decodedGroupKey)) ?? EMPTY_ETF_GROUP_DETAIL;
   const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
     country: decodedCountry,
     groupKey: decodedGroupKey,

--- a/insights-ui/src/app/etfs/countries/[country]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/page.tsx
@@ -1,12 +1,8 @@
-import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
 import EtfGroupsIndex from '@/components/etfs/EtfGroupsIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfGroupsIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
-import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { EMPTY_ETF_GROUPS_INDEX, fetchEtfGroupsIndex } from '@/utils/etf-listing-fetchers';
+import { groupsIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfCountryListingBreadcrumbJsonLd, generateEtfCountryListingMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -15,41 +11,17 @@ type PageProps = {
   params: Promise<{ country: string }>;
 };
 
-const EMPTY_GROUPS_INDEX: EtfGroupsIndexResponse = {
-  categoryValues: {},
-  categoryCounts: {},
-  groupCounts: {},
-  others: { items: [], count: 0 },
-};
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchGroupsIndex(country: EtfSupportedCountry): Promise<EtfGroupsIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/groups-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfGroupsIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchGroupsIndex failed (${res.status}): ${url}`);
-      return EMPTY_GROUPS_INDEX;
-    }
-    return (await res.json()) as EtfGroupsIndexResponse;
-  } catch (e) {
-    console.error('fetchGroupsIndex error:', e);
-    return EMPTY_GROUPS_INDEX;
-  }
-}
-
 export async function generateMetadata(props: { params: Promise<{ country: string }> }): Promise<Metadata> {
   const { country } = await props.params;
   const decoded = resolveEtfCountryParam(country, '/etfs');
-  return generateEtfCountryListingMetadata(decoded);
+  const data = await fetchEtfGroupsIndex(decoded);
+  return { ...generateEtfCountryListingMetadata(decoded), ...groupsIndexRobots(data) };
 }
 
 export default async function CountryEtfsPage({ params }: PageProps) {
   const { country } = await params;
   const decoded = resolveEtfCountryParam(country, '/etfs');
-  const data = await fetchGroupsIndex(decoded);
+  const data = (await fetchEtfGroupsIndex(decoded)) ?? EMPTY_ETF_GROUPS_INDEX;
   return (
     <EtfGroupsIndex
       country={decoded}

--- a/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/[provider]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { etfBrowseDetailPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { getEtfProviderBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { fetchEtfProvidersIndex } from '@/utils/etf-listing-fetchers';
+import { providerDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfProviderDetailBreadcrumbJsonLd, generateEtfProviderDetailMetadata } from '@/utils/etf-metadata-generators';
 import { permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -18,11 +20,13 @@ export async function generateMetadata(props: { params: Promise<{ country: strin
   const { country, provider } = await props.params;
   const slug = slugifyEtfTag(decodeURIComponent(provider));
   const decodedCountry = resolveEtfCountryParam(country, etfBrowseDetailPath(SupportedCountries.US, 'providers', slug));
-  return generateEtfProviderDetailMetadata({
+  const base = generateEtfProviderDetailMetadata({
     country: decodedCountry,
     providerCanonical: getEtfProviderBySlug(slug),
     providerSlug: slug,
   });
+  const index = await fetchEtfProvidersIndex(decodedCountry);
+  return { ...base, ...providerDetailRobots(index, slug) };
 }
 
 export default async function CountryEtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/providers/page.tsx
@@ -1,12 +1,8 @@
-import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
 import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { getEtfProvidersIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
-import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { EMPTY_ETF_PROVIDERS_INDEX, fetchEtfProvidersIndex } from '@/utils/etf-listing-fetchers';
+import { providersIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
@@ -15,36 +11,17 @@ type PageProps = {
   params: Promise<{ country: string }>;
 };
 
-const EMPTY_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {} };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchProvidersIndex(country: EtfSupportedCountry): Promise<EtfProvidersIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/providers-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfProvidersIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchProvidersIndex failed (${res.status}): ${url}`);
-      return EMPTY_PROVIDERS_INDEX;
-    }
-    return (await res.json()) as EtfProvidersIndexResponse;
-  } catch (e) {
-    console.error('fetchProvidersIndex error:', e);
-    return EMPTY_PROVIDERS_INDEX;
-  }
-}
-
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { country } = await props.params;
   const decoded = resolveEtfCountryParam(country, '/etfs/providers');
-  return generateEtfProvidersIndexMetadata(decoded);
+  const data = await fetchEtfProvidersIndex(decoded);
+  return { ...generateEtfProvidersIndexMetadata(decoded), ...providersIndexRobots(data) };
 }
 
 export default async function CountryEtfsProvidersIndexPage({ params }: PageProps) {
   const { country } = await params;
   const decoded = resolveEtfCountryParam(country, '/etfs/providers');
-  const data = await fetchProvidersIndex(decoded);
+  const data = (await fetchEtfProvidersIndex(decoded)) ?? EMPTY_ETF_PROVIDERS_INDEX;
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(generateEtfProvidersIndexBreadcrumbJsonLd(decoded)) }} />

--- a/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/categories/[category]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { getEtfCategoryByName, getEtfCategoryBySlug, getEtfGroupByKey, slugifyEtfCategory } from '@/utils/etf-categorization-utils';
 import { etfGroupCategoryPath } from '@/utils/etf-country-route-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { fetchEtfGroupDetail } from '@/utils/etf-listing-fetchers';
+import { groupCategoryDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfGroupCategoryListingBreadcrumbJsonLd, generateEtfGroupCategoryListingMetadata } from '@/utils/etf-metadata-generators';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -20,12 +22,16 @@ export async function generateMetadata(props: { params: Promise<{ group: string;
   const decodedCategory = decodeURIComponent(category);
   const groupObj = getEtfGroupByKey(decodedGroup);
   const cat = getEtfCategoryBySlug(decodedCategory) ?? getEtfCategoryByName(decodedCategory);
-  return generateEtfGroupCategoryListingMetadata({
+  const base = generateEtfGroupCategoryListingMetadata({
     country: SupportedCountries.US,
     groupKey: cat?.group ?? decodedGroup,
     groupName: groupObj?.name ?? decodedGroup,
     categoryName: cat?.name ?? decodedCategory,
   });
+  // Unknown category → the page 404s, so there's nothing to index either way.
+  if (!cat) return base;
+  const groupData = await fetchEtfGroupDetail(SupportedCountries.US, cat.group);
+  return { ...base, ...groupCategoryDetailRobots(groupData, cat.name) };
 }
 
 export default async function EtfGroupCategoryPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -8,6 +8,7 @@ import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
 import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -51,12 +52,16 @@ export async function generateMetadata(props: { params: Promise<{ group: string 
 export default async function EtfsByGroupPage({ params }: PageProps) {
   const { group } = await params;
   const groupKey = decodeURIComponent(group);
-  const data = await fetchGroupDetail(SupportedCountries.US, groupKey);
+  // Reject unknown group keys with a real 404 instead of rendering an empty
+  // listing (a soft 404). Uses the local category config so transient API
+  // failures on a valid key still fail-soft via EMPTY_GROUP_DETAIL.
   const groupObj = getEtfGroupByKey(groupKey);
+  if (!groupObj) notFound();
+  const data = await fetchGroupDetail(SupportedCountries.US, groupKey);
   const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
     country: SupportedCountries.US,
     groupKey,
-    groupName: groupObj?.name ?? groupKey,
+    groupName: groupObj.name,
   });
   return (
     <>

--- a/insights-ui/src/app/etfs/groups/[group]/page.tsx
+++ b/insights-ui/src/app/etfs/groups/[group]/page.tsx
@@ -1,12 +1,9 @@
-import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listings/group/route';
 import EtfGroupDetail from '@/components/etfs/EtfGroupDetail';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfGroupDetailTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
 import { getEtfGroupByKey } from '@/utils/etf-categorization-utils';
+import { EMPTY_ETF_GROUP_DETAIL, fetchEtfGroupDetail } from '@/utils/etf-listing-fetchers';
+import { groupDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfGroupDetailBreadcrumbJsonLd, generateEtfGroupDetailMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
@@ -16,37 +13,19 @@ type PageProps = {
   params: Promise<{ group: string }>;
 };
 
-const EMPTY_GROUP_DETAIL: EtfGroupDetailResponse = { found: false, values: {}, counts: {}, others: null };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchGroupDetail(country: SupportedCountries, groupKey: string): Promise<EtfGroupDetailResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/group?country=${encodeURIComponent(
-    country
-  )}&groupKey=${encodeURIComponent(groupKey)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfGroupDetailTag(country, groupKey));
-    if (!res.ok) {
-      console.error(`fetchGroupDetail failed (${res.status}): ${url}`);
-      return EMPTY_GROUP_DETAIL;
-    }
-    return (await res.json()) as EtfGroupDetailResponse;
-  } catch (e) {
-    console.error('fetchGroupDetail error:', e);
-    return EMPTY_GROUP_DETAIL;
-  }
-}
-
 export async function generateMetadata(props: { params: Promise<{ group: string }> }): Promise<Metadata> {
   const { group } = await props.params;
   const groupKey = decodeURIComponent(group);
   const groupObj = getEtfGroupByKey(groupKey);
-  return generateEtfGroupDetailMetadata({
+  const base = generateEtfGroupDetailMetadata({
     country: SupportedCountries.US,
     groupKey,
     groupName: groupObj?.name ?? groupKey,
   });
+  // Unknown key → the page 404s, so there's nothing to index either way.
+  if (!groupObj) return base;
+  const data = await fetchEtfGroupDetail(SupportedCountries.US, groupKey);
+  return { ...base, ...groupDetailRobots(data) };
 }
 
 export default async function EtfsByGroupPage({ params }: PageProps) {
@@ -54,10 +33,10 @@ export default async function EtfsByGroupPage({ params }: PageProps) {
   const groupKey = decodeURIComponent(group);
   // Reject unknown group keys with a real 404 instead of rendering an empty
   // listing (a soft 404). Uses the local category config so transient API
-  // failures on a valid key still fail-soft via EMPTY_GROUP_DETAIL.
+  // failures on a valid key still fail-soft via EMPTY_ETF_GROUP_DETAIL.
   const groupObj = getEtfGroupByKey(groupKey);
   if (!groupObj) notFound();
-  const data = await fetchGroupDetail(SupportedCountries.US, groupKey);
+  const data = (await fetchEtfGroupDetail(SupportedCountries.US, groupKey)) ?? EMPTY_ETF_GROUP_DETAIL;
   const breadcrumb = generateEtfGroupDetailBreadcrumbJsonLd({
     country: SupportedCountries.US,
     groupKey,

--- a/insights-ui/src/app/etfs/page.tsx
+++ b/insights-ui/src/app/etfs/page.tsx
@@ -1,43 +1,19 @@
-import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
 import EtfGroupsIndex from '@/components/etfs/EtfGroupsIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfGroupsIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
+import { EMPTY_ETF_GROUPS_INDEX, fetchEtfGroupsIndex } from '@/utils/etf-listing-fetchers';
+import { groupsIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfListingBreadcrumbJsonLd, generateEtfListingJsonLd, generateEtfListingMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = generateEtfListingMetadata();
-
-const EMPTY_GROUPS_INDEX: EtfGroupsIndexResponse = {
-  categoryValues: {},
-  categoryCounts: {},
-  groupCounts: {},
-  others: { items: [], count: 0 },
-};
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchGroupsIndex(country: SupportedCountries): Promise<EtfGroupsIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/groups-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfGroupsIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchGroupsIndex failed (${res.status}): ${url}`);
-      return EMPTY_GROUPS_INDEX;
-    }
-    return (await res.json()) as EtfGroupsIndexResponse;
-  } catch (e) {
-    console.error('fetchGroupsIndex error:', e);
-    return EMPTY_GROUPS_INDEX;
-  }
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchEtfGroupsIndex(SupportedCountries.US);
+  return { ...generateEtfListingMetadata(), ...groupsIndexRobots(data) };
 }
 
 export default async function EtfsPage() {
-  const data = await fetchGroupsIndex(SupportedCountries.US);
+  const data = (await fetchEtfGroupsIndex(SupportedCountries.US)) ?? EMPTY_ETF_GROUPS_INDEX;
   return (
     <EtfGroupsIndex
       country={SupportedCountries.US}

--- a/insights-ui/src/app/etfs/providers/[provider]/page.tsx
+++ b/insights-ui/src/app/etfs/providers/[provider]/page.tsx
@@ -3,6 +3,8 @@ import { EtfSearchParams } from '@/utils/etf-filter-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfProviderBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
 import { etfBrowseDetailPath } from '@/utils/etf-country-route-utils';
+import { fetchEtfProvidersIndex } from '@/utils/etf-listing-fetchers';
+import { providerDetailRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfProviderDetailBreadcrumbJsonLd, generateEtfProviderDetailMetadata } from '@/utils/etf-metadata-generators';
 import { permanentRedirect } from 'next/navigation';
 import type { Metadata } from 'next';
@@ -17,11 +19,13 @@ type PageProps = {
 export async function generateMetadata(props: { params: Promise<{ provider: string }> }): Promise<Metadata> {
   const { provider } = await props.params;
   const slug = slugifyEtfTag(decodeURIComponent(provider));
-  return generateEtfProviderDetailMetadata({
+  const base = generateEtfProviderDetailMetadata({
     country: SupportedCountries.US,
     providerCanonical: getEtfProviderBySlug(slug),
     providerSlug: slug,
   });
+  const index = await fetchEtfProvidersIndex(SupportedCountries.US);
+  return { ...base, ...providerDetailRobots(index, slug) };
 }
 
 export default async function EtfsByProviderPage({ params, searchParams: searchParamsPromise }: PageProps) {

--- a/insights-ui/src/app/etfs/providers/page.tsx
+++ b/insights-ui/src/app/etfs/providers/page.tsx
@@ -1,38 +1,19 @@
-import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
 import EtfProvidersIndex from '@/components/etfs/EtfProvidersIndex';
-import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
-import { getEtfProvidersIndexTag } from '@/utils/etf-cache-utils';
-import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
+import { EMPTY_ETF_PROVIDERS_INDEX, fetchEtfProvidersIndex } from '@/utils/etf-listing-fetchers';
+import { providersIndexRobots } from '@/utils/etf-listing-noindex';
 import { generateEtfProvidersIndexBreadcrumbJsonLd, generateEtfProvidersIndexMetadata } from '@/utils/etf-metadata-generators';
-import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = generateEtfProvidersIndexMetadata(SupportedCountries.US);
-
-const EMPTY_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {} };
-
-// Fail-soft so the first preview/prod build after introducing the listings
-// API routes can still prerender. The 1-week tag + ISR repopulates the page
-// on the first real request once the new route is live in the target env.
-async function fetchProvidersIndex(country: SupportedCountries): Promise<EtfProvidersIndexResponse> {
-  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/providers-index?country=${encodeURIComponent(country)}`;
-  try {
-    const res = await fetchEtfListingsIndex(url, getEtfProvidersIndexTag(country));
-    if (!res.ok) {
-      console.error(`fetchProvidersIndex failed (${res.status}): ${url}`);
-      return EMPTY_PROVIDERS_INDEX;
-    }
-    return (await res.json()) as EtfProvidersIndexResponse;
-  } catch (e) {
-    console.error('fetchProvidersIndex error:', e);
-    return EMPTY_PROVIDERS_INDEX;
-  }
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchEtfProvidersIndex(SupportedCountries.US);
+  return { ...generateEtfProvidersIndexMetadata(SupportedCountries.US), ...providersIndexRobots(data) };
 }
 
 export default async function EtfsProvidersIndexPage() {
-  const data = await fetchProvidersIndex(SupportedCountries.US);
+  const data = (await fetchEtfProvidersIndex(SupportedCountries.US)) ?? EMPTY_ETF_PROVIDERS_INDEX;
   return (
     <>
       <script

--- a/insights-ui/src/app/etfs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/sitemap.xml/route.ts
@@ -35,12 +35,6 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
   }
 
   for (const country of ETF_SUPPORTED_COUNTRIES) {
-    // Section index pages. The groups index collapses onto the country root (/etfs for US,
-    // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it.
-    urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
-    urls.push({ url: etfBrowsePath(country, 'asset-classes'), changefreq: 'weekly', priority: 0.7 });
-    urls.push({ url: etfBrowsePath(country, 'providers'), changefreq: 'weekly', priority: 0.7 });
-
     // Counts come from the same bucketing the index pages use, so a group/category/asset-class page
     // only enters the sitemap when at least one populated ETF lands in it. Providers are already
     // populated-only and content-derived.
@@ -50,6 +44,24 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'assetClass', assetClassValueToKey, country),
       fetchEtfProvidersForCountry(KoalaGainsSpaceId, country),
     ]);
+
+    // Section index pages. The groups index collapses onto the country root (/etfs for US,
+    // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it. Each section index
+    // enters the sitemap only when it has content — mirroring the `noindex` that the empty listing
+    // pages now return (see etf-listing-noindex.ts) so we never submit a URL that resolves to
+    // `noindex` (which Search Console would flag as "Submitted URL marked noindex").
+    const hasGroups = Object.values(byGroup.counts).some((count) => count > 0);
+    const hasAssetClasses = Object.values(byAssetClass.counts).some((count) => count > 0);
+    const hasProviders = providers.providers.length > 0;
+    if (hasGroups || hasAssetClasses || hasProviders) {
+      urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
+    }
+    if (hasAssetClasses) {
+      urls.push({ url: etfBrowsePath(country, 'asset-classes'), changefreq: 'weekly', priority: 0.7 });
+    }
+    if (hasProviders) {
+      urls.push({ url: etfBrowsePath(country, 'providers'), changefreq: 'weekly', priority: 0.7 });
+    }
 
     for (const group of groups) {
       if ((byGroup.counts[group.key] ?? 0) > 0) {

--- a/insights-ui/src/app/etfs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/sitemap.xml/route.ts
@@ -1,4 +1,4 @@
-import { fetchEtfProvidersForCountry, fetchEtfsForGroupings } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import { fetchEtfProvidersForCountry, fetchEtfsForGroupings, fetchUncategorizedEtfPreview } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
@@ -38,22 +38,25 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
     // Counts come from the same bucketing the index pages use, so a group/category/asset-class page
     // only enters the sitemap when at least one populated ETF lands in it. Providers are already
     // populated-only and content-derived.
-    const [byGroup, byCategory, byAssetClass, providers] = await Promise.all([
+    const [byGroup, byCategory, byAssetClass, providers, others] = await Promise.all([
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', groupValueToKey, country),
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', categoryValueToKey, country),
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'assetClass', assetClassValueToKey, country),
       fetchEtfProvidersForCountry(KoalaGainsSpaceId, country),
+      fetchUncategorizedEtfPreview(KoalaGainsSpaceId, country),
     ]);
 
     // Section index pages. The groups index collapses onto the country root (/etfs for US,
     // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it. Each section index
-    // enters the sitemap only when it has content — mirroring the `noindex` that the empty listing
-    // pages now return (see etf-listing-noindex.ts) so we never submit a URL that resolves to
-    // `noindex` (which Search Console would flag as "Submitted URL marked noindex").
+    // enters the sitemap only when it has content — mirroring EXACTLY the `noindex` that the empty
+    // listing pages now return (see etf-listing-noindex.ts) so we never submit a URL that resolves
+    // to `noindex` (which Search Console would flag as "Submitted URL marked noindex"). The groups
+    // index / country root renders only group buckets + the uncategorized "others" bucket, so its
+    // gate mirrors `groupsIndexRobots` (groups OR others) — not asset-class / provider counts.
     const hasGroups = Object.values(byGroup.counts).some((count) => count > 0);
     const hasAssetClasses = Object.values(byAssetClass.counts).some((count) => count > 0);
     const hasProviders = providers.providers.length > 0;
-    if (hasGroups || hasAssetClasses || hasProviders) {
+    if (hasGroups || others.count > 0) {
       urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
     }
     if (hasAssetClasses) {

--- a/insights-ui/src/app/etfs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/sitemap.xml/route.ts
@@ -1,4 +1,4 @@
-import { fetchEtfProvidersForCountry, fetchEtfsForGroupings, fetchUncategorizedEtfPreview } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import { fetchEtfProvidersForCountry, fetchEtfsForGroupings } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categorization-utils';
@@ -35,36 +35,21 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
   }
 
   for (const country of ETF_SUPPORTED_COUNTRIES) {
+    // Section index pages. The groups index collapses onto the country root (/etfs for US,
+    // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it.
+    urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
+    urls.push({ url: etfBrowsePath(country, 'asset-classes'), changefreq: 'weekly', priority: 0.7 });
+    urls.push({ url: etfBrowsePath(country, 'providers'), changefreq: 'weekly', priority: 0.7 });
+
     // Counts come from the same bucketing the index pages use, so a group/category/asset-class page
     // only enters the sitemap when at least one populated ETF lands in it. Providers are already
     // populated-only and content-derived.
-    const [byGroup, byCategory, byAssetClass, providers, others] = await Promise.all([
+    const [byGroup, byCategory, byAssetClass, providers] = await Promise.all([
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', groupValueToKey, country),
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'category', categoryValueToKey, country),
       fetchEtfsForGroupings(KoalaGainsSpaceId, 'assetClass', assetClassValueToKey, country),
       fetchEtfProvidersForCountry(KoalaGainsSpaceId, country),
-      fetchUncategorizedEtfPreview(KoalaGainsSpaceId, country),
     ]);
-
-    // Section index pages. The groups index collapses onto the country root (/etfs for US,
-    // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it. Each section index
-    // enters the sitemap only when it has content — mirroring EXACTLY the `noindex` that the empty
-    // listing pages now return (see etf-listing-noindex.ts) so we never submit a URL that resolves
-    // to `noindex` (which Search Console would flag as "Submitted URL marked noindex"). The groups
-    // index / country root renders only group buckets + the uncategorized "others" bucket, so its
-    // gate mirrors `groupsIndexRobots` (groups OR others) — not asset-class / provider counts.
-    const hasGroups = Object.values(byGroup.counts).some((count) => count > 0);
-    const hasAssetClasses = Object.values(byAssetClass.counts).some((count) => count > 0);
-    const hasProviders = providers.providers.length > 0;
-    if (hasGroups || others.count > 0) {
-      urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
-    }
-    if (hasAssetClasses) {
-      urls.push({ url: etfBrowsePath(country, 'asset-classes'), changefreq: 'weekly', priority: 0.7 });
-    }
-    if (hasProviders) {
-      urls.push({ url: etfBrowsePath(country, 'providers'), changefreq: 'weekly', priority: 0.7 });
-    }
 
     for (const group of groups) {
       if ((byGroup.counts[group.key] ?? 0) > 0) {

--- a/insights-ui/src/utils/etf-listing-fetchers.ts
+++ b/insights-ui/src/utils/etf-listing-fetchers.ts
@@ -1,0 +1,74 @@
+import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
+import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listings/group/route';
+import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
+import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getEtfAssetClassesIndexTag, getEtfGroupDetailTag, getEtfGroupsIndexTag, getEtfProvidersIndexTag } from '@/utils/etf-cache-utils';
+import { fetchEtfListingsIndex } from '@/utils/etf-listing-visibility';
+import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+
+/**
+ * Server-only fetchers for the ETF listings index/detail API routes, shared by
+ * the listing pages (which render the data) and their `generateMetadata` (which
+ * uses it only to decide `robots` — see `etf-listing-noindex.ts`).
+ *
+ * Each fetcher returns `null` on a failed/non-OK fetch instead of an empty
+ * sentinel. The caller coalesces `null` to its own `EMPTY_*` constant for
+ * rendering (fail-soft, unchanged behaviour), but the SEO layer treats `null`
+ * as "could not confirm" and stays indexable — so a transient API blip can
+ * never deindex a populated, ranking page. A genuine HTTP-200 empty response is
+ * the only thing that yields `noindex`.
+ *
+ * `generateMetadata` and the page component each call the same fetcher; Next.js
+ * request memoization collapses that into a single upstream request per render.
+ */
+
+export const EMPTY_ETF_GROUPS_INDEX: EtfGroupsIndexResponse = {
+  categoryValues: {},
+  categoryCounts: {},
+  groupCounts: {},
+  others: { items: [], count: 0 },
+};
+
+export const EMPTY_ETF_ASSET_CLASSES_INDEX: EtfAssetClassesIndexResponse = { values: {}, counts: {} };
+
+export const EMPTY_ETF_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {} };
+
+export const EMPTY_ETF_GROUP_DETAIL: EtfGroupDetailResponse = { found: false, values: {}, counts: {}, others: null };
+
+async function fetchListingJson<T>(url: string, tag: string, label: string): Promise<T | null> {
+  try {
+    const res = await fetchEtfListingsIndex(url, tag);
+    if (!res.ok) {
+      console.error(`${label} failed (${res.status}): ${url}`);
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (e) {
+    console.error(`${label} error:`, e);
+    return null;
+  }
+}
+
+export async function fetchEtfGroupsIndex(country: EtfSupportedCountry): Promise<EtfGroupsIndexResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/groups-index?country=${encodeURIComponent(country)}`;
+  return fetchListingJson<EtfGroupsIndexResponse>(url, getEtfGroupsIndexTag(country), 'fetchEtfGroupsIndex');
+}
+
+export async function fetchEtfAssetClassesIndex(country: EtfSupportedCountry): Promise<EtfAssetClassesIndexResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/asset-classes-index?country=${encodeURIComponent(country)}`;
+  return fetchListingJson<EtfAssetClassesIndexResponse>(url, getEtfAssetClassesIndexTag(country), 'fetchEtfAssetClassesIndex');
+}
+
+export async function fetchEtfProvidersIndex(country: EtfSupportedCountry): Promise<EtfProvidersIndexResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/providers-index?country=${encodeURIComponent(country)}`;
+  return fetchListingJson<EtfProvidersIndexResponse>(url, getEtfProvidersIndexTag(country), 'fetchEtfProvidersIndex');
+}
+
+export async function fetchEtfGroupDetail(country: EtfSupportedCountry, groupKey: string): Promise<EtfGroupDetailResponse | null> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/listings/group?country=${encodeURIComponent(
+    country
+  )}&groupKey=${encodeURIComponent(groupKey)}`;
+  return fetchListingJson<EtfGroupDetailResponse>(url, getEtfGroupDetailTag(country, groupKey), 'fetchEtfGroupDetail');
+}

--- a/insights-ui/src/utils/etf-listing-noindex.ts
+++ b/insights-ui/src/utils/etf-listing-noindex.ts
@@ -1,0 +1,88 @@
+import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
+import type { EtfGroupDetailResponse } from '@/app/api/[spaceId]/etfs-v1/listings/group/route';
+import type { EtfGroupsIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/groups-index/route';
+import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
+import { slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
+import type { Metadata } from 'next';
+
+/**
+ * SEO guard for ETF *listing* pages (group / category / asset-class / provider
+ * indexes and detail pages, US + every country).
+ *
+ * Those pages are deliberately kept OUT of the sitemap when they hold no ETFs
+ * (see `app/etfs/sitemap.xml/route.ts`), but Google still discovers them via the
+ * cross-country switcher links (`EtfCountryAlternatives`) and on-page
+ * breadcrumbs. An empty-but-valid listing returns HTTP 200 with a "no ETFs"
+ * shell, which Search Console flags as a *soft 404*.
+ *
+ * Fix: emit `noindex, follow` when — and ONLY when — we have a CONFIRMED empty
+ * response. Every predicate takes a `... | null` argument; `null` means the
+ * upstream fetch could not be confirmed (it failed and fell back to an empty
+ * sentinel) and is treated as INDEXABLE. We never noindex on uncertainty, so a
+ * transient API blip can never deindex a populated, ranking page. This makes
+ * the noindex rule the exact mirror of the sitemap-inclusion rule
+ * ("in sitemap ⇔ indexable").
+ *
+ * `follow` is kept so the page still passes link equity to the (indexable) ETF
+ * report pages it lists once it has content.
+ */
+
+const NOINDEX_FOLLOW: Pick<Metadata, 'robots'> = { robots: { index: false, follow: true } };
+const INDEXABLE: Pick<Metadata, 'robots'> = {};
+
+/** Spread into a page's metadata: `{ ...baseMeta, ...etfListingRobots(empty) }`. */
+export function etfListingRobots(confirmedEmpty: boolean): Pick<Metadata, 'robots'> {
+  return confirmedEmpty ? NOINDEX_FOLLOW : INDEXABLE;
+}
+
+function allCountsZero(counts: Record<string, number>): boolean {
+  return Object.values(counts).every((count) => !count);
+}
+
+/** Groups index = a country root page (`/etfs`, `/etfs/countries/<c>`). Empty
+ *  when no group bucket and no "others" bucket holds an ETF. */
+export function groupsIndexRobots(data: EtfGroupsIndexResponse | null): Pick<Metadata, 'robots'> {
+  if (!data) return INDEXABLE;
+  return etfListingRobots(allCountsZero(data.groupCounts) && (data.others?.count ?? 0) === 0);
+}
+
+export function assetClassesIndexRobots(data: EtfAssetClassesIndexResponse | null): Pick<Metadata, 'robots'> {
+  if (!data) return INDEXABLE;
+  return etfListingRobots(allCountsZero(data.counts));
+}
+
+export function providersIndexRobots(data: EtfProvidersIndexResponse | null): Pick<Metadata, 'robots'> {
+  if (!data) return INDEXABLE;
+  return etfListingRobots(data.providers.length === 0);
+}
+
+/** Group detail page. `found:false` means an unknown key (the page 404s anyway)
+ *  or a failed fetch — neither is a confirmed-empty 200, so stay indexable. */
+export function groupDetailRobots(data: EtfGroupDetailResponse | null): Pick<Metadata, 'robots'> {
+  if (!data || !data.found) return INDEXABLE;
+  return etfListingRobots(allCountsZero(data.counts) && (data.others?.count ?? 0) === 0);
+}
+
+/** Group-category detail page: empty when the parent group's detail buckets no
+ *  ETF under this category name (group-detail counts are keyed by category name). */
+export function groupCategoryDetailRobots(group: EtfGroupDetailResponse | null, categoryName: string): Pick<Metadata, 'robots'> {
+  if (!group || !group.found) return INDEXABLE;
+  return etfListingRobots((group.counts[categoryName] ?? 0) === 0);
+}
+
+/** Asset-class detail page: empty when no asset class in the country index
+ *  slugifies to this slug with a non-zero count. Slug-matched so canonical/value
+ *  casing differences can never trigger a false noindex. */
+export function assetClassDetailRobots(index: EtfAssetClassesIndexResponse | null, assetClassSlug: string): Pick<Metadata, 'robots'> {
+  if (!index) return INDEXABLE;
+  const present = Object.entries(index.counts).some(([value, count]) => count > 0 && slugifyEtfTag(value) === assetClassSlug);
+  return etfListingRobots(!present);
+}
+
+/** Provider detail page: empty when no issuer in the country index slugifies to
+ *  this provider slug. */
+export function providerDetailRobots(index: EtfProvidersIndexResponse | null, providerSlug: string): Pick<Metadata, 'robots'> {
+  if (!index) return INDEXABLE;
+  const present = index.providers.some((issuer) => slugifyEtfTag(issuer) === providerSlug);
+  return etfListingRobots(!present);
+}


### PR DESCRIPTION
## Problem

ETF **listing** pages (group / category / asset-class / provider indexes and detail pages, US + every country) render an HTTP-200 *"no ETFs"* shell when they hold no ETFs. Even though these URLs are excluded from the sitemap, Google still discovers them through the cross-country switcher links (`EtfCountryAlternatives`, which links every other country unconditionally) and on-page breadcrumbs — and flags them as **soft 404s** in Search Console. As more countries are added before they have ETFs, every listing page under an empty country is a soft 404.

## Changes

1. **Unknown group keys → real 404.** `groups/[group]` and `countries/[country]/groups/[group]` call `notFound()` for keys not in the category config (local lookup, so transient API failures still fail-soft).

2. **Valid-but-empty listing pages → `noindex, follow`.** Applied to all listing pages (US + country): groups/country root, asset-classes index, providers index, and group / category / asset-class / provider detail pages.
   - **Safety first:** noindex fires **only on a confirmed-empty API response**. New shared fetchers (`src/utils/etf-listing-fetchers.ts`) return `null` on a failed/non-OK fetch instead of an empty sentinel; the SEO predicates (`src/utils/etf-listing-noindex.ts`) treat `null` as **indexable**. A transient API blip can therefore **never** deindex a populated, ranking page.
   - `generateMetadata` and the page component call the same fetcher → **Next.js request memoization** collapses it into one upstream request on the canonical crawl path (no extra round-trip).
   - `follow` is kept so the page still passes link equity to the ETF report pages once it has content.
   - Net effect on the 14 existing listing pages is **−122 lines**: each page's hand-rolled, copy-pasted inline fetcher is replaced by the shared fetcher + a 3-line `generateMetadata`.

## Why it's safe for the most-important pages

We never noindex on an unconfirmed/failed fetch, so a backend hiccup cannot deindex live pages. US pages are always populated, so noindex never fires for them. The emptiness signal is the same `counts` source the sitemap already uses to decide inclusion, so a page is noindexed precisely when the sitemap already excludes it.

## Not included

The sitemap (`app/etfs/sitemap.xml/route.ts`) is intentionally left **unchanged**. Stock-analysis data always supplies issuer, asset class and category, so a country is all-or-nothing populated; the section-index URLs only matter for countries that already have ETFs.

## Checks
`yarn compile` ✅ · `yarn prettier-check` ✅ · `yarn lint` ✅
