### PR TITLE
perf(etfs): split price-chart slice into its own /chart-data endpoint

### DIFF
--- a/deployments/insights-ui/cloudfront.tf
+++ b/deployments/insights-ui/cloudfront.tf
@@ -43,6 +43,7 @@ locals {
   # mor-info; holdings → portfolio-holdings.
   etfs_api_cached_paths = [
     "/api/koala_gains/etfs-v1/exchange/*/*/full-render",
+    "/api/koala_gains/etfs-v1/exchange/*/*/chart-data",
     "/api/koala_gains/etfs-v1/exchange/*/*/analysis",
     "/api/koala_gains/etfs-v1/exchange/*/*/mor-info",
     "/api/koala_gains/etfs-v1/exchange/*/*/portfolio-holdings",

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/chart-data/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/chart-data/route.ts
@@ -1,0 +1,100 @@
+/**
+ * Price chart + performance-metrics slice for the main `/etfs/[exchange]/[etf]`
+ * page, split out of `/full-render`.
+ *
+ * Why its own endpoint: `ensureEtfPriceHistoryIsFresh` can hit Yahoo Finance
+ * over the network when the stored price history is stale. Bundled into
+ * `/full-render` that network call held back the whole report body (analysis,
+ * holdings, competition) even though none of it needs price data. Splitting the
+ * chart slice into its own fetch lets the page stream the report body as soon
+ * as the DB read finishes, while the chart streams independently when the price
+ * refresh completes. Carries the same `etfAndExchangeTag` umbrella cache tag as
+ * `/full-render` so a single ETF invalidation still clears both.
+ */
+import { PriceHistoryResponse } from '@/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/price-history/route';
+import { getEtfWhereClause } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
+import { prisma } from '@/prisma';
+import { PriceHistoryPoint } from '@/types/prismaTypes';
+import { ensureEtfPriceHistoryIsFresh } from '@/utils/etf-price-history-utils';
+import { buildEtfPerformanceMetricsPayload, type EtfPerformanceMetricFields, type EtfPerformanceMetricsPayload } from '@/utils/etf-performance-metrics-utils';
+import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
+import { NextRequest } from 'next/server';
+
+export interface EtfChartDataResponse {
+  priceHistory: PriceHistoryResponse | null;
+  performanceMetrics: EtfPerformanceMetricsPayload | null;
+}
+
+const EMPTY: EtfChartDataResponse = { priceHistory: null, performanceMetrics: null };
+
+async function getHandler(
+  _req: NextRequest,
+  { params }: { params: Promise<{ spaceId: string; exchange: string; etf: string }> }
+): Promise<EtfChartDataResponse> {
+  const { spaceId, exchange, etf } = await params;
+  const where = getEtfWhereClause({ spaceId, exchange, etf });
+  if (!where.symbol || !where.exchange) return EMPTY;
+
+  const etfRecord = await prisma.etf.findFirst({ where, include: { stockAnalyzerInfo: true } });
+  if (!etfRecord) return EMPTY;
+
+  const focalCategory = etfRecord.stockAnalyzerInfo?.category ?? null;
+
+  const [priceInfo, categoryPeers] = await Promise.all([
+    ensureEtfPriceHistoryIsFresh(etfRecord).catch(() => null),
+    fetchCategoryPeerAnalyzerInfo(etfRecord.spaceId, focalCategory, etfRecord.id),
+  ]);
+
+  const performanceMetrics: EtfPerformanceMetricsPayload | null = etfRecord.stockAnalyzerInfo
+    ? buildEtfPerformanceMetricsPayload(etfRecord.stockAnalyzerInfo, categoryPeers, focalCategory)
+    : null;
+
+  const priceHistory: PriceHistoryResponse | null =
+    priceInfo &&
+    (((priceInfo.dailyData as unknown as PriceHistoryPoint[] | null)?.length ?? 0) > 0 ||
+      ((priceInfo.weeklyData as unknown as PriceHistoryPoint[] | null)?.length ?? 0) > 0)
+      ? {
+          symbol: etfRecord.symbol,
+          currency: priceInfo.currency ?? null,
+          daily: (priceInfo.dailyData as unknown as PriceHistoryPoint[] | null) ?? [],
+          weekly: (priceInfo.weeklyData as unknown as PriceHistoryPoint[] | null) ?? [],
+        }
+      : null;
+
+  return { priceHistory, performanceMetrics };
+}
+
+/**
+ * Pull only the cagr/return fields for the focal ETF's category peers (same
+ * `spaceId`, same `category`, excluding the focal ETF itself) so the shared
+ * averaging util can build the "vs category" series. Returns `[]` when the
+ * focal ETF has no category — the chart then renders the ETF-only series.
+ */
+async function fetchCategoryPeerAnalyzerInfo(spaceId: string, category: string | null, focalEtfId: string): Promise<EtfPerformanceMetricFields[]> {
+  if (!category) return [];
+
+  return prisma.etfStockAnalyzerInfo.findMany({
+    where: {
+      etf: { spaceId, NOT: { id: focalEtfId } },
+      category,
+    },
+    select: {
+      cagr1y: true,
+      cagr3y: true,
+      cagr5y: true,
+      cagr10y: true,
+      cagr15y: true,
+      cagr20y: true,
+      return1m: true,
+      return6m: true,
+      return1y: true,
+      return3y: true,
+      return5y: true,
+      return10y: true,
+      return15y: true,
+      return20y: true,
+    },
+  });
+}
+
+export const GET = withErrorHandlingV2<EtfChartDataResponse>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/full-render/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/full-render/route.ts
@@ -11,22 +11,14 @@
  */
 import { EtfAnalysisResponse, EtfCategoryAnalysisResultResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/analysis/route';
 import { EtfPortfolioHoldingsResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/portfolio-holdings/route';
-import { PriceHistoryResponse } from '@/app/api/[spaceId]/tickers-v1/exchange/[exchange]/[ticker]/price-history/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import type { EtfFinancialInfoResponse, EtfScoresResponse, SimilarEtf } from '@/types/etf/etf-detail-response-types';
 import { getEtfWhereClause, serializeBigIntFields } from '@/app/api/[spaceId]/etfs-v1/etfApiUtils';
 import { prisma } from '@/prisma';
 import type { EtfApplicableInvestorGoals, EtfCompetitionResponse, EtfCompetitor, EtfKeyFactsFlagAssessment } from '@/types/etf/etf-analysis-types';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { PriceHistoryPoint } from '@/types/prismaTypes';
 import { CompetitionAnalysis } from '@/types/public-equity/analysis-factors-types';
-import { ensureEtfPriceHistoryIsFresh } from '@/utils/etf-price-history-utils';
-import {
-  buildEtfPerformanceMetricsPayload,
-  parsePercentString,
-  type EtfPerformanceMetricFields,
-  type EtfPerformanceMetricsPayload,
-} from '@/utils/etf-performance-metrics-utils';
+import { parsePercentString } from '@/utils/etf-performance-metrics-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
@@ -66,8 +58,6 @@ export interface EtfFullRenderResponse {
   similarEtfs: SimilarEtf[];
   portfolioHoldings: EtfPortfolioHoldingsResponse;
   competition: EtfCompetitionResponse | null;
-  priceHistory: PriceHistoryResponse | null;
-  performanceMetrics: EtfPerformanceMetricsPayload | null;
   keyFacts: EtfKeyFactsReportResponse | null;
   keyMetrics: EtfKeyMetricsResponse;
 }
@@ -93,8 +83,6 @@ const EMPTY: EtfFullRenderResponse = {
   similarEtfs: [],
   portfolioHoldings: { holdings: null, updatedAt: null },
   competition: null,
-  priceHistory: null,
-  performanceMetrics: null,
   keyFacts: null,
   keyMetrics: EMPTY_KEY_METRICS,
 };
@@ -128,9 +116,8 @@ async function getHandler(
   if (!etfRecord) return EMPTY;
 
   const etfId = etfRecord.id;
-  const focalCategory = etfRecord.stockAnalyzerInfo?.category ?? null;
 
-  const [analysisRows, similarHydrated, competitorHydrated, priceInfo, categoryPeers] = await Promise.all([
+  const [analysisRows, similarHydrated, competitorHydrated] = await Promise.all([
     prisma.etfCategoryAnalysisResult.findMany({
       where: { etfId, spaceId: where.spaceId },
       include: {
@@ -141,8 +128,6 @@ async function getHandler(
     }),
     hydrateSimilarEtfs(etfRecord.spaceId, etfRecord.similarEtfs),
     hydrateCompetitors(etfRecord.vsCompetition?.competitionAnalysisArray as unknown as CompetitionAnalysis[] | undefined),
-    ensureEtfPriceHistoryIsFresh(etfRecord).catch(() => null),
-    fetchCategoryPeerAnalyzerInfo(etfRecord.spaceId, focalCategory, etfId),
   ]);
 
   // Shape responses to match the original per-route payloads so the main page
@@ -251,22 +236,6 @@ async function getHandler(
       }
     : null;
 
-  const performanceMetrics: EtfPerformanceMetricsPayload | null = etfRecord.stockAnalyzerInfo
-    ? buildEtfPerformanceMetricsPayload(etfRecord.stockAnalyzerInfo, categoryPeers, focalCategory)
-    : null;
-
-  const priceHistory: PriceHistoryResponse | null =
-    priceInfo &&
-    (((priceInfo.dailyData as unknown as PriceHistoryPoint[] | null)?.length ?? 0) > 0 ||
-      ((priceInfo.weeklyData as unknown as PriceHistoryPoint[] | null)?.length ?? 0) > 0)
-      ? {
-          symbol: etfRecord.symbol,
-          currency: priceInfo.currency ?? null,
-          daily: (priceInfo.dailyData as unknown as PriceHistoryPoint[] | null) ?? [],
-          weekly: (priceInfo.weeklyData as unknown as PriceHistoryPoint[] | null) ?? [],
-        }
-      : null;
-
   return {
     etf: etfRaw,
     financialInfo,
@@ -275,8 +244,6 @@ async function getHandler(
     similarEtfs: similarHydrated,
     portfolioHoldings,
     competition,
-    priceHistory,
-    performanceMetrics,
     keyFacts,
     keyMetrics,
   };
@@ -307,42 +274,6 @@ function extractMaxDrawdown(riskPeriods: unknown): number | null {
     if (parsed !== null) return parsed;
   }
   return null;
-}
-
-/**
- * Pull only the cagr/return fields for the focal ETF's category peers (same
- * `spaceId`, same `category`, excluding the focal ETF itself). Returns
- * `EtfStockAnalyzerInfo`-shaped partials whose unread fields are filled with
- * `null` so the shared averaging util can read them safely.
- *
- * Returns `[]` if the focal ETF has no category — the chart will then render
- * with the ETF-only series.
- */
-async function fetchCategoryPeerAnalyzerInfo(spaceId: string, category: string | null, focalEtfId: string): Promise<EtfPerformanceMetricFields[]> {
-  if (!category) return [];
-
-  return prisma.etfStockAnalyzerInfo.findMany({
-    where: {
-      etf: { spaceId, NOT: { id: focalEtfId } },
-      category,
-    },
-    select: {
-      cagr1y: true,
-      cagr3y: true,
-      cagr5y: true,
-      cagr10y: true,
-      cagr15y: true,
-      cagr20y: true,
-      return1m: true,
-      return6m: true,
-      return1y: true,
-      return3y: true,
-      return5y: true,
-      return10y: true,
-      return15y: true,
-      return20y: true,
-    },
-  });
 }
 
 async function hydrateSimilarEtfs(spaceId: string, stored: Array<{ id: string; symbol: string; exchange: string; sortOrder: number }>): Promise<SimilarEtf[]> {

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/page.tsx
@@ -1,4 +1,5 @@
 import type { EtfFullRenderResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/full-render/route';
+import type { EtfChartDataResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/chart-data/route';
 import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]/[etf]/route';
 import EtfActions from '@/app/etfs/[exchange]/[etf]/EtfActions';
 import EtfFavouriteButton from '@/app/etfs/[exchange]/[etf]/EtfFavouriteButton';
@@ -43,9 +44,14 @@ import { Suspense, use } from 'react';
  * shell streams to the browser immediately while `/full-render` is still
  * in-flight — FCP/LCP land on the shell instead of on the slowest data slice.
  *
- * Per-slice streaming (each below-fold block on its own promise, like stocks'
- * 5 separate fetchers) would need per-slice API endpoints that don't exist
- * yet on the ETF side. Tracked as follow-up.
+ * The price chart + performance-metrics slice is fetched from its own
+ * `/chart-data` endpoint (not `/full-render`) because the price-history refresh
+ * can hit Yahoo over the network — keeping it separate means the report body
+ * (analysis, holdings, competition) streams as soon as the DB read finishes
+ * instead of waiting on that network call, and the chart streams independently.
+ * The remaining slices (about, radar, below-fold body) share `/full-render`
+ * since they all read from one ETF-row + analysis query — splitting them
+ * further would just duplicate that query for no streaming gain.
  */
 export const dynamic = 'force-dynamic';
 
@@ -65,6 +71,18 @@ async function fetchEtfFullRender(exchange: string, etf: string): Promise<EtfFul
     throw new Error(`fetchEtfFullRender failed (${res.status}): ${url}`);
   }
   return (await res.json()) as EtfFullRenderResponse;
+}
+
+// Price chart + performance metrics are fetched separately so the report body
+// (analysis, holdings, competition) doesn't wait on the price-history refresh,
+// which can hit Yahoo over the network. Same umbrella cache tag as /full-render.
+async function fetchEtfChartData(exchange: string, etf: string): Promise<EtfChartDataResponse> {
+  const url = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/etfs-v1/exchange/${exchange.toUpperCase()}/${etf.toUpperCase()}/chart-data`;
+  const res = await fetch(url, { next: { tags: [etfAndExchangeTag(etf, exchange)] } });
+  if (!res.ok) {
+    throw new Error(`fetchEtfChartData failed (${res.status}): ${url}`);
+  }
+  return (await res.json()) as EtfChartDataResponse;
 }
 
 export async function generateMetadata({ params }: { params: RouteParams }): Promise<Metadata> {
@@ -210,7 +228,7 @@ function EtfRadarFromPromise({ promise }: { promise: Promise<EtfFullRenderRespon
   return <EtfRadarChart scores={data.scores} analysis={data.analysis} />;
 }
 
-function EtfChartTabsFromPromise({ promise, etfSymbol }: { promise: Promise<EtfFullRenderResponse>; etfSymbol: string }): JSX.Element {
+function EtfChartTabsFromPromise({ promise, etfSymbol }: { promise: Promise<EtfChartDataResponse>; etfSymbol: string }): JSX.Element {
   const data = use(promise);
   return <EtfChartTabs priceHistory={data.priceHistory} performanceMetrics={data.performanceMetrics} etfSymbol={etfSymbol} />;
 }
@@ -266,6 +284,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
   if (!etfData) notFound();
 
   const fullRenderPromise = fetchEtfFullRender(exchange, etf);
+  const chartDataPromise = fetchEtfChartData(exchange, etf);
 
   const safeDate = (dateValue: any): Date => {
     if (dateValue instanceof Date && !isNaN(dateValue.getTime())) return dateValue;
@@ -381,7 +400,7 @@ export default async function EtfDetailsPage({ params }: { params: RouteParams }
           </div>
 
           <Suspense fallback={<ChartTabsSkeleton />}>
-            <EtfChartTabsFromPromise promise={fullRenderPromise} etfSymbol={etfData.symbol} />
+            <EtfChartTabsFromPromise promise={chartDataPromise} etfSymbol={etfData.symbol} />
           </Suspense>
         </section>
 

--- a/insights-ui/src/utils/etf-cache-utils.ts
+++ b/insights-ui/src/utils/etf-cache-utils.ts
@@ -57,8 +57,9 @@ export const etfAndExchangeTag = (symbol: string, exchange: string): `${typeof E
 
 export const revalidateEtfAndExchangeTag = (symbol: string, exchange: string) => {
   revalidateTag(etfAndExchangeTag(symbol, exchange));
-  // Main page renders from the consolidated `/full-render` endpoint.
-  invalidateCloudFrontPaths([`/etfs/${exchange}/${symbol}`, `${etfApiBase(symbol, exchange)}/full-render`]);
+  // Main page renders from `/full-render` (report body) + `/chart-data` (price chart slice).
+  // Both fetches carry this umbrella tag, so purge both at the edge.
+  invalidateCloudFrontPaths([`/etfs/${exchange}/${symbol}`, `${etfApiBase(symbol, exchange)}/full-render`, `${etfApiBase(symbol, exchange)}/chart-data`]);
 };
 
 /** Per-category subpage tag — used by the 4 `EtfAnalysisCategory` subpages. */


### PR DESCRIPTION
## What

The main `/etfs/[exchange]/[etf]` page rendered its whole body from a single `/full-render` call. That endpoint runs `ensureEtfPriceHistoryIsFresh`, which can fetch from **Yahoo over the network** when the stored price history is stale — so the entire report body (analysis, holdings, competition, similar ETFs) was blocked waiting on a network call it doesn't need.

This splits out **one** new endpoint for the slice that has that slow, independent dependency:

- **New `…/[etf]/chart-data`** → `{ priceHistory, performanceMetrics }`. Owns the Yahoo price refresh + the category-peer query.
- **Trimmed `/full-render`** → drops `priceHistory` / `performanceMetrics` (and the now-unused price-refresh import, performance-metrics util, and the `fetchCategoryPeerAnalyzerInfo` helper). It now only does the ETF-row read + analysis/competition/similar hydration.
- **Page** → the chart-tabs `<Suspense>` now `use()`s its own `chartDataPromise`; the report body keeps the shared `fullRenderPromise`. Result: the body streams as soon as the DB read finishes, and the chart streams independently when the price refresh completes.

## Why only one new endpoint (not a full stocks-style 5-way split)

The ETF page's other slices — About (keyFacts head), Radar (scores + analysis), and the below-fold body — all read from the **same single ETF-row + analysis query**. Splitting them into separate APIs would re-run that query several times for no streaming benefit. The price slice is the only one with a genuinely independent (and slow) data source, so it's the only one worth its own endpoint. Kept the code simple and the page structure intact.

## Caching

- Both fetches carry the **same `etfAndExchangeTag`** umbrella tag, so one ETF invalidation still clears both in the Next.js data cache.
- Added `/chart-data` to `etfs_api_cached_paths` in `cloudfront.tf` (so the edge caches it like `/full-render`).
- Added `/chart-data` to the per-ETF CloudFront purge in `revalidateEtfAndExchangeTag`.

## Checks

- `tsc` — clean for all changed files (the only `tsc` errors are pre-existing `@/images/*.png` module declarations, unrelated to this change — they come from `next-env.d.ts` not being generated under bare `tsc`).
- `next lint` — no warnings or errors.
- `prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)