### PR TITLE
Remove UK ETFs from sitemaps and cross-country listing links

### DIFF
--- a/insights-ui/src/app/etfs/sitemap.xml/route.ts
+++ b/insights-ui/src/app/etfs/sitemap.xml/route.ts
@@ -5,8 +5,9 @@ import { getAllEtfGroups, getCategoriesForGroupKey } from '@/utils/etf-categoriz
 import { etfBrowseDetailPath, etfBrowsePath, etfGroupCategoryPath, etfSectionIndexPath } from '@/utils/etf-country-route-utils';
 import { ETF_ASSET_CLASS_OPTIONS } from '@/utils/etf-filter-utils';
 import { slugifyEtfTag } from '@/utils/etf-tag-slug-utils';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { ETF_SUPPORTED_COUNTRIES } from '@/utils/etfCountryExchangeUtils';
-import { buildEtfSitemapResponse, SiteMapUrl } from '@/utils/etfSitemapUtils';
+import { buildEtfSitemapResponse, SITEMAP_EXCLUDED_ETF_EXCHANGES, SiteMapUrl } from '@/utils/etfSitemapUtils';
 import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -34,7 +35,11 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
     if (option.value !== '') assetClassValueToKey.set(option.value, option.value);
   }
 
-  for (const country of ETF_SUPPORTED_COUNTRIES) {
+  // UK ETF pages stay live but are kept out of the sitemap so Google stops rediscovering them
+  // (see SITEMAP_EXCLUDED_ETF_EXCHANGES) — skip the UK listing/browse section here.
+  const sitemapCountries = ETF_SUPPORTED_COUNTRIES.filter((country) => country !== SupportedCountries.UK);
+
+  for (const country of sitemapCountries) {
     // Section index pages. The groups index collapses onto the country root (/etfs for US,
     // /etfs/countries/<country> otherwise), so use etfSectionIndexPath for it.
     urls.push({ url: etfSectionIndexPath(country, 'groups'), changefreq: 'daily', priority: 0.8 });
@@ -80,6 +85,7 @@ async function generateEtfUrls(): Promise<SiteMapUrl[]> {
     where: {
       spaceId: KoalaGainsSpaceId,
       cachedScore: { isNot: null },
+      exchange: { notIn: SITEMAP_EXCLUDED_ETF_EXCHANGES },
     },
     select: {
       symbol: true,

--- a/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
+++ b/insights-ui/src/components/etfs/EtfCountryAlternatives.tsx
@@ -1,7 +1,16 @@
 import Link from 'next/link';
 import { GlobeAltIcon } from '@heroicons/react/24/outline';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { EtfSupportedCountry } from '@/utils/etfCountryExchangeUtils';
 import { ALL_ETF_COUNTRIES, EtfBrowseSection, etfBasePath, etfCountryDisplayName, etfSectionIndexPath } from '@/utils/etf-country-route-utils';
+
+/**
+ * Countries we still cross-link to from the "Also view" switcher. UK is intentionally excluded:
+ * the UK ETF pages stay live (they don't 404), but we no longer surface them from other listing
+ * pages or the home page, so Google stops rediscovering them via internal links. The UK pages are
+ * also dropped from the sitemaps (see `etfSitemapUtils.ts` / `etfs/sitemap.xml`).
+ */
+const SWITCHER_ETF_COUNTRIES = ALL_ETF_COUNTRIES.filter((c) => c !== SupportedCountries.UK);
 
 interface EtfCountryAlternativesProps {
   currentCountry: EtfSupportedCountry;
@@ -22,7 +31,7 @@ interface EtfCountryAlternativesProps {
 }
 
 export default function EtfCountryAlternatives({ currentCountry, section, buildHref, includeCurrent = false, className = '' }: EtfCountryAlternativesProps) {
-  const alternatives = includeCurrent ? [...ALL_ETF_COUNTRIES] : ALL_ETF_COUNTRIES.filter((c) => c !== currentCountry);
+  const alternatives = includeCurrent ? [...SWITCHER_ETF_COUNTRIES] : SWITCHER_ETF_COUNTRIES.filter((c) => c !== currentCountry);
   if (alternatives.length === 0) return null;
 
   return (

--- a/insights-ui/src/utils/etfSitemapUtils.ts
+++ b/insights-ui/src/utils/etfSitemapUtils.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/prisma';
 import { EtfAnalysisCategory } from '@/types/etf/etf-analysis-types';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { SupportedCountries } from '@/utils/countryExchangeUtils';
+import { getEtfExchangesByCountry } from '@/utils/etfCountryExchangeUtils';
 import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
 import { Prisma } from '@prisma/client';
 import { NextResponse } from 'next/server';
@@ -12,6 +14,14 @@ export interface SiteMapUrl {
   priority?: number;
   lastmod?: string;
 }
+
+/**
+ * ETF exchanges excluded from every sitemap. UK ETFs (LSE) are being retired from search: the UK
+ * pages stay live (HTTP 200) so already-indexed URLs don't 404, but we no longer want Google to
+ * (re)discover them via the sitemaps. Used as a Prisma `exchange notIn` filter across every ETF
+ * sitemap query. The main sitemap (`etfs/sitemap.xml`) additionally drops the UK listing/browse pages.
+ */
+export const SITEMAP_EXCLUDED_ETF_EXCHANGES: string[] = getEtfExchangesByCountry(SupportedCountries.UK);
 
 /** Stream a list of URLs into an XML sitemap response — shared by every ETF sitemap route. */
 export async function buildEtfSitemapResponse(urls: SiteMapUrl[]): Promise<NextResponse<Buffer>> {
@@ -54,6 +64,7 @@ export async function buildEtfCategoryReportSitemap(categoryKey: EtfAnalysisCate
       categoryKey,
       // The sub-page renders overallAnalysisDetails; an empty body is a thin page.
       overallAnalysisDetails: { not: '' },
+      etf: { is: { exchange: { notIn: SITEMAP_EXCLUDED_ETF_EXCHANGES } } },
     },
     select: {
       updatedAt: true,
@@ -81,6 +92,7 @@ export async function buildEtfCompetitionSitemap(): Promise<NextResponse<Buffer>
     where: {
       spaceId: KoalaGainsSpaceId,
       overallAnalysisDetails: { not: '' },
+      etf: { is: { exchange: { notIn: SITEMAP_EXCLUDED_ETF_EXCHANGES } } },
     },
     select: {
       updatedAt: true,
@@ -108,6 +120,7 @@ export async function buildEtfHoldingsSitemap(): Promise<NextResponse<Buffer>> {
     where: {
       spaceId: KoalaGainsSpaceId,
       morPortfolioInfo: { is: { holdings: { not: Prisma.DbNull } } },
+      exchange: { notIn: SITEMAP_EXCLUDED_ETF_EXCHANGES },
     },
     select: {
       symbol: true,


### PR DESCRIPTION
## What

Removes UK ETFs from search discovery **without** breaking already-indexed pages:

- **Sitemaps:** UK (LSE) ETFs are excluded from every ETF sitemap — the main `etfs/sitemap.xml` (UK listing/browse section + individual UK ETF report pages) and all 6 sub-report sitemaps (holdings, competition, risk-analysis, performance-returns, cost-efficiency-team, future-performance-outlook).
- **Internal links:** the `EtfCountryAlternatives` "Also view" switcher no longer links to UK, so no listing page (or the home-page showcase) points at UK ETF pages.

## What this does NOT do (intentional)

- UK is **still a supported ETF country** — `/etfs/countries/UK` and `/etfs/LSE/<symbol>` pages stay live and return **HTTP 200**. Nothing 404s, so already-indexed UK URLs are not broken.
- **No `noindex` yet.** Removing pages from the sitemap does not deindex them; existing UK pages remain in Google's index for now. This matches the requested scope ("these changes are enough for now"). A follow-up can add `noindex` (the project already has `src/utils/etf-listing-noindex.ts`) if we later want them fully dropped from search.

## Changes

- `src/utils/etfSitemapUtils.ts` — add `SITEMAP_EXCLUDED_ETF_EXCHANGES` (UK/LSE) and apply it as a Prisma `exchange notIn` filter to the holdings, competition, and per-category report sitemap builders.
- `src/app/etfs/sitemap.xml/route.ts` — skip the UK listing/browse section and exclude UK individual ETF report pages.
- `src/components/etfs/EtfCountryAlternatives.tsx` — drop UK from the cross-country switcher (US / Canada / Australia links preserved).

## Note

This supersedes the earlier approach on this branch that removed UK from the supported-country list (which caused `/etfs/countries/UK` to 404). That commit was dropped; UK support is left intact.

## Checks

`yarn lint`, `yarn prettier-check`, and `yarn compile` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
