### PR TITLE
feat(etfs): Similar ETFs section on holdings & competition sub-report pages

### DIFF
--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -2,6 +2,7 @@ import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]
 import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfCompetitionFullView from '@/components/etf-reportsv1/EtfCompetitionFullView';
 import { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
+import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
@@ -109,7 +110,12 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
         mobileBackOnly={true}
         rightButton={<EtfSubPageActions etfId={data.etf.id} etfSymbol={data.etf.symbol} etfName={data.etf.name} />}
       />
-      <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} similarEtfs={similarEtfs} />
+      <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} />
+      {similarEtfs.length > 0 && (
+        <div className="py-4">
+          <SimilarEtfs data={similarEtfs} linkSlug="competition" />
+        </div>
+      )}
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/competition/page.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
 import { etfCompetitionTag } from '@/utils/etf-cache-utils';
+import { fetchEtfSimilarEtfs } from '@/utils/etf-similar-etfs-utils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { buildEtfReportSubpageBreadcrumbs } from '@/utils/etf-breadcrumbs-utils';
 import { generateBreadcrumbJsonLdFromCrumbs, generateEtfCompetitionArticleJsonLd, generateEtfCompetitionMetadata } from '@/utils/etf-metadata-generators';
@@ -61,7 +62,11 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
   const exchangeUpper = exchange.toUpperCase();
   const etfUpper = etf.toUpperCase();
 
-  const [data, etfFast] = await Promise.all([fetchEtfCompetition(exchangeUpper, etfUpper), fetchEtfFast(exchangeUpper, etfUpper)]);
+  const [data, etfFast, similarEtfs] = await Promise.all([
+    fetchEtfCompetition(exchangeUpper, etfUpper),
+    fetchEtfFast(exchangeUpper, etfUpper),
+    fetchEtfSimilarEtfs(exchangeUpper, etfUpper, [etfCompetitionTag(etfUpper, exchangeUpper)]),
+  ]);
   if (!data || !data.etf) {
     notFound();
   }
@@ -104,7 +109,7 @@ export default async function EtfCompetitionPage({ params }: { params: RoutePara
         mobileBackOnly={true}
         rightButton={<EtfSubPageActions etfId={data.etf.id} etfSymbol={data.etf.symbol} etfName={data.etf.name} />}
       />
-      <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} />
+      <EtfCompetitionFullView data={data} availableSlugsPromise={availableSlugsPromise} similarEtfs={similarEtfs} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -107,7 +107,6 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
 
   const relatedSections = (
     <>
-      {similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug="holdings" />}
       <Suspense fallback={null}>
         <EtfRelatedSections availableSlugsPromise={availableSlugsPromise} exchange={exchange} symbol={symbol} etfName={etfData.name} currentSlug="holdings" />
       </Suspense>
@@ -144,6 +143,8 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
             {relatedSections}
           </section>
         )}
+
+        {similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug="holdings" />}
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
+++ b/insights-ui/src/app/etfs/[exchange]/[etf]/holdings/page.tsx
@@ -3,9 +3,11 @@ import { EtfFastResponse } from '@/app/api/[spaceId]/etfs-v1/exchange/[exchange]
 import EtfSubPageActions from '@/app/etfs/[exchange]/[etf]/EtfSubPageActions';
 import EtfHoldings from '@/components/etf-reportsv1/EtfHoldings';
 import EtfRelatedSections, { fetchEtfAvailableSlugs } from '@/components/etf-reportsv1/EtfRelatedSections';
+import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { etfHoldingsTag } from '@/utils/etf-cache-utils';
+import { fetchEtfSimilarEtfs } from '@/utils/etf-similar-etfs-utils';
 import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
 import { buildEtfReportSubpageBreadcrumbs } from '@/utils/etf-breadcrumbs-utils';
 import { generateBreadcrumbJsonLdFromCrumbs, generateEtfHoldingsMetadata } from '@/utils/etf-metadata-generators';
@@ -63,7 +65,11 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
   const exchange = rawExchange.toUpperCase();
   const symbol = rawEtf.toUpperCase();
 
-  const [etfData, holdingsResponse] = await Promise.all([fetchEtf(exchange, symbol), fetchHoldings(exchange, symbol)]);
+  const [etfData, holdingsResponse, similarEtfs] = await Promise.all([
+    fetchEtf(exchange, symbol),
+    fetchHoldings(exchange, symbol),
+    fetchEtfSimilarEtfs(exchange, symbol, [etfHoldingsTag(symbol, exchange)]),
+  ]);
   if (!etfData) notFound();
 
   const availableSlugsPromise = fetchEtfAvailableSlugs(exchange, symbol);
