### PR TITLE
feat(stocks): show Top Similar Companies on all stock report sub-pages

### DIFF
--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -134,7 +134,7 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
 
       <BusinessAndMoat tickerData={tickerData} data={bmData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="business-and-moat" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/business-and-moat/page.tsx
@@ -12,6 +12,7 @@ import {
   truncateForMeta,
 } from '@/utils/performance-page-utils';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -132,6 +133,8 @@ export default async function BusinessAndMoatPage({ params }: { params: RoutePar
       />
 
       <BusinessAndMoat tickerData={tickerData} data={bmData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -223,7 +223,7 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
 
       <Competition tickerData={tickerData} data={competitionData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="competition" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/competition/page.tsx
@@ -10,6 +10,7 @@ import { enforceMovedRedirect } from '@/utils/ticker-moved-redirect';
 import { enforceDeletedTicker } from '@/utils/ticker-deleted-handler';
 import { generateCompetitionArticleSchema, generateCompetitionBreadcrumbSchema } from '@/utils/metadata-generators';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
@@ -221,6 +222,8 @@ export default async function CompetitionPage({ params }: { params: RouteParams 
       />
 
       <Competition tickerData={tickerData} data={competitionData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -138,7 +138,7 @@ export default async function FairValuePage({ params }: { params: RouteParams })
 
       <FairValue tickerData={tickerData} data={fairValueData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="fair-value" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/fair-value/page.tsx
@@ -11,6 +11,7 @@ import {
   truncateForMeta,
 } from '@/utils/performance-page-utils';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -136,6 +137,8 @@ export default async function FairValuePage({ params }: { params: RouteParams })
       />
 
       <FairValue tickerData={tickerData} data={fairValueData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -11,6 +11,7 @@ import {
   truncateForMeta,
 } from '@/utils/performance-page-utils';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -137,6 +138,8 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
       />
 
       <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/financial-statement-analysis/page.tsx
@@ -139,7 +139,7 @@ export default async function FinancialStatementAnalysisPage({ params }: { param
 
       <FinancialStatementAnalysis tickerData={tickerData} data={financialStatementData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="financial-statement-analysis" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -11,6 +11,7 @@ import {
   truncateForMeta,
 } from '@/utils/performance-page-utils';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -136,6 +137,8 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
       />
 
       <FuturePerformance tickerData={tickerData} data={futurePerformanceData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/future-performance/page.tsx
@@ -138,7 +138,7 @@ export default async function FuturePerformancePage({ params }: { params: RouteP
 
       <FuturePerformance tickerData={tickerData} data={futurePerformanceData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="future-performance" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -284,9 +284,11 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
             </div>
           </div>
         </footer>
-
-        <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="management-team" />
       </article>
+
+      <div className="py-4">
+        <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="management-team" />
+      </div>
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -13,6 +13,7 @@ import { generateManagementTeamArticleSchema, generateManagementTeamBreadcrumbSc
 import { TickerV1FastResponse } from '@/utils/ticker-v1-model-utils';
 import { parseMarkdown } from '@/util/parse-markdown';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { unstable_noStore as noStore } from 'next/cache';
@@ -283,6 +284,8 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
             </div>
           </div>
         </footer>
+
+        <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/management-team/page.tsx
@@ -285,7 +285,7 @@ export default async function ManagementTeamPage({ params }: { params: RoutePara
           </div>
         </footer>
 
-        <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+        <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="management-team" />
       </article>
     </PageWrapper>
   );

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/page.tsx
@@ -16,6 +16,7 @@ import FinancialInfo, { FinancialCard } from '@/components/ticker-reportsv1/Fina
 import PriceChart from '@/components/ticker-reportsv1/PriceChartLazy';
 import QuarterlyMetricsChart from '@/components/ticker-reportsv1/QuarterlyMetricsChartLazy';
 import SimilarTickers from '@/components/ticker-reportsv1/SimilarTickers';
+import { fetchSimilarTickers } from '@/utils/fetchSimilarTickers';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { SpiderGraphForTicker, SpiderGraphPie } from '@/types/public-equity/ticker-report-types';
@@ -45,7 +46,7 @@ import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
 import { generateStockReportArticleSchema, generateStockReportBreadcrumbSchema } from '@/utils/metadata-generators';
 import { enforceMovedRedirect } from '@/utils/ticker-moved-redirect';
 import { enforceDeletedTicker } from '@/utils/ticker-deleted-handler';
-import { FullTickerV1CategoryAnalysisResult, SimilarTicker, TickerV1FastResponse } from '@/utils/ticker-v1-model-utils';
+import { FullTickerV1CategoryAnalysisResult, TickerV1FastResponse } from '@/utils/ticker-v1-model-utils';
 import { BreadcrumbsOjbect } from '@dodao/web-core/components/core/breadcrumbs/BreadcrumbsWithChevrons';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
@@ -157,16 +158,6 @@ async function getTickerOrRedirect(params: RouteParams): Promise<TickerV1FastRes
 const EIGHT_DAYS_IN_SECONDS = 8 * 24 * 60 * 60;
 
 /** Similar + financial fetchers (promise-based for Suspense) */
-async function fetchSimilar(exchange: string, ticker: string): Promise<SimilarTicker[]> {
-  const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/similar-tickers`;
-
-  const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
-  if (!res.ok) throw new Error(`fetchSimilar failed (${res.status}): ${url}`);
-
-  const arr = (await res.json()) as SimilarTicker[];
-  return arr;
-}
-
 async function fetchFinancialInfo(exchange: string, ticker: string): Promise<FinancialInfoResponse | null> {
   const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/financial-info`;
 
@@ -778,7 +769,7 @@ export default async function TickerDetailsPage({ params }: { params: RouteParam
     })();
 
   // Promises consumed by child components via `use()` under Suspense
-  const similarPromise = retryWithCanonical(fetchSimilar);
+  const similarPromise = retryWithCanonical(fetchSimilarTickers);
   const financialInfoPromise = retryWithCanonical(fetchFinancialInfo);
   const quarterlyChartPromise = retryWithCanonical(fetchQuarterlyChartData);
   const priceHistoryPromise = retryWithCanonical(fetchPriceHistory);

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -138,7 +138,7 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
 
       <PastPerformance tickerData={tickerData} data={pastPerformanceData} />
 
-      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} subPageSlug="past-performance" />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
+++ b/insights-ui/src/app/stocks/[exchange]/[ticker]/past-performance/page.tsx
@@ -11,6 +11,7 @@ import {
   truncateForMeta,
 } from '@/utils/performance-page-utils';
 import { getCountryByExchange, USExchanges, CanadaExchanges, IndiaExchanges, UKExchanges } from '@/utils/countryExchangeUtils';
+import SimilarTickersSection from '@/components/ticker-reportsv1/SimilarTickersSection';
 import PageWrapper from '@dodao/web-core/components/core/page/PageWrapper';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -136,6 +137,8 @@ export default async function PastPerformancePage({ params }: { params: RoutePar
       />
 
       <PastPerformance tickerData={tickerData} data={pastPerformanceData} />
+
+      <SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />
     </PageWrapper>
   );
 }

--- a/insights-ui/src/components/ticker-reportsv1/Competition.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/Competition.tsx
@@ -94,7 +94,7 @@ export default function Competition({ tickerData, data }: CompetitionProps): JSX
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+    <div className="py-4">
       <article className="bg-surface rounded-lg shadow-sm border border-color p-6 md:p-8" itemScope itemType="https://schema.org/Article">
         {/* Hidden datePublished for schema - machine readable only */}
         <meta itemProp="datePublished" content={publishedDate.toISOString()} />

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickers.tsx
@@ -7,9 +7,16 @@ import { use } from 'react';
 export interface SimilarTickersProps {
   /** Promise-based fetch (resolved via `use()` to keep Suspense at the caller). */
   dataPromise: Promise<SimilarTicker[]>;
+  /**
+   * Optional sub-page slug (e.g. `competition`, `fair-value`). When set, each
+   * peer links to that same sub-page for the peer instead of its main report,
+   * so navigating from a sub-page keeps the reader on the same section. When
+   * omitted (main report page), peers link to the main report.
+   */
+  subPageSlug?: string;
 }
 
-export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JSX.Element | null {
+export default function SimilarTickers({ dataPromise, subPageSlug }: SimilarTickersProps): JSX.Element | null {
   const similarTickers: ReadonlyArray<SimilarTicker> = use(dataPromise);
   if (!similarTickers || similarTickers.length === 0) {
     return null;
@@ -24,10 +31,13 @@ export default function SimilarTickers({ dataPromise }: SimilarTickersProps): JS
           const scoreValue: number | '-' = similarTicker.cachedScoreEntry?.finalScore ?? '-';
           const { textColorClass } = typeof scoreValue === 'number' ? getScoreColorClasses(scoreValue) : { textColorClass: 'text-muted' };
 
+          const tickerBasePath = `/stocks/${similarTicker.exchange.toUpperCase()}/${similarTicker.symbol.toUpperCase()}`;
+          const href = subPageSlug ? `${tickerBasePath}/${subPageSlug}` : tickerBasePath;
+
           return (
             <Link
               key={similarTicker.id}
-              href={`/stocks/${similarTicker.exchange.toUpperCase()}/${similarTicker.symbol.toUpperCase()}`}
+              href={href}
               prefetch={false}
               className="block bg-surface-2 p-3 sm:p-4 rounded-md border border-border hover:border-primary transition-colors group"
             >

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickersSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickersSection.tsx
@@ -1,0 +1,28 @@
+import SimilarTickers from '@/components/ticker-reportsv1/SimilarTickers';
+import { fetchSimilarTickers } from '@/utils/fetchSimilarTickers';
+import { Suspense } from 'react';
+
+export interface SimilarTickersSectionProps {
+  /** Canonical exchange for the ticker (e.g. `NASDAQ`). */
+  exchange: string;
+  /** Canonical ticker symbol (e.g. `AAPL`). */
+  ticker: string;
+}
+
+/**
+ * Self-contained "Top Similar Companies" section: fetches from the shared
+ * `similar-tickers` API and streams <SimilarTickers> behind its own Suspense
+ * boundary. Drop-in for the stock report sub-pages so they show the same
+ * section as the main stock report page.
+ */
+export default function SimilarTickersSection({ exchange, ticker }: SimilarTickersSectionProps): JSX.Element {
+  const similarPromise = fetchSimilarTickers(exchange, ticker);
+
+  return (
+    <div className="[content-visibility:auto] [contain-intrinsic-size:auto_800px]">
+      <Suspense fallback={null}>
+        <SimilarTickers dataPromise={similarPromise} />
+      </Suspense>
+    </div>
+  );
+}

--- a/insights-ui/src/components/ticker-reportsv1/SimilarTickersSection.tsx
+++ b/insights-ui/src/components/ticker-reportsv1/SimilarTickersSection.tsx
@@ -7,21 +7,28 @@ export interface SimilarTickersSectionProps {
   exchange: string;
   /** Canonical ticker symbol (e.g. `AAPL`). */
   ticker: string;
+  /**
+   * Sub-page slug of the page hosting this section (e.g. `competition`,
+   * `fair-value`). Each peer then links to the *same* sub-page for that peer,
+   * keeping the reader on the section they were viewing.
+   */
+  subPageSlug: string;
 }
 
 /**
  * Self-contained "Top Similar Companies" section: fetches from the shared
  * `similar-tickers` API and streams <SimilarTickers> behind its own Suspense
  * boundary. Drop-in for the stock report sub-pages so they show the same
- * section as the main stock report page.
+ * section as the main stock report page, with peer links pointing back to the
+ * same sub-page.
  */
-export default function SimilarTickersSection({ exchange, ticker }: SimilarTickersSectionProps): JSX.Element {
+export default function SimilarTickersSection({ exchange, ticker, subPageSlug }: SimilarTickersSectionProps): JSX.Element {
   const similarPromise = fetchSimilarTickers(exchange, ticker);
 
   return (
     <div className="[content-visibility:auto] [contain-intrinsic-size:auto_800px]">
       <Suspense fallback={null}>
-        <SimilarTickers dataPromise={similarPromise} />
+        <SimilarTickers dataPromise={similarPromise} subPageSlug={subPageSlug} />
       </Suspense>
     </div>
   );

--- a/insights-ui/src/utils/fetchSimilarTickers.ts
+++ b/insights-ui/src/utils/fetchSimilarTickers.ts
@@ -1,0 +1,20 @@
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { getBaseUrlForServerSidePages } from '@/utils/getBaseUrlForServerSidePages';
+import { tickerAndExchangeTag } from '@/utils/ticker-v1-cache-utils';
+import type { SimilarTicker } from '@/utils/ticker-v1-model-utils';
+
+/**
+ * Fetches the top similar companies for a ticker from the shared
+ * `similar-tickers` API (same endpoint the main stock report page uses).
+ *
+ * Promise-based so callers can hand it to <SimilarTickers> via `use()` and keep
+ * the Suspense boundary at the call site.
+ */
+export async function fetchSimilarTickers(exchange: string, ticker: string): Promise<SimilarTicker[]> {
+  const url: string = `${getBaseUrlForServerSidePages()}/api/${KoalaGainsSpaceId}/tickers-v1/exchange/${exchange.toUpperCase()}/${ticker.toUpperCase()}/similar-tickers`;
+
+  const res: Response = await fetch(url, { next: { tags: [tickerAndExchangeTag(ticker, exchange)] } });
+  if (!res.ok) throw new Error(`fetchSimilarTickers failed (${res.status}): ${url}`);
+
+  return (await res.json()) as SimilarTicker[];
+}


### PR DESCRIPTION
## What

The main stock report page shows a **Top Similar Companies** section (`SimilarTickers`). This adds that same section to every stock report **sub-page**:

- `business-and-moat`
- `competition`
- `fair-value`
- `financial-statement-analysis`
- `future-performance`
- `management-team`
- `past-performance`

## How

- Extracted the existing inline `fetchSimilar` logic from the main page into a shared util `src/utils/fetchSimilarTickers.ts` (same `similar-tickers` API endpoint).
- Added a self-contained server component `SimilarTickersSection` that fetches similar tickers and streams `<SimilarTickers>` behind its own `Suspense` boundary, wrapped in the same `content-visibility:auto` container used on the main page.
- Rendered `<SimilarTickersSection exchange={tickerData.exchange} ticker={tickerData.symbol} />` at the bottom of each sub-page (canonical exchange/symbol from the already-redirected ticker data).
- Refactored the main stock report page to reuse the shared util (removes duplication; no behavior change).

The section renders nothing when there are no peers (component returns `null`), matching main-page behavior.

## Testing

- `yarn lint` — clean
- `yarn prettier-check` — clean
- `yarn compile` — clean