### PR TITLE
perf(analytics): lazy-load LogRocket + Clarity SDKs out of the shared bundle

### DIFF
--- a/docs/insights-ui/stock-page-performance.md
+++ b/docs/insights-ui/stock-page-performance.md
@@ -37,30 +37,5 @@ real cost. Splitting it further is optional and low priority.
 
 ---
 
-## What the bundle analyzer showed (Jul 2026)
-
-We ran `pnpm analyze`. Note: the **server** report (`nodejs.html`) does **not** matter for page
-speed — those big boxes (API routes, admin `create` pages) run on the server and are never sent to
-the browser. Only the **browser** report (`client.html`) counts. Its heavy pieces:
-
-- **Two big shared JS chunks** ("index.js + 580 modules" and "index.js + 320 modules", ~1 MB and
-  ~0.6 MB) — the bundled vendor code. This is issue #2. Needs a closer look at what's inside.
-- **chart.js** — shows up, but it's already loaded lazily (only when you scroll to a chart), so it's
-  **not** in the first load. Leave it.
-- **katex** (`katex.mjs`, a math-rendering library) — bundled into the browser even though KaTeX is
-  **intentionally turned off** in insights-ui. It gets pulled in for free through the markdown helper
-  (`parseMarkdown` → `getMarkedRenderer` → the katex extension → `import katex`), and some `'use
-  client'` components import `parseMarkdown`, so it lands in the browser. This is dead weight — a few
-  hundred KB we download and never use.
-  **Next step:** stop importing katex when the extension isn't registered (a small change in
-  `shared/web-core`'s `getMarkedRenderer` / `katexMarketExtension`, e.g. lazy/`import type`), or keep
-  the markdown rendering server-side so it never ships to the browser.
-
-So the two concrete JavaScript wins are: **(a)** drop the unused **katex** from the client bundle, and
-**(b)** open the two big shared chunks to see which other libraries can be lazy-loaded.
-
----
-
 **In short:** #1 (the biggest problem) is fixed. #2 and #3 are the next wins — both are about
-sending and running less JavaScript (the analyzer points at unused **katex** and two big shared
-chunks). #4 is a quick, cheap improvement. #5 is basically handled.
+sending and running less JavaScript. #4 is a quick, cheap improvement. #5 is basically handled.

--- a/docs/insights-ui/stock-page-performance.md
+++ b/docs/insights-ui/stock-page-performance.md
@@ -37,5 +37,30 @@ real cost. Splitting it further is optional and low priority.
 
 ---
 
+## What the bundle analyzer showed (Jul 2026)
+
+We ran `pnpm analyze`. Note: the **server** report (`nodejs.html`) does **not** matter for page
+speed — those big boxes (API routes, admin `create` pages) run on the server and are never sent to
+the browser. Only the **browser** report (`client.html`) counts. Its heavy pieces:
+
+- **Two big shared JS chunks** ("index.js + 580 modules" and "index.js + 320 modules", ~1 MB and
+  ~0.6 MB) — the bundled vendor code. This is issue #2. Needs a closer look at what's inside.
+- **chart.js** — shows up, but it's already loaded lazily (only when you scroll to a chart), so it's
+  **not** in the first load. Leave it.
+- **katex** (`katex.mjs`, a math-rendering library) — bundled into the browser even though KaTeX is
+  **intentionally turned off** in insights-ui. It gets pulled in for free through the markdown helper
+  (`parseMarkdown` → `getMarkedRenderer` → the katex extension → `import katex`), and some `'use
+  client'` components import `parseMarkdown`, so it lands in the browser. This is dead weight — a few
+  hundred KB we download and never use.
+  **Next step:** stop importing katex when the extension isn't registered (a small change in
+  `shared/web-core`'s `getMarkedRenderer` / `katexMarketExtension`, e.g. lazy/`import type`), or keep
+  the markdown rendering server-side so it never ships to the browser.
+
+So the two concrete JavaScript wins are: **(a)** drop the unused **katex** from the client bundle, and
+**(b)** open the two big shared chunks to see which other libraries can be lazy-loaded.
+
+---
+
 **In short:** #1 (the biggest problem) is fixed. #2 and #3 are the next wins — both are about
-sending and running less JavaScript. #4 is a quick, cheap improvement. #5 is basically handled.
+sending and running less JavaScript (the analyzer points at unused **katex** and two big shared
+chunks). #4 is a quick, cheap improvement. #5 is basically handled.

--- a/insights-ui/src/app/ClarityComponent.tsx
+++ b/insights-ui/src/app/ClarityComponent.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useEffect } from 'react';
-import Clarity from '@microsoft/clarity';
+// NOTE: `@microsoft/clarity` is intentionally NOT imported statically — that would
+// pull the SDK into the shared client bundle that loads on every page. It's
+// dynamically imported inside `init` (which runs on idle, after load), so the SDK
+// chunk is fetched on demand instead of up front.
 import { PROD_HOST } from './LogRocketComponent';
 
 const CLARITY_PROJECT_ID = 'u82d3rnsxw';
@@ -22,11 +25,14 @@ export default function ClarityComponent(): null {
 
     const init = (): void => {
       if (cancelled) return;
-      try {
-        Clarity.init(CLARITY_PROJECT_ID);
-      } catch {
-        /* swallow — analytics must not break the app */
-      }
+      // Load the SDK on demand (keeps it out of the initial/shared bundle).
+      import('@microsoft/clarity')
+        .then((m) => {
+          if (!cancelled) m.default.init(CLARITY_PROJECT_ID);
+        })
+        .catch(() => {
+          /* swallow — analytics must not break the app */
+        });
     };
 
     const scheduleIdle = (): void => {

--- a/insights-ui/src/app/LogRocketComponent.tsx
+++ b/insights-ui/src/app/LogRocketComponent.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import LogRocket from 'logrocket';
+// NOTE: `logrocket` is intentionally NOT imported statically — a top-level import
+// pulls the SDK into the shared client bundle that loads on every page. It's
+// dynamically imported inside `connectAndIdentify` (which only runs after the
+// user is engaged), so the SDK chunk is fetched on demand, not up front.
 
 const PROJECT_ID = 'm3ahri/koalagains';
 const MIN_CLICKS = 2; // Require at least 2 clicks in the current session
@@ -145,7 +148,10 @@ function hasMinSessionClicks(): boolean {
 
 /* ----------------- LogRocket connect/identify ----------------- */
 
-function connectAndIdentify(country: string | null): void {
+async function connectAndIdentify(country: string | null): Promise<void> {
+  // Load the SDK on demand (keeps it out of the initial/shared bundle).
+  const LogRocket = (await import('logrocket')).default;
+
   // init once per session (StrictMode-safe)
   if (!window.__LR_INIT__ && ssOnce(SS.inited)) {
     LogRocket.init(PROJECT_ID);
@@ -175,7 +181,7 @@ function connectAndIdentify(country: string | null): void {
  */
 function gateConnectionOnSessionClicks(country: string | null): () => void {
   if (hasMinSessionClicks()) {
-    connectAndIdentify(country);
+    void connectAndIdentify(country);
     return () => {};
   }
 
@@ -185,7 +191,7 @@ function gateConnectionOnSessionClicks(country: string | null): () => void {
 
     const { session } = incrementSessionClickCount();
     if (session >= MIN_CLICKS) {
-      connectAndIdentify(country);
+      void connectAndIdentify(country);
       document.removeEventListener('click', onClick, { capture: true } as AddEventListenerOptions);
     }
   };


### PR DESCRIPTION
Follow-up to the merged CloudFront static-asset fix (#1668).

## Lazy-load the LogRocket + Clarity SDKs

Both `logrocket` and `@microsoft/clarity` were imported **statically** at the top of their `'use client'` components (`LogRocketComponent.tsx`, `ClarityComponent.tsx`), which render in the **root layout** — so both SDKs were bundled into the shared client chunk that loads on **every page's initial render**, even though neither runs until the user is engaged (LogRocket = after 2 clicks) or the page is idle (Clarity = after `load`).

Switched both to dynamic `import()` at the point of use:
- **LogRocket** — `connectAndIdentify` is now async and imports `logrocket` on demand, still behind the existing 2-click session gate (call sites use `void`).
- **Clarity** — the idle `init()` imports `@microsoft/clarity` on demand.

Behavior is identical (same gating/deferral); the SDK code just moves into its own on-demand chunk instead of the initial bundle, trimming up-front JS parse/exec (helps TBT). "Reduce, not remove" — the tools still run exactly as before.

## Testing
`tsc`, `eslint`, `prettier` all pass on the changed files. No behavior change to analytics gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