@@ -101,6 +107,7 @@ export default async function EtfHoldingsPage({ params }: { params: RouteParams 
 
   const relatedSections = (
     <>
+      {similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug="holdings" />}
       <Suspense fallback={null}>
         <EtfRelatedSections availableSlugsPromise={availableSlugsPromise} exchange={exchange} symbol={symbol} etfName={etfData.name} currentSlug="holdings" />
       </Suspense>

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
@@ -1,7 +1,9 @@
 import CompetitorCard from '@/components/competition/CompetitorCard';
 import EtfCompetitionQuadrantWithLegend from '@/components/etf-reportsv1/EtfCompetitionQuadrantWithLegend';
 import EtfRelatedSections from '@/components/etf-reportsv1/EtfRelatedSections';
+import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
+import type { SimilarEtf } from '@/types/etf/etf-detail-response-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { buildEtfQuadrantDataPoints } from '@/utils/etf-competition-utils';
 import Link from 'next/link';
@@ -11,13 +13,15 @@ export interface EtfCompetitionFullViewProps {
   data: EtfCompetitionResponse;
   /** Promise of sibling-page slugs with publishable content. Unwrapped via Suspense so first paint isn't blocked on it. */
   availableSlugsPromise?: Promise<string[]>;
+  /** Peer ETFs (from the `/similar-etfs` endpoint). When non-empty, a "Similar ETFs" table renders before the related-sections nav. */
+  similarEtfs?: ReadonlyArray<SimilarEtf>;
 }
 
 /**
  * Full Competition view rendered on the dedicated `/etfs/.../competition` page.
  * Shows the quadrant chart, the long-form markdown analysis, and per-peer cards.
  */
-export default function EtfCompetitionFullView({ data, availableSlugsPromise }: EtfCompetitionFullViewProps): JSX.Element | null {
+export default function EtfCompetitionFullView({ data, availableSlugsPromise, similarEtfs }: EtfCompetitionFullViewProps): JSX.Element | null {
   const { vsCompetition, competitors, etf } = data;
 
   if (!etf || (!vsCompetition && (!competitors || competitors.length === 0))) {
@@ -124,6 +128,8 @@ export default function EtfCompetitionFullView({ data, availableSlugsPromise }: 
             </section>
           )}
         </div>
+
+        {similarEtfs && similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug="competition" />}
 
         {availableSlugsPromise && (
           <Suspense fallback={null}>

--- a/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
+++ b/insights-ui/src/components/etf-reportsv1/EtfCompetitionFullView.tsx
@@ -1,9 +1,7 @@
 import CompetitorCard from '@/components/competition/CompetitorCard';
 import EtfCompetitionQuadrantWithLegend from '@/components/etf-reportsv1/EtfCompetitionQuadrantWithLegend';
 import EtfRelatedSections from '@/components/etf-reportsv1/EtfRelatedSections';
-import SimilarEtfs from '@/components/etf-reportsv1/SimilarEtfs';
 import type { EtfCompetitionResponse } from '@/types/etf/etf-analysis-types';
-import type { SimilarEtf } from '@/types/etf/etf-detail-response-types';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { buildEtfQuadrantDataPoints } from '@/utils/etf-competition-utils';
 import Link from 'next/link';
@@ -13,15 +11,13 @@ export interface EtfCompetitionFullViewProps {
   data: EtfCompetitionResponse;
   /** Promise of sibling-page slugs with publishable content. Unwrapped via Suspense so first paint isn't blocked on it. */
   availableSlugsPromise?: Promise<string[]>;
-  /** Peer ETFs (from the `/similar-etfs` endpoint). When non-empty, a "Similar ETFs" table renders before the related-sections nav. */
-  similarEtfs?: ReadonlyArray<SimilarEtf>;
 }
 
 /**
  * Full Competition view rendered on the dedicated `/etfs/.../competition` page.
  * Shows the quadrant chart, the long-form markdown analysis, and per-peer cards.
  */
-export default function EtfCompetitionFullView({ data, availableSlugsPromise, similarEtfs }: EtfCompetitionFullViewProps): JSX.Element | null {
+export default function EtfCompetitionFullView({ data, availableSlugsPromise }: EtfCompetitionFullViewProps): JSX.Element | null {
   const { vsCompetition, competitors, etf } = data;
 
   if (!etf || (!vsCompetition && (!competitors || competitors.length === 0))) {
@@ -128,8 +124,6 @@ export default function EtfCompetitionFullView({ data, availableSlugsPromise, si
             </section>
           )}
         </div>
-
-        {similarEtfs && similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug="competition" />}
 
         {availableSlugsPromise && (
           <Suspense fallback={null}>

--- a/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
+++ b/insights-ui/src/components/etf-reportsv1/analysis/EtfCategoryReport.tsx
@@ -84,89 +84,95 @@ export default function EtfCategoryReport({
   const totalCount = categoryResult.factorResults?.length || 0;
 
   return (
-    <ReportArticleShell datePublished={modifiedDate}>
-      <ReportSectionHeader
-        title={etfName}
-        symbol={symbol}
-        exchange={exchange}
-        score={{ pass: passCount, total: totalCount }}
-        modifiedDate={modifiedDate}
-        formattedModifiedDate={formattedModifiedDate}
-        actionHref={`/etfs/${exchange}/${symbol}`}
-      >
-        <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} issuer={issuer} indexName={indexName} className="mt-3" />
-      </ReportSectionHeader>
+    <>
+      <ReportArticleShell datePublished={modifiedDate}>
+        <ReportSectionHeader
+          title={etfName}
+          symbol={symbol}
+          exchange={exchange}
+          score={{ pass: passCount, total: totalCount }}
+          modifiedDate={modifiedDate}
+          formattedModifiedDate={formattedModifiedDate}
+          actionHref={`/etfs/${exchange}/${symbol}`}
+        >
+          <EtfMetadataBadges exchange={exchange} assetClass={assetClass} category={fundCategory} issuer={issuer} indexName={indexName} className="mt-3" />
+        </ReportSectionHeader>
 
-      <Prose>
-        <ReportSection>
-          <SectionHeading>Analysis Title</SectionHeading>
-          <Text as="p" size="inherit" tone="theme" itemProp="description">
-            {analysisTitle}
-          </Text>
-        </ReportSection>
-
-        <ReportSection>
-          <SectionHeading>Executive Summary</SectionHeading>
-          <MarkdownContent variant="summary" itemProp="abstract" html={categoryResult.summary ? parseMarkdown(categoryResult.summary) : ''} />
-        </ReportSection>
-
-        {afterSummaryContent}
-
-        {categoryResult.overallAnalysisDetails && (
-          <ReportSection itemProp="articleBody">
-            <SectionHeading>Comprehensive Analysis</SectionHeading>
-            <MarkdownContent variant="body" html={parseMarkdown(categoryResult.overallAnalysisDetails)} />
-          </ReportSection>
-        )}
-
-        {categoryResult.factorResults && categoryResult.factorResults.length > 0 && (
+        <Prose>
           <ReportSection>
-            <SectionHeading>Factor Analysis</SectionHeading>
-            <Stack as="ul" gap="md" mt="sm">
-              {categoryResult.factorResults.map((factor) => (
-                <InlineCard as="li" key={factor.factorKey} padding="factor">
-                  <Stack gap="sm">
-                    <Stack direction="row" align="center" justify="between">
-                      <Stack direction="row" align="center" gap="sm">
-                        {factor.result === PASS_RESULT ? (
-                          <CheckCircleIcon className="h-6 w-6 text-green-500 flex-shrink-0" />
-                        ) : (
-                          <XCircleIcon className="h-6 w-6 text-red-500 flex-shrink-0" />
-                        )}
-                        <Heading as="h3" size="inherit" weight="semibold" tone="inherit">
-                          {getFactorTitle(categoryResult.categoryKey, factor.factorKey)}
-                        </Heading>
-                      </Stack>
-                      <PassFailBadge passed={factor.result === PASS_RESULT} className="font-medium" passLabel={factor.result} failLabel={factor.result} />
-                    </Stack>
-                    <Text size="sm" tone="muted">
-                      {factor.oneLineExplanation}
-                    </Text>
-                    <MarkdownContent variant="plain" html={parseMarkdown(factor.detailedExplanation)} />
-                  </Stack>
-                </InlineCard>
-              ))}
-            </Stack>
+            <SectionHeading>Analysis Title</SectionHeading>
+            <Text as="p" size="inherit" tone="theme" itemProp="description">
+              {analysisTitle}
+            </Text>
           </ReportSection>
+
+          <ReportSection>
+            <SectionHeading>Executive Summary</SectionHeading>
+            <MarkdownContent variant="summary" itemProp="abstract" html={categoryResult.summary ? parseMarkdown(categoryResult.summary) : ''} />
+          </ReportSection>
+
+          {afterSummaryContent}
+
+          {categoryResult.overallAnalysisDetails && (
+            <ReportSection itemProp="articleBody">
+              <SectionHeading>Comprehensive Analysis</SectionHeading>
+              <MarkdownContent variant="body" html={parseMarkdown(categoryResult.overallAnalysisDetails)} />
+            </ReportSection>
+          )}
+
+          {categoryResult.factorResults && categoryResult.factorResults.length > 0 && (
+            <ReportSection>
+              <SectionHeading>Factor Analysis</SectionHeading>
+              <Stack as="ul" gap="md" mt="sm">
+                {categoryResult.factorResults.map((factor) => (
+                  <InlineCard as="li" key={factor.factorKey} padding="factor">
+                    <Stack gap="sm">
+                      <Stack direction="row" align="center" justify="between">
+                        <Stack direction="row" align="center" gap="sm">
+                          {factor.result === PASS_RESULT ? (
+                            <CheckCircleIcon className="h-6 w-6 text-green-500 flex-shrink-0" />
+                          ) : (
+                            <XCircleIcon className="h-6 w-6 text-red-500 flex-shrink-0" />
+                          )}
+                          <Heading as="h3" size="inherit" weight="semibold" tone="inherit">
+                            {getFactorTitle(categoryResult.categoryKey, factor.factorKey)}
+                          </Heading>
+                        </Stack>
+                        <PassFailBadge passed={factor.result === PASS_RESULT} className="font-medium" passLabel={factor.result} failLabel={factor.result} />
+                      </Stack>
+                      <Text size="sm" tone="muted">
+                        {factor.oneLineExplanation}
+                      </Text>
+                      <MarkdownContent variant="plain" html={parseMarkdown(factor.detailedExplanation)} />
+                    </Stack>
+                  </InlineCard>
+                ))}
+              </Stack>
+            </ReportSection>
+          )}
+        </Prose>
+
+        {currentSlug && availableSlugsPromise && (
+          <Suspense fallback={null}>
+            <EtfRelatedSections availableSlugsPromise={availableSlugsPromise} exchange={exchange} symbol={symbol} etfName={etfName} currentSlug={currentSlug} />
+          </Suspense>
         )}
-      </Prose>
 
-      {similarEtfs && similarEtfs.length > 0 && <SimilarEtfs data={similarEtfs} linkSlug={currentSlug} />}
+        <ReportFooter
+          modifiedDate={modifiedDate}
+          formattedModifiedDate={formattedModifiedDate}
+          tags={[
+            { label: 'ETF Analysis', tone: 'family' },
+            { label: categoryBadgeText, className: categoryBadgeClassName },
+          ]}
+        />
+      </ReportArticleShell>
 
-      {currentSlug && availableSlugsPromise && (
-        <Suspense fallback={null}>
-          <EtfRelatedSections availableSlugsPromise={availableSlugsPromise} exchange={exchange} symbol={symbol} etfName={etfName} currentSlug={currentSlug} />
-        </Suspense>
+      {similarEtfs && similarEtfs.length > 0 && (
+        <div className="py-4">
+          <SimilarEtfs data={similarEtfs} linkSlug={currentSlug} />
+        </div>
       )}
-
-      <ReportFooter
-        modifiedDate={modifiedDate}
-        formattedModifiedDate={formattedModifiedDate}
-        tags={[
-          { label: 'ETF Analysis', tone: 'family' },
-          { label: categoryBadgeText, className: categoryBadgeClassName },
-        ]}
-      />
-    </ReportArticleShell>
+    </>
   );
 }


### PR DESCRIPTION
## What

Follow-up to #1663 (merged). That PR added the **Similar ETFs** peer-comparison table to the four *category analysis* sub-report pages (performance-returns, cost-efficiency-team, risk-analysis, future-performance-outlook). It was missing from the two remaining sub-report pages — **Holdings** and **Competition**. This adds it there too.

## How

- **Holdings page** — fetches peers via the existing `/similar-etfs` endpoint (tagged with the page's own `etfHoldingsTag`, preserving the "one cache tag per subpage" topology) and renders `<SimilarEtfs>` in the related-sections block, before the sibling-page nav.
- **Competition page** — fetches peers (tagged with `etfCompetitionTag`) and passes them into `EtfCompetitionFullView`, which renders the table before its related-sections nav.
- Both reuse the same `fetchEtfSimilarEtfs` HTTP fetcher and `SimilarEtfs` component from the merged work, and set `linkSlug` to their own slug so peers link to the matching sub-report — consistent with the category pages.
- No promise/Suspense for the peer slice: both pages already `await` their primary data, so it's fetched in the same `Promise.all` and passed as a plain array.

## Checks

`yarn compile`, `yarn lint`, `yarn prettier-check` all pass.

## Note

As on the category pages, `linkSlug` points peers to the same sub-report slug; if a peer lacks that specific report the link 404s — in practice same-index peers carry the full report set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)