### PR TITLE
fix(etfs): country-aware breadcrumbs on ETF sub-report pages

### DIFF
--- a/insights-ui/src/utils/etf-breadcrumbs-utils.ts
+++ b/insights-ui/src/utils/etf-breadcrumbs-utils.ts
@@ -1,10 +1,16 @@
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import { getEtfFundCategoryHierarchy } from '@/utils/etf-categorization-utils';
+import { getCountryByExchange, SupportedCountries, toExchange } from '@/utils/countryExchangeUtils';
 
 /**
  * Breadcrumb trail for an ETF report sub-page (e.g. risk-analysis, holdings).
- * Pattern: US ETFs → Group → Fund Category → Symbol → Report Section.
+ * Pattern: {Country} ETFs → Group → Fund Category → Symbol → Report Section.
  * Uses the symbol (not "Name (SYMBOL)") so the trail stays compact.
+ *
+ * The root crumb + group/category links are country-aware (mirrors the main ETF
+ * detail page in `etfs/[exchange]/[etf]/page.tsx`). Non-US exchanges (e.g. TSX,
+ * ASX) must not be labelled "US ETFs" or point at the US-only `/etfs/groups/...`
+ * listings.
  */
 export function buildEtfReportSubpageBreadcrumbs({
   exchange,
@@ -19,12 +25,22 @@ export function buildEtfReportSubpageBreadcrumbs({
   sectionName: string;
   sectionSlug: string;
 }): BreadcrumbsOjbect[] {
+  const country = getCountryByExchange(toExchange(exchange));
   const { groupKey, groupName, fundCategoryName, fundCategorySlug } = getEtfFundCategoryHierarchy(fundCategory);
-  const crumbs: BreadcrumbsOjbect[] = [{ name: 'US ETFs', href: '/etfs', current: false }];
+
+  const rootCrumb: BreadcrumbsOjbect =
+    country === SupportedCountries.US
+      ? { name: 'US ETFs', href: `/etfs`, current: false }
+      : country
+      ? { name: `${country} ETFs`, href: `/etfs/countries/${country}`, current: false }
+      : { name: 'ETFs', href: `/etfs`, current: false };
+  const countryPrefix = country === SupportedCountries.US ? '/etfs' : country ? `/etfs/countries/${country}` : '/etfs';
+
+  const crumbs: BreadcrumbsOjbect[] = [rootCrumb];
   if (groupKey && groupName) {
-    crumbs.push({ name: groupName, href: `/etfs/groups/${groupKey}`, current: false });
+    crumbs.push({ name: groupName, href: `${countryPrefix}/groups/${groupKey}`, current: false });
     if (fundCategoryName && fundCategorySlug) {
-      crumbs.push({ name: fundCategoryName, href: `/etfs/groups/${groupKey}/categories/${fundCategorySlug}`, current: false });
+      crumbs.push({ name: fundCategoryName, href: `${countryPrefix}/groups/${groupKey}/categories/${fundCategorySlug}`, current: false });
     }
   }
   crumbs.push({ name: symbol, href: `/etfs/${exchange}/${symbol}`, current: false });


### PR DESCRIPTION
## Problem

On ETF **sub-report** pages, the breadcrumb trail always started with **"US ETFs"** — even for non-US exchanges. Examples reported:

- https://koalagains.com/etfs/TSX/HXT/future-performance-outlook (Canada)
- https://koalagains.com/etfs/ASX/VEU/future-performance-outlook (Australia)

The **main** ETF detail pages rendered the correct country (`/etfs/TSX/HXT`, `/etfs/ASX/VEU` were fine), so the trail was inconsistent between a fund's overview page and its sub-reports.

## Cause

`buildEtfReportSubpageBreadcrumbs` in `src/utils/etf-breadcrumbs-utils.ts` hardcoded the root crumb as `{ name: 'US ETFs', href: '/etfs' }` and linked group/category crumbs at the US-only `/etfs/groups/...` paths, ignoring the exchange's country.

## Fix

The util now derives the country from the exchange (`getCountryByExchange(toExchange(exchange))`) and builds a country-aware root crumb + `countryPrefix`, mirroring `buildBreadcrumbs` in `etfs/[exchange]/[etf]/page.tsx`:

- **US** → `US ETFs` → `/etfs`
- **Other country** (e.g. Canada, Australia) → `{Country} ETFs` → `/etfs/countries/{country}`, group/category links under `/etfs/countries/{country}/groups/...`
- **Unknown** → `ETFs` → `/etfs`

This is a shared util, so the fix applies to all 7 ETF sub-report pages at once (holdings, risk-analysis, financial-data, competition, cost-efficiency-team, future-performance-outlook, performance-returns). The breadcrumb JSON-LD generated from these crumbs is corrected too.

## Checks

`yarn prettier-check`, `yarn lint`, and `yarn compile` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)