### PR TITLE
fix(tariff-calculator): 404 + friendly message for unknown HTS codes

### DIFF
--- a/insights-ui/src/app/api/tariff-calculator/calculate/route.ts
+++ b/insights-ui/src/app/api/tariff-calculator/calculate/route.ts
@@ -11,8 +11,25 @@ import { NextRequest } from 'next/server';
 // candidate-codes feed for the requested HTS 10-digit line if we don't
 // already have it, then runs the duty engine and returns the breakdown.
 
+// Thrown for the two "we don't have this code" cases in loadCandidates(). The
+// error middleware reads `statusCode` and returns a 404 (instead of a 500), so a
+// typo'd or unknown HTS code reads as "not found" to the user and to crawlers
+// rather than logging a server error. The message is shown directly in the UI,
+// so keep it plain-English and free of internal hints.
+class HtsLookupError extends Error {
+  readonly statusCode = 404;
+  constructor(message: string) {
+    super(message);
+    this.name = 'HtsLookupError';
+  }
+}
+
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function formatHts10(hts10: string): string {
+  return hts10.replace(/(\d{4})(\d{2})(\d{2})(\d{2})/, '$1.$2.$3.$4');
 }
 
 function parseHts10(raw: unknown): string {
@@ -93,7 +110,7 @@ async function loadCandidates(hts10: string): Promise<CandidateCodeListItem[]> {
     select: { id: true },
   });
   if (!htsRow) {
-    throw new Error(`HTS code ${hts10} is not in the HTSUS catalog. Ingest the chapter first.`);
+    throw new HtsLookupError(`We couldn't find HTS code ${formatHts10(hts10)} in the US tariff schedule. Double-check the 10-digit code and try again.`);
   }
 
   const fetchLinks = () =>
@@ -112,7 +129,7 @@ async function loadCandidates(hts10: string): Promise<CandidateCodeListItem[]> {
 
   let links = await fetchLinks();
   if (links.length === 0) {
-    throw new Error(`No candidate codes found for HTS ${hts10}. Ingest candidate codes into the DB before running the calculator.`);
+    throw new HtsLookupError(`We don't have duty data for HTS code ${formatHts10(hts10)} yet. Try a different code or check back later.`);
   }
 
   return links

--- a/insights-ui/src/app/tariff-calculator/CalculatorClient.tsx
+++ b/insights-ui/src/app/tariff-calculator/CalculatorClient.tsx
@@ -112,8 +112,10 @@ export default function CalculatorClient(): JSX.Element {
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const payload = (await res.json().catch(() => ({}))) as { message?: string; errorMessage?: string };
-        throw new Error(payload.errorMessage ?? payload.message ?? `Calculation failed (HTTP ${res.status})`);
+        // The error middleware returns `{ error }`; fall back to the other
+        // shapes and finally a generic message so the user always sees text.
+        const payload = (await res.json().catch(() => ({}))) as { error?: string; message?: string; errorMessage?: string };
+        throw new Error(payload.error ?? payload.errorMessage ?? payload.message ?? `Calculation failed (HTTP ${res.status})`);
       }
       const data = (await res.json()) as CalculatorResult;
       if (seq !== requestSeqRef.current) return;

--- a/shared/web-core/src/api/helpers/middlewares/withErrorHandling.ts
+++ b/shared/web-core/src/api/helpers/middlewares/withErrorHandling.ts
@@ -88,7 +88,12 @@ export function withErrorHandlingV2<T>(handler: Handler2<T> | Handler2WithReq<T>
 
       const userMessage = (error as any)?.response?.data || (error as any)?.message || 'An unknown error occurred';
 
-      const statusCode = isJwtError(error) ? 401 : isPrismaNotFound ? 404 : 500;
+      // Handlers can throw an error carrying an explicit `statusCode` (e.g. 404
+      // for "resource not found") so an expected user error doesn't surface as a
+      // generic 500. Falls back to the JWT/Prisma/500 detection below.
+      const customStatusCode = typeof (error as any)?.statusCode === 'number' ? (error as any).statusCode : undefined;
+
+      const statusCode = customStatusCode ?? (isJwtError(error) ? 401 : isPrismaNotFound ? 404 : 500);
       console.log(`[withErrorHandlingV2] Returning user-friendly error message with status ${statusCode}:`, userMessage);
       return NextResponse.json({ error: userMessage }, { status: statusCode });
     }


### PR DESCRIPTION
## Problem

On https://koalagains.com/tariff-calculator, entering a wrong/unknown 10-digit HTS code directly and clicking **Calculate duties** returned a generic red **"Calculation failed (HTTP 500)"**. The 10-digit validation passes, but the code doesn't exist in the catalog — so the API blew up as a server error (bad UX, and noisy 500s in logs/SEO/monitoring).

Two root causes:
1. `POST /api/tariff-calculator/calculate` threw a plain `Error` for the "HTS not in catalog" and "no candidate codes" cases — always a **500** — with developer-facing copy (`Ingest the chapter first.`).
2. The client read `payload.errorMessage ?? payload.message`, but the error middleware returns `{ error }`. So even the message was dropped and the UI fell back to the generic `Calculation failed (HTTP {status})`.

## Fix

- **`withErrorHandlingV2`** now honors an explicit `statusCode` on a thrown error, falling back to the existing JWT / Prisma-not-found / 500 detection. This is the "send another status code" hook.
- **calculate route** throws a `404` `HtsLookupError` with plain-English, user-facing copy:
  - not in catalog → *"We couldn't find HTS code 6110.20.20.40 in the US tariff schedule. Double-check the 10-digit code and try again."*
  - no duty data → *"We don't have duty data for HTS code … yet. Try a different code or check back later."*
- **`CalculatorClient`** reads the `error` field so the friendly message is displayed instead of the generic HTTP text.

## Result

Unknown codes now return **404** with clear, user-friendly text in the result panel — no more 500 server errors for ordinary typos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)