### PR TITLE
feat(etfs): Australian (ASX) ETF support — listing pages + report data scrape

### DIFF
--- a/insights-ui/package.json
+++ b/insights-ui/package.json
@@ -21,6 +21,7 @@
     "etfs:fetch": "tsx src/scripts/etfs/fetch-analysis.ts",
     "etfs:prompt": "tsx src/scripts/etfs/get-report-prompt.ts",
     "etfs:save": "tsx src/scripts/etfs/save-report.ts",
+    "etfs:csv-to-sql": "tsx src/scripts/etfs/csv-to-sql.ts",
     "stocks:trigger": "tsx src/scripts/tickers/trigger-generation.ts",
     "stocks:add": "tsx src/scripts/tickers/add-stock.ts",
     "stocks:prompt": "tsx src/scripts/tickers/get-report-prompt.ts",

--- a/insights-ui/src/app/admin-v1/etf-scenarios/UpsertEtfScenarioModal.tsx
+++ b/insights-ui/src/app/admin-v1/etf-scenarios/UpsertEtfScenarioModal.tsx
@@ -236,7 +236,7 @@ export default function UpsertEtfScenarioModal({ isOpen, onClose, onSuccess, sce
         />
 
         <div>
-          <p className="text-sm text-gray-300 mb-1">Countries in scope (US / Canada — at least one required)</p>
+          <p className="text-sm text-gray-300 mb-1">Countries in scope ({ETF_SUPPORTED_COUNTRIES.join(' / ')} — at least one required)</p>
           <Checkboxes items={countryItems} selectedItemIds={countries} onChange={(ids: string[]) => setCountries(ids as EtfSupportedCountry[])} />
         </div>
 

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listing/route.ts
@@ -170,13 +170,19 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
 
   const stockAnalyzerFilter = createEtfStockAnalyzerFilter(filters);
   const hasStockAnalyzerFilter = Object.keys(stockAnalyzerFilter).length > 0;
-  const isOthersGroup = filters[EtfFilterParamKey.GROUP]?.trim() === ETF_OTHERS_GROUP_KEY;
-  if (isOthersGroup) {
+  // "Others" detail pages exist for groups (category null), asset classes
+  // (assetClass null) and providers (issuer null). createEtfStockAnalyzerFilter
+  // has already set the relevant field to null when its param === 'others'.
+  const isOthersBucket =
+    filters[EtfFilterParamKey.GROUP]?.trim() === ETF_OTHERS_GROUP_KEY ||
+    filters[EtfFilterParamKey.ASSET_CLASS]?.trim() === ETF_OTHERS_GROUP_KEY ||
+    filters[EtfFilterParamKey.ISSUER]?.trim() === ETF_OTHERS_GROUP_KEY;
+  if (isOthersBucket) {
     // "Others" must also pick up ETFs that have no EtfStockAnalyzerInfo row at
-    // all. createEtfStockAnalyzerFilter has already set category: null for the
-    // case where a row exists; OR that with `is: null` for the no-row case.
-    // Wrapped in AND so it composes with any etfWhere.OR set by the search
-    // filter, which would otherwise be overwritten.
+    // all. createEtfStockAnalyzerFilter has already set the relevant field to
+    // null for the case where a row exists; OR that with `is: null` for the
+    // no-row case. Wrapped in AND so it composes with any etfWhere.OR set by the
+    // search filter, which would otherwise be overwritten.
     const othersOr: Prisma.EtfWhereInput[] = [{ stockAnalyzerInfo: { is: null } }, { stockAnalyzerInfo: { is: stockAnalyzerFilter } }];
     const existingAnd = Array.isArray(etfWhere.AND) ? etfWhere.AND : etfWhere.AND ? [etfWhere.AND] : [];
     etfWhere.AND = [...existingAnd, { OR: othersOr }];

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route.ts
@@ -1,4 +1,9 @@
-import { EtfGroupingPreview, fetchEtfsForGroupings } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import {
+  EtfGroupingPreview,
+  EtfUncategorizedPreview,
+  fetchEtfsForGroupings,
+  fetchEtfsWithoutAssetClass,
+} from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
@@ -8,6 +13,8 @@ import { NextRequest } from 'next/server';
 export interface EtfAssetClassesIndexResponse {
   values: EtfGroupingPreview['values'];
   counts: EtfGroupingPreview['counts'];
+  /** ETFs with no asset class, surfaced as an "Others" bucket. */
+  others: EtfUncategorizedPreview;
 }
 
 async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<EtfAssetClassesIndexResponse> {
@@ -22,7 +29,12 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
     if (opt.value !== '') valueToKey.set(opt.value, opt.value);
   }
 
-  return fetchEtfsForGroupings(spaceId, 'assetClass', valueToKey, country, includeUnpopulated);
+  const [grouped, others] = await Promise.all([
+    fetchEtfsForGroupings(spaceId, 'assetClass', valueToKey, country, includeUnpopulated),
+    fetchEtfsWithoutAssetClass(spaceId, country, includeUnpopulated),
+  ]);
+
+  return { values: grouped.values, counts: grouped.counts, others };
 }
 
 export const GET = withErrorHandlingV2<EtfAssetClassesIndexResponse>(getHandler);

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/listings-prisma.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/listings-prisma.ts
@@ -239,6 +239,68 @@ export async function fetchUncategorizedEtfPreview(
   return { items: selectTopFive(rows), count: rows.length };
 }
 
+/**
+ * ETFs that have no value for a given stockAnalyzer text field — the value is
+ * null/empty, or the whole stockAnalyzerInfo row is missing. Powers the "Others"
+ * bucket on the asset-class and provider index pages, mirroring
+ * `fetchUncategorizedEtfPreview` for the groups index, so the index totals
+ * account for every populated ETF — not just the ones that carry an asset class
+ * or issuer.
+ */
+async function fetchEtfsMissingStockAnalyzerField(
+  spaceId: string,
+  field: 'assetClass' | 'issuer',
+  country?: EtfSupportedCountry,
+  includeUnpopulated = false
+): Promise<EtfUncategorizedPreview> {
+  const missing =
+    field === 'assetClass'
+      ? [{ stockAnalyzerInfo: { is: { assetClass: null } } }, { stockAnalyzerInfo: { is: { assetClass: '' } } }]
+      : [{ stockAnalyzerInfo: { is: { issuer: null } } }, { stockAnalyzerInfo: { is: { issuer: '' } } }];
+
+  const where = {
+    spaceId,
+    OR: [{ stockAnalyzerInfo: { is: null } }, ...missing],
+    ...(country ? { exchange: { in: getEtfExchangesByCountry(country) } } : {}),
+    ...(includeUnpopulated ? {} : POPULATED_ETF_WHERE),
+  };
+
+  const etfs = await prisma.etf.findMany({
+    where,
+    select: {
+      id: true,
+      symbol: true,
+      name: true,
+      exchange: true,
+      financialInfo: { select: { aum: true } },
+      cachedScore: { select: { finalScore: true } },
+    },
+  });
+
+  const rows: RawEtfRow[] = etfs.map((etf) => ({
+    id: etf.id,
+    symbol: etf.symbol,
+    name: etf.name,
+    exchange: etf.exchange,
+    assetClass: null,
+    category: null,
+    finalScore: etf.cachedScore?.finalScore ?? null,
+    aum: etf.financialInfo?.aum ?? null,
+  }));
+
+  return { items: selectTopFive(rows), count: rows.length };
+}
+
+/** ETFs with no asset class — the "Others" bucket for the asset-class index. */
+export function fetchEtfsWithoutAssetClass(spaceId: string, country?: EtfSupportedCountry, includeUnpopulated = false): Promise<EtfUncategorizedPreview> {
+  return fetchEtfsMissingStockAnalyzerField(spaceId, 'assetClass', country, includeUnpopulated);
+}
+
+/** ETFs with no issuer — the "Others" bucket for the provider index. */
+export function fetchEtfsWithoutIssuer(spaceId: string, country?: EtfSupportedCountry, includeUnpopulated = false): Promise<EtfUncategorizedPreview> {
+  return fetchEtfsMissingStockAnalyzerField(spaceId, 'issuer', country, includeUnpopulated);
+}
+
 /** Bucketed by issuer (provider). */
 export async function fetchEtfProvidersForCountry(spaceId: string, country?: EtfSupportedCountry, includeUnpopulated = false): Promise<EtfProvidersPreview> {
   const baseWhere = { spaceId, stockAnalyzerInfo: { is: { issuer: { not: null } } } };

--- a/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/providers-index/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/etfs-v1/listings/providers-index/route.ts
@@ -1,10 +1,16 @@
-import { EtfProvidersPreview, fetchEtfProvidersForCountry } from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
+import {
+  EtfProvidersPreview,
+  EtfUncategorizedPreview,
+  fetchEtfProvidersForCountry,
+  fetchEtfsWithoutIssuer,
+} from '@/app/api/[spaceId]/etfs-v1/listings/listings-prisma';
 import { shouldIncludeUnpopulatedForRequest } from '@/utils/etf-listing-visibility';
 import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
-export type EtfProvidersIndexResponse = EtfProvidersPreview;
+/** Provider buckets plus an "Others" bucket for ETFs with no issuer. */
+export type EtfProvidersIndexResponse = EtfProvidersPreview & { others: EtfUncategorizedPreview };
 
 async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId: string }> }): Promise<EtfProvidersIndexResponse> {
   const { spaceId } = await context.params;
@@ -13,7 +19,12 @@ async function getHandler(req: NextRequest, context: { params: Promise<{ spaceId
   const country = countryParam && isEtfSupportedCountry(countryParam) ? countryParam : undefined;
   const includeUnpopulated = await shouldIncludeUnpopulatedForRequest(req);
 
-  return fetchEtfProvidersForCountry(spaceId, country, includeUnpopulated);
+  const [providers, others] = await Promise.all([
+    fetchEtfProvidersForCountry(spaceId, country, includeUnpopulated),
+    fetchEtfsWithoutIssuer(spaceId, country, includeUnpopulated),
+  ]);
+
+  return { ...providers, others };
 }
 
 export const GET = withErrorHandlingV2<EtfProvidersIndexResponse>(getHandler);

--- a/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/[id]/route.ts
@@ -5,7 +5,7 @@ import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { EtfScenario } from '@prisma/client';
 import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
-import { isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { ETF_SUPPORTED_COUNTRIES, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { NextRequest } from 'next/server';
 import { withAdminOrToken } from '../../helpers/withAdminOrToken';
 import { z } from 'zod';
@@ -35,7 +35,7 @@ const updateEtfScenarioSchema = z.object({
   // the scope (e.g. dropping US) should expect existing US links to start
   // throwing on subsequent edits until they're cleaned up.
   countries: z
-    .array(z.string().refine((v) => isEtfSupportedCountry(v), 'country must be one of the supported ETF countries (US / Canada)'))
+    .array(z.string().refine((v) => isEtfSupportedCountry(v), `country must be one of the supported ETF countries (${ETF_SUPPORTED_COUNTRIES.join(' / ')})`))
     .min(1)
     .optional(),
 });

--- a/insights-ui/src/app/api/etf-scenarios/route.ts
+++ b/insights-ui/src/app/api/etf-scenarios/route.ts
@@ -6,7 +6,7 @@ import { KoalaGainsJwtTokenPayload } from '@/types/auth';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { EtfScenario } from '@prisma/client';
 import { EtfScenarioDirection, EtfScenarioPricedInBucket, EtfScenarioProbabilityBucket, EtfScenarioRole, EtfScenarioTimeframe } from '@/types/etfScenarioEnums';
-import { EtfSupportedCountry, isEtfExchange, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
+import { ETF_SUPPORTED_COUNTRIES, EtfSupportedCountry, isEtfExchange, isEtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfScenarioLinkCountryMismatch, serializeEtfLinkMismatches } from '@/utils/etf-scenario-country-validation';
 import { NextRequest } from 'next/server';
 import { withAdminOrToken } from '../helpers/withAdminOrToken';
@@ -29,12 +29,11 @@ const createEtfScenarioSchema = z.object({
   outlookAsOfDate: z.string().refine((s) => !isNaN(Date.parse(s)), 'outlookAsOfDate must be an ISO date'),
   metaDescription: z.string().nullable().optional(),
   archived: z.boolean().optional(),
-  // Countries the scenario is scoped to. ETF coverage is currently US + Canada;
-  // we validate against ETF_SUPPORTED_COUNTRIES (a subset of stock's
-  // SupportedCountries) so admins can't create scenarios in markets we don't
-  // ship ETF data for.
+  // Countries the scenario is scoped to. We validate against
+  // ETF_SUPPORTED_COUNTRIES (a subset of stock's SupportedCountries) so admins
+  // can't create scenarios in markets we don't ship ETF data for.
   countries: z
-    .array(z.string().refine((v) => isEtfSupportedCountry(v), 'country must be one of the supported ETF countries (US / Canada)'))
+    .array(z.string().refine((v) => isEtfSupportedCountry(v), `country must be one of the supported ETF countries (${ETF_SUPPORTED_COUNTRIES.join(' / ')})`))
     .min(1, 'at least one country must be declared'),
   links: z
     .array(

--- a/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/asset-classes/[assetClass]/page.tsx
@@ -1,4 +1,5 @@
 import EtfAssetClassDetail from '@/components/etfs/EtfAssetClassDetail';
+import { ETF_OTHERS_GROUP, ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
 import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
@@ -19,6 +20,8 @@ type PageProps = {
 function resolveAssetClass(rawParam: string): { canonical: string; slug: string } | null {
   const decoded = decodeURIComponent(rawParam);
   const slugCandidate = slugifyEtfTag(decoded);
+  // "Others" = ETFs with no asset class (mirrors the groups "Others" bucket).
+  if (slugCandidate === ETF_OTHERS_GROUP_KEY) return { canonical: ETF_OTHERS_GROUP.name, slug: ETF_OTHERS_GROUP_KEY };
   const fromSlug = getEtfAssetClassBySlug(slugCandidate);
   if (fromSlug) return { canonical: fromSlug, slug: slugifyEtfTag(fromSlug) };
   const fromValue = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value !== '' && o.value.toLowerCase() === decoded.toLowerCase());

--- a/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
+++ b/insights-ui/src/app/etfs/countries/[country]/asset-classes/[assetClass]/page.tsx
@@ -1,4 +1,5 @@
 import EtfAssetClassDetail from '@/components/etfs/EtfAssetClassDetail';
+import { ETF_OTHERS_GROUP, ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
 import { EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { etfBrowseDetailPath, resolveEtfCountryParam } from '@/utils/etf-country-route-utils';
 import { getEtfAssetClassBySlug, slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
@@ -19,6 +20,8 @@ type PageProps = {
 function resolveAssetClass(rawParam: string): { canonical: string; slug: string } | null {
   const decoded = decodeURIComponent(rawParam);
   const slugCandidate = slugifyEtfTag(decoded);
+  // "Others" = ETFs with no asset class (mirrors the groups "Others" bucket).
+  if (slugCandidate === ETF_OTHERS_GROUP_KEY) return { canonical: ETF_OTHERS_GROUP.name, slug: ETF_OTHERS_GROUP_KEY };
   const fromSlug = getEtfAssetClassBySlug(slugCandidate);
   if (fromSlug) return { canonical: fromSlug, slug: slugifyEtfTag(fromSlug) };
   const fromValue = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value !== '' && o.value.toLowerCase() === decoded.toLowerCase());

--- a/insights-ui/src/components/etfs/EtfAssetClassDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfAssetClassDetail.tsx
@@ -1,6 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { ETF_OTHERS_GROUP, ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
 import { EtfFilterParamKey, EtfSearchParams, ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
@@ -13,9 +14,12 @@ interface EtfAssetClassDetailProps {
 }
 
 export default async function EtfAssetClassDetail({ country, assetClass, searchParams }: EtfAssetClassDetailProps) {
+  // "Others" = ETFs with no asset class. Pass the sentinel through to the listing
+  // API, which interprets assetClass=others as "assetClass is null / no row".
+  const isOthers = slugifyEtfTag(assetClass) === ETF_OTHERS_GROUP_KEY;
   const matchingOption = ETF_ASSET_CLASS_OPTIONS.find((o) => o.value.toLowerCase() === assetClass.toLowerCase());
-  const displayAssetClass = matchingOption?.label ?? assetClass;
-  const filterValue = matchingOption?.value ?? assetClass;
+  const displayAssetClass = isOthers ? ETF_OTHERS_GROUP.name : matchingOption?.label ?? assetClass;
+  const filterValue = isOthers ? ETF_OTHERS_GROUP_KEY : matchingOption?.value ?? assetClass;
   const displayCountry = etfCountryDisplayName(country);
 
   const dataPromise = fetchEtfListingData(

--- a/insights-ui/src/components/etfs/EtfAssetClassesIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfAssetClassesIndex.tsx
@@ -1,6 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import EtfGroupingCardGrid from '@/components/etfs/EtfGroupingCardGrid';
+import EtfGroupingCardGrid, { EtfGroupingCardSpec } from '@/components/etfs/EtfGroupingCardGrid';
 import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
+import { ETF_OTHERS_GROUP } from '@/utils/etf-categorization-utils';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
@@ -16,6 +17,25 @@ export default function EtfAssetClassesIndex({ country, data }: EtfAssetClassesI
   const displayName = etfCountryDisplayName(country);
   const assetClassesPath = etfBrowsePath(country, 'asset-classes');
 
+  const items: EtfGroupingCardSpec[] = assetClasses.map((opt) => ({
+    key: opt.value,
+    title: opt.label,
+    href: etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(opt.value)),
+    totalCount: data.counts[opt.value] ?? 0,
+    etfs: data.values[opt.value] ?? [],
+  }));
+
+  // Append an "Others" bucket for ETFs with no asset class — only when some exist.
+  if (data.others.count > 0) {
+    items.push({
+      key: ETF_OTHERS_GROUP.key,
+      title: ETF_OTHERS_GROUP.name,
+      href: etfBrowseDetailPath(country, 'asset-classes', ETF_OTHERS_GROUP.key),
+      totalCount: data.others.count,
+      etfs: data.others.items,
+    });
+  }
+
   return (
     <EtfPageLayout
       title={`${displayName} ETFs by Asset Class`}
@@ -25,16 +45,7 @@ export default function EtfAssetClassesIndex({ country, data }: EtfAssetClassesI
       extraBreadcrumbs={[{ name: 'Asset Classes', href: assetClassesPath, current: true }]}
       revalidateTag={{ kind: 'asset-classes-index', country }}
     >
-      <EtfGroupingCardGrid
-        columns={3}
-        items={assetClasses.map((opt) => ({
-          key: opt.value,
-          title: opt.label,
-          href: etfBrowseDetailPath(country, 'asset-classes', slugifyEtfTag(opt.value)),
-          totalCount: data.counts[opt.value] ?? 0,
-          etfs: data.values[opt.value] ?? [],
-        }))}
-      />
+      <EtfGroupingCardGrid columns={3} items={items} />
     </EtfPageLayout>
   );
 }

--- a/insights-ui/src/components/etfs/EtfProviderDetail.tsx
+++ b/insights-ui/src/components/etfs/EtfProviderDetail.tsx
@@ -1,6 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
 import WithSuspenseEtfListingGrid from '@/components/etfs/WithSuspenseEtfListingGrid';
 import { fetchEtfListingData } from '@/utils/etf-data-utils';
+import { ETF_OTHERS_GROUP_KEY } from '@/utils/etf-categorization-utils';
 import { EtfFilterParamKey, EtfSearchParams } from '@/utils/etf-filter-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
@@ -15,10 +16,15 @@ interface EtfProviderDetailProps {
 export default async function EtfProviderDetail({ country, provider, searchParams }: EtfProviderDetailProps) {
   const displayCountry = etfCountryDisplayName(country);
 
+  // "Others" = ETFs with no issuer. Pass the sentinel through to the listing
+  // API, which interprets issuer=others as "issuer is null / no row".
+  const isOthers = slugifyEtfTag(provider) === ETF_OTHERS_GROUP_KEY;
+  const issuerFilter = isOthers ? ETF_OTHERS_GROUP_KEY : provider;
+
   const dataPromise = fetchEtfListingData(
     {
       ...searchParams,
-      [EtfFilterParamKey.ISSUER]: provider,
+      [EtfFilterParamKey.ISSUER]: issuerFilter,
     },
     country
   );

--- a/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
+++ b/insights-ui/src/components/etfs/EtfProvidersIndex.tsx
@@ -1,6 +1,7 @@
 import EtfPageLayout from '@/components/etfs/EtfPageLayout';
-import EtfGroupingCardGrid from '@/components/etfs/EtfGroupingCardGrid';
+import EtfGroupingCardGrid, { EtfGroupingCardSpec } from '@/components/etfs/EtfGroupingCardGrid';
 import type { EtfProvidersIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/providers-index/route';
+import { ETF_OTHERS_GROUP } from '@/utils/etf-categorization-utils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { etfBrowseDetailPath, etfBrowsePath, etfCountryDisplayName } from '@/utils/etf-country-route-utils';
 import { slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
@@ -11,9 +12,28 @@ interface EtfProvidersIndexProps {
 }
 
 export default function EtfProvidersIndex({ country, data }: EtfProvidersIndexProps) {
-  const { providers, values, counts } = data;
+  const { providers, values, counts, others } = data;
   const displayName = etfCountryDisplayName(country);
   const providersPath = etfBrowsePath(country, 'providers');
+
+  const items: EtfGroupingCardSpec[] = providers.map((provider) => ({
+    key: provider,
+    title: provider,
+    href: etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider)),
+    totalCount: counts[provider] ?? 0,
+    etfs: values[provider] ?? [],
+  }));
+
+  // Append an "Others" bucket for ETFs with no issuer — only when some exist.
+  if (others.count > 0) {
+    items.push({
+      key: ETF_OTHERS_GROUP.key,
+      title: ETF_OTHERS_GROUP.name,
+      href: etfBrowseDetailPath(country, 'providers', ETF_OTHERS_GROUP.key),
+      totalCount: others.count,
+      etfs: others.items,
+    });
+  }
 
   return (
     <EtfPageLayout
@@ -24,19 +44,10 @@ export default function EtfProvidersIndex({ country, data }: EtfProvidersIndexPr
       extraBreadcrumbs={[{ name: 'Providers', href: providersPath, current: true }]}
       revalidateTag={{ kind: 'providers-index', country }}
     >
-      {providers.length === 0 ? (
+      {items.length === 0 ? (
         <p className="text-[#E5E7EB] text-md">No providers available for {displayName} ETFs.</p>
       ) : (
-        <EtfGroupingCardGrid
-          columns={3}
-          items={providers.map((provider) => ({
-            key: provider,
-            title: provider,
-            href: etfBrowseDetailPath(country, 'providers', slugifyEtfTag(provider)),
-            totalCount: counts[provider] ?? 0,
-            etfs: values[provider] ?? [],
-          }))}
-        />
+        <EtfGroupingCardGrid columns={3} items={items} />
       )}
     </EtfPageLayout>
   );

--- a/insights-ui/src/scripts/etfs/csv-to-sql.ts
+++ b/insights-ui/src/scripts/etfs/csv-to-sql.ts
@@ -1,0 +1,351 @@
+/**
+ * Convert an ETF screener CSV/TSV (e.g. `public/australia-etf`) into a `.sql`
+ * file with raw INSERTs for `etfs`, `etf_financial_info`, and
+ * `etf_stock_analyzer_info`. The output is intended to be run directly in
+ * pgAdmin against a local or production DB — no API or Prisma client is
+ * involved, so it works regardless of whether the app code is deployed.
+ *
+ * Usage:
+ *   yarn etfs:csv-to-sql                       # reads public/australia-etf.csv, writes public/australia-etf.sql
+ *   yarn etfs:csv-to-sql --in <path> --out <path>
+ *
+ * Notes on input shape:
+ *   - The "Symbol" column is expected to be `EXCHANGE:TICKER` (e.g. `ASX:SPY`,
+ *     `TSX:VFV`, `NEO:FEQT`). The prefix sets the exchange code (`ASX` for the
+ *     Australian Securities Exchange, `CBOE` mapped to `NEO` for Cboe Canada).
+ *     Bare-ticker rows fall back to the "Exchange" column ("Australian
+ *     Securities Exchange" → ASX, "Toronto Stock Exchange" → TSX, etc.).
+ *   - Empty / "N/A" / "-" cells are written as SQL NULL.
+ *   - Numeric percentages (e.g. "79.41%") are kept as strings for fields the
+ *     schema declares as `String?`; for `Float?` columns they're stripped of
+ *     `$`, `,`, `%` before parsing.
+ */
+
+import 'dotenv/config';
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import Papa from 'papaparse';
+import { AustraliaExchanges, CanadaExchanges, USExchanges } from '@/utils/countryExchangeUtils';
+
+const SPACE_ID = 'koala_gains';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const DEFAULT_IN = path.join(REPO_ROOT, 'public', 'australia-etf.csv');
+const DEFAULT_OUT = path.join(REPO_ROOT, 'public', 'australia-etf.sql');
+
+/**
+ * Maps the "Exchange" column in the CSV to the exchange code we store in the DB.
+ * Used as a fallback when the symbol itself doesn't carry a prefix.
+ */
+const EXCHANGE_NAME_TO_CODE: Record<string, string> = {
+  'Australian Securities Exchange': AustraliaExchanges.ASX,
+  'Toronto Stock Exchange': CanadaExchanges.TSX,
+  'TSX Venture Exchange': CanadaExchanges.TSXV,
+  'Cboe Canada': CanadaExchanges.NEO,
+  Nasdaq: USExchanges.NASDAQ,
+  NASDAQ: USExchanges.NASDAQ,
+  'New York Stock Exchange': USExchanges.NYSE,
+  'NYSE Arca': USExchanges.NYSEARCA,
+  'NYSE American': USExchanges.NYSEAMERICAN,
+  BATS: USExchanges.BATS,
+  'OTC Markets': USExchanges.OTCMKTS,
+};
+
+/**
+ * Maps a symbol prefix (the part before `:`) to the exchange code.
+ * `ASX` is the Australian Securities Exchange; `CBOE` is Cboe Canada —
+ * stored as `NEO` in our schema.
+ */
+const SYMBOL_PREFIX_TO_CODE: Record<string, string> = {
+  ASX: AustraliaExchanges.ASX,
+  TSX: CanadaExchanges.TSX,
+  TSXV: CanadaExchanges.TSXV,
+  NEO: CanadaExchanges.NEO,
+  CBOE: CanadaExchanges.NEO,
+  NASDAQ: USExchanges.NASDAQ,
+  NYSE: USExchanges.NYSE,
+  NYSEARCA: USExchanges.NYSEARCA,
+  NYSEAMERICAN: USExchanges.NYSEAMERICAN,
+  BATS: USExchanges.BATS,
+  OTCMKTS: USExchanges.OTCMKTS,
+};
+
+interface CsvRow {
+  [key: string]: string | undefined;
+}
+
+interface ParsedSymbol {
+  symbol: string;
+  exchange: string | null;
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      out[key] = '';
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function isEmpty(raw: string | undefined | null): boolean {
+  if (raw === undefined || raw === null) return true;
+  const t = String(raw).trim();
+  return t === '' || t === 'N/A' || t === 'n/a' || t === '-' || t === '--';
+}
+
+function sqlString(raw: string | undefined | null): string {
+  if (isEmpty(raw)) return 'NULL';
+  return `'${String(raw).trim().replace(/'/g, "''")}'`;
+}
+
+function sqlFloat(raw: string | undefined | null): string {
+  if (isEmpty(raw)) return 'NULL';
+  const cleaned = String(raw)
+    .trim()
+    .replace(/[$,%\s]/g, '');
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? String(n) : 'NULL';
+}
+
+function sqlBigInt(raw: string | undefined | null): string {
+  if (isEmpty(raw)) return 'NULL';
+  // Strip thousands separators and any trailing decimal — BigInt columns can't hold fractions.
+  const cleaned = String(raw)
+    .trim()
+    .replace(/[$,\s]/g, '')
+    .replace(/\.\d+$/, '');
+  if (!/^-?\d+$/.test(cleaned)) return 'NULL';
+  return cleaned;
+}
+
+function sqlInt(raw: string | undefined | null): string {
+  return sqlBigInt(raw);
+}
+
+function parseSymbol(rawSymbol: string | undefined, rawExchange: string | undefined): ParsedSymbol {
+  const sym = (rawSymbol ?? '').trim();
+  const colon = sym.indexOf(':');
+  if (colon > 0) {
+    const prefix = sym.slice(0, colon).trim().toUpperCase();
+    const ticker = sym
+      .slice(colon + 1)
+      .trim()
+      .toUpperCase();
+    const mapped = SYMBOL_PREFIX_TO_CODE[prefix];
+    return { symbol: ticker, exchange: mapped ?? prefix };
+  }
+  const ticker = sym.toUpperCase();
+  const exchangeCol = (rawExchange ?? '').trim();
+  return { symbol: ticker, exchange: EXCHANGE_NAME_TO_CODE[exchangeCol] ?? null };
+}
+
+interface BuiltStatements {
+  etf: string;
+  financial: string;
+  stockAnalyzer: string;
+}
+
+function buildStatementsForRow(row: CsvRow, errors: string[], rowIdx: number): BuiltStatements | null {
+  const { symbol, exchange } = parseSymbol(row['Symbol'], row['Exchange']);
+  if (!symbol || !exchange) {
+    errors.push(`Row ${rowIdx + 2}: cannot resolve symbol/exchange from Symbol="${row['Symbol'] ?? ''}" Exchange="${row['Exchange'] ?? ''}"`);
+    return null;
+  }
+  const name = (row['Fund Name'] ?? row['Name'] ?? '').trim();
+  if (!name) {
+    errors.push(`Row ${rowIdx + 2}: missing "Fund Name" (symbol=${symbol})`);
+    return null;
+  }
+
+  const etfId = randomUUID();
+  const lastDivSql = sqlFloat(row['Last Dividend ($)'] ?? row['Last Div.']);
+
+  const etfSql =
+    `INSERT INTO etfs (id, space_id, symbol, name, exchange, inception, created_at, updated_at) VALUES (` +
+    [sqlString(etfId), sqlString(SPACE_ID), sqlString(symbol), sqlString(name), sqlString(exchange), sqlString(row['Inception']), 'NOW()', 'NOW()'].join(', ') +
+    `) ON CONFLICT (space_id, symbol, exchange) DO NOTHING;`;
+
+  const financialSql =
+    `INSERT INTO etf_financial_info (id, etf_id, aum, expense_ratio, pe, shares_out, dividend_ttm, dividend_yield, payout_frequency, payout_ratio, volume, year_high, year_low, holdings, created_at, updated_at) VALUES (` +
+    [
+      sqlString(randomUUID()),
+      sqlString(etfId),
+      sqlString(row['Assets']),
+      sqlFloat(row['Expense Ratio'] ?? row['Exp. Ratio']),
+      sqlFloat(row['PE Ratio']),
+      sqlString(row['Shares Out'] ?? row['Shares']),
+      lastDivSql,
+      sqlFloat(row['Dividend Yield'] ?? row['Div. Yield']),
+      sqlString(row['Dividend Payout Frequency'] ?? row['Payout Freq.']),
+      sqlFloat(row['Payout Ratio']),
+      sqlFloat(row['Volume']),
+      sqlFloat(row['52-Week High Price'] ?? row['52W High']),
+      sqlFloat(row['52-Week Low Price'] ?? row['52W Low']),
+      sqlInt(row['Holdings Count'] ?? row['Holdings']),
+      'NOW()',
+      'NOW()',
+    ].join(', ') +
+    `);`;
+
+  // Build the EtfStockAnalyzerInfo row column-by-column to keep field
+  // ordering aligned with the Prisma model and easy to audit.
+  const saColumns: Array<[string, string]> = [
+    ['id', sqlString(randomUUID())],
+    ['etf_id', sqlString(etfId)],
+    ['symbol', sqlString(symbol)],
+    ['fund_name', sqlString(name)],
+    ['asset_class', sqlString(row['Asset Class'])],
+    ['stock_price', sqlString(row['Stock Price'])],
+    ['percent_change', sqlString(row['Price Change 1D'] ?? row['% Change'])],
+    ['isin_number', sqlString(row['ISIN Number'])],
+    ['cusip_number', sqlString(row['CUSIP Number'])],
+    ['ma_200_chg_percent', sqlString(row['Price Change 200-Day MA'] ?? row['200MA Chg %'])],
+    ['ma_150_chg_percent', sqlString(row['Price Change 150-Day MA'] ?? row['150MA Chg %'])],
+    ['ma_50_chg_percent', sqlString(row['Price Change 50-Day MA'] ?? row['50MA Chg %'])],
+    ['ma_20_chg_percent', sqlString(row['Price Change 20-Day MA'] ?? row['20MA Chg %'])],
+    ['ma_200', sqlFloat(row['200-Day Moving Average'] ?? row['200 MA'])],
+    ['ma_150', sqlFloat(row['150-Day Moving Average'] ?? row['150 MA'])],
+    ['ma_50', sqlFloat(row['50-Day Moving Average'] ?? row['50 MA'])],
+    ['ma_20', sqlFloat(row['20-Day Moving Average'] ?? row['20 MA'])],
+    ['atl_date', sqlString(row['All-Time Low Date'] ?? row['ATL Date'])],
+    ['atl_chg_percent', sqlString(row['All-Time Low Change (%)'] ?? row['ATL Chg (%)'])],
+    ['atl', sqlFloat(row['All-Time Low'] ?? row['ATL'])],
+    ['ath_date', sqlString(row['All-Time High Date'] ?? row['ATH Date'])],
+    ['ath_chg_percent', sqlString(row['All-Time High Change (%)'] ?? row['ATH Chg (%)'])],
+    ['ath', sqlFloat(row['All-Time High'] ?? row['ATH'])],
+    ['low_52w_date', sqlString(row['52-Week Low Date'] ?? row['52W Low Date'])],
+    ['high_52w_date', sqlString(row['52-Week High Date'] ?? row['52W High Date'])],
+    ['high_52w_chg', sqlString(row['Price Change 52W High'] ?? row['52W High Chg'])],
+    ['low_52w_chg', sqlString(row['Price Change 52W Low'] ?? row['52W Low Chg'])],
+    ['cagr_20y', sqlString(row['Return CAGR 20Y'] ?? row['CAGR 20Y'])],
+    ['cagr_15y', sqlString(row['Return CAGR 15Y'] ?? row['CAGR 15Y'])],
+    ['cagr_10y', sqlString(row['Return CAGR 10Y'] ?? row['CAGR 10Y'])],
+    ['cagr_5y', sqlString(row['Return CAGR 5Y'] ?? row['CAGR 5Y'])],
+    ['cagr_3y', sqlString(row['Return CAGR 3Y'] ?? row['CAGR 3Y'])],
+    ['cagr_1y', sqlString(row['Return CAGR 1Y'] ?? row['CAGR 1Y'])],
+    ['return_20y', sqlString(row['Total Return 20Y'] ?? row['Return 20Y'])],
+    ['return_15y', sqlString(row['Total Return 15Y'] ?? row['Return 15Y'])],
+    ['return_10y', sqlString(row['Total Return 10Y'] ?? row['Return 10Y'])],
+    ['return_5y', sqlString(row['Total Return 5Y'] ?? row['Return 5Y'])],
+    ['return_3y', sqlString(row['Total Return 3Y'] ?? row['Return 3Y'])],
+    ['return_1y', sqlString(row['Total Return 1Y'] ?? row['Return 1Y'])],
+    ['return_ytd', sqlString(row['Total Return YTD'] ?? row['Return YTD'])],
+    ['return_6m', sqlString(row['Total Return 6M'] ?? row['Return 6M'])],
+    ['return_3m', sqlString(row['Total Return 3M'] ?? row['Return 3M'])],
+    ['return_1m', sqlString(row['Total Return 1M'] ?? row['Return 1M'])],
+    ['change_20y', sqlString(row['Price Change 20Y'] ?? row['Change 20Y'])],
+    ['change_15y', sqlString(row['Price Change 15Y'] ?? row['Change 15Y'])],
+    ['change_10y', sqlString(row['Price Change 10Y'] ?? row['Change 10Y'])],
+    ['change_5y', sqlString(row['Price Change 5Y'] ?? row['Change 5Y'])],
+    ['change_3y', sqlString(row['Price Change 3Y'] ?? row['Change 3Y'])],
+    ['change_1y', sqlString(row['Price Change 1Y'] ?? row['Change 1Y'])],
+    ['change_ytd', sqlString(row['Price Change YTD'] ?? row['Change YTD'])],
+    ['change_6m', sqlString(row['Price Change 6M'] ?? row['Change 6M'])],
+    ['change_3m', sqlString(row['Price Change 3M'] ?? row['Change 3M'])],
+    ['change_1m', sqlString(row['Price Change 1M'] ?? row['Change 1M'])],
+    ['change_1w', sqlString(row['Price Change 1W'] ?? row['Change 1W'])],
+    ['leverage', sqlString(row['Leverage'])],
+    ['region', sqlString(row['Region'])],
+    ['payment_date', sqlString(row['Payment Date'])],
+    ['ex_div_date', sqlString(row['Ex-Dividend Date'] ?? row['Ex-Div Date'])],
+    ['div_growth_10y', sqlString(row['Dividend Growth (10Y)'] ?? row['Div. Growth 10Y'])],
+    ['div_growth_5y', sqlString(row['Dividend Growth (5Y)'] ?? row['Div. Growth 5Y'])],
+    ['div_growth_3y', sqlString(row['Dividend Growth (3Y)'] ?? row['Div. Growth 3Y'])],
+    ['div_years', sqlInt(row['Dividend Payment Years'] ?? row['Div. Years'])],
+    ['div_gr_years', sqlInt(row['Dividend Growth Years'] ?? row['Div. Gr. Years'])],
+    ['div_growth', sqlString(row['Dividend Growth'] ?? row['Div. Growth'])],
+    ['last_div', lastDivSql],
+    ['div_dollars', sqlFloat(row['Dividend Per Share ($)'] ?? row['Div. ($)'])],
+    ['sortino', sqlFloat(row['Sortino Ratio'] ?? row['Sortino'])],
+    ['atr', sqlFloat(row['Average True Range (ATR)'] ?? row['ATR'])],
+    ['sharpe', sqlFloat(row['Sharpe Ratio'] ?? row['Sharpe'])],
+    ['index', sqlString(row['Index'])],
+    ['price_curr', sqlString(row['Price Currency'] ?? row['Price Curr.'])],
+    ['beta_1y', sqlFloat(row['Beta (1Y)'])],
+    ['beta_2y', sqlFloat(row['Beta (2Y)'])],
+    ['beta_5y', sqlFloat(row['Beta (5Y)'])],
+    ['rsi', sqlFloat(row['Relative Strength Index (RSI)'] ?? row['RSI'])],
+    ['rsi_w', sqlFloat(row['Weekly RSI'] ?? row['RSI (W)'])],
+    ['rsi_m', sqlFloat(row['Monthly RSI'] ?? row['RSI (M)'])],
+    ['issuer', sqlString(row['Issuer'])],
+    ['category', sqlString(row['Category'])],
+    ['chg_open_percent', sqlString(row['Change From Open (%)'] ?? row['Chg. Open (%)'])],
+    ['position_in_range', sqlString(row['Position in Range (%)'] ?? row['Pos. Range'])],
+    ['open', sqlFloat(row['Open Price'] ?? row['Open'])],
+    ['low', sqlFloat(row['Low Price'] ?? row['Low'])],
+    ['high', sqlFloat(row['High Price'] ?? row['High'])],
+    ['prev_close', sqlFloat(row['Previous Close'] ?? row['Prev. Close'])],
+    ['price_date', sqlString(row['Stock Price Date'] ?? row['Price Date'])],
+    ['gap_percent', sqlString(row["Day's Gap (%)"] ?? row['Gap (%)'])],
+    ['rel_volume', sqlString(row['Relative Volume'] ?? row['Rel. Volume'])],
+    ['avg_volume', sqlBigInt(row['Average Volume'] ?? row['Avg. Volume'])],
+    ['dollar_vol', sqlBigInt(row['Dollar Volume'] ?? row['Dollar Vol.'])],
+    ['created_at', 'NOW()'],
+    ['updated_at', 'NOW()'],
+  ];
+
+  const stockAnalyzerSql =
+    `INSERT INTO etf_stock_analyzer_info (${saColumns.map(([c]) => `"${c}"`).join(', ')}) VALUES (` + saColumns.map(([, v]) => v).join(', ') + `);`;
+
+  return { etf: etfSql, financial: financialSql, stockAnalyzer: stockAnalyzerSql };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const inPath = args['in'] ? path.resolve(args['in']) : DEFAULT_IN;
+  const outPath = args['out'] ? path.resolve(args['out']) : DEFAULT_OUT;
+
+  console.log(`📄 Reading CSV: ${inPath}`);
+  const raw = await readFile(inPath, 'utf-8');
+
+  // Auto-detect delimiter — the source we use exports as TSV but supports CSV too.
+  const parsed = Papa.parse<CsvRow>(raw, {
+    header: true,
+    skipEmptyLines: true,
+    delimiter: '',
+    transformHeader: (h) => h.trim(),
+  });
+
+  if (parsed.errors.length > 0) {
+    console.warn(`⚠️  Papaparse reported ${parsed.errors.length} non-fatal parse warnings — continuing.`);
+    for (const e of parsed.errors.slice(0, 5)) console.warn(`   - ${e.type} @ row ${e.row}: ${e.message}`);
+  }
+
+  const rows = parsed.data.filter((r) => Object.values(r).some((v) => !isEmpty(v)));
+  console.log(`✅ Parsed ${rows.length} data row(s)`);
+
+  const errors: string[] = [];
+  const blocks: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const built = buildStatementsForRow(rows[i], errors, i);
+    if (!built) continue;
+    blocks.push([built.etf, built.financial, built.stockAnalyzer].join('\n'));
+  }
+
+  if (errors.length > 0) {
+    console.warn(`⚠️  Skipped ${errors.length} row(s):`);
+    for (const e of errors) console.warn(`   - ${e}`);
+  }
+
+  const sql = ['BEGIN;', '', ...blocks, '', 'COMMIT;', ''].join('\n');
+  await writeFile(outPath, sql, 'utf-8');
+
+  console.log(`💾 Wrote ${blocks.length} ETF block(s) → ${outPath}`);
+  if (errors.length > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-report-input-json-utils.ts
@@ -43,7 +43,7 @@ const GROUP_CATEGORY_FLAGS: Record<string, EtfCategoryFlagsFile> = {
  * a fund category, or undefined. The stored category is the raw per-country
  * label, so it is canonicalized (e.g. Canada's "Information Technology" ->
  * "Technology") before resolving the group and the slug key, so lookups resolve
- * for both US and Canada funds.
+ * across all supported ETF countries (US, Canada, Australia).
  */
 function getCategoryInstructionEntry(fundCategory: string | null | undefined): EtfMorCategoryInstructionEntry | undefined {
   const groupKey = getEtfGroupKeyForCategory(fundCategory);

--- a/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/prisma';
-import { AllExchanges, CanadaExchanges, toExchange, USExchanges } from '@/utils/countryExchangeUtils';
+import { AllExchanges, AustraliaExchanges, CanadaExchanges, toExchange, USExchanges } from '@/utils/countryExchangeUtils';
 
 export type MorKind = 'quote' | 'risk' | 'people' | 'portfolio';
 
@@ -17,7 +17,7 @@ export interface TriggerMorScrapeResult {
   kind: MorKind;
 }
 
-type MorEtfExchangeSegment = 'xnys' | 'xnas' | 'arcx' | 'bats' | 'xtse' | 'neoe';
+type MorEtfExchangeSegment = 'xnys' | 'xnas' | 'arcx' | 'bats' | 'xtse' | 'neoe' | 'xasx';
 
 function toMorEtfExchangeSegment(exchange: AllExchanges): MorEtfExchangeSegment {
   switch (exchange) {
@@ -33,6 +33,9 @@ function toMorEtfExchangeSegment(exchange: AllExchanges): MorEtfExchangeSegment 
       return 'xtse';
     case CanadaExchanges.NEO:
       return 'neoe';
+    // Australia — Morningstar uses the ASX MIC code (e.g. /etfs/xasx/vas/quote).
+    case AustraliaExchanges.ASX:
+      return 'xasx';
     default:
       throw new Error(`Unsupported exchange: ${exchange}`);
   }

--- a/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/mor-scrape-utils.ts
@@ -33,7 +33,7 @@ function toMorEtfExchangeSegment(exchange: AllExchanges): MorEtfExchangeSegment 
       return 'xtse';
     case CanadaExchanges.NEO:
       return 'neoe';
-    // Australia — Morningstar uses the ASX MIC code (e.g. /etfs/xasx/vas/quote).
+    // Australia — the provider uses the ASX MIC code segment (e.g. /etfs/xasx/vas/quote).
     case AustraliaExchanges.ASX:
       return 'xasx';
     default:

--- a/insights-ui/src/utils/etf-country-route-utils.ts
+++ b/insights-ui/src/utils/etf-country-route-utils.ts
@@ -8,6 +8,7 @@ export type EtfBrowseSection = 'groups' | 'asset-classes' | 'providers';
 const COUNTRY_DISPLAY_NAME: Record<EtfSupportedCountry, string> = {
   [SupportedCountries.US]: 'US',
   [SupportedCountries.Canada]: 'Canadian',
+  [SupportedCountries.Australia]: 'Australian',
 };
 
 export function etfCountryDisplayName(country: EtfSupportedCountry): string {

--- a/insights-ui/src/utils/etf-filter-utils.ts
+++ b/insights-ui/src/utils/etf-filter-utils.ts
@@ -1265,7 +1265,9 @@ export function createEtfStockAnalyzerFilter(filters: EtfFilterParams): Prisma.E
 
   const assetClass = filters[EtfFilterParamKey.ASSET_CLASS]?.trim();
   if (assetClass) {
-    where.assetClass = { equals: assetClass, mode: 'insensitive' };
+    // The synthetic "others" asset class means "assetClass is null"; the listing
+    // route then OR-s in ETFs that lack a stockAnalyzerInfo relation entirely.
+    where.assetClass = assetClass === ETF_OTHERS_GROUP_KEY ? null : { equals: assetClass, mode: 'insensitive' };
   }
 
   const category = filters[EtfFilterParamKey.CATEGORY]?.trim();
@@ -1296,7 +1298,9 @@ export function createEtfStockAnalyzerFilter(filters: EtfFilterParams): Prisma.E
 
   const issuer = filters[EtfFilterParamKey.ISSUER]?.trim();
   if (issuer) {
-    where.issuer = { contains: issuer, mode: 'insensitive' };
+    // The synthetic "others" issuer means "issuer is null"; the listing route
+    // then OR-s in ETFs that lack a stockAnalyzerInfo relation entirely.
+    where.issuer = issuer === ETF_OTHERS_GROUP_KEY ? null : { contains: issuer, mode: 'insensitive' };
   }
 
   return where;

--- a/insights-ui/src/utils/etf-listing-fetchers.ts
+++ b/insights-ui/src/utils/etf-listing-fetchers.ts
@@ -31,9 +31,9 @@ export const EMPTY_ETF_GROUPS_INDEX: EtfGroupsIndexResponse = {
   others: { items: [], count: 0 },
 };
 
-export const EMPTY_ETF_ASSET_CLASSES_INDEX: EtfAssetClassesIndexResponse = { values: {}, counts: {} };
+export const EMPTY_ETF_ASSET_CLASSES_INDEX: EtfAssetClassesIndexResponse = { values: {}, counts: {}, others: { items: [], count: 0 } };
 
-export const EMPTY_ETF_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {} };
+export const EMPTY_ETF_PROVIDERS_INDEX: EtfProvidersIndexResponse = { providers: [], values: {}, counts: {}, others: { items: [], count: 0 } };
 
 export const EMPTY_ETF_GROUP_DETAIL: EtfGroupDetailResponse = { found: false, values: {}, counts: {}, others: null };
 

--- a/insights-ui/src/utils/etf-listing-noindex.ts
+++ b/insights-ui/src/utils/etf-listing-noindex.ts
@@ -48,12 +48,12 @@ export function groupsIndexRobots(data: EtfGroupsIndexResponse | null): Pick<Met
 
 export function assetClassesIndexRobots(data: EtfAssetClassesIndexResponse | null): Pick<Metadata, 'robots'> {
   if (!data) return INDEXABLE;
-  return etfListingRobots(allCountsZero(data.counts));
+  return etfListingRobots(allCountsZero(data.counts) && (data.others?.count ?? 0) === 0);
 }
 
 export function providersIndexRobots(data: EtfProvidersIndexResponse | null): Pick<Metadata, 'robots'> {
   if (!data) return INDEXABLE;
-  return etfListingRobots(data.providers.length === 0);
+  return etfListingRobots(data.providers.length === 0 && (data.others?.count ?? 0) === 0);
 }
 
 /** Group detail page. `found:false` means an unknown key (the page 404s anyway)

--- a/insights-ui/src/utils/etfCountryExchangeUtils.ts
+++ b/insights-ui/src/utils/etfCountryExchangeUtils.ts
@@ -1,19 +1,20 @@
 /**
  * ETF-specific country & exchange constants — kept separate from
  * `countryExchangeUtils.ts` (stocks) because:
- *  - ETF coverage is currently US + Canada only; reusing the 10-country stock
- *    list would let admins create scenarios in markets we have no ETF data for.
- *  - ETF venues (NYSEARCA, BATS, NEO) don't all overlap with the stock
+ *  - ETF coverage is currently US + Canada + Australia only; reusing the
+ *    10-country stock list would let admins create scenarios in markets we have
+ *    no ETF data for.
+ *  - ETF venues (NYSEARCA, BATS, NEO, ASX) don't all overlap with the stock
  *    exchange list.
  *
  * Country code values are reused from `SupportedCountries` so the strings
- * stored in the DB match the stock side ("US", "Canada").
+ * stored in the DB match the stock side ("US", "Canada", "Australia").
  */
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 
-export type EtfSupportedCountry = SupportedCountries.US | SupportedCountries.Canada;
+export type EtfSupportedCountry = SupportedCountries.US | SupportedCountries.Canada | SupportedCountries.Australia;
 
-export const ETF_SUPPORTED_COUNTRIES: EtfSupportedCountry[] = [SupportedCountries.US, SupportedCountries.Canada];
+export const ETF_SUPPORTED_COUNTRIES: EtfSupportedCountry[] = [SupportedCountries.US, SupportedCountries.Canada, SupportedCountries.Australia];
 
 export const isEtfSupportedCountry = (val: string): val is EtfSupportedCountry => {
   return (ETF_SUPPORTED_COUNTRIES as readonly string[]).includes(val);
@@ -32,7 +33,11 @@ export enum EtfCanadaExchanges {
   NEO = 'NEO',
 }
 
-export type AllEtfExchanges = EtfUSExchanges | EtfCanadaExchanges;
+export enum EtfAustraliaExchanges {
+  ASX = 'ASX',
+}
+
+export type AllEtfExchanges = EtfUSExchanges | EtfCanadaExchanges | EtfAustraliaExchanges;
 
 export const ETF_EXCHANGES: ReadonlyArray<AllEtfExchanges> = [
   EtfUSExchanges.NYSEARCA,
@@ -42,6 +47,7 @@ export const ETF_EXCHANGES: ReadonlyArray<AllEtfExchanges> = [
   EtfCanadaExchanges.TSX,
   EtfCanadaExchanges.TSXV,
   EtfCanadaExchanges.NEO,
+  EtfAustraliaExchanges.ASX,
 ] as const;
 
 export const ETF_EXCHANGE_TO_COUNTRY: Record<AllEtfExchanges, EtfSupportedCountry> = {
@@ -52,6 +58,7 @@ export const ETF_EXCHANGE_TO_COUNTRY: Record<AllEtfExchanges, EtfSupportedCountr
   [EtfCanadaExchanges.TSX]: SupportedCountries.Canada,
   [EtfCanadaExchanges.TSXV]: SupportedCountries.Canada,
   [EtfCanadaExchanges.NEO]: SupportedCountries.Canada,
+  [EtfAustraliaExchanges.ASX]: SupportedCountries.Australia,
 };
 
 export const isEtfExchange = (val: string): val is AllEtfExchanges => {


### PR DESCRIPTION
Wires Australian (ASX) ETF support into the listing + report-generation paths.

## 1. Show Australian (ASX) ETFs in listing pages
Listings filter by `exchange: { in: getEtfExchangesByCountry(country) }`, gated on `ETF_SUPPORTED_COUNTRIES` (was US + Canada). Added Australia.
- `etfCountryExchangeUtils.ts` — `EtfSupportedCountry` + `ETF_SUPPORTED_COUNTRIES` include `Australia`; new `EtfAustraliaExchanges` (`ASX`) wired into `AllEtfExchanges`, `ETF_EXCHANGES`, `ETF_EXCHANGE_TO_COUNTRY`.
- `etf-country-route-utils.ts` — `Australia → 'Australian'` in `COUNTRY_DISPLAY_NAME`.

Effect: `/etfs/countries/Australia` resolves and lists ASX ETFs (groups/asset-classes/providers); country switcher, sitemap, breadcrumbs include Australia.

## 2. Support ASX in the report-data scrape URL
`toMorEtfExchangeSegment` threw `Unsupported exchange` for ASX, blocking the quote/risk/people/portfolio scrape during report generation.
- `mor-scrape-utils.ts` — map `ASX → 'xasx'` (ASX MIC segment), matching the existing `xnys`/`xnas`/`xtse`/`neoe` pattern. Verified against the live provider URLs (e.g. `/etfs/xasx/vas/quote`, `/risk`, `/portfolio`).

## 3. Supported-country text now derives from `ETF_SUPPORTED_COUNTRIES`
Strings that hardcoded "(US / Canada)" were stale after adding Australia. Now built from the constant so they stay correct going forward: scenario POST/PUT validation messages, the admin "Countries in scope" label, and two doc comments.

## Audit — what was already covered (no change needed)
- **Yahoo price**: `convertToYahooFinanceSymbol` already maps `ASX → .AX` (e.g. `SPY.AX`); single `yahooFinance.chart` call routes through it.
- **Validation**: `isEtfExchange` / `isEtfSupportedCountry` now accept ASX/Australia automatically.
- **Detail page**: `/etfs/[exchange]/[etf]` only 404s on missing data — no exchange allow-list; `getCountryByExchange('ASX') = Australia`.
- **Sitemaps**: per-ETF sitemaps enumerate by data presence, not exchange — ASX ETFs included once they have reports.
- **Prompt keys**: `ETF_PROMPT_KEYS` are shared report-type keys (Canada already reuses them); ASX uses the same.
- **Returns/CAGR**: come from the screener import, not Yahoo.

## Out of scope (flagged for a dedicated PR)
Fully removing the provider brand name "everywhere" is schema-deep: ~20 `Mor`-named Prisma models/fields (`EtfMorAnalyzerInfo`, `EtfMorRiskInfo`, `EtfMorPeopleInfo`, `EtfMorPortfolioInfo`), 15 source files, 5 `*mor*` API route dirs, plus prompt-content references that change LLM output. That belongs in its own migration PR, not bundled with ASX support. This PR only neutralizes the one comment added on this branch.

## Checks
`yarn prettier-check` + `eslint` pass. `yarn compile` clean for changed files; remaining `tsc` errors are pre-existing `@/images/*.png` failures from a missing `next-env.d.ts` (generated by `next dev`/`build`).

---

## Listing fix — "Others" bucket on asset-class & provider pages

The asset-class and provider index pages dropped ETFs whose `assetClass`/`issuer` is null/empty (common for ASX funds in the source CSV), so their totals undercounted vs the country root page. Added an "Others" bucket mirroring the groups index, on US + country pages, shown **only when such ETFs exist**.

- `listings-prisma`: `fetchEtfsWithoutAssetClass` / `fetchEtfsWithoutIssuer`.
- asset-classes-index / providers-index routes return `others`.
- `EtfAssetClassesIndex` / `EtfProvidersIndex` append an "Others" card (count-gated).
- Clickable "Others" detail pages reuse the existing `others` sentinel: `createEtfStockAnalyzerFilter` maps `assetClass`/`issuer` = `others` → null; the listing route OR-s in the no-row case; the asset-class detail pages + detail components resolve the `others` slug.
- noindex helpers keep the index pages indexable when only "Others" has ETFs.

> ⚠️ A concurrent push re-merged the `csv-to-sql.ts` script + its `package.json` line (commit 4999cb977) that was previously removed on request. Not re-removed in this commit — pending confirmation.