### PR TITLE
fix(cache): allow homepage `/` to be CloudFront-invalidated

### DIFF
--- a/insights-ui/src/utils/cloudfront-cache-utils.ts
+++ b/insights-ui/src/utils/cloudfront-cache-utils.ts
@@ -54,6 +54,14 @@ const CACHED_PATH_PREFIXES = [
   '/api/koala_gains/etfs-v1/exchange/',
 ] as const;
 
+/**
+ * Exact paths CloudFront caches — matched by equality, NOT prefix. The homepage
+ * behavior in `cloudfront.tf` is `path_pattern = "/"`, which matches only the root
+ * document. It can't live in `CACHED_PATH_PREFIXES` because `startsWith('/')` is
+ * true for every path, which would wrongly forward all paths to AWS.
+ */
+const CACHED_EXACT_PATHS: readonly string[] = ['/'];
+
 let client: CloudFrontClient | null = null;
 
 function getClient(): CloudFrontClient | null {
@@ -66,6 +74,7 @@ function getClient(): CloudFrontClient | null {
 }
 
 function isCloudFrontCachedPath(path: string): boolean {
+  if (CACHED_EXACT_PATHS.includes(path)) return true;
   return CACHED_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 


### PR DESCRIPTION
## Problem

The homepage (`https://koalagains.com/`) is edge-cached at CloudFront via an **exact** `path_pattern = "/"` behavior in `deployments/insights-ui/cloudfront.tf`. After the S3 static-assets change, the stale cached homepage HTML kept referencing old content-hashed asset URLs, so the **koala icon and the architecture diagram under the "KoalaGains Platform" section 404'd** and disappeared.

The obvious remedy — invalidate `/` from the admin `/admin-v1/invalidate-cache` page — failed with:

> None of the provided paths matched a CloudFront-cached prefix, so nothing was sent.
> Skipped — not under any CloudFront-cached prefix (1): /

## Root cause

The invalidation allow-list in `src/utils/cloudfront-cache-utils.ts` (`CACHED_PATH_PREFIXES`) uses **prefix** matching (`path.startsWith(prefix)`). `/` was never in that list, and it *can't* be added as a prefix — `startsWith('/')` is true for **every** path, which would forward all paths to AWS and burn the invalidation quota. So the homepage, though genuinely cached at the edge, was un-invalidatable.

## Fix

Add a separate exact-match list `CACHED_EXACT_PATHS = ['/']`, checked (by equality) before the prefix scan in `isCloudFrontCachedPath()`. This mirrors the exact `path_pattern = "/"` CloudFront behavior, so `/` (and a full `https://koalagains.com/` URL, which the admin page parses down to `/`) is now forwarded to CloudFront while every other path still routes through prefix matching unchanged.

After deploy, invalidating `/` from the admin page will purge the stale homepage HTML and restore the koala icon + architecture diagram.

## Notes
- Could not run `yarn compile`/`lint` locally: this worktree has no `node_modules` and the monorepo's `@dodao/web-core` workspace package isn't resolvable via a standalone install. Change is a self-contained, type-safe 9-line addition; formatting verified against the repo `.prettierrc` (printWidth 160) with standalone prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)