### PR TITLE
feat(insights-ui): real, sourced commodity reports (5 metals + 3 livestock + 5 energy)

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -104,46 +104,6 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ---
 
-## Commodities
-
-> Today commodity reports are **static JSON, no DB, no LLM generation** — hand-authored files
-> under `insights-ui/src/commodity-data/reports/<slug>.json`, imported through
-> `commodity-reports-registry.ts` and served by the `/api/.../commodities-v1/*` routes. Only
-> `gold.json` is filled in; the other launch commodities show the neutral placeholder. See
-> `insights-ui/src/commodity-data/README.md` and `src/types/commodity/commodity-analysis-types.ts`.
-> The shape already mirrors ETF reports (4 scored categories × 5 Pass/Fail factors + Key Facts +
-> Final Summary), so the generation task is to build the commodity-side parallel of the existing
-> ETF pipeline rather than invent a new model.
-
-### Generate commodity reports (replace static JSON with an LLM pipeline)
-
-- [ ] **Persistence** — add the commodity Prisma models that mirror the ETF report tables
-  (`Commodity` anchor row keyed by `slug`; `CommodityKeyFactsReport`; `CommodityCategoryAnalysisResult`
-  for the 4 scored categories with `categoryKey` as TEXT; `CommodityAnalysisCategoryFactorResult` reusing
-  the existing `EvaluationResult` enum; `CommodityCachedScore`; `CommodityGenerationRequest` mirroring
-  `EtfGenerationRequest`). Seed the anchor rows from `commodities.json`. Migrate `gold.json` into the
-  tables so nothing is lost, then switch the fetchers to read the DB with the static JSON as fallback.
-- [ ] **Prompts** — author the source-of-truth prompt text per scored category
-  (Supply & Demand, Price & Value, Volatility & Risk, Future Outlook) + Key Facts + Final Summary under
-  `docs/insights-ui/` (parallel to `etf-prompts/`); feed the `commodity-analysis-factors-*.json` factor
-  configs as input so each factor gets a grounded Pass/Fail verdict + one-line + detailed explanation.
-- [ ] **Pipeline** — build `commodity-generation-report-utils.ts` (parallel to
-  `etf-analysis-reports/etf-generation-report-utils.ts`) using `getLLMResponseForPromptViaInvocation`
-  with a single `promptKey` per category; per-category status tracking on `CommodityGenerationRequest`;
-  a save-callback that writes categories + factors + key facts + cached score.
-- [ ] **Trigger surfaces** — a `generate-commodity-v1-request` API route (parallel to
-  `etfs-v1/generate-etf-v1-request`) + a per-commodity regenerate route; an admin "Generate report"
-  button on the commodity admin/detail page reusing the ETF report-status UI patterns.
-- [ ] **Off-hours automation** — pick commodities whose reports are not generated yet (or are stale) and
-  generate the whole report on the off-hours Claude-Code runner, same idea as the stock/ETF refresh crons.
-- [ ] **Cache** — on successful generation, revalidate the `commodity:<slug>` tag + the listing tag so a
-  regenerate takes effect without a redeploy (today, publishing new JSON only lands on redeploy).
-- [ ] Open: keep static JSON as an authoring fallback for commodities with no generated report, or drop it
-  once every launch commodity is generated? Where does the price-symbol / futures-curve data come from for
-  the Price & Value + Volatility categories (Yahoo price history is already wired; futures curve is not)?
-
----
-
 ## Trends page
 
 > Decide once: shared `Trend` model linked to both stock and ETF join tables, or parallel

--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -104,6 +104,46 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ---
 
+## Commodities
+
+> Today commodity reports are **static JSON, no DB, no LLM generation** — hand-authored files
+> under `insights-ui/src/commodity-data/reports/<slug>.json`, imported through
+> `commodity-reports-registry.ts` and served by the `/api/.../commodities-v1/*` routes. Only
+> `gold.json` is filled in; the other launch commodities show the neutral placeholder. See
+> `insights-ui/src/commodity-data/README.md` and `src/types/commodity/commodity-analysis-types.ts`.
+> The shape already mirrors ETF reports (4 scored categories × 5 Pass/Fail factors + Key Facts +
+> Final Summary), so the generation task is to build the commodity-side parallel of the existing
+> ETF pipeline rather than invent a new model.
+
+### Generate commodity reports (replace static JSON with an LLM pipeline)
+
+- [ ] **Persistence** — add the commodity Prisma models that mirror the ETF report tables
+  (`Commodity` anchor row keyed by `slug`; `CommodityKeyFactsReport`; `CommodityCategoryAnalysisResult`
+  for the 4 scored categories with `categoryKey` as TEXT; `CommodityAnalysisCategoryFactorResult` reusing
+  the existing `EvaluationResult` enum; `CommodityCachedScore`; `CommodityGenerationRequest` mirroring
+  `EtfGenerationRequest`). Seed the anchor rows from `commodities.json`. Migrate `gold.json` into the
+  tables so nothing is lost, then switch the fetchers to read the DB with the static JSON as fallback.
+- [ ] **Prompts** — author the source-of-truth prompt text per scored category
+  (Supply & Demand, Price & Value, Volatility & Risk, Future Outlook) + Key Facts + Final Summary under
+  `docs/insights-ui/` (parallel to `etf-prompts/`); feed the `commodity-analysis-factors-*.json` factor
+  configs as input so each factor gets a grounded Pass/Fail verdict + one-line + detailed explanation.
+- [ ] **Pipeline** — build `commodity-generation-report-utils.ts` (parallel to
+  `etf-analysis-reports/etf-generation-report-utils.ts`) using `getLLMResponseForPromptViaInvocation`
+  with a single `promptKey` per category; per-category status tracking on `CommodityGenerationRequest`;
+  a save-callback that writes categories + factors + key facts + cached score.
+- [ ] **Trigger surfaces** — a `generate-commodity-v1-request` API route (parallel to
+  `etfs-v1/generate-etf-v1-request`) + a per-commodity regenerate route; an admin "Generate report"
+  button on the commodity admin/detail page reusing the ETF report-status UI patterns.
+- [ ] **Off-hours automation** — pick commodities whose reports are not generated yet (or are stale) and
+  generate the whole report on the off-hours Claude-Code runner, same idea as the stock/ETF refresh crons.
+- [ ] **Cache** — on successful generation, revalidate the `commodity:<slug>` tag + the listing tag so a
+  regenerate takes effect without a redeploy (today, publishing new JSON only lands on redeploy).
+- [ ] Open: keep static JSON as an authoring fallback for commodities with no generated report, or drop it
+  once every launch commodity is generated? Where does the price-symbol / futures-curve data come from for
+  the Price & Value + Volatility categories (Yahoo price history is already wired; futures curve is not)?
+
+---
+
 ## Trends page
 
 > Decide once: shared `Trend` model linked to both stock and ETF join tables, or parallel

--- a/insights-ui/src/commodity-data/reports/brent-crude-oil.json
+++ b/insights-ui/src/commodity-data/reports/brent-crude-oil.json
@@ -1,0 +1,207 @@
+{
+  "slug": "brent-crude-oil",
+  "name": "Crude Oil (Brent)",
+  "commodityGroup": "Energy",
+  "priceSymbol": "BZ=F",
+  "exchange": "ICE",
+  "unit": "barrel",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on Brent crude, the world's oil benchmark: near $72 a barrel in mid-2026 after a Middle East spike to $117, cheap versus history but heading into a 2027 oversupply. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Cautious. A tactical geopolitical trade, not a structural buy.\n\nBrent is the world's benchmark crude — roughly two-thirds of internationally traded oil is priced off it (Europe, Africa, Asia, Middle East exports). Because it is waterborne (seaborne cargoes), Brent is even more sensitive to shipping chokepoints and geopolitics than US-centric WTI. In early July 2026 it trades near $72 a barrel, its usual ~$3 premium over WTI, and about 51% below its 2008 record of $147.50.\n\n2026 has been a two-regime year: a Strait of Hormuz crisis spiked Brent from about $71 to $117 by April, then it collapsed back to ~$72 as tankers resumed and OPEC+ began adding barrels. On value Brent looks cheap — low in its range, well below its inflation-adjusted high, and near the cost of the marginal barrel. But the fundamentals are bearish: global demand is contracting slightly in 2026, OPEC+ holds ~5 million barrels a day of spare capacity, and both the EIA and banks (Goldman ~$71 for Q4, JPMorgan ~$60 and warning of the $30s) expect prices at or below today's level as a surplus returns in 2027. Strip out the war-risk premium and the underlying picture is soft. Treat Brent as a tactical trade on geopolitics rather than a long-term hold.",
+  "keyFacts": {
+    "keyFacts": "Brent crude is a light, sweet oil originally from the North Sea that serves as the pricing benchmark for most of the world's internationally traded oil. It is priced per barrel in US dollars, with the ICE front-month future (BZ=F) as the reference. When the news says 'the oil price,' it usually means Brent. In early July 2026 that price is about $72 a barrel.\n\nThe key difference from WTI is that Brent is waterborne — it is shipped by sea — so it is more exposed to shipping chokepoints (the Strait of Hormuz, the Red Sea) and to global rather than just US events. That makes Brent the more geopolitically sensitive of the two benchmarks. 2026 showed this clearly: a Strait of Hormuz crisis drove Brent from about $71 in February to $117 in April, before it fell back to ~$72 by July as flows resumed and OPEC+ added supply. Brent trades at its normal ~$3 premium to WTI, and its price is a tug-of-war between OPEC+ policy, non-OPEC growth (US, Brazil, Guyana), the health of the world economy, and Middle East risk.",
+    "greenFlags": [
+      {
+        "flag": "Cheap versus its own history",
+        "explanation": "At about $72, Brent is low-to-mid in its 5- and 10-year range and roughly 61% below its inflation-adjusted all-time high (the 2008 peak of $147.50 is worth about $186 in today's dollars). On value alone, oil is not expensive.",
+        "result": "Pass"
+      },
+      {
+        "flag": "A cost floor under the price",
+        "explanation": "The marginal barrel — US shale (~$45-65 breakeven) and new deepwater from Brazil and Guyana — sits below the current price, while Saudi Arabia needs roughly $80-85 to balance its budget. That combination puts a floor under prices and pressures OPEC to defend them.",
+        "result": "Pass"
+      },
+      {
+        "flag": "A useful inflation and pro-cyclical hedge",
+        "explanation": "Brent feeds global gasoline, diesel and jet prices, so it rises with inflation and with a strengthening world economy. For an investor worried about an energy-driven inflation shock, oil exposure is one of the more direct hedges available.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Oversupply returning in 2027",
+        "explanation": "OPEC+ is adding barrels into contracting demand, spare capacity is about 5 million barrels a day, and non-OPEC growth from Brazil and Guyana keeps rising. The IEA and EIA expect the market back in surplus by late 2026 with a large 2027 supply wave — a clear headwind.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Forecasts sit at or below today's price",
+        "explanation": "Goldman Sachs sees Brent around $71 in Q4 2026, JPMorgan around $60 (and warns of the $30s in a glut), and the EIA about $79 in 2027. With Brent near $72, the consensus points flat-to-lower, so the upside case rests almost entirely on geopolitics that agencies expect to fade.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Transportation fuels (gasoline, diesel, jet fuel)", "Petrochemicals and plastics", "Heating oil", "Lubricants and asphalt"],
+    "topProducers": [
+      { "country": "United States", "share": "~16%" },
+      { "country": "Russia", "share": "~11%" },
+      { "country": "Saudi Arabia", "share": "~11%" },
+      { "country": "Iraq", "share": "~5%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "BNO", "note": "United States Brent Oil Fund; the most direct Brent-specific retail vehicle" },
+      { "type": "Futures", "name": "BZ=F", "note": "ICE Brent front-month; leveraged, roll costs, for experienced traders" },
+      { "type": "Equities", "name": "XLE / integrated majors", "note": "Shell, BP, TotalEnergies, Exxon, Chevron; indirect, pay dividends" },
+      { "type": "Note", "name": "USO tracks WTI", "note": "Not Brent — a common beginner mix-up; oil ETFs also suffer contango decay" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Supply is expanding — OPEC+ unwinding cuts, non-OPEC growth from Brazil and Guyana, and about 5 million barrels a day of spare capacity — while global demand is contracting slightly in 2026. Only currently tight inventories and mild summer seasonality lean supportive. Net bearish.",
+      "overallAnalysisDetails": "The supply side is heavy. OPEC+ is actively unwinding its cuts (a recent +188,000 barrels-a-day monthly hike), Saudi Aramco cut its Asian selling price by $11 a barrel signalling soft demand, and non-OPEC supply from Brazil (heading to 4 million barrels a day), Guyana (over 900,000 and rising) and Argentina keeps growing. OPEC+ also holds about 5 million barrels a day of spare capacity — Saudi Arabia alone around 3 million — which caps rallies.\n\nDemand is a drag. The IEA and EIA see global demand near 104 million barrels a day but contracting roughly 1 million in 2026, as high prices and the conflict destroy some jet, LPG and petrochemical use, and EVs weigh on China. The offsets are near-term: OECD on-land stocks fell sharply in 2026 and are heading toward their lowest since 2003, and summer driving season adds seasonal support. But those are short-term positives against an expanding-supply, soft-demand backdrop.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "OPEC+ unwinding cuts plus non-OPEC growth.",
+          "detailedExplanation": "OPEC+ is adding barrels back (a recent +188,000 barrels-a-day hike), and non-OPEC supply from Brazil, Guyana and Argentina is growing strongly. Global supply is projected to rebound sharply in 2027. Expanding, unwinding supply is a headwind for prices rather than a support.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Inventories are tight and drawing right now.",
+          "detailedExplanation": "OECD on-land stocks fell about 146 million barrels in April 2026 alone and are heading toward their lowest since 2003, below the roughly 2.8-billion-barrel five-year average. Tight, drawing inventories give the current price real near-term support, even as a surplus is expected to build later in the year.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Global demand is contracting about 1 million barrels a day in 2026.",
+          "detailedExplanation": "The IEA and EIA see world demand near 104 million barrels a day but shrinking roughly 1 million in 2026, hurt by high prices, conflict-driven demand destruction, and China's shift to EVs and hybrids. India is the main growth engine, but overall demand is soft. A commodity with falling demand has a weak base.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "About 5 million barrels a day of spare capacity caps upside.",
+          "detailedExplanation": "OPEC+ holds roughly 5 million barrels a day of spare capacity, with Saudi Arabia alone around 3 million, plus a wave of new non-OPEC supply from Brazil, Guyana and Argentina. This large ready cushion acts as a price ceiling: rallies tend to bring idle and new barrels into the market, limiting the upside.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Summer demand is mildly supportive.",
+          "detailedExplanation": "Summer driving and cooling demand (June-August) is seasonally supportive, and refinery maintenance in spring and autumn plus winter heating create the usual annual rhythm. In early July this is a modest positive, but in 2026 the seasonal signal is swamped by OPEC policy and geopolitics.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "On value Brent looks attractive: near $72 it is low-to-mid in its range, about 61% below its inflation-adjusted high, near the marginal cost of production and below Saudi Arabia's budget breakeven, at a normal premium to WTI, and roughly 51% below its record. Value is the standout positive.",
+      "overallAnalysisDetails": "Judged on price alone, Brent is not expensive. At about $72 it sits low-to-mid in its 5- and 10-year range and roughly 61% below its inflation-adjusted all-time high — the 2008 peak of $147.50 would be worth about $186 in today's money. So there is little 'overvaluation' risk to the downside.\n\nThe cost floor matters most. The marginal barrel — US shale (~$45-65 breakeven) and new deepwater from Brazil and Guyana — sits below the current price, while Saudi Arabia's fiscal breakeven of roughly $80-85 is above it, pressuring OPEC to defend prices. Brent trades at its normal ~$3 premium to WTI, with no unusual dislocation, and it is about 51% below its record. As always, 'cheap' does not guarantee 'rising' — a well-supplied market can sit near cost for a long time — but the value pillar is clearly supportive.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Low-to-mid in its 5- and 10-year range.",
+          "detailedExplanation": "At about $72, Brent sits in the lower-middle of its multi-year range (roughly $16-$128 over ten years) — well below 2022's $100+ and its own 2026 spike to $117, but above the 2016 and 2020 lows. It is a reasonable entry level on valuation, not a stretched one.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "About 61% below its inflation-adjusted record.",
+          "detailedExplanation": "The 2008 peak of $147.50 would be worth roughly $186 a barrel in today's dollars, so at about $72 Brent is around 61% below its real all-time high. Oil is historically cheap in real terms, so buyers are not paying an inflated real price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Below Saudi Arabia's ~$80-85 budget breakeven.",
+          "detailedExplanation": "The marginal barrel (US shale, new deepwater) sits below today's price, while Saudi Arabia needs roughly $80-85 to balance its budget — above the current $72. That gap pressures OPEC to support prices and puts a practical floor under the market, even though the very cheapest barrels are produced well below $72.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Normal ~$3 premium over WTI, no distortion.",
+          "detailedExplanation": "Brent trades about $3 a barrel above WTI, its usual structural premium as the global waterborne benchmark. There is no extreme gap versus WTI, and global gas (via LNG) only competes at price extremes. The relative-value picture is normal and healthy.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 51% below the 2008 record of $147.50.",
+          "detailedExplanation": "Brent near $72 is about 51% below its nominal all-time high of $147.50 (July 2008), so there is plenty of theoretical headroom rather than fresh-record risk. For a cyclical commodity this is normal, but it confirms the price is nowhere near a valuation ceiling.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Brent is high-risk: 30-40%+ annual volatility, repeated -50% to -75% crashes, and the highest geopolitical exposure of any benchmark because it is waterborne (Hormuz, Red Sea, Russia). The one positive is that it is a genuine inflation and pro-cyclical hedge. Four of five risk factors fail.",
+      "overallAnalysisDetails": "Brent is a volatile, event-driven asset. Its annualized volatility commonly runs 30-40% and spikes far higher in crises — 2026 saw it swing from $117 to $72 in a matter of months. Its drawdown history is severe: about -75% in 2008, another deep slide in 2014-2016, and a fall to roughly $16 in the 2020 COVID crash (it avoided WTI's negative prices only because it is waterborne, not landlocked).\n\nBrent's defining risk is geopolitics, and it is structurally higher than WTI's. Because Brent is seaborne, it is directly exposed to the Strait of Hormuz (the 2026 crisis), Red Sea and Houthi shipping attacks, and Russia sanctions. It is priced in dollars, so a strong dollar is a headwind. The single redeeming feature is that Brent is a useful inflation and pro-cyclical hedge — it feeds global fuel prices and rises with a strengthening world economy — which is why it earns one Pass in this category. But overall this is a commodity for investors who can tolerate sharp, geopolitically-driven swings.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "Structurally high, 30-40%+ a year.",
+          "detailedExplanation": "Brent's realized volatility commonly runs 30-40% a year and spikes much higher in crises. In 2026 it swung from $117 in April to $72 by July. That is far above the stock market and makes Brent uncomfortable to hold for anyone who cannot stomach large, fast moves.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Repeated -50% to -75% crashes.",
+          "detailedExplanation": "Brent fell about 75% in 2008 ($147 to $36), slid from $115 to $27 in 2014-2016, and dropped to roughly $16 in the 2020 COVID crash. It avoided WTI's negative prices only because it is waterborne. The history of deep, fast drawdowns is a serious downside risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Highest geopolitical exposure of any benchmark.",
+          "detailedExplanation": "Because Brent is seaborne, it is more exposed than WTI to shipping chokepoints — the Strait of Hormuz (the 2026 crisis), Red Sea and Houthi attacks — plus Russia sanctions and Middle East conflict. This can spike the price up, but it is a source of instability and shock, not a dependable support, so it counts as a risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Priced in dollars, so a strong dollar is a headwind.",
+          "detailedExplanation": "Brent is bought and sold in US dollars and generally moves inversely to the dollar: a stronger dollar makes oil pricier for foreign buyers and softens demand. With no clear dollar tailwind today, this standard inverse link is a background risk rather than a help.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "A genuine inflation and pro-cyclical hedge.",
+          "detailedExplanation": "Brent feeds global gasoline, diesel and jet prices, so it rises with inflation and with a strengthening world economy. For an investor worried about an energy-driven inflation shock, Brent exposure is one of the more direct hedges available — the clearest positive in its risk profile, even though it means oil also falls in recessions.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The forward view is bearish. The IEA and EIA see a surplus returning by late 2026 with a big 2027 supply wave; the EIA sees Brent around $79 in 2027; and banks (Goldman ~$71 Q4, JPMorgan ~$60) forecast prices at or below today's $72. The bull case is almost entirely geopolitical. All five factors fail.",
+      "overallAnalysisDetails": "The forward setup is the weakest pillar. Before the 2026 crisis, Brent was headed for a large surplus; the Hormuz shock flipped it to a mid-year deficit, but the balance edges back to surplus by around October 2026, and 2027 brings a big supply rebound (potentially +8 million barrels a day) into soft demand.\n\nForecasts sit at or below spot. The EIA's June 2026 outlook (published mid-crisis) sees Brent falling to about $79 in 2027, and its pre-crisis view was in the mid-to-high $50s. Goldman Sachs sees roughly $71 in Q4 2026 and structural oversupply pulling prices to the mid-$60s in 2027; JPMorgan is around $60 and warns of the $30s in a glut. In short, the consensus points flat-to-lower from $72. The bull case — renewed Hormuz or Red Sea disruption, tighter Russia sanctions, OPEC+ discipline, Chinese stimulus — is real but rests on geopolitics that agencies expect to fade. The forward-looking evidence leans clearly bearish.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Surplus returns by late 2026, big 2027 supply wave.",
+          "detailedExplanation": "The 2026 crisis flipped a looming surplus into a temporary deficit, but the balance edges back to oversupply by around October 2026, and 2027 brings a large supply rebound into contracting demand. A return to structural surplus is a clear negative for future prices.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "EIA sees Brent around $79 in 2027.",
+          "detailedExplanation": "The EIA's June 2026 outlook expects Brent to fall from a conflict-inflated 2026 average to about $79 in 2027, and its pre-crisis view was even lower (mid-to-high $50s). The official agency view is for prices to ease from here, which is a headwind for a long position.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Bank targets sit at or below today's $72.",
+          "detailedExplanation": "Goldman Sachs sees Brent around $71 in Q4 2026 and the mid-$60s in 2027; JPMorgan is around $60 and warns of the $30s in a glut. With Brent near $72, the consensus implies flat-to-down rather than upside. Analyst views lean bearish.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Bear case is better supported; bull case is geopolitical.",
+          "detailedExplanation": "The bull case is renewed Hormuz or Red Sea disruption, tighter Russia sanctions and OPEC+ discipline lifting Brent to $100+. The bear case — normalized flows, OPEC+ unwinding into weak demand, the 2027 supply wave and EV drag — has more institutional backing and points to the $50s-$60s. The skew is unfavorable.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Rich catalyst calendar, but base case leans bearish.",
+          "detailedExplanation": "Watch monthly OPEC+ meetings, Strait of Hormuz and Red Sea shipping, Russia sanctions, China stimulus, and the 2027 non-OPEC supply ramp. These make Brent highly tradable, but the base case — normalizing supply into soft demand — means most catalysts point toward lower prices rather than higher.",
+          "result": "Fail"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/copper.json
+++ b/insights-ui/src/commodity-data/reports/copper.json
@@ -1,0 +1,202 @@
+{
+  "slug": "copper",
+  "name": "Copper",
+  "commodityGroup": "Metals",
+  "priceSymbol": "HG=F",
+  "exchange": "COMEX",
+  "unit": "pound",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on copper: about $6.18/lb (~$13,600/tonne) in mid-2026, near record highs. The metal of electrification — grids, EVs and AI data centers — facing a looming structural shortage, but expensive today and tightly tied to the economic cycle. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Positive long-term, but expensive and cyclical today.\n\nCopper is the metal that wires the modern world. About three-quarters of it goes into anything that carries electricity — power grids, buildings, motors, electronics — and it is central to the big growth stories of the decade: electric vehicles (which use up to four times the copper of a gas car), renewable-energy grids, and the surge in AI data centers. Because copper rises and falls with the global economy, traders nickname it 'Dr. Copper,' treating its price as a read on world growth.\n\nIn early July 2026 copper trades around $6.18 a pound (about $13,600 a tonne), only ~7-8% below its all-time high. The long-term case is compelling: demand could nearly double by 2035 while new mines are scarce, slow and hugely expensive to build, pointing to a structural shortage that many forecasters say will require much higher prices. The near-term catch is that copper is already historically expensive, and as a cyclical metal it can fall hard in a recession or a China slowdown, moving down alongside the stock market rather than protecting against it. Best suited to investors who want long-horizon exposure to electrification and can ride out sharp, economy-driven swings.",
+  "keyFacts": {
+    "keyFacts": "Copper is the workhorse industrial metal. Roughly 75% of it is used to conduct electricity — in power lines, building wiring, motors, appliances and electronics — with construction the single largest end-market. Because it is used everywhere in the economy, copper's price tends to rise and fall with global growth, which is why markets treat 'Dr. Copper' as a barometer of the world economy.\n\nIn early July 2026 copper trades around $6.18 a pound, or about $13,600 a tonne, sitting only ~7-8% below its record high (it spiked in 2025 partly on US tariff speculation). For a beginner, the two big ideas are (1) copper is the essential metal of electrification — grids, electric cars and AI data centers all need enormous amounts of it, and demand could nearly double by 2035 — and (2) new supply is very hard to add, because big mines take a decade and billions of dollars to build. The tension is that this bullish long-term story is running into an already-high price and copper's habit of dropping sharply whenever the economy stumbles.",
+    "greenFlags": [
+      {
+        "flag": "The essential metal of electrification",
+        "explanation": "Grids, electric vehicles (which use up to 4x the copper of a gas car), renewables and AI data centers all need huge amounts of copper. Energy-transition demand could more than triple by the mid-2030s and total demand could nearly double by 2035, giving copper one of the strongest structural demand stories in commodities.",
+        "result": "Pass"
+      },
+      {
+        "flag": "New supply is scarce and expensive",
+        "explanation": "Big new copper mines take a decade and billions of dollars to build, ore grades are falling, and recent disruptions (the Grasberg mine flood, the shut Cobre Panamá mine) have tightened supply. The IEA warns of a ~30% supply gap by 2035, and analysts say prices may need to rise sharply just to justify new mines.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Historically expensive right now",
+        "explanation": "At ~$6.18/lb, copper is near its all-time high and in roughly the top few percent of its 5- and 10-year price range (it traded near $2.20 a decade ago). A lot of the bullish electrification story is already in the price, leaving a thin margin of safety for new buyers.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Moves with the economy, not against it",
+        "explanation": "Copper is pro-cyclical: it tends to fall alongside stocks in a recession or a China slowdown, and China alone is about half of global demand. It has crashed 50-65% in past downturns (2008, 2011-2016). It is a growth bet, not a safe-haven hedge.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Construction and building wiring", "Electrical grid and power", "Transport and electric vehicles", "Electronics, appliances and machinery"],
+    "topProducers": [
+      { "country": "Chile", "share": "~23%" },
+      { "country": "DR Congo", "share": "~14%" },
+      { "country": "Peru", "share": "~12%" },
+      { "country": "China", "share": "~8%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "CPER", "note": "Tracks copper futures" },
+      { "type": "Futures", "name": "HG=F", "note": "COMEX front-month contract (priced per pound)" },
+      { "type": "Equities", "name": "Copper miners (e.g. Freeport-McMoRan)", "note": "Leveraged, operational exposure to the price" },
+      { "type": "Miners ETF", "name": "COPX", "note": "Basket of copper-mining companies" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Copper has one of the strongest demand stories in commodities — electrification is set to nearly double demand by 2035 — while new mine supply is scarce, slow and disruption-prone. The balance is tightening toward a structural shortage.",
+      "overallAnalysisDetails": "Copper's demand story is exceptional. About 75% of copper conducts electricity, and the world is electrifying fast: power grids need roughly 2 million extra tonnes a year over the next decade, electric-vehicle copper demand is set to climb from ~1.7 to ~4.3 million tonnes a year by 2035, and AI data centers are an entirely new draw that could reach ~1 million tonnes a year by 2030. China, about half of global demand, has a weak property sector but is offsetting much of that with grid and manufacturing investment. In aggregate, total demand could nearly double by 2035.\n\nSupply, meanwhile, struggles to keep up. Mine production is around 23 million tonnes a year and growing only slowly (about 1-2%), held back by falling ore grades, permitting delays and big disruptions — a 2025 flood shut much of the giant Grasberg mine, and Cobre Panamá (~1.5% of world supply) has been closed since 2023. New mines take a decade and billions of dollars to build, so the pipeline is thin. The result is a market tipping from a small 2025 surplus into deficit in 2026, with forecasters like the IEA warning of a ~30% supply gap by 2035.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Mine supply grows only ~1-2% and is disruption-prone.",
+          "detailedExplanation": "Output is around 23 million tonnes a year but barely growing, held back by falling ore grades, permitting delays and accidents (the Grasberg flood, Cobre Panamá's closure). Chile (~23%), the DR Congo (~14%) and Peru (~12%) dominate. Supply that struggles to grow into surging demand is supportive for price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Tightening from a small 2025 surplus into a 2026 deficit.",
+          "detailedExplanation": "Major mine disruptions flipped the market from a modest surplus in 2025 toward a deficit in 2026, keeping inventories tight. With demand rising and supply growth slowing, the stock buffer is thin — a supportive backdrop for prices.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Electrification could nearly double demand by 2035.",
+          "detailedExplanation": "Grids, electric vehicles (up to 4x the copper of a gas car), renewables and AI data centers are all powerful, structural demand drivers. Energy-transition copper demand could more than triple by the mid-2030s. This is one of the strongest growth stories in the metals complex, so this factor clearly passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Thin new-mine pipeline; projects take a decade to build.",
+          "detailedExplanation": "There is little spare capacity and few big new mines coming online soon — greenfield projects take roughly a decade and billions of dollars, and grades keep falling. That limited supply response means a demand-driven rally is hard to cap, which supports prices.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Mild construction-season pattern, not a strong signal.",
+          "detailedExplanation": "Copper has a modest seasonal lift around spring construction activity, but it is weak and easily overwhelmed by the global growth cycle, China's stimulus decisions, and supply news. It is not a reliable seasonal edge for investors.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Copper is historically expensive today — near record highs and at the top of its multi-year range. The saving grace is that prices may need to rise even further to justify the new mines the world needs, so the long-term cost 'floor' sits above today's price even as the near-term entry looks stretched.",
+      "overallAnalysisDetails": "On most value measures, copper looks expensive right now. At ~$6.18 a pound it is near its all-time high and in roughly the top few percent of its five- and ten-year range — it traded near $2.20 a decade ago and ~$4.20-4.70 five years ago. In real, inflation-adjusted terms it is also close to record levels. Much of the bullish electrification narrative appears to be priced in, and copper's high price even makes switching to cheaper aluminum attractive in some wiring and grid uses (though most easy substitution is already done).\n\nThe important nuance is the cost of new supply. Analysts widely argue that copper prices need to rise substantially — some say toward $9 a pound or more — to make the marginal new mines the world needs economically viable. In other words, the 'incentive price' that unlocks fresh supply sits above today's price. That supports the long-term floor and the bull case, even though it does not make copper a cheap entry at current levels.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Near record highs — top of its 5- and 10-year range.",
+          "detailedExplanation": "At ~$6.18/lb, copper sits in roughly the top few percent of its multi-year range, far above the ~$2.20 of a decade ago. On this measure it is expensive, with limited room to rise on valuation alone, so the factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Near record levels in real terms too.",
+          "detailedExplanation": "Even after adjusting for inflation, copper is close to its highest levels ever, exceeding prior real peaks. On this long-run yardstick the price is stretched rather than cheap, so the factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "New mines need higher prices — the incentive price is above spot.",
+          "detailedExplanation": "Existing mines are profitable at today's price, but the 'incentive price' needed to justify building the new mines the world requires is widely put above ~$9/lb — well above the current ~$6.18. Because supply won't grow without higher prices, that acts as a long-term floor and supports the bull case, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "High price invites some aluminum substitution.",
+          "detailedExplanation": "Copper's elevated price makes switching to cheaper aluminum attractive in parts of grids and wiring. Most feasible substitution is already done and copper is technically superior, but the current premium does encourage some switching away, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "Only ~7-8% below its record.",
+          "detailedExplanation": "Copper trades just ~7-8% below its all-time high on a strong but fully-recognized electrification story. Buying so close to a record — on fundamentals that are already widely appreciated — carries poor-entry-timing risk, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Copper is a cyclical metal: more volatile than gold, prone to deep crashes in downturns, and it moves WITH the stock market rather than hedging it. Its supply risks (Chile, Peru, DR Congo, droughts) are real but spread across several countries rather than a single point of failure.",
+      "overallAnalysisDetails": "Copper carries the risks of a growth-sensitive industrial metal. Its volatility runs around 20-30% a year, above gold and above the stock market, and its drawdowns can be severe — it fell about 65% in the 2008 crisis and more than 50% during the 2011-2016 downturn, though it recovered each time. The defining risk is that copper is pro-cyclical: because it is tied to construction, manufacturing and especially China (about half of demand), it tends to fall alongside equities in a recession, exactly when a hedge would be useful. That makes it a bet on global growth, not a safe haven.\n\nThe supply-side risks are meaningful but, unlike the platinum-group metals, spread across several countries: Chile, Peru and the DR Congo dominate mining, so resource nationalism, higher royalties, permitting delays and Andean droughts (mining uses a lot of water) all matter — but no single country is an overwhelming point of failure. Copper also has a strong inverse link to the US dollar, so a firm dollar is a headwind.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "~20-30% a year — normal for a cyclical base metal.",
+          "detailedExplanation": "Copper's annualized volatility of roughly 20-30% is higher than gold's and above the stock market's, but it is normal and well-understood for a cyclical industrial metal. With sensible sizing it is manageable, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Deep crashes in downturns, but it recovers.",
+          "detailedExplanation": "Copper fell ~65% in 2008 and 50%+ over 2011-2016, and dropped 25%+ in 2022 — painful, cyclical declines. But it has recovered from each, so the drawdowns, while real, have been survivable, and this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Real but spread across several countries.",
+          "detailedExplanation": "Chile, Peru and the DR Congo dominate supply, bringing resource-nationalism, royalty, permitting and Andean-drought risks. But because production is spread across several nations rather than one, copper is not hostage to a single fragile source, so the exposure is understood and roughly symmetric — a pass.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Strong inverse link to the dollar is a headwind.",
+          "detailedExplanation": "Copper has a strong negative correlation to the US dollar (around -0.7 to -0.8), so a firm dollar and high real yields weigh on the price. With the dollar backdrop currently firm, this is a persistent headwind, so the factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Moves with stocks — not a diversifier.",
+          "detailedExplanation": "As 'Dr. Copper,' the metal is pro-cyclical and correlates with equities and global growth, so it tends to fall alongside stocks in a downturn rather than hedge them. It is a growth exposure, not portfolio insurance, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The long-term outlook is strong — a structural supply deficit widening toward 2035 and many bank targets pointing higher — but the near-term is clouded by a high starting price and China/recession risk. On balance the multi-year setup favors the investor.",
+      "overallAnalysisDetails": "Copper's forward story is one of the most compelling in commodities over a multi-year horizon. Supply is tightening from a small 2025 surplus into deficit in 2026, and longer-run forecasts see the gap widening sharply — the IEA projects a ~30% supply shortfall by 2035, and BloombergNEF a large structural deficit by 2050 as electrification demand triples. The scarcity of new mines is the backbone of the bull case.\n\nBank targets skew higher, especially further out: UBS sees $15,000 a tonne by early 2027, Goldman Sachs around $13,800 for 2027, and Traxys $15,000 within a few years — versus ~$13,600 today — though some near-term 2026 averages (Bank of America, J.P. Morgan) sit a bit below spot, reflecting cyclical risk. The bull case is the electrification supercycle meeting a thin supply pipeline; the bear case is a China property/industrial slowdown or global recession hitting demand, plus substitution and 'thrifting' (using less copper per application). Watch mine-disruption news (Grasberg and Cobre Panamá restarts), US copper tariff policy, China stimulus, the Fed and the dollar, and the pace of the AI data-center build-out.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "A structural deficit widening toward 2035.",
+          "detailedExplanation": "The market moves into deficit in 2026, and the shortfall is projected to widen dramatically as electrification demand outruns new supply — the IEA sees a ~30% gap by 2035. A tightening, deficit-bound forward balance is strongly supportive, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "ICSG and IEA point to tightening and shortfalls.",
+          "detailedExplanation": "The International Copper Study Group has the market flipping to deficit in 2026, and the IEA counts copper among the minerals where planned projects fall well short of 2035 demand. The authoritative view supports the structural-shortage thesis, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Longer-term bank targets point above spot.",
+          "detailedExplanation": "UBS ($15,000/t by early 2027), Goldman Sachs (~$13,800/t for 2027) and Traxys ($15,000/t within a few years) sit above today's ~$13,600, even though some near-term 2026 averages are slightly below spot. The multi-year consensus leans higher, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Long-term upside skew, near-term cyclical risk.",
+          "detailedExplanation": "Bull case: an electrification supercycle meeting a thin supply pipeline and a structural deficit. Bear case: a China slowdown or global recession hitting demand, plus substitution and thrifting. Over a multi-year horizon the scarcity-driven upside outweighs the cyclical downside, so the skew favors the investor and this factor passes — with near-term caution.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Mine disruptions, US tariffs, China stimulus, and AI build-out.",
+          "detailedExplanation": "The clearest catalysts are mine-disruption and restart news (Grasberg, Cobre Panamá), US copper tariff policy, China stimulus, the Fed and dollar direction, and the pace of the AI data-center build-out. These are watchable and, on balance, lean supportive over a multi-year horizon.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/feeder-cattle.json
+++ b/insights-ui/src/commodity-data/reports/feeder-cattle.json
@@ -1,0 +1,204 @@
+{
+  "slug": "feeder-cattle",
+  "name": "Feeder Cattle",
+  "commodityGroup": "Livestock",
+  "priceSymbol": "GF=F",
+  "exchange": "CME",
+  "unit": "pound",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on feeder cattle: about 360 cents/lb ($360/cwt) in mid-2026, near record highs on the tightest US calf supply since 1941. The young cattle that feedlots fatten — leveraged to corn prices and finished-cattle prices. Covers supply, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Tight supply, but the most expensive and most volatile part of the cattle complex.\n\nFeeder cattle are young cattle (roughly 500-850 lb) that ranchers sell to feedlots, where they are fattened on grain into finished 'live' cattle for slaughter. The futures (GF=F) settle against a cash index and are quoted in US cents per pound; the industry says dollars per hundredweight ('cwt' = 100 lb). In early July 2026 feeder cattle trade around 360 cents/lb (about $360/cwt, with the cash index near $371), only ~3-5% below the record ~$381/cwt set in October 2025 — and roughly 2 to 2.5 times their levels of five and ten years ago.\n\nFeeder prices are driven by three things: how many young cattle exist (right now, very few — the 2025 US calf crop was the smallest since 1941), the price of corn (cheap corn lets feedlots pay more, and corn is cheap today at ~$4.25/bushel), and the price of finished cattle (also at records). The same screwworm border closure that hit live cattle bites harder here, because it cut off the ~1.2 million young cattle the US imports from Mexico. The risk is that feeders are the most leveraged, most volatile link in the chain: they sit at all-time highs, feedlots lose money on some purchases, and a jump in corn prices would hit them hard. Attractive scarcity story, but an expensive and jumpy entry.",
+  "keyFacts": {
+    "keyFacts": "Feeder cattle are weaned young cattle that are not yet ready for slaughter. Feedlots buy them and fatten them for several months on grain (mostly corn) until they become finished 'live' cattle. So a feeder's value is really a bet on margins: what a feedlot can pay depends on the cost of corn to fatten the animal and the price it will fetch as finished cattle. The futures (GF=F) trade in cents per pound; 360 cents/lb equals $360 per hundredweight ('cwt' = 100 lb).\n\nIn early July 2026 feeder cattle are around 360 cents/lb, near October 2025's record of ~$381/cwt. Two forces have pushed them to records: the tightest supply of young cattle in generations (the 2025 US calf crop was the lowest since 1941, and the herd is at a 75-year low), and cheap corn (~$4.25/bushel), which lets feedlots afford to bid up. A third factor made it worse: a screwworm outbreak in Mexico closed the border to the ~1.2 million feeder cattle the US imports each year. For a beginner, the key point is that feeder cattle are more volatile than finished cattle, because they are leveraged to both feed costs and finished-cattle prices — a rise in corn would squeeze them quickly.",
+    "greenFlags": [
+      {
+        "flag": "Smallest US calf crop since 1941",
+        "explanation": "The 2025 US calf crop fell to about 32.9 million head — the lowest since 1941 — and the overall herd is at a 75-year low. Fewer calves means fewer feeder cattle, an extreme scarcity that has driven prices to records.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Cheap corn supports high feeder prices",
+        "explanation": "Corn — the feed used to fatten cattle — is comparatively cheap at ~$4.25/bushel, far below its 2022 peak near $8. Cheap feed lowers a feedlot's cost of gain, so it can afford to pay more for feeder cattle, directly supporting feeder prices.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Record prices near the limit of what feedlots can pay",
+        "explanation": "At ~$360/cwt, feeders sit ~3-5% below their October 2025 record and at the top of their history. Feedlots already lose money on some purchases at these prices, betting that finished-cattle prices keep rising to bail them out — a stretched, risky setup.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Highly leveraged to corn prices",
+        "explanation": "Because feeder value is a residual between feed cost and finished-cattle price, a spike in corn would raise the cost of fattening and crush feeder prices fast. Today's cheap corn is a key prop that could be knocked away by a poor US corn harvest.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Fattened in feedlots into finished (slaughter) cattle",
+      "Stocker/backgrounding operations (grazed before the feedlot)",
+      "Ultimately beef and byproducts"
+    ],
+    "topProducers": [
+      { "country": "United States", "share": "~94%" },
+      { "country": "Mexico", "share": "~5%" },
+      { "country": "Canada", "share": "~1%" }
+    ],
+    "waysToInvest": [
+      { "type": "Futures", "name": "GF=F", "note": "CME feeder cattle contract, cash-settled to the CME Feeder Cattle Index; the main direct exposure" },
+      { "type": "Options", "name": "Options on GF=F", "note": "Used by ranchers/feedlots to hedge; no major pure feeder-cattle ETF exists" },
+      { "type": "Equities", "name": "Cattle / beef companies", "note": "Indirect exposure to the broader cattle cycle" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Feeder supply is the tightest in generations — the smallest calf crop since 1941, heifers being held back to rebuild the herd, and Mexican imports cut off by screwworm. Feedlot demand is strong thanks to cheap corn and record finished-cattle prices.",
+      "overallAnalysisDetails": "The supply of feeder cattle is extraordinarily tight. The 2025 US calf crop was the smallest since 1941, following years of drought-driven herd liquidation that left the overall herd at a 75-year low. There is a further twist: as ranchers begin, tentatively, to hold back young female cattle (heifers) to rebuild the herd, those heifers are pulled out of the feeder pipeline — so the early stage of a herd rebuild actually makes feeder supply even tighter before it gets looser. The screwworm border closure compounds it by cutting off the ~1.2 million young cattle the US imports from Mexico each year (about 5% of feedlot placements).\n\nDemand from feedlots has stayed strong because the economics still work: finished-cattle prices are at records, and corn (the main cost of fattening) is cheap, so feedlots can afford to bid aggressively for the few feeders available. Good grazing conditions in parts of the Plains have added stocker demand. The result is a market where very tight supply meets willing buyers — a recipe for the record prices seen.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Smallest US calf crop since 1941.",
+          "detailedExplanation": "The supply of new feeder cattle depends on the calf crop, which fell to its lowest since 1941 in 2025 as the herd hit a 75-year low. Sharply falling production into strong feedlot demand is very supportive for price, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Heifer retention and closed border shrink availability.",
+          "detailedExplanation": "Available feeder supply is squeezed on two fronts: ranchers keeping heifers back to breed (pulling them out of the feeder pool) and the screwworm border closure cutting off Mexican imports. With placements down, the pool of feeders is thin, which supports prices — a pass.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Feedlots bid strongly on cheap corn and record fed prices.",
+          "detailedExplanation": "Feedlot demand is driven by the profitability of fattening cattle. With finished-cattle prices at records and corn cheap, feedlots can afford to pay up for feeders, keeping demand strong. That supports the market, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Supply gets tighter before it loosens.",
+          "detailedExplanation": "There is no quick new supply: heifers retained now won't produce feeder cattle until roughly 2028-2029, and the border remains closed to Mexican cattle. If anything, the start of a herd rebuild tightens near-term feeder supply, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Fall 'run' of calves is a mild seasonal pattern.",
+          "detailedExplanation": "Feeder markets see a seasonal autumn 'run' when spring-born calves are weaned and sold, which can pressure prices, but the effect is modest against the overwhelming supply shortage and feed dynamics. It is not a reliable edge right now.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Feeder cattle are the most expensive part of the cattle complex — at all-time records, roughly 2 to 2.5 times their levels of a decade ago, and priced so high that feedlots lose money on some purchases. There is little value cushion at these levels.",
+      "overallAnalysisDetails": "By almost every value measure, feeder cattle are stretched. At ~$360/cwt they are near October 2025's record and roughly 2 to 2.5 times their five- and ten-year levels, exceeding even the prior-cycle peak of ~$241/cwt in real terms. The clearest warning sign is feedlot economics: at these prices, feedlots lose money on a meaningful share of the feeders they buy, effectively betting that record finished-cattle prices will climb even higher to cover the cost. When buyers are already underwater on the input, the price is testing the ceiling of what the chain can bear.\n\nRelative to finished cattle, feeders trade at an unusually wide premium (about $360/cwt versus ~$250/cwt for fed cattle), another sign the young-cattle price is stretched. The one genuine support is cheap corn, which keeps the cost of gain low and lets feedlots justify high feeder bids — but that support is exactly what a poor corn harvest could remove.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "At all-time records — top of its range.",
+          "detailedExplanation": "At ~$360/cwt, feeder cattle are near their October 2025 record and at the very top of their historical range, well above prior cycle peaks. On this measure they are as expensive as they have ever been, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Record even after adjusting for inflation.",
+          "detailedExplanation": "Feeder prices exceed the prior-cycle peak (~$241/cwt in 2014-15) even in real, inflation-adjusted terms — genuine record territory. A price this stretched versus history offers no value cushion, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Priced above feedlot breakeven on many purchases.",
+          "detailedExplanation": "Rather than sitting near a protective cost floor, feeders are priced so high that feedlots lose money on a meaningful share of buys, betting fed-cattle prices rise further. Because the price is above sustainable feedlot economics, downside is not well protected, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Very wide premium over finished cattle.",
+          "detailedExplanation": "Feeders trade at an unusually large premium to the finished (live) cattle they become — about $360/cwt versus ~$250/cwt. That stretched relationship signals the young-cattle price is rich relative to the end product, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "Only ~3-5% below the October 2025 record.",
+          "detailedExplanation": "Feeder cattle sit just ~3-5% below their all-time high on fundamentals that are fully recognized. Buying essentially at the record carries high poor-entry-timing risk, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Feeder cattle are more volatile than finished cattle because they are leveraged to both feed costs and finished-cattle prices, and they have suffered sharp limit-down moves. Deep past drawdowns recovered, but the disease, drought and corn-price risks are all live.",
+      "overallAnalysisDetails": "Feeder cattle are the jumpiest link in the cattle chain. Their price is a residual — what's left after subtracting the cost of feed from the expected finished-cattle price — so small changes in corn prices or fed-cattle prices swing feeders more than either. That leverage showed up in late 2025, when a trade-policy surprise triggered multiple limit-down sessions. Their worst historical drawdown, the 2015-2016 collapse, exceeded 50%, deeper than finished cattle, though it eventually recovered.\n\nThe risk list is the full livestock set plus an extra: alongside screwworm, H5N1 bird flu and drought (which stress pastures and the herd), feeders carry direct corn-crop-weather risk — a drought-driven corn spike would raise the cost of gain and hit feeder prices hard. As with cattle generally, the US dollar is a secondary factor and the correlation to stocks is low, so feeders can diversify a portfolio even as they carry these commodity-specific hazards.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "More volatile than finished cattle; prone to limit moves.",
+          "detailedExplanation": "Because feeders are leveraged to both feed costs and fed-cattle prices, they swing more than live cattle and have hit multiple limit-down sessions recently. That elevated, margin-driven volatility — especially at record prices — earns a fail on a risk-adjusted basis.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Fell 50%+ in 2015-16, but recovered.",
+          "detailedExplanation": "Feeder cattle dropped more than 50% in the 2015-2016 downturn — deeper than finished cattle — and fell hard in 2020, but recovered from both. The drawdowns are severe yet survivable, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Disease, drought, and corn-crop weather all bite.",
+          "detailedExplanation": "Feeders face the livestock disease risks (screwworm, H5N1, foot-and-mouth tail risk) plus drought that stresses pastures and, uniquely, corn-crop weather — a bad corn year would spike feed costs and hit feeder prices. This broad, hard-to-predict risk set fails the factor.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "A domestic market; the dollar is secondary.",
+          "detailedExplanation": "Feeder prices are set by domestic supply, corn and fed-cattle prices, not the dollar, which matters only indirectly through the broader beef trade. The dollar is not a binding headwind, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Low stock correlation; a real-asset play.",
+          "detailedExplanation": "Feeder cattle move with agricultural fundamentals rather than the stock market, giving low equity correlation and some inflation-hedge character as a food commodity. The diversification value is genuine, so this factor passes.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "Supply stays exceptionally tight into 2028, and USDA sees record average prices — but with feeders already at all-time highs, feedlots stretched, and corn-spike risk overhead, the risk/reward from here is not clearly favorable.",
+      "overallAnalysisDetails": "The supply squeeze has a long runway. Heifers retained now won't calve until 2027, and their calves won't reach feeder weight until 2028-2029, so feeder supply gets tighter before it loosens. USDA projects 750-800 lb feeder steers averaging ~$364/cwt in 2026, up about 13% year over year and a fresh record, and Rabobank and CattleFax see new highs in 2026 and 2027.\n\nThe catch is the entry point. The bull case — record-tight supply, closed Mexican border, cheap corn, record fed-cattle prices — is already reflected in all-time-high prices. The bear case is potent: any rise in corn prices would squeeze feeder economics fast, feedlots are already losing money on some purchases, an eventual herd rebuild will loosen supply from 2028, and consumer beef-demand fatigue is a risk. Watch USDA Cattle on Feed placements, the corn crop and WASDE, the screwworm/Mexican border situation, and the January heifer-retention data.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Tighter before looser — squeeze runs into 2028.",
+          "detailedExplanation": "Because retained heifers won't produce feeder cattle until 2028-2029, the supply shortage intensifies near term before easing. A forward balance this tight is supportive for price, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "USDA projects record ~$364/cwt for 2026.",
+          "detailedExplanation": "USDA forecasts feeder steers averaging ~$364/cwt in 2026 (+13% year over year), a record, and Rabobank/CattleFax see new highs in 2026-2027. The official view is constructive, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Forecasts at or above current record levels.",
+          "detailedExplanation": "USDA's ~$364/cwt 2026 average is around current futures, and CattleFax/Rabobank see further highs — so the consensus points to at least holding, and likely exceeding, today's levels. That earns a pass, albeit with limited upside from a record.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Record prices plus corn-spike risk cap the reward.",
+          "detailedExplanation": "The tight-supply bull case is well known and fully priced at all-time highs. Against it, a corn-price spike, stretched feedlot margins, and an eventual herd rebuild are real downside risks. At record prices the payoff is not clearly skewed up, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Placements, corn/WASDE, screwworm, heifer retention.",
+          "detailedExplanation": "The clearest catalysts are USDA Cattle on Feed placements, corn prices and the WASDE, the screwworm/Mexican border situation, and heifer-retention data. These are watchable and near-term lean supportive, so this factor passes.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/gasoline-rbob.json
+++ b/insights-ui/src/commodity-data/reports/gasoline-rbob.json
@@ -1,0 +1,210 @@
+{
+  "slug": "gasoline-rbob",
+  "name": "RBOB Gasoline",
+  "commodityGroup": "Energy",
+  "priceSymbol": "RB=F",
+  "exchange": "NYMEX",
+  "unit": "gallon",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on RBOB gasoline: near $2.95 a gallon wholesale in mid-2026, supported by refinery closures and tight inventories but facing a long-term EV demand decline. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Mixed. A decent tactical trade, not a long-term hold.\n\nRBOB is wholesale gasoline before ethanol is blended in — a refined product, so buying it is essentially a bet on crude oil price plus the refining margin (the 'crack spread') plus US summer driving demand. In early July 2026 it trades near $2.95 a gallon wholesale (the AAA pump price of ~$3.84 adds ethanol, taxes and retail margin), about 30% below its June 2022 record of $4.33.\n\nThe near-term picture is supportive. US refining capacity is shrinking — LyondellBasell's Houston refinery closed in 2025 and Phillips 66's Los Angeles plant closed in late 2025, removing ~400,000 barrels a day — while inventories sit about 7% below their five-year average and refining margins have been elevated. Strong summer seasonality helps too. But gasoline carries a structural problem crude does not: US demand already peaked in 2018 and is slowly declining as EVs (now over 10% of new sales), efficiency and remote work eat into it. The EIA officially forecasts lower gasoline prices in 2026, and volatility is high with a history of near-total collapses (2008, 2020). Best treated as a cyclical or crack-spread trade — often expressed through refiner equities — rather than a buy-and-hold, because it faces a permanent demand-destruction overhang.",
+  "keyFacts": {
+    "keyFacts": "RBOB stands for 'Reformulated Blendstock for Oxygenate Blending' — it is wholesale gasoline before ethanol is blended in. It is priced per gallon in US dollars, with the NYMEX front-month future (RB=F) as the benchmark. In early July 2026 that wholesale price is about $2.95 a gallon. Note this is not the pump price: the AAA national average of about $3.84 adds ethanol, federal and state taxes (~$0.50-0.60), distribution and retailer margin.\n\nFor a beginner, the key is that RBOB is a refined product, one step downstream of crude oil. Its price is really crude oil plus the 'crack spread' — the profit margin refiners earn turning crude into gasoline. So RBOB moves with crude, but it also swings on refining margins and on US driving demand, which peaks in summer. It carries one extra long-term risk that crude does not: gasoline demand is being slowly eroded by electric vehicles and fuel efficiency. In 2026 the market was distorted by a Strait of Hormuz crisis that spiked crude and refining margins in the spring before normalizing.",
+    "greenFlags": [
+      {
+        "flag": "US refining capacity is shrinking",
+        "explanation": "The US lost about 400,000 barrels a day of refining capacity as LyondellBasell's Houston plant closed in 2025 and Phillips 66's Los Angeles refinery closed in late 2025, with no major new US refineries being built. Tighter refining supports gasoline prices and refining margins even as demand slowly falls.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Tight inventories and elevated crack spreads",
+        "explanation": "US gasoline inventories sit about 7% below their five-year average — tight for the season — and the 3-2-1 crack spread (the refining margin) spiked to multi-decade highs in spring 2026 and remains healthy. Both support the wholesale price and reward refiner exposure.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Strong, tradable summer seasonality",
+        "explanation": "Gasoline is one of the most seasonal commodities: the spring switch to summer-grade fuel and the Memorial Day-to-Labor Day driving season reliably lift prices, while the autumn switch to cheaper winter-grade pressures them. This pattern is exploitable with good timing.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "US gasoline demand has already peaked and is declining",
+        "explanation": "US gasoline demand peaked at about 9.3 million barrels a day in 2018 and has drifted to ~9.0 million despite population growth, as EVs (over 10% of new sales), efficiency and remote work erode it. This is a permanent, structural headwind that crude oil does not face to the same degree.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Official forecasts point to lower prices, with brutal crash history",
+        "explanation": "The EIA expects retail gasoline to fall about 6% in 2026 as crude drops to its lowest annual average since 2020. Gasoline is also volatile (~35-45% a year) with a history of near-total collapses — over 80% in 2008 and a plunge to well under $1 a gallon in the 2020 COVID demand shock.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Transportation fuel for light-duty vehicles"],
+    "topProducers": [
+      { "country": "United States", "share": "Largest refiner (~18.2 mb/d capacity)" },
+      { "country": "China", "share": "Major refiner" },
+      { "country": "India", "share": "Major refiner/exporter" },
+      { "country": "Note", "share": "'Producers' here means refiners, not oil fields" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "UGA", "note": "United States Gasoline Fund; tracks RBOB futures — watch roll/contango cost" },
+      { "type": "Futures", "name": "RB=F", "note": "NYMEX RBOB (42,000 gal); leveraged, advanced traders only" },
+      {
+        "type": "Equities",
+        "name": "Refiners (VLO, MPC, PSX)",
+        "note": "The crack-spread play; profit from refining margins, pay dividends, carry equity risk"
+      }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "The supply side is genuinely tight — shrinking US refining capacity, high utilization, and inventories ~7% below the five-year average — and summer seasonality helps. The one clear negative is demand: US gasoline use peaked in 2018 and is slowly declining. On balance, supportive near-term.",
+      "overallAnalysisDetails": "The supply picture is the bullish part of gasoline. US refining capacity is shrinking — down about 1% in 2025 to 18.2 million barrels a day, with LyondellBasell's Houston plant (~264,000 barrels a day) closing in 2025 and Phillips 66's Los Angeles refinery (~139,000) closing in late 2025 — and no major new US refineries are being built. Refineries are running hard (utilization around 90-92%, above seasonal norms), and gasoline inventories sit about 7% below their five-year average, which is tight for the season. Add strong summer seasonality and the near-term supply-demand setup is genuinely supportive.\n\nThe exception, and it is an important one, is demand. US gasoline demand peaked at about 9.3 million barrels a day in 2018 and has drifted to roughly 9.0 million even as population grew, because EVs (over 10% of new sales), better fuel efficiency and remote work steadily erode it. So while the current balance is tight, the long-run demand trend is down — a structural headwind that separates gasoline from crude oil.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Shrinking US refining capacity tightens supply.",
+          "detailedExplanation": "US refining capacity fell about 1% in 2025 to 18.2 million barrels a day, with the Houston and Los Angeles refinery closures removing ~400,000 barrels a day and no major new US plants being built. Refineries run at 90-92% utilization. Shrinking, high-run capacity is supportive for gasoline prices and refining margins.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Inventories about 7% below the five-year average.",
+          "detailedExplanation": "US gasoline inventories sit roughly 7% below their five-year average, which is tight for the season. Low stocks mean less cushion against a refinery outage or a demand spike, which supports the price and leaves the market prone to bullish squeezes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "US demand peaked in 2018 and is slowly declining.",
+          "detailedExplanation": "US gasoline demand peaked at about 9.3 million barrels a day in 2018 and has drifted to ~9.0 million despite population growth, as EVs (over 10% of new sales), efficiency and remote work erode it. A commodity whose core demand has already peaked and is structurally declining has a weak long-run base — the clearest negative in the gasoline story.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Tight spare capacity after refinery closures.",
+          "detailedExplanation": "With US refineries closing and none being built, domestic spare refining capacity is tight, and the gap is filled by imports and elevated run rates. Limited slack means a refinery outage can quickly tighten the market, which is supportive for prices and margins.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Strong, tradable summer-driving seasonality.",
+          "detailedExplanation": "Gasoline is highly seasonal: the spring switch to more expensive summer-grade fuel plus the peak Memorial Day-to-Labor Day driving season lift prices, while the autumn switch to cheaper winter-grade pressures them. This reliable pattern is a genuine, exploitable feature with the right timing.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "On value gasoline looks reasonable: near $2.95 it is in the upper-middle of its range, below its inflation-adjusted high, supported by a crude-plus-margin cost floor, with elevated crack spreads rewarding refiner exposure, and about 30% below its 2022 record. Value is broadly supportive.",
+      "overallAnalysisDetails": "Judged on price, RBOB is not expensive. At about $2.95 a gallon it sits in the upper-middle of its 52-week range ($1.68-$3.76) and is well below its 2022 record of $4.33 — which, adjusted for inflation, is even higher. So the price is elevated versus last year but not at an extreme.\n\nBecause RBOB is a refined product, its value floor is crude cost plus the refining margin. With WTI near $68 (about $1.63 a gallon of crude) plus a healthy crack spread, $2.95 implies a solid but off-peak margin, and crude sets the floor. The crack spread itself — the refining margin — spiked to multi-decade highs (~$56 a barrel on a 3-2-1 basis) during the spring 2026 Hormuz crisis and remains elevated, which is the core reason to own gasoline or refiners now. At about 30% below its all-time high, there is headroom. The value pillar is supportive, though it rides on crude, which forecasters expect to ease.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Upper-middle of its 52-week range.",
+          "detailedExplanation": "At about $2.95, RBOB sits in the upper-middle of its 52-week range ($1.68-$3.76) — elevated versus a year ago (up ~37%) but not at an extreme. There is room in the range without the price being stretched to a ceiling.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Below its inflation-adjusted all-time high.",
+          "detailedExplanation": "The 2022 record of $4.33 a gallon is even higher in today's dollars, so at about $2.95 RBOB is well below its real all-time high. Long-run real gasoline prices are not at extremes, so buyers are not paying an inflated real price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Crude-plus-margin floor sits near current levels.",
+          "detailedExplanation": "RBOB is priced as crude cost plus refining margin. With WTI near $68 (~$1.63 a gallon) plus a crack spread, the ~$2.95 price implies a healthy but off-peak margin, and crude provides the floor. If crude holds, the cost floor cushions the downside; if crude falls, gasoline follows.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Elevated crack spread rewards refiner exposure.",
+          "detailedExplanation": "The key relative-value measure for a refined product is the crack spread — the margin over crude. It spiked to multi-decade highs (~$56 a barrel on a 3-2-1 basis) during the spring 2026 Hormuz crisis and remains elevated. A wide crack rewards owning gasoline (or refiners) versus crude, a mild positive on relative value.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 30% below the 2022 record of $4.33.",
+          "detailedExplanation": "RBOB near $2.95 is about 30% below its all-time high of $4.33 a gallon (June 2022), leaving headroom rather than record-high risk. For a cyclical, crude-linked product this is normal, but it means the price is not near a valuation ceiling.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Gasoline is high-risk: ~35-45% annual volatility (crude plus refining-margin swings), a history of near-total collapses (2008, 2020), and heavy hurricane exposure to Gulf Coast refineries, plus dollar sensitivity. The one plus is that it is a real inflation and pro-cyclical hedge. Four of five factors fail.",
+      "overallAnalysisDetails": "RBOB is a volatile, event-driven product. Its annualized volatility runs about 35-45% — often more than crude itself, because it swings on both crude prices and independent refining-margin moves. Its drawdown history is severe: over 80% in the 2008 financial crisis, and a plunge to well under $1 a gallon in the 2020 COVID demand collapse.\n\nThe standout risk is weather: Gulf Coast hurricanes (like Harvey in 2017) can knock out a big chunk of US refining and spike RBOB overnight, and refinery fires and outages do the same. Crude geopolitics feed straight through, as the 2026 Hormuz crisis showed. RBOB is priced off crude in dollars, so a strong dollar is a modest headwind. The redeeming feature is that gasoline is a core consumer and inflation item and is pro-cyclical — strong in expansions — so it offers a genuine inflation hedge, which earns the one Pass here. But overall this is a commodity that can move violently, and the retail futures are not beginner-friendly.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "High, ~35-45% a year — often more than crude.",
+          "detailedExplanation": "RBOB's annualized volatility runs about 35-45%, frequently exceeding crude's because it swings on both crude prices and independent refining-margin (crack-spread) moves. That makes it a fast-moving, risky instrument for anyone not actively watching it.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Near-total collapses in 2008 and 2020.",
+          "detailedExplanation": "Gasoline fell over 80% in the 2008 financial crisis and crashed to well under $1 a gallon in the 2020 COVID demand collapse. These deep, fast drawdowns show how brutally the price can fall in a recession or demand shock — a serious downside risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Heavy hurricane exposure to Gulf Coast refineries.",
+          "detailedExplanation": "Gasoline supply is concentrated in Gulf Coast refineries, so hurricanes (like Harvey in 2017), refinery fires and outages can spike RBOB overnight, and crude geopolitics (the 2026 Hormuz crisis) feed straight through. This can push the price up, but it is a source of shock and instability, so it counts as a risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Crude-linked and priced in dollars.",
+          "detailedExplanation": "RBOB is priced off crude oil in US dollars, so a stronger dollar is a modest headwind (it softens crude and global fuel demand). It is not the primary driver, but the standard inverse dollar link adds a background risk rather than a support.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "A genuine inflation and pro-cyclical hedge.",
+          "detailedExplanation": "Gasoline is a core consumer and inflation item (it shows up directly in CPI and consumer sentiment) and is pro-cyclical — demand is strong in economic expansions. For an investor worried about fuel-price inflation, RBOB exposure is one of the more direct hedges, the clearest positive in its risk profile, though it also means gasoline falls in recessions.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The near-term balance is supportive (tight refining), but the forward view is capped: the EIA expects gasoline prices to fall in 2026 as crude eases, targets are muted, and the long-term outlook is dominated by a structural EV-driven demand decline. Only the near-term tight-refining balance passes.",
+      "overallAnalysisDetails": "The forward setup is a tension between a tight refining market and a shrinking demand base. On the supportive side, refinery closures and tight inventories could keep refining margins (crack spreads) elevated even as gasoline volumes slowly fall — a genuine near-term prop. That is the one clear positive in the outlook.\n\nBut most forward signals are soft. The EIA expects retail gasoline to fall about 6% in 2026 (roughly $0.20 a gallon) as crude drops to its lowest annual average since 2020, with a wholesale forecast near $2.98 in 2026 easing to ~$2.61 in 2027. Analyst attention is really on refiner equities (Valero, Marathon, Phillips 66) as a crack-spread play rather than on gasoline itself rising. And the dominant long-term force is structural: EVs, efficiency and remote work are permanently eroding gasoline demand, which caps the multi-year upside. The net is a commodity that can work tactically on tight refining, but faces a lower ceiling than crude because of the EV overhang.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Tight refining can support margins near-term.",
+          "detailedExplanation": "Refinery closures and tight inventories could keep refining margins elevated even as gasoline volumes slowly decline, so the near-term supply-demand balance is genuinely supportive for the wholesale price and for refiners. This tight-refining dynamic is the one clear positive in the forward outlook.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "EIA expects gasoline prices to fall in 2026.",
+          "detailedExplanation": "The EIA expects retail gasoline to fall about 6% in 2026 (roughly $0.20 a gallon) as crude drops to its lowest annual average since 2020, with wholesale easing from ~$2.98 (2026) to ~$2.61 (2027). An official forecast for lower prices is a headwind for a long position.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Focus is on refiner equities, not gasoline rising.",
+          "detailedExplanation": "Analyst attention centers on refiners (Valero, Marathon, Phillips 66) as a crack-spread play — capturing refining margins — rather than on the gasoline price itself climbing. That reflects a view that the opportunity is in margins, not in higher outright prices, so the outright price outlook is muted.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Bull case is tight refining; bear case is structural decline.",
+          "detailedExplanation": "The bull case is refinery closures and tight inventories keeping cracks elevated, with hurricanes spiking prices. The bear case — structural demand decline from EVs and efficiency, plus gasoline following crude lower into a supply glut — is a permanent overhang crude does not share to the same degree. The balance is roughly even-to-negative over a multi-year view.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "EV adoption is a structural headwind over time.",
+          "detailedExplanation": "Near-term catalysts (driving season, hurricanes, refinery outages, crude and OPEC+) can move the price both ways, but the dominant multi-year catalyst is EV adoption and efficiency steadily eroding gasoline demand. That structural headwind caps the long-run upside, so the catalyst mix leans unfavorable for a buy-and-hold.",
+          "result": "Fail"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/gold.json
+++ b/insights-ui/src/commodity-data/reports/gold.json
@@ -6,46 +6,46 @@
   "exchange": "COMEX",
   "unit": "troy ounce",
   "currency": "USD",
-  "metaDescription": "A plain-English investor read on gold — what drives its price, its supply and demand balance, valuation, volatility and risk, and the forward outlook.",
-  "updatedAt": "2026-07-06",
-  "summary": "Overall stance: Positive.\n\nGold remains the deepest, most liquid safe-haven asset, backed by steady central-bank buying and resilient jewelry and investment demand. Supply is slow-moving, so price is set mostly by demand and by real interest rates. Valuation looks full versus its long-term real-price range, which tempers the upside. Volatility is moderate for a commodity, and gold's low correlation to equities makes it a useful portfolio diversifier. The forward outlook is constructive but hinges on the path of real rates and the US dollar. Best suited to investors who want a long-horizon hedge rather than a short-term trade.",
+  "metaDescription": "A plain-English investor read on gold: near $4,180/oz in mid-2026 after a record $5,602 high in January, with strong central-bank and ETF demand but a full valuation. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Positive, with a valuation caveat.\n\nGold is the world's deepest, most trusted safe-haven asset. In early July 2026 it trades near $4,180 per ounce, about 25% below the record ~$5,602 it hit on 28 January 2026, but still up roughly a quarter over the past year. Demand is strong and broad: central banks bought 863 tonnes in 2025 and gold ETFs grew by 801 tonnes to a record 4,025 tonnes. Mine supply barely grows (about +1% a year), so the price is set mostly by investment demand and by real interest rates, not by production.\n\nThe main caution is price. Even after the pullback, gold trades near the top of its 10-year range and at roughly 2.5x the industry's ~$1,600/oz mining cost, so the margin of safety for new buyers is thin. Volatility (about 15% a year) is similar to the S&P 500, and gold's low link to stocks makes it a genuine diversifier. Major banks' late-2026 targets ($4,900 at Goldman Sachs, ~$6,000 at JPMorgan) sit above today's price. Best suited to investors who want a long-horizon hedge, not a quick trade.",
   "keyFacts": {
-    "keyFacts": "Gold is a precious metal held primarily as a store of value rather than for industrial consumption. It trades globally around the clock, with the COMEX front-month future (GC=F) and the London spot market setting the reference price per troy ounce in US dollars.\n\nFor a retail investor, the two things that matter most are real interest rates and the US dollar: gold tends to rise when real yields fall and the dollar weakens, and to struggle when the opposite holds. Because mine supply grows only slowly, swings in investment and central-bank demand — not production — drive most of the price action.",
+    "keyFacts": "Gold is a precious metal held mainly as a store of value rather than used up in industry. It trades globally around the clock, with the COMEX front-month future (GC=F) and the London spot market setting the reference price per troy ounce in US dollars. In early July 2026 that price is about $4,180, down from a record ~$5,602 reached on 28 January 2026 during a year that saw 53 all-time highs.\n\nFor a beginner, two forces matter most: real interest rates (the interest rate after inflation) and the US dollar. Gold tends to rise when real yields fall and the dollar weakens, and to struggle when the opposite happens. Right now real 10-year yields are high (about 2.25%), which would normally be a headwind, yet gold has stayed strong because central banks and investors keep buying. Because mine supply grows only about 1% a year, swings in investment and central-bank demand — not production — drive most of the price action.",
     "greenFlags": [
       {
-        "flag": "Sustained central-bank accumulation",
-        "explanation": "Central banks have been net buyers of gold for over a decade, adding a durable, price-insensitive source of demand that supports the market. This buying tends to persist regardless of short-term price moves.",
+        "flag": "Steady central-bank buying",
+        "explanation": "Central banks bought a net 863 tonnes of gold in 2025. That is down from the record 1,136 tonnes in 2022, but still far above the 2010-2021 average of about 473 tonnes a year. Poland alone added 102 tonnes. This is durable, price-insensitive demand that supports the market.",
         "result": "Pass"
       },
       {
-        "flag": "Deep liquidity and safe-haven status",
-        "explanation": "Gold is one of the most liquid assets in the world and is the reference safe-haven during market stress. That liquidity lowers the cost of getting in and out and makes it a reliable hedge.",
+        "flag": "Record investor demand and deep liquidity",
+        "explanation": "Global gold ETFs grew by 801 tonnes in 2025 to an all-time high of 4,025 tonnes, pulling in a record $89 billion. Gold is also one of the most liquid assets on earth, so it is cheap to buy and sell and reliable as a hedge during market stress.",
         "result": "Pass"
       },
       {
-        "flag": "Low correlation to equities",
-        "explanation": "Gold has historically shown low-to-negative correlation with stocks, so it can cushion a portfolio during equity drawdowns. This diversification benefit is a core reason investors hold it.",
+        "flag": "Low correlation to stocks",
+        "explanation": "Gold has historically shown low-to-negative correlation with equities, so it can cushion a portfolio when stocks fall. This diversification benefit is a core reason investors hold it.",
         "result": "Pass"
       }
     ],
     "redFlags": [
       {
-        "flag": "No yield or cash flow",
-        "explanation": "Gold pays no dividend or interest, so its entire return depends on price appreciation. When real rates are high, the opportunity cost of holding it rises.",
+        "flag": "No yield, and cash pays a lot right now",
+        "explanation": "Gold pays no dividend or interest, so its whole return depends on the price going up. With real 10-year yields near 2.25%, the opportunity cost of holding a zero-yield asset instead of bonds is high.",
         "result": "Fail"
       },
       {
-        "flag": "Full valuation versus real-price history",
-        "explanation": "In inflation-adjusted terms gold sits in the upper part of its multi-decade range, which limits the margin of safety for new buyers. A mean-reversion move would pressure returns.",
+        "flag": "Expensive versus history and mining cost",
+        "explanation": "At about $4,180, gold trades near the top of its 10-year range and at roughly 2.5x the industry's ~$1,600/oz all-in cost to mine it. That leaves a thin margin of safety and limited downside protection from the cost floor.",
         "result": "Fail"
       }
     ],
     "mainUses": ["Investment and store of value", "Central-bank reserves", "Jewelry", "Electronics and industrial (minor)"],
     "topProducers": [
       { "country": "China", "share": "~10%" },
-      { "country": "Australia", "share": "~9%" },
       { "country": "Russia", "share": "~9%" },
-      { "country": "United States", "share": "~5%" }
+      { "country": "Australia", "share": "~8%" },
+      { "country": "Canada", "share": "~5%" }
     ],
     "waysToInvest": [
       { "type": "ETF", "name": "GLD / IAU", "note": "Physically-backed spot gold ETFs" },
@@ -57,148 +57,148 @@
   "categories": [
     {
       "categoryKey": "SupplyAndDemand",
-      "summary": "Gold's supply is slow-moving and its demand is broad and resilient, anchored by central banks, jewelry and investment. The balance currently favors demand, which is supportive of price.",
-      "overallAnalysisDetails": "Mine production grows only about 1-2% per year and is geographically diversified, so supply is inelastic to price in the short run. Above-ground stocks are enormous relative to annual flow, meaning gold rarely faces the kind of physical shortages that move industrial commodities.\n\nOn the demand side, central-bank buying has been the standout driver, adding a large, price-insensitive bid. Jewelry demand (led by India and China) is seasonal but steady, and investment demand via ETFs and bars ebbs and flows with macro sentiment. With central banks accumulating and mine supply flat, the net balance leans supportive.",
+      "summary": "Supply barely grows — mine output rose just 1% to a record 3,672 tonnes in 2025 — while total demand topped 5,000 tonnes, led by central banks and ETFs. That imbalance is supportive for the price.",
+      "overallAnalysisDetails": "New gold comes out of the ground slowly. Mine production rose only about 1% in 2025 to a record 3,672 tonnes, and it takes a decade or more to bring a new mine online, so supply cannot respond quickly to higher prices. There is a huge amount of gold already above ground — roughly 216,000 tonnes ever mined — but about 45% of it is jewelry and 22% is bars and coins, and most sits with central banks and long-term holders who rarely sell. So the 'available' float is far smaller than the headline number suggests.\n\nDemand, by contrast, is broad and strong. Central banks bought 863 tonnes in 2025, gold ETFs added 801 tonnes (a record $89 billion of inflows), and consumers in China (~910 tonnes) and India (~780 tonnes) bought jewelry, bars and coins. Total 2025 demand set a record above 5,000 tonnes. With flat supply meeting record, diversified demand, the balance leans supportive.",
       "factors": [
         {
           "factorKey": "production_output_trend",
-          "oneLineExplanation": "Mine output grows slowly (~1-2%/yr) and is diversified.",
-          "detailedExplanation": "Global mine production has plateaued, with new discoveries and grades declining. This slow, inelastic supply means demand shifts dominate price. Net positive for holders.",
+          "oneLineExplanation": "Mine output grew only ~1% to a record 3,672 tonnes in 2025.",
+          "detailedExplanation": "Production is at a record but growing very slowly, and is spread across China (~380t), Russia (~330t) and Australia (~284t), so no single country can flood the market. Grades are falling and big new discoveries are rare. Slow, hard-to-grow supply meeting steady demand is good for holders.",
           "result": "Pass"
         },
         {
           "factorKey": "global_inventories_stockpiles",
-          "oneLineExplanation": "Huge above-ground stocks, but tightly held.",
-          "detailedExplanation": "Most gold ever mined still exists, but a large share sits in central-bank vaults and long-term investment hands that rarely sell. Available float is smaller than headline stocks suggest.",
+          "oneLineExplanation": "About 216,000 tonnes above ground, but tightly held.",
+          "detailedExplanation": "Almost all gold ever mined still exists, but most is locked up as jewelry, central-bank reserves, and long-term investment. Gold ETFs are at a record 4,025 tonnes and central banks keep adding, so the metal available to trade is scarce rather than piling up. No glut is building.",
           "result": "Pass"
         },
         {
           "factorKey": "demand_drivers",
-          "oneLineExplanation": "Central banks, jewelry and investment all contribute.",
-          "detailedExplanation": "Demand is unusually diversified for a commodity. Central-bank reserve buying provides a durable floor, while investment demand adds cyclical upside during stress or falling real rates.",
+          "oneLineExplanation": "Central banks, ETFs and Asian jewelry all buying at once.",
+          "detailedExplanation": "Demand is unusually diversified for a commodity: central banks (863t in 2025), investors via ETFs (+801t), and consumers in China (~910t) and India (~780t). Central-bank buying gives a durable floor, while ETF demand adds upside when real rates fall or markets get nervous. This spread of buyers makes demand resilient.",
           "result": "Pass"
         },
         {
           "factorKey": "spare_capacity_new_supply",
-          "oneLineExplanation": "Little near-term new supply to cap price.",
-          "detailedExplanation": "New mines take a decade to develop and few large projects are coming online, so there is limited spare capacity to blunt a demand-driven rally.",
+          "oneLineExplanation": "Little quick new supply to cap a rally.",
+          "detailedExplanation": "Unlike oil, gold has no 'spare capacity' that can be switched on. New mines take roughly a decade to permit and build, and analysts think mined output may be near a plateau. So a demand-driven rally is hard to cap with fresh supply in the short run.",
           "result": "Pass"
         },
         {
           "factorKey": "seasonality",
-          "oneLineExplanation": "Mild seasonality tied to jewelry buying.",
-          "detailedExplanation": "There is some seasonal strength around Indian wedding and festival demand and Chinese New Year, but the effect is modest and easily overwhelmed by macro drivers.",
+          "oneLineExplanation": "Mild seasonal demand, easily overwhelmed by macro.",
+          "detailedExplanation": "There is some seasonal strength around Indian weddings (which drive 50-60% of India's jewelry demand across ~10-12 million weddings a year) and Chinese New Year. But the effect is small and usually swamped by moves in real rates and the dollar, so it is not a reliable tailwind on its own.",
           "result": "Fail"
         }
       ]
     },
     {
       "categoryKey": "PriceAndValue",
-      "summary": "Gold looks fully valued against its long-term real-price range and sits near record nominal highs, so the margin of safety for new buyers is thin.",
-      "overallAnalysisDetails": "On an inflation-adjusted basis, gold trades in the upper portion of its multi-decade range, which historically has preceded periods of flat-to-lower real returns. There is no cash-flow-based valuation anchor, so 'value' is judged against its own history and against substitutes.\n\nAgainst silver and other stores of value, gold is not obviously cheap. The lack of a production-cost floor that meaningfully constrains price on the downside (as it can for oil or agriculture) means valuation discipline matters more here.",
+      "summary": "Even after falling about 25% from January 2026's record, gold is historically expensive: near the top of its 10-year range and roughly 2.5x its mining cost. The pullback adds some headroom, and it is not dear versus silver, but the margin of safety is still thin.",
+      "overallAnalysisDetails": "Gold has no earnings, so 'value' means comparing today's price to its own history and to what it costs to produce. At about $4,180, gold is far above where it traded five years ago (~$1,800) and ten years ago (~$1,100), and it sits in the upper part of its inflation-adjusted range. Past times gold reached similar real highs (1980, 2011) were followed by years of flat-to-lower returns, which is the main reason for caution.\n\nOn the other hand, gold is about 25% below its 28 January 2026 record of ~$5,602, so there is real headroom to the old high. And compared with silver, gold is not obviously expensive: the gold-to-silver ratio is about 60, a bit below its long-run 65-70 average. The catch is the cost floor — miners' all-in cost is only around $1,600/oz, far below the current price, so the 'cost support' that protects oil or crops when they fall does not really apply to gold here.",
       "factors": [
         {
           "factorKey": "price_vs_range",
-          "oneLineExplanation": "Trading in the top of its 5/10-year range.",
-          "detailedExplanation": "Gold sits near the high end of its recent range, leaving less room for multiple expansion and more vulnerability to pullbacks if real rates rise.",
+          "oneLineExplanation": "Still near the top of its 5- and 10-year range.",
+          "detailedExplanation": "Even after the pullback to ~$4,180, gold is close to the high end of its multi-year range (it was near $1,800 five years ago). That leaves less room to rise on valuation alone and more vulnerability to a fall if real rates climb further.",
           "result": "Fail"
         },
         {
           "factorKey": "inflation_adjusted_price",
-          "oneLineExplanation": "Elevated in real terms versus history.",
-          "detailedExplanation": "Adjusted for inflation, gold is in the upper part of its multi-decade band. Prior periods at similar real levels saw muted forward returns.",
+          "oneLineExplanation": "Elevated in real (inflation-adjusted) terms.",
+          "detailedExplanation": "After adjusting for inflation, gold sits in the upper part of its multi-decade band. Prior peaks at similar real levels (1980 and 2011) were followed by long stretches of weak returns, so today's real price is a headwind for new buyers.",
           "result": "Fail"
         },
         {
           "factorKey": "cost_of_production_floor",
-          "oneLineExplanation": "Production cost sits well below spot.",
-          "detailedExplanation": "All-in sustaining costs are far below the current price, so the cost floor offers little downside protection at today's levels.",
+          "oneLineExplanation": "Price is ~2.5x the ~$1,600/oz mining cost.",
+          "detailedExplanation": "The industry's all-in sustaining cost is around $1,500-1,650 an ounce, while gold trades near $4,180. Miners are making huge margins, and the cost 'floor' is roughly 60% below the price — so it offers almost no downside protection at today's levels.",
           "result": "Fail"
         },
         {
           "factorKey": "price_vs_substitute",
-          "oneLineExplanation": "Not clearly cheap versus silver/other havens.",
-          "detailedExplanation": "The gold/silver ratio and comparisons to other safe havens do not flag gold as unusually cheap, tempering the relative-value case.",
-          "result": "Fail"
+          "oneLineExplanation": "Not expensive versus silver.",
+          "detailedExplanation": "The gold-to-silver ratio is about 60, a little below its long-run 65-70 average, so gold is roughly fair-to-slightly-cheap relative to silver. Gold is not priced at a premium that would push buyers to switch away from it, which is a mild positive on relative value.",
+          "result": "Pass"
         },
         {
           "factorKey": "distance_from_all_time_high",
-          "oneLineExplanation": "At or near all-time highs.",
-          "detailedExplanation": "Gold is close to record nominal levels. Momentum can persist, but buying at highs raises the risk of poor entry timing.",
-          "result": "Fail"
+          "oneLineExplanation": "About 25% below the January 2026 record.",
+          "detailedExplanation": "Gold trades near $4,180 versus its ~$5,602 record on 28 January 2026, so there is meaningful headroom to the old high rather than fresh-record risk. With central banks and ETFs still buying and bank targets above spot, that headroom looks supportable, even if valuation is stretched.",
+          "result": "Pass"
         }
       ]
     },
     {
       "categoryKey": "VolatilityAndRisk",
-      "summary": "Gold is moderately volatile for a commodity, with shallow drawdowns relative to equities and a low correlation that makes it a genuine diversifier. Its main risk is sensitivity to real rates and the dollar.",
-      "overallAnalysisDetails": "Realized volatility is lower than energy or agriculture and its worst drawdowns have generally been shallower and shorter than equity bear markets. The dominant risk factors are macro: rising real yields and a stronger dollar are the classic headwinds.\n\nBecause gold's correlation to stocks is low, it tends to help portfolio-level risk even though it is volatile on its own. Geopolitical and weather risks are minimal for a metal held as a store of value.",
+      "summary": "Gold's price swings (about 15% a year) are similar to the S&P 500, its worst fall (-45% in 2011-2015) was gradual and fully recovered, and its low link to stocks makes it a real diversifier. The clearest single risk today is high real interest rates.",
+      "overallAnalysisDetails": "Gold is less wild than most commodities. Its annualized volatility is about 15% over the last 30 years — close to the S&P 500's ~14% — and roughly 19% over 2004-2024, again similar to stocks. Its deepest drawdown was a 45% slide from the 2011 peak to the 2015 low, but that fall was gradual and the price eventually recovered and went on to new highs, unlike equity crashes of 2000-2002 and 2007-2009 that each topped 50%.\n\nThe main risk is macro, not supply. Gold usually falls when the US dollar strengthens and when real yields rise; the long-run link to real yields is strongly negative (about -0.82). Right now real 10-year yields are high (~2.25%), which has been a headwind that gold has so far shrugged off thanks to central-bank buying — but if that support fades, the high-real-yield backdrop could reassert itself. Weather and single-country supply shocks, which hit oil and crops, barely matter for a durable, widely-held metal like gold.",
       "factors": [
         {
           "factorKey": "historical_volatility",
-          "oneLineExplanation": "Moderate volatility, below energy/ags.",
-          "detailedExplanation": "Gold's realized volatility is meaningful but lower than most commodities, making position sizing easier for a diversified investor.",
+          "oneLineExplanation": "About 15% a year — similar to the S&P 500.",
+          "detailedExplanation": "Gold's annualized volatility is roughly 15% over 30 years and ~19% over the last two decades, close to US stocks and below energy or agricultural commodities. That makes position sizing manageable for a diversified investor.",
           "result": "Pass"
         },
         {
           "factorKey": "worst_drawdowns",
-          "oneLineExplanation": "Drawdowns shallower than equities.",
-          "detailedExplanation": "Historic peak-to-trough declines, while real, have generally been less severe and shorter-lived than equity bear markets.",
+          "oneLineExplanation": "Worst fall -45% (2011-2015), and it recovered.",
+          "detailedExplanation": "Gold's deepest peak-to-trough drop was about 45% from 2011 to 2015. That is painful but was gradual and fully recovered, versus equity bear markets that exceeded 50% in 2000-2002 and 2007-2009. Drawdowns here are survivable.",
           "result": "Pass"
         },
         {
           "factorKey": "geopolitical_weather_risk",
-          "oneLineExplanation": "Minimal supply-disruption risk.",
-          "detailedExplanation": "As a durable, non-perishable store of value with diversified supply, gold is largely insulated from the weather and single-region geopolitical shocks that hit ags and energy.",
+          "oneLineExplanation": "Very little supply-disruption risk.",
+          "detailedExplanation": "Gold does not rot, spoil, or depend on one fragile region or shipping chokepoint. Supply is diversified across China, Russia, Australia and Canada, and above-ground stocks are enormous, so weather and single-country shocks barely move it. Geopolitics tend to help gold (safe-haven buying) rather than hurt it.",
           "result": "Pass"
         },
         {
           "factorKey": "us_dollar_sensitivity",
-          "oneLineExplanation": "Inverse to the US dollar.",
-          "detailedExplanation": "Gold typically falls when the dollar strengthens. A sustained dollar bull market is the clearest single risk to the price.",
+          "oneLineExplanation": "High real yields and a firm dollar are the key headwind.",
+          "detailedExplanation": "Gold is priced in dollars and normally falls when the dollar strengthens and real yields rise (historical correlation to real yields around -0.82). Real 10-year yields are currently high at ~2.25%. Gold has climbed anyway, but that 'decoupling' is itself a risk: if the classic relationship reasserts, a strong-dollar, high-real-yield regime could pressure the price.",
           "result": "Fail"
         },
         {
           "factorKey": "correlation_to_inflation_and_stocks",
-          "oneLineExplanation": "Low equity correlation, imperfect inflation hedge.",
-          "detailedExplanation": "Gold diversifies equity risk well but is an inconsistent short-term inflation hedge; its real driver is real yields rather than headline inflation.",
+          "oneLineExplanation": "Good stock diversifier; only a rough inflation hedge.",
+          "detailedExplanation": "Gold's low-to-negative correlation with equities means it tends to hold up when stocks fall, which is its main portfolio benefit. It is a less reliable short-term inflation hedge, because its real driver is real interest rates rather than headline inflation, but the diversification case is genuine.",
           "result": "Pass"
         }
       ]
     },
     {
       "categoryKey": "FutureOutlook",
-      "summary": "The forward outlook is constructive, supported by central-bank demand and the prospect of falling real rates, but full valuation caps the upside. The path of real yields and the dollar is the swing factor.",
-      "overallAnalysisDetails": "If real rates ease and the dollar softens, gold has a clear tailwind and could extend gains, especially with central banks still buying. The bear case is a durable rise in real yields that raises the opportunity cost of holding a zero-yield asset.\n\nOfficial forecasts and analyst targets cluster around modest further upside rather than a dramatic move, reflecting the tension between strong structural demand and stretched valuation. Watch real yields, central-bank reserve data, and dollar trends as the key catalysts.",
+      "summary": "The outlook is constructive: mine supply stays flat, central banks and ETFs keep buying, and major banks' late-2026 targets ($4,900-$6,000) sit above today's ~$4,180. The swing factor is the path of real interest rates and the dollar.",
+      "overallAnalysisDetails": "The forward setup is supportive on supply and demand: production is flat-to-plateauing while central banks and ETFs keep accumulating, and the World Gold Council sees the structural case for gold still intact. The bull case is falling real rates plus a weaker dollar plus continued official-sector buying, which could push gold back toward its highs. The bear case is real yields staying high (around 2.25% today) or the dollar strengthening, which raises the cost of holding a zero-yield asset.\n\nBank forecasts lean positive but have been trimmed. JPMorgan sees gold averaging about $6,000/oz by Q4 2026 and pushing $6,300 in 2027, while Goldman Sachs cut its year-end 2026 target to $4,900 (from $5,400) as it pushed expected Fed rate cuts into 2027. Both targets are above the current ~$4,180, so the consensus skew is to the upside, though full valuation caps how far. Watch the Fed's rate path, monthly central-bank reserve data, and the dollar as the key catalysts.",
       "factors": [
         {
           "factorKey": "forward_supply_demand_balance",
-          "oneLineExplanation": "Demand-led balance stays supportive.",
-          "detailedExplanation": "With flat mine supply and continued official-sector buying, the forward balance leans supportive absent a demand shock.",
+          "oneLineExplanation": "Flat supply plus ongoing central-bank and ETF buying.",
+          "detailedExplanation": "With mine output growing only ~1% a year and official-sector plus ETF demand still strong, the forward balance leans supportive. It would take a sharp drop in investment demand to tip it, and central-bank buying provides a floor.",
           "result": "Pass"
         },
         {
           "factorKey": "official_agency_forecast",
-          "oneLineExplanation": "Forecasts point to modest upside.",
-          "detailedExplanation": "Official and institutional forecasts generally see gold holding or grinding higher rather than a sharp move in either direction.",
+          "oneLineExplanation": "World Gold Council sees the structural case intact.",
+          "detailedExplanation": "The World Gold Council notes that although central-bank buying cooled 21% in 2025, long-term strategic demand for gold remains firmly in place, and total demand hit a record. Official commentary is constructive rather than warning of weakness.",
           "result": "Pass"
         },
         {
           "factorKey": "analyst_price_targets",
-          "oneLineExplanation": "Targets cluster near current levels.",
-          "detailedExplanation": "Sell-side targets imply limited upside from here, consistent with a fully-valued but well-supported market.",
-          "result": "Fail"
+          "oneLineExplanation": "Bank targets ($4,900-$6,000) sit above spot.",
+          "detailedExplanation": "JPMorgan targets about $6,000/oz by late 2026 and Goldman Sachs $4,900 (trimmed from $5,400). Both are above today's ~$4,180, implying roughly +17% to +44% upside. The consensus points meaningfully higher, which is a positive.",
+          "result": "Pass"
         },
         {
           "factorKey": "bull_vs_bear_scenario",
-          "oneLineExplanation": "Bull case on falling real rates; bear on rising ones.",
-          "detailedExplanation": "The outcome hinges on real yields: falling real rates and a weaker dollar drive the bull case, while a rate/dollar bull market anchors the bear case.",
+          "oneLineExplanation": "Skew leans up, but valuation caps the upside.",
+          "detailedExplanation": "Bull case: falling real rates, a softer dollar and continued central-bank buying take gold back toward its record. Bear case: real yields stay high and the dollar firms, pressuring a zero-yield asset. With bank targets above spot and a durable demand floor, the balance modestly favors the upside, though a full valuation limits how far.",
           "result": "Pass"
         },
         {
           "factorKey": "key_catalysts_to_watch",
-          "oneLineExplanation": "Real yields, the dollar, and central-bank buying.",
-          "detailedExplanation": "The clearest catalysts are the direction of real interest rates, the US dollar trend, and the pace of central-bank reserve accumulation.",
+          "oneLineExplanation": "Fed rate path, dollar, and central-bank buying.",
+          "detailedExplanation": "The clearest catalysts are the Federal Reserve's rate decisions (rate cuts have been pushed toward 2027, a near-term headwind but a longer-term tailwind), the monthly central-bank reserve data, and the US dollar trend. These are watchable and, on balance, lean supportive over a multi-year horizon.",
           "result": "Pass"
         }
       ]

--- a/insights-ui/src/commodity-data/reports/heating-oil.json
+++ b/insights-ui/src/commodity-data/reports/heating-oil.json
@@ -1,0 +1,211 @@
+{
+  "slug": "heating-oil",
+  "name": "Heating Oil",
+  "commodityGroup": "Energy",
+  "priceSymbol": "HO=F",
+  "exchange": "NYMEX",
+  "unit": "gallon",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on heating oil / diesel (ULSD): near $3.26 a gallon in mid-2026, with the strongest fundamentals in the oil complex — record-low stocks and wide refining margins — but high volatility and a declining heating-oil end-use. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Constructive. The strongest cut of the oil barrel, but a bumpy ride.\n\nDespite the name, the NYMEX 'heating oil' contract (HO=F) is ultra-low-sulfur distillate — the pricing benchmark for the whole middle-distillate complex: on-road diesel, home heating oil and, indirectly, jet fuel. Diesel is the workhorse fuel of the global economy (trucking, rail, shipping, farming, industry), and distillate is often the tightest, strongest-margin part of the barrel. In early July 2026 HO=F trades near $3.26 a gallon, up about 33% year-over-year and roughly 44% below its 2022 record of ~$5.86.\n\nThe fundamentals are the best in the oil complex right now. US and global distillate inventories are at multi-year lows and below their five-year average, refining margins (diesel crack spreads) have been historically wide (over $90 a barrel during the spring Iran-war spike, settling near $63), Western refinery closures constrain supply, and Ukrainian drone strikes have knocked out roughly a quarter of Russia's refining capacity — a major global diesel disruption. That is why this scores well above the crude benchmarks. But three real weaknesses hold it back: high volatility (~35-45% a year) with deep 2008/2020 crashes; a US home-heating-oil end-demand that is in structural decline as the Northeast switches to natural gas and heat pumps; and no clean pure-play retail vehicle (exposure means leveraged futures or refiner equities). Best understood as a global-diesel bet, not a home-heating one.",
+  "keyFacts": {
+    "keyFacts": "The NYMEX 'heating oil' future (HO=F) is really the NY Harbor ultra-low-sulfur distillate (ULSD) contract. Distillate is the middle slice of the crude barrel, and the same slice becomes on-road diesel, home heating oil and (adjacent) jet fuel. So HO=F is best thought of as a diesel/distillate benchmark, not a niche home-heating bet. It is priced per gallon in US dollars. In early July 2026 that price is about $3.26 a gallon.\n\nFor a beginner, the important idea is that diesel is the 'workhorse fuel' — trucks, trains, ships, tractors and factories all run on it — so its demand tracks industrial and freight activity worldwide. Distillate is frequently the tightest, highest-margin part of the barrel, which is the central story here. Like other refined products, HO=F is priced as crude oil plus a refining margin (the diesel 'crack spread'). The key tension for investors: diesel's global fundamentals (low inventories, wide margins, refinery outages) are among the strongest in energy right now, but the US home-heating-oil end-use is slowly shrinking as the Northeast switches to natural gas and heat pumps.",
+    "greenFlags": [
+      {
+        "flag": "Record-low inventories and wide refining margins",
+        "explanation": "US distillate stocks fell far faster than normal in 2025 and are forecast to stay at multi-year lows, below the five-year average. Diesel crack spreads (the refining margin) topped $90 a barrel during the spring 2026 Iran-war spike and remain historically wide near $63 — the strongest margins in the oil complex.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Supply disruption from Western closures and Russia",
+        "explanation": "Western refinery closures limit distillate output, and Ukrainian drone strikes have disabled roughly a quarter of Russia's refining capacity — Russia being a major global diesel exporter — with Moscow even weighing a diesel export ban. These supply shocks keep the global diesel market tight.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Deep, economically-sensitive global demand",
+        "explanation": "Diesel powers trucking, rail, marine shipping, agriculture and industry worldwide, plus winter heating in the US Northeast and Europe. This broad, essential demand base is far less exposed to the EV threat than gasoline, since heavy transport and industry are hard to electrify.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "High volatility with deep crash history",
+        "explanation": "Distillate is volatile (~35-45% a year), tracking crude plus swinging refining margins, and it crashed hard in the 2008 financial crisis and the 2020 COVID demand collapse. In 2026 the crack spread itself swung from over $90 to about $63 a barrel — a reminder this is not a smooth ride.",
+        "result": "Fail"
+      },
+      {
+        "flag": "US heating-oil end-demand is in structural decline",
+        "explanation": "The home-heating-oil use (concentrated in the US Northeast, ~4.8 million households) is shrinking as households switch to natural gas and heat pumps. That erodes one leg of demand over time, even as global diesel demand stays firm.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Diesel for trucking, rail, marine and industry",
+      "Agriculture (farm equipment)",
+      "Home heating oil (US Northeast, Europe)",
+      "Jet-fuel-adjacent (same distillate cut)"
+    ],
+    "topProducers": [
+      { "country": "United States", "share": "Largest producer & exporter" },
+      { "country": "Russia", "share": "Major diesel exporter (now disrupted)" },
+      { "country": "China", "share": "Major refiner" },
+      { "country": "India / Middle East", "share": "Major distillate exporters" }
+    ],
+    "waysToInvest": [
+      { "type": "Futures", "name": "HO=F", "note": "Direct exposure; leverage, roll and expiry risk — not beginner-friendly" },
+      { "type": "Equities", "name": "Refiners (VLO, MPC, PSX)", "note": "Leveraged to diesel crack spreads; pay dividends, carry equity risk" },
+      { "type": "ETF", "name": "Broad energy funds", "note": "No clean pure-play diesel/heating-oil ETF; diesel exposure sits inside broad energy ETFs" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "The strongest supply-demand setup in the oil complex: multi-year-low inventories, Western refinery closures, a major Russia-driven supply disruption, deep global diesel demand, and reliable winter seasonality. All five factors pass.",
+      "overallAnalysisDetails": "Distillate has the tightest fundamentals in the oil complex. Inventories are the key theme: US distillate stocks fell about 17% in the first half of 2025 (versus a normal 10% draw) and are forecast to end both 2025 and 2026 at multi-year lows, below the five-year average. Supply is constrained by Western refinery closures and, dramatically, by Ukrainian drone strikes that have disabled roughly a quarter of Russia's refining capacity — Russia being a major global diesel exporter — with Moscow even weighing a diesel export ban. New refining capacity is being added mainly in the Middle East and Asia (Kuwait's Al Zour, Saudi Arabia's Jubail, India's Jamnagar), not the West.\n\nDemand is broad and essential. Diesel powers freight, rail, marine shipping, agriculture and industry across the world, plus winter heating in the US Northeast and Europe, and it competes with jet fuel for the same molecules. This demand is economically sensitive but hard to electrify, so it is more durable than gasoline demand. Add reliable winter and harvest seasonality, and every factor here leans supportive.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Western refinery closures constrain distillate output.",
+          "detailedExplanation": "Global distillate output is constrained by refinery closures in the West, even as the US remains the largest refined-products producer and exporter. New capacity is concentrated in the Middle East and Asia, not where demand is highest. Tight, constrained supply of the distillate cut is supportive for prices.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Stocks at multi-year lows, below the five-year average.",
+          "detailedExplanation": "US distillate stocks fell about 17% in the first half of 2025 (versus a normal 10% draw) and are forecast to stay at multi-year lows, below the five-year average, through 2026. Structurally low inventories are the central bullish theme — there is little cushion against a cold winter or a supply shock.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Deep, essential, global diesel demand.",
+          "detailedExplanation": "Diesel powers trucking, rail, marine shipping, agriculture and industry worldwide, plus winter heating and jet-fuel-adjacent use. This demand is economically sensitive but hard to electrify, so it is more durable than gasoline demand. A broad, essential, global demand base is a genuine strength.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Little new distillate-heavy capacity in the West.",
+          "detailedExplanation": "Refining is tight and few new distillate-heavy refineries are being built in the West; new capacity (Kuwait's Al Zour, Saudi Arabia's Jubail, India's Jamnagar) is in the Middle East and Asia and takes time to ramp. Limited near-term spare capacity means tightness persists, which is supportive.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Reliable winter heating and harvest demand.",
+          "detailedExplanation": "Distillate has strong seasonality: winter heating demand (Q4/Q1) plus harvest-season diesel reliably lift prices in the colder months. This dependable seasonal tailwind, on top of already-low inventories, is a genuine supportive feature.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Value is broadly supportive: near $3.26 it is mid-range, below its inflation-adjusted high, backed by a wide-crack cost floor, and about 44% below its 2022 record. The one negative is that natural gas and heat pumps are structurally displacing the heating-oil end-use.",
+      "overallAnalysisDetails": "On price, distillate is reasonable. At about $3.26 a gallon it sits in the upper-middle of a multi-decade range (roughly $0.29 to $5.86) and is below its inflation-adjusted 2022 record, so it is elevated versus a year ago but not at an extreme.\n\nThe cost floor is unusually firm because diesel crack spreads are wide: the refining margin over crude has been historically strong (over $90 a barrel during the spring 2026 spike, settling near $63), giving the price solid support above crude cost. HO=F is about 44% below its all-time high, leaving headroom. The one clear negative on value is the substitute picture for the heating-oil end-use: natural gas and heat pumps are steadily displacing home heating oil in the US Northeast, a structural loss of one demand leg. That single factor fails, but the rest of the value pillar is supportive.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Upper-middle of a wide multi-decade range.",
+          "detailedExplanation": "At about $3.26, HO=F sits in the upper-middle of its multi-decade range (roughly $0.29 low to $5.86 high). It is elevated versus a year ago (up ~33%) but not stretched to an extreme, so there is room in the range without the price being at a ceiling.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Below its inflation-adjusted all-time high.",
+          "detailedExplanation": "The 2022 record of ~$5.86 a gallon is even higher in today's dollars, so at about $3.26 distillate is well below its real all-time high. It is not historically expensive in real terms, so buyers are not paying an inflated real price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Wide diesel crack spread gives firm support.",
+          "detailedExplanation": "HO=F is priced as crude plus the diesel crack spread, and that crack has been historically wide (over $90 a barrel during the spring 2026 spike, settling near $63). A wide, strong refining margin provides firm support above crude cost — the diesel cut is the most profitable part of the barrel right now.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Natural gas and heat pumps displace heating oil.",
+          "detailedExplanation": "For the home-heating end-use, natural gas and heat pumps are cheaper and are steadily displacing heating oil in the US Northeast, a structural loss of one demand leg. While diesel's crack spread versus crude is strong, this substitution pressure on the heating-oil side is a genuine negative on relative value.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 44% below the 2022 record of ~$5.86.",
+          "detailedExplanation": "HO=F near $3.26 is about 44% below its all-time high of ~$5.86 a gallon (2022), leaving headroom rather than record-high risk. For a crude-linked product this is normal, and with fundamentals tight, that headroom looks more supportable than for gasoline or crude.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Distillate is volatile (~35-45% a year) with deep 2008/2020 crashes, and geopolitics (Russia refinery attacks, Red Sea shipping) cut both ways. The positives are manageable dollar sensitivity and a genuine inflation/pro-cyclical role. Two of five factors pass.",
+      "overallAnalysisDetails": "Diesel is a high-volatility product. Its annualized volatility runs about 35-45%, tracking crude plus swinging refining margins — the 2026 crack spread alone moved from over $90 to about $63 a barrel. Its worst drawdowns came in the 2008 financial crisis and the 2020 COVID demand collapse, so it can fall hard in a recession.\n\nGeopolitics is a double-edged sword: Ukrainian drone strikes on Russian refineries, a possible Russian export ban, the earlier 2026 Iran war and Red Sea shipping risk have all tightened diesel and can spike it, but they are also sources of shock and instability. On the positive side, distillate's US-dollar sensitivity is manageable (a modest headwind, not a primary driver), and diesel is a genuine inflation and pro-cyclical input — freight and industrial costs feed straight into inflation — so it offers a real hedge. Those two positives partly offset the high volatility, geopolitical shock risk and crash history.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "High, ~35-45% a year.",
+          "detailedExplanation": "Distillate's annualized volatility runs about 35-45%, tracking crude plus swinging refining margins. In 2026 the crack spread alone moved from over $90 to about $63 a barrel. This is a fast-moving product, not a smooth hold, so volatility is a real risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Deep crashes in 2008 and 2020.",
+          "detailedExplanation": "Distillate's deepest falls came in the 2008 financial crisis and the 2020 COVID demand collapse, when freight and industrial activity seized up. Because diesel demand is tied to the economy, a recession can drive a severe, fast drawdown — a genuine downside risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Russia attacks and shipping risk cut both ways.",
+          "detailedExplanation": "Geopolitics is currently tightening diesel — Ukrainian drone strikes have disabled ~a quarter of Russian refining, Moscow is weighing an export ban, and Red Sea shipping is disrupted — plus cold winters and Gulf hurricanes add spikes. These support prices now, but they are sources of shock and instability, so on a risk basis this counts as a hazard.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Manageable dollar sensitivity.",
+          "detailedExplanation": "Distillate is crude-linked and priced in dollars, so a stronger dollar is a modest headwind, but it is not the primary driver of the price — tight inventories and refining margins matter more. That relatively manageable currency exposure is a mild positive versus more dollar-sensitive commodities.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "A genuine inflation and pro-cyclical hedge.",
+          "detailedExplanation": "Diesel is a core industrial and freight cost — it feeds straight into inflation because moving goods runs on diesel — and it is pro-cyclical, strengthening with economic activity. For an investor worried about industrial-cost inflation, diesel exposure is one of the most direct hedges, a clear positive in its risk profile.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The forward view is the most constructive in the oil complex: tight balance from low stocks and refinery closures, an EIA outlook keeping stocks below average and margins above 2025, and modestly higher 12-month targets. The caveats are the two-sided bull/bear balance and structurally declining heating-oil demand. Three of five factors pass.",
+      "overallAnalysisDetails": "Distillate's forward setup is genuinely constructive. Refinery closures plus record-low stocks point to a market that could stay structurally tight near-term, and the EIA expects distillate inventories to remain below the five-year average with refining margins staying above 2025 levels — a supportive official view, even if headline price forecasts swing with geopolitics (the April 2026 outlook lifted diesel forecasts sharply on the Iran war and Russia crisis). Twelve-month model targets sit modestly higher (around $3.90 a gallon), and refining analysts see margins staying elevated for a couple of years given the refinery crunch.\n\nTwo caveats keep this from a perfect score. First, the bull/bear balance is two-sided: the bull case (tight refining, low stocks, Russia disruption, winter demand) is strong, but the bear case (a recession cutting freight demand, plus new Middle East and Asian refining capacity ramping) is real. Second, the key long-term catalyst mix includes the structural decline of US home-heating-oil demand as the Northeast switches to gas and heat pumps. So while the near-term outlook is the best in the oil complex, it is not one-way.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Low stocks and refinery closures keep it tight.",
+          "detailedExplanation": "Refinery closures plus record-low distillate stocks point to a market that could stay structurally tight near-term, supporting prices and margins. Firm freight and industrial demand meeting constrained supply is a genuinely supportive forward balance — the strongest in the oil complex.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "EIA keeps stocks below average, margins above 2025.",
+          "detailedExplanation": "The EIA expects distillate inventories to stay below the five-year average and refining margins to hold above 2025 levels. Headline price forecasts swing with geopolitics (the April 2026 outlook lifted diesel forecasts on the Iran war and Russia crisis), but the underlying tight-stocks, firm-margin picture is supportive.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Modestly higher 12-month targets.",
+          "detailedExplanation": "Model-based 12-month targets sit modestly higher (around $3.90 a gallon versus ~$3.26 today), and refining analysts expect diesel margins to stay elevated for a couple of years given the refinery crunch. A mildly upward-skewed target set is a positive for a long position.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Strong bull case, but a real recession/capacity bear case.",
+          "detailedExplanation": "The bull case is tight refining, low stocks, Russia disruption and winter demand keeping cracks strong. The bear case is a recession cutting freight and industrial diesel demand, plus new Middle East and Asian refining capacity ramping up. Both are credible, so the scenario balance is two-sided rather than clearly favorable.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Structural heating-oil decline weighs long-term.",
+          "detailedExplanation": "Near-term catalysts (winter weather, distillate stock reports, Russia refinery attacks, freight and PMI data) lean bullish, but the key long-term catalyst is the structural decline of US home-heating-oil demand as the Northeast switches to natural gas and heat pumps. That erosion of one demand leg caps the multi-year upside, so the catalyst mix is not one-way.",
+          "result": "Fail"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/lean-hogs.json
+++ b/insights-ui/src/commodity-data/reports/lean-hogs.json
@@ -1,0 +1,210 @@
+{
+  "slug": "lean-hogs",
+  "name": "Lean Hogs",
+  "commodityGroup": "Livestock",
+  "priceSymbol": "HE=F",
+  "exchange": "CME",
+  "unit": "pound",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on lean hogs: about 93 cents/lb ($93/cwt) in mid-2026, ~30% below the 2014 record. A cyclical, mean-reverting, high-volatility meat market dominated by China and by African Swine Fever. Covers global supply, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Neutral / Cautious — cheap versus beef, but cyclical, volatile, and near a seasonal peak.\n\nLean hogs are the futures market for pork — the value of a market-weight hog's lean meat. The contract (HE=F) is quoted in US cents per pound; the industry says dollars per hundredweight ('cwt' = 100 lb). In early July 2026 lean hogs trade around 93 cents/lb (about $93/cwt), roughly 30% below the record 133.80 set in July 2014, and down about 13% over the past year. Unlike cattle, hogs are strongly cyclical and mean-reverting — they swing around a long-run average rather than trending to ever-higher records.\n\nThis is a global story dominated by two forces. China produces and eats about half the world's pork, so its herd decisions and imports swing the market; and African Swine Fever (ASF) — a deadly, vaccine-less pig disease now flaring in Europe and Asia — is the single biggest wildcard, catastrophic if it ever reaches the US. Today the picture is mixed: the US breeding herd is the smallest since 2014, yet record productivity (more pigs per litter) keeps pork output growing anyway, so there is no cattle-style shortage. Hogs are cheap relative to record-priced beef, and producers are profitable on cheap feed — but prices sit near a seasonal summer high with official forecasts pointing lower. Best understood as a volatile, cyclical trade with real disease tail-risk, not a buy-and-hold.",
+  "keyFacts": {
+    "keyFacts": "Lean hogs are the futures market for pork. The price reflects how much a market-weight hog's meat is worth, driven by how many hogs are being raised, how much pork people want at home and abroad, and the cost of feed (corn and soybean meal, together ~60-70% of a hog's cost). The contract (HE=F) is quoted in cents per pound; 93 cents/lb is $93 per hundredweight ('cwt' = 100 lb).\n\nIn early July 2026 lean hogs are around 93 cents/lb, well below the July 2014 record of 133.80. A crucial difference from cattle: hogs are cyclical and mean-reverting — they do not trend to permanent new highs, because pigs breed fast (a sow can produce two litters a year), so supply responds quickly. Two global forces dominate: China, which produces and consumes about half the world's pork, and African Swine Fever (ASF), a deadly pig disease with no widely used vaccine. ASF abroad is bullish for US pork (it tightens global supply and lifts exports); ASF in the US would be a disaster (it would trigger export bans and crash prices). For a beginner, hogs are best seen as a fast-moving, disease-sensitive market.",
+    "greenFlags": [
+      {
+        "flag": "Cheap versus record-priced beef",
+        "explanation": "Retail beef has hit records around $9-10/lb while retail pork is roughly flat near $4.89/lb. That wide, growing price gap pushes budget-conscious shoppers toward pork, a real demand tailwind — and US pork exports are running near record volumes (Mexico is the top market).",
+        "result": "Pass"
+      },
+      {
+        "flag": "Producers profitable on cheap feed",
+        "explanation": "Feed is ~60-70% of a hog's cost, and with corn cheap (~$4.25/bushel) the hog-to-corn ratio is comfortably profitable — producers are earning roughly $15-25 per head. Cheap feed and tight pork cold-storage stocks support the market.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "US ASF outbreak is a catastrophic tail risk",
+        "explanation": "African Swine Fever has no widely deployed vaccine and is spreading in Europe (Spain saw its first case since 1994) and Asia. Because exports are ~25%+ of US production, a US outbreak would slam export markets shut and crash prices — a low-probability but devastating risk unique to hogs.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Productivity keeps output growing despite a smaller herd",
+        "explanation": "The US breeding herd is the smallest since 2014, yet record pigs-per-litter (11.9) push total pork production higher anyway. Unlike cattle, hogs have no genuine supply shortage — output grinds up on productivity, capping prices.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Fresh pork (chops, loin, ribs)",
+      "Processed pork (bacon, ham, sausage)",
+      "Pork exports (Mexico, Japan, Korea, China)",
+      "Byproducts (lard, gelatin, pharmaceuticals)"
+    ],
+    "topProducers": [
+      { "country": "China", "share": "~48%" },
+      { "country": "European Union", "share": "~19%" },
+      { "country": "United States", "share": "~11%" },
+      { "country": "Brazil", "share": "~4%" }
+    ],
+    "waysToInvest": [
+      { "type": "Futures", "name": "HE=F", "note": "CME lean hogs contract (cents per pound); the main direct exposure" },
+      { "type": "ETN", "name": "COW", "note": "iPath Series B Bloomberg Livestock ETN — a basket of lean hogs + live cattle futures" },
+      {
+        "type": "Equities",
+        "name": "Pork processors (e.g. Tyson Foods, WH Group/Smithfield)",
+        "note": "Indirect; processor margins can move opposite to hog prices"
+      }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Unlike cattle, hogs have no real shortage: a smaller US breeding herd is more than offset by record productivity, so pork output keeps growing. Demand is a bright spot — cheap versus beef, strong exports, tight cold storage — but supply and seasonality lean against prices.",
+      "overallAnalysisDetails": "The hog supply story is very different from cattle. The US breeding herd is the smallest since 2014, which sounds bullish, but record productivity — a record 11.9 pigs saved per litter — means the pig crop and total pork production keep rising anyway. Pigs also breed fast (a sow farrows about twice a year, with large litters), so supply can respond within about a year, which is why hogs are cyclical and mean-reverting rather than prone to lasting shortages. Globally, China (about half of world pork) is deliberately cutting its sow herd to fight oversupply, the EU herd is shrinking, and Brazil is expanding as the world's number-three exporter.\n\nDemand is the stronger side of the ledger. US pork is cheap relative to record-priced beef, driving substitution toward pork; exports are near record volumes (Mexico is the top market, with Japan and Korea rebounding); and pork in cold storage is unusually tight. The offsets: China's own supply is ample so its import demand is soft, and the US market is heading out of its summer-demand peak into the seasonally weaker fall.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Output grinds higher on productivity despite a smaller herd.",
+          "detailedExplanation": "The US breeding herd is the smallest since 2014, but record pigs-per-litter push total pork production up about 1-2% anyway. Because supply is adequate and growing rather than shrinking, there is no shortage to lift prices, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Pork cold-storage stocks are unusually tight.",
+          "detailedExplanation": "Pork in US cold storage has run below the prior year every month and hit the lowest August since 2010, roughly 17% under the five-year average. Low, drawing stocks are a genuinely supportive signal, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Cheap versus beef, with strong exports.",
+          "detailedExplanation": "Record beef prices are pushing consumers toward much cheaper pork, and US exports are near record volumes led by Mexico, Japan and Korea. Resilient, growing demand is a real support, so this factor passes — though soft Chinese import demand is a limiting factor.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Fast breeding cycle means supply can grow quickly.",
+          "detailedExplanation": "Hogs reproduce quickly and productivity keeps rising, so the industry can add pork supply within about a year if prices rise. That ready spare capacity caps the upside, unlike cattle's multi-year lag, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Heading out of the summer peak into weaker months.",
+          "detailedExplanation": "Hog prices typically peak in summer on grilling demand and lighter supply, then fall into autumn and winter as marketings get heavy. In July the market sits near its seasonal high and is heading into the weaker window, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Hogs are mid-range and mean-reverting — well below their 2014 record and cheap versus beef, but sitting above their cost of production and in the upper part of their recent range. Not stretched like cattle, but not a bargain either.",
+      "overallAnalysisDetails": "Hog value is a middle-of-the-road picture, which is normal for a mean-reverting market. At ~93 cents/lb, hogs are about 30% below their 2014 record and, in inflation-adjusted terms, well below past real peaks — so they are not stretched the way cattle are. Against beef they look genuinely cheap: retail pork near $4.89/lb versus record beef around $9-10/lb, a gap that supports pork demand.\n\nThe less favorable side: hogs sit in the upper part of their recent five-year range (roughly 14% above the five-year average) and comfortably above their cost of production. Producer breakeven is around $61/cwt liveweight while hogs trade near $93, so producers are profitable — but that also means the price has room to fall back toward cost if demand softens, and the protective 'floor' is well below the current level. The hog-to-corn ratio is favorable and packer margins (the pork 'cutout' trades above the live-hog price) are healthy, both supportive, but none of this makes hogs cheap in absolute terms.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Upper part of its recent range, ~14% above the 5-year average.",
+          "detailedExplanation": "At ~93 cents/lb, hogs sit in the upper portion of their five-year range and about 14% above the five-year average, near a seasonal high. On this measure they are not cheap, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Well below its real (inflation-adjusted) peaks.",
+          "detailedExplanation": "The nominal record was set back in 2014, so in real terms today's ~93 cents/lb is well below past peaks, and hogs have no long-term real uptrend. On this long-run measure the price is not stretched, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Trading well above the ~$61/cwt breakeven.",
+          "detailedExplanation": "Producer breakeven is roughly $61/cwt liveweight while hogs trade near $93, so the price sits well above cost with producers profitable. Because the price is not near its floor, downside is less protected, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Very cheap versus beef.",
+          "detailedExplanation": "Retail pork (~$4.89/lb) is roughly half the price of record beef ($9-10/lb), so demand should keep rotating toward the cheaper protein. Being inexpensive versus its main substitute is a favorable relative-value point, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 30% below the 2014 record.",
+          "detailedExplanation": "Hogs trade ~30% below their 2014 all-time high, so there is no fresh-record risk, and tight cold storage plus cheap-versus-beef pricing offer some support. That headroom (with no imminent record) earns a pass, though hogs' mean-reverting nature limits how meaningful the old high is.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Hogs are among the most volatile agricultural commodities, with a history of catastrophic crashes (COVID 2020, 1998) and a unique, devastating tail risk in African Swine Fever. The low correlation to stocks is the main redeeming feature.",
+      "overallAnalysisDetails": "Lean hogs are a high-risk market. They are among the most volatile agricultural commodities, whipsawed by seasonality, a fixed ~10-month biological production lag (which causes over- and under-shooting), and disease. Their history includes truly catastrophic crashes: in 2020 COVID shut meatpacking plants, cash prices collapsed and some producers had to euthanize hogs; in 1998 a sudden loss of packing capacity drove live hog prices to roughly 8 cents/lb, the lowest in US history in real terms.\n\nThe defining risk is African Swine Fever. It has no widely deployed vaccine and is a double-edged sword: an outbreak abroad (as in Spain, Vietnam and the Philippines) is bullish for US pork by tightening global supply, but an outbreak inside the US would immediately shut export markets — which take more than a quarter of US production — and crater prices. Add California's Prop 12 housing rules disrupting the supply chain, plus trade frictions with China and Mexico. The one clear positive is that hog prices move on their own supply/disease fundamentals, giving a low correlation to the stock market.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "Among the most volatile ag commodities.",
+          "detailedExplanation": "Hogs swing hard on seasonality, the fixed production lag and disease shocks, far more than equities and more than cattle. That high, hard-to-predict volatility fails the factor on a risk-adjusted basis.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Catastrophic crashes in 2020 and 1998.",
+          "detailedExplanation": "Hogs crashed in 2020 (plant shutdowns forced euthanasia and cash prices near collapse) and in 1998 (live prices near 8 cents/lb, a real-terms record low). These are among the most severe drawdowns in commodities, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "African Swine Fever is a catastrophic, asymmetric tail risk.",
+          "detailedExplanation": "ASF has no widely used vaccine and is spreading in Europe and Asia. A US outbreak would ban exports (25%+ of production) and crash prices — a low-probability but devastating, hog-specific risk. That asymmetric danger fails the factor.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Export-sensitive, but supply and disease dominate.",
+          "detailedExplanation": "Exports are a big share of US pork, so a strong dollar can hurt competitiveness versus the EU and Brazil. But the price is driven far more by domestic supply, China and disease than by the dollar, so the dollar is not the binding constraint and this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Low correlation to stocks.",
+          "detailedExplanation": "Hog prices move on protein-supply, disease and trade fundamentals rather than with equities, giving a low correlation to the stock market and some diversification value as a food commodity. That genuine diversification earns a pass.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The near-term setup is soft: prices sit near a seasonal peak while USDA forecasts averages well below current levels, and productivity keeps output growing. The real upside is optional — an ASF flare-up abroad or a China restock — rather than a base case.",
+      "overallAnalysisDetails": "The forward picture is cautious. USDA projects hog prices averaging around $69/cwt in 2026 and easing to ~$66.50 in 2027 as productivity and heavier weights push pork production higher — both well below the current ~$93 summer-peak price, which reflects seasonal strength that typically fades. Rabobank is similarly guarded, seeing global sow-herd contraction but a stalled US rebuild and prices subdued in the first half of 2026 before a tighter-supply rebound later.\n\nThe bull case is mostly optionality rather than a base case: an ASF flare-up in Europe or Asia (or a Chinese herd shortfall) could suddenly lift US export demand, cheap feed is keeping producers profitable, and beef-to-pork substitution is a steady tailwind. The bear case is the base case: productivity-driven output growth, soft Chinese demand amid its own oversupply, Prop 12 disruption, and the ever-present US ASF tail risk. Watch the quarterly Hogs & Pigs report, the WASDE, China import data and sow-herd policy, ASF headlines, corn and soybean-meal prices, and weekly export sales.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Output grows on productivity — balance not tightening.",
+          "detailedExplanation": "US pork production is forecast to keep rising on record productivity and heavier weights, so the forward balance is roughly adequate rather than tightening in the producer's favor. That caps prices, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "USDA sees prices averaging below current levels.",
+          "detailedExplanation": "USDA forecasts 2026 hog prices averaging ~$69/cwt and 2027 ~$66.50 — well below the current ~$93 summer-peak — as production rises. An official forecast pointing lower fails the factor, even allowing for seasonality.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Forecasts sit below the current seasonal-peak price.",
+          "detailedExplanation": "With current futures near $93 at the summer peak and USDA/analyst averages nearer $69, the consensus expects prices to ease back toward the long-run average rather than rise. Because targets point lower, this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Base case is mean-reversion; upside is optional.",
+          "detailedExplanation": "The near-term skew is to the downside from a seasonal peak, with productivity-driven supply and soft China demand as the base case. The bull drivers (ASF abroad, China restock) are real but optional wildcards rather than the central path, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "ASF headlines and China are watchable, potentially bullish wildcards.",
+          "detailedExplanation": "There are genuinely actionable catalysts: an ASF flare-up abroad or a shift in Chinese import policy could quickly tighten global supply and lift US exports, alongside the quarterly Hogs & Pigs report, WASDE and feed prices. These watchable, potentially supportive events earn a pass even within a cautious outlook.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/live-cattle.json
+++ b/insights-ui/src/commodity-data/reports/live-cattle.json
@@ -1,0 +1,211 @@
+{
+  "slug": "live-cattle",
+  "name": "Live Cattle",
+  "commodityGroup": "Livestock",
+  "priceSymbol": "LE=F",
+  "exchange": "CME",
+  "unit": "pound",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on live cattle: about 239 cents/lb ($239/cwt) in mid-2026, near record highs as the US herd sits at a 75-year low. Covers the cattle cycle, global beef trade (Brazil, Australia), the screwworm border closure, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Positive on supply, but prices are at record highs — a late-cycle caution.\n\nLive cattle are finished, market-weight cattle (around 1,200-1,400 lb) ready for slaughter into beef. The futures (LE=F) are quoted in US cents per pound; the industry usually talks in dollars per hundredweight ('cwt', or 100 lb). In early July 2026 live cattle trade around 239 cents/lb (about $239/cwt), only ~7-8% below the record ~$258/cwt set in June 2026, and up about 11% over the past year.\n\nThe reason is a genuine, historic supply squeeze: the US cattle herd has shrunk to about 86 million head — the smallest since 1951 — after years of drought forced ranchers to sell off animals. On top of that, a New World screwworm outbreak in Mexico has closed the US border to the ~1.2 million feeder cattle it normally imports each year. Beef demand has stayed surprisingly strong despite record retail prices. The catch is that all of this good news is already in the price: cattle sit near all-time highs, beef packers are losing money and closing plants, and once ranchers start rebuilding the herd (a slow, multi-year process) supply will eventually loosen. Best understood as a tight-supply story that is already richly priced — attractive fundamentals, expensive entry.",
+  "keyFacts": {
+    "keyFacts": "Live cattle are fully-grown cattle ready to be processed into beef. Their price is set by how many cattle are available (supply), how much beef people want (demand), and the cost of the feed used to fatten them. The futures contract (LE=F) trades in US cents per pound; the industry usually quotes dollars per hundredweight ('cwt' = 100 lb), so 239 cents/lb is the same as $239/cwt.\n\nIn early July 2026 live cattle are around 239 cents/lb, just below June 2026's record of ~$258/cwt. The dominant fact is scarcity: the US cattle herd is at its smallest since 1951, the result of years of drought-driven herd 'liquidation.' Cattle also breed slowly — it takes two to three years to expand a herd — so supply cannot bounce back quickly. For a beginner, three things matter: the cattle cycle (long swings between herd shrinking and rebuilding), the cost of feed (corn), and animal-disease and trade events (like the screwworm outbreak that closed the Mexican border). This is also a global market: Brazil is now the world's largest beef producer and exporter, with Australia at record output.",
+    "greenFlags": [
+      {
+        "flag": "US herd at a 75-year low",
+        "explanation": "The total US cattle herd fell to about 86.2 million head as of January 2026 — the smallest since 1951 — and the beef-cow herd (27.6 million) is the lowest since 1961, the seventh straight annual decline. Because cattle take years to breed and raise, this scarcity supports prices for a long time.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Screwworm has cut off Mexican cattle imports",
+        "explanation": "A New World screwworm (a flesh-eating parasite) outbreak in Mexico has kept the US border closed to live Mexican cattle for much of 2025-2026. The US normally imports ~1.2 million cattle a year from Mexico, so removing that supply tightens an already-short market.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Beef demand has stayed strong despite record prices",
+        "explanation": "Even with retail beef at record highs (ground beef near $6.70/lb), US beef consumption held up — per-person consumption was actually revised slightly higher for 2026. Resilient demand into tight supply is a supportive combination.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Prices are at all-time records",
+        "explanation": "Live cattle sit only ~7-8% below June 2026's record, in the top few percent of their entire price history. Most of the bullish supply story is already reflected in the price, leaving a thin margin of safety and real risk of poor entry timing.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Packers are losing money and closing plants",
+        "explanation": "At record cattle costs, beef processors ('packers') are deeply unprofitable — Tyson guided to a $400-600 million beef-segment loss for its fiscal 2026 and has closed plants. Less slaughter capacity ultimately means weaker demand for live cattle, a headwind building beneath the record prices.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Beef for domestic consumption",
+      "Beef exports (Japan, Korea, China)",
+      "Ground beef (blended with lean imported trim)",
+      "Byproducts (hides/leather, tallow)"
+    ],
+    "topProducers": [
+      { "country": "Brazil", "share": "~17%" },
+      { "country": "United States", "share": "~16%" },
+      { "country": "China", "share": "~10%" },
+      { "country": "European Union", "share": "~9%" }
+    ],
+    "waysToInvest": [
+      { "type": "Futures", "name": "LE=F", "note": "CME live cattle contract (cents per pound); the main direct exposure" },
+      { "type": "ETN", "name": "COW", "note": "iPath Series B Bloomberg Livestock ETN — a basket of live cattle + lean hogs futures" },
+      { "type": "Equities", "name": "Meatpackers (e.g. Tyson Foods)", "note": "Indirect and imperfect — packer margins move opposite to cattle prices" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Supply is historically tight — the US herd is at a 75-year low, the border is closed to Mexican cattle, and rebuilding takes years — while beef demand has held up despite record prices. The balance strongly favors demand.",
+      "overallAnalysisDetails": "This is one of the tightest cattle-supply pictures in living memory. Years of drought dried out pastures and pushed ranchers to sell off breeding animals, shrinking the US herd to about 86 million head — the smallest since 1951 — with the 2025 calf crop the lowest since 1941. Cattle also reproduce slowly (a cow produces one calf a year, and it takes two to three years to expand a herd), so supply cannot respond quickly. A New World screwworm outbreak in Mexico has closed the US border to the ~1.2 million cattle it usually imports each year, tightening things further.\n\nDemand has been the pleasant surprise: despite record retail beef prices, US consumption held up and even ticked higher. Globally the market is shifting — Brazil is now the world's largest beef producer and exporter and Australia is at record output, and the US has swung from a net exporter toward importing more lean beef trim (from Brazil and Australia) to stretch its short domestic supply. But for the US-based futures, the story is clear: record-tight supply meeting resilient demand.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "US herd at its smallest since 1951 and still shrinking.",
+          "detailedExplanation": "The US cattle herd fell to ~86 million head in 2026 (smallest since 1951), the seventh straight yearly decline, and the calf crop is the lowest since 1941. Falling production into steady demand is strongly supportive for price, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Cattle-on-feed and available supply are tight.",
+          "detailedExplanation": "Cattle on feed have edged down and the pipeline of animals is thin, squeezed further by the screwworm border closure cutting off Mexican imports. There is no glut building; the buffer of available cattle is small, which supports prices.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Beef demand resilient despite record prices.",
+          "detailedExplanation": "US per-person beef consumption held up (and was nudged higher for 2026) even as retail prices hit records, and global import demand (led by China) is firm. Consumers are trading down within beef rather than abandoning it. Resilient demand is a pass.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "No quick new supply — herds take years to rebuild.",
+          "detailedExplanation": "Unlike a factory, a cattle herd cannot be switched back on. Even if ranchers start keeping more heifers today, those calves take two to three years to reach market. With the border still cutting off Mexican cattle, there is little near-term supply to cap prices, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Mild grilling-season demand, not a strong signal.",
+          "detailedExplanation": "Beef demand rises modestly around the summer grilling season and holidays, but the effect is small next to the herd cycle, feed costs and trade events. It is not a reliable edge for an investor right now.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Cattle are historically expensive — near all-time records and in the top few percent of their price range. The one cushion is that the cost to raise them (record-priced feeder cattle plus feed) is also very high, which underpins the price. Beef is now dear versus pork and chicken.",
+      "overallAnalysisDetails": "On value, live cattle look stretched. At ~$239/cwt they are near June 2026's record and in the top few percent of their entire history, and in inflation-adjusted terms they are also at record levels. Beef has become expensive relative to its substitutes — retail beef is roughly double the price of pork — which encourages budget-conscious shoppers to switch to cheaper proteins, a headwind to demand.\n\nThe supportive nuance is the cost floor. A finished animal's cost is mostly the young 'feeder' cattle that go into the feedlot plus the feed to fatten them. Feeder cattle are themselves at record highs (~$364/cwt), so the breakeven cost of producing a finished animal is very high — which puts a high, relatively close floor under the live-cattle price. Feed (corn) is comparatively cheap, keeping feedlots roughly profitable, but the packers who buy the finished cattle are losing money, a sign the price is testing the ceiling of what the supply chain can bear.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Near record highs — top of its multi-decade range.",
+          "detailedExplanation": "At ~$239/cwt, live cattle sit just below June 2026's record and in the top few percent of their historical range. On this measure they are expensive, with limited room to rise on valuation alone, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "At record levels even after adjusting for inflation.",
+          "detailedExplanation": "Cattle prices are at records not just in nominal terms but in real (inflation-adjusted) terms too, and beef is a leading driver of food inflation. A price this stretched versus history is a headwind for new buyers, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Record feeder and feed costs underpin the price.",
+          "detailedExplanation": "The cost of producing a finished animal — record-priced feeder cattle (~$364/cwt) plus feed and yardage — is very high, so the breakeven floor sits close beneath the live-cattle price. That high cost base genuinely limits how far prices can fall in the near term, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Beef is expensive versus pork and chicken.",
+          "detailedExplanation": "Retail beef is roughly twice the price of pork and far above chicken, which pushes cost-conscious consumers toward cheaper proteins. Being the premium meat at record prices encourages switching away, a demand headwind, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "Only ~7-8% below the June 2026 record.",
+          "detailedExplanation": "Live cattle trade just ~7-8% below their all-time high on fundamentals that are already widely understood. Buying so close to a record raises poor-entry-timing risk, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Live cattle are one of the calmer commodities — relatively low volatility, drawdowns that have recovered, and a low correlation to stocks that makes them a diversifier. The defining risk is biological: animal disease (screwworm, bird flu, foot-and-mouth) and drought.",
+      "overallAnalysisDetails": "For a commodity, live cattle are comparatively steady: annualized volatility around 15% is well below energy and grains, and cattle have a low correlation to the stock market, so they can diversify a portfolio. Their worst falls — a roughly 40% slide in 2015-2016 and the sharp COVID-2020 crash when meatpacking plants shut down — were painful but recovered.\n\nThe risks that set livestock apart from metals are biological and weather-driven. A New World screwworm outbreak is already disrupting trade; H5N1 bird flu has spread into US dairy cattle (with limited beef impact so far); and the tail risk is a foot-and-mouth disease (FMD) outbreak, which would slam export markets shut and crater prices. Drought is a constant threat to pastures and feed. These shocks cut both ways — a supply scare can spike prices, but a demand-side disease event can be devastating — so they are the key thing a cattle investor must watch. The US dollar matters only modestly, mainly through beef export and import competitiveness versus Brazil and Australia.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "About 15% a year — low for a commodity.",
+          "detailedExplanation": "Live cattle's annualized volatility of roughly 15% is among the lowest in the commodity world, well below energy and grains. That relative steadiness makes it easier to size and hold, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Fell ~40% in 2015-16 and in 2020, but recovered.",
+          "detailedExplanation": "Cattle dropped about 40% in the 2015-2016 downturn and crashed when COVID shut meatpacking plants in 2020, but recovered from both. The drawdowns are real but have been survivable, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Disease and drought are the defining risks.",
+          "detailedExplanation": "Livestock live and die by biology: the active screwworm outbreak, H5N1 bird flu in dairy cattle, the foot-and-mouth-disease tail risk (which would shut export markets), and recurring drought all threaten supply and trade. These shocks can be sudden and hard to predict, so this factor fails despite the diversified production base.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Mostly a domestic market; the dollar is secondary.",
+          "detailedExplanation": "Cattle prices are driven far more by domestic supply and demand than by the US dollar, which matters mainly at the margin for beef exports and imports. The dollar is not a binding headwind here, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Low stock correlation; tracks food inflation.",
+          "detailedExplanation": "Live cattle have a low correlation to equities, so they diversify a stock portfolio, and beef is a large, visible part of food inflation, giving cattle some inflation-hedge character. The diversification case is genuine, so this factor passes.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The near-term outlook stays tight — the herd rebuild is slow and supply won't recover for 18-24 months — and analysts see new highs. But at record prices, with packers losing money and a rebuild eventually coming, the risk/reward is no longer clearly skewed up.",
+      "overallAnalysisDetails": "Supply will stay tight for a while. Even with the first small signs of ranchers holding back heifers to rebuild, those animals won't produce market cattle for two to three years, so most analysts expect another 18-24 months of tight supply and firm prices, with meaningful herd growth only from 2027 onward. Forecasters like Rabobank see new market highs in 2026 and 2027, and USDA has raised its price projections.\n\nThe balance of the argument, though, is finely poised. The bull case is the record-low herd, the closed Mexican border, and resilient demand. The bear case is real too: demand could finally crack at record retail prices, packers are losing money and closing plants (reducing slaughter demand for live cattle), cheaper pork and chicken are pulling some consumers away, and the eventual herd rebuild will add supply. Key things to watch: USDA's monthly Cattle on Feed and semi-annual inventory reports, the WASDE, corn prices, screwworm and the Mexican border, and any H5N1 or foot-and-mouth developments.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Tight for another 18-24 months.",
+          "detailedExplanation": "Because herd rebuilding is slow and cattle take years to raise, the supply shortage is expected to persist well into 2027. A forward balance that stays tight is supportive, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "USDA and Rabobank see continued strength.",
+          "detailedExplanation": "USDA raised its cattle price forecasts and Rabobank projects new market highs in 2026 and 2027 before prices ease as the herd rebuilds. The authoritative view is constructive, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Analysts point to further record highs.",
+          "detailedExplanation": "Rabobank and CattleFax see new highs in 2026 and 2027, implying upside from current levels on continued tight supply. Because the consensus points higher, this factor passes — though the upside is more limited from record levels.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Tight supply, but buying at record highs caps the reward.",
+          "detailedExplanation": "The bull case (record-low herd, closed border, firm demand) is well known and largely priced. Against it, packer losses and plant closures, cheaper substitute meats, and the eventual herd rebuild are building risks. At all-time-high prices the payoff is no longer clearly skewed to the upside, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Cattle on Feed, inventory reports, screwworm, and corn.",
+          "detailedExplanation": "The clearest catalysts are USDA's Cattle on Feed and inventory reports, the WASDE, corn/feed prices, the screwworm situation and Mexican border, and H5N1 or foot-and-mouth news. These are watchable and, near term, lean supportive, so this factor passes.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/natural-gas.json
+++ b/insights-ui/src/commodity-data/reports/natural-gas.json
@@ -1,0 +1,217 @@
+{
+  "slug": "natural-gas",
+  "name": "Natural Gas",
+  "commodityGroup": "Energy",
+  "priceSymbol": "NG=F",
+  "exchange": "NYMEX",
+  "unit": "MMBtu",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on US natural gas (Henry Hub): near $3.20/MMBtu in mid-2026, historically cheap with a real LNG and AI-data-center demand story, but the most volatile major commodity. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: High-risk. A good value story wrapped in brutal volatility.\n\nUS natural gas (Henry Hub) trades near $3.20 per MMBtu in early July 2026. It is historically cheap in real terms, comfortably above the roughly $2.00 cost to produce it, and about 78% below its 2005 record of ~$14.49. There is a genuine multi-year demand story: the US LNG export boom (new terminals like Plaquemines, Corpus Christi and Golden Pass ramping up) and surging electricity demand from AI data centers are structurally lifting the demand floor. US gas also trades at roughly one-fifth the price of European (~$16) and Asian (~$18) gas, which is what drives the export machine.\n\nBut natural gas is the single most volatile major commodity — nicknamed 'the widowmaker.' Its volatility hit 179% in early 2022, and 80-90% crashes are routine, not rare (it fell 64% in just three months in early 2026). Supply is a wall of cheap, price-elastic shale that floods every rally, and US storage currently sits about 6% above its five-year average. It is also a poor inflation hedge — it crashed 80% during the 2022 inflation spike. For a beginner the retail vehicles are dangerous (the UNG ETF suffers heavy roll decay; futures are highly leveraged). The value case is fine, but the risk profile dominates — producer or LNG-infrastructure equities are a more prudent way to play the bullish thesis than the commodity itself.",
+  "keyFacts": {
+    "keyFacts": "Natural gas is the fuel that generates about 40% of US electricity and heats most US homes. In the US it is priced per MMBtu (one million British thermal units, a unit of energy) at the Henry Hub in Louisiana, with the NYMEX front-month future (NG=F) as the benchmark. In early July 2026 that price is about $3.20 per MMBtu.\n\nTwo things make gas unusual for a beginner. First, it is extremely local and weather-driven: unlike oil, it is hard to ship, so a cold snap or a hot summer can double or halve the price in weeks. That is why it is the most volatile major commodity. Second, it is slowly 'globalizing' through liquefied natural gas (LNG) exports — the US now ships gas by sea to Europe and Asia, where prices are about five times higher (~$16 in Europe, ~$18 in Asia versus ~$3.20 at home). That export boom, plus new electricity demand from AI data centers, is the core bullish story. Against it stands a wall of cheap US shale supply that can be switched on fast and floods every rally.",
+    "greenFlags": [
+      {
+        "flag": "A real structural demand story (LNG + AI data centers)",
+        "explanation": "US LNG exports are set to rise from about 17 to 18.6 billion cubic feet a day as new terminals ramp up, and AI data centers are adding a genuinely new source of electricity demand (gas is ~40% of US power). Both are durable, multi-year demand drivers that lift the price floor over time.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Historically cheap with a cost floor",
+        "explanation": "At about $3.20, gas is cheap in real terms (the 2005 peak would be over $22 in today's dollars) and comfortably above the ~$2.00 cost to produce the best Appalachian gas. Cheap-versus-history plus a cost floor limits how far it can fall.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Very cheap per unit of energy versus oil",
+        "explanation": "At ~$65 oil and ~$3.20 gas, oil costs roughly 3.5x more per unit of energy than the historical 6:1 parity. That wide gap makes gas attractive for power, industry and export, underwriting the demand story.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "The most volatile major commodity",
+        "explanation": "Natural gas is nicknamed 'the widowmaker.' Its volatility hit 179% in February 2022, and 80-90% crashes are routine — it fell 64% in just three months in early 2026 ($7.72 to $2.77). This is a market that can wipe out leveraged positions overnight on a weather forecast.",
+        "result": "Fail"
+      },
+      {
+        "flag": "A wall of cheap supply and a storage surplus",
+        "explanation": "US production is at a record (~111 billion cubic feet a day and rising), much of it near-costless 'associated' gas from oil wells, and storage sits about 6% above its five-year average. Shale can be switched on within weeks, so every rally invites a supply flood that caps the upside.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Electric power generation (~40% of US electricity)",
+      "Heating (homes, business, industry)",
+      "Industrial feedstock and process heat",
+      "LNG export",
+      "Fertilizer (ammonia/nitrogen)"
+    ],
+    "topProducers": [
+      { "country": "United States", "share": "~26%" },
+      { "country": "Russia", "share": "~14%" },
+      { "country": "Iran", "share": "~6%" },
+      { "country": "China", "share": "~5%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "UNG", "note": "Tracks front-month gas futures; SEVERE contango/roll decay — a trading tool, not a hold" },
+      { "type": "Futures", "name": "NG=F", "note": "Direct but highly leveraged; the 'widowmaker' — experienced traders only" },
+      { "type": "Equities", "name": "Gas producers / E&Ps", "note": "Appalachia-focused producers; cyclical but avoids roll decay" },
+      {
+        "type": "Equities",
+        "name": "LNG / midstream infrastructure",
+        "note": "Fee-based cash flows less tied to spot price; a steadier way to play the thesis"
+      }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "A genuine demand story (LNG exports + AI data centers) and strong seasonality are offset by record price-elastic production, a storage surplus (~6% above the five-year average), and a huge shale cushion that floods every rally. On balance, supply pressure wins.",
+      "overallAnalysisDetails": "The demand side is the bullish part. US LNG exports are projected to rise from about 17.2 to 18.6 billion cubic feet a day as Plaquemines, Corpus Christi Stage 3 and Golden Pass ramp up, and AI data centers are adding a new, structural source of electricity demand (gas generates ~40% of US power). Total US consumption is forecast to climb toward 95 billion cubic feet a day in 2027.\n\nBut supply overwhelms it. US dry-gas production is at a record — about 111 billion cubic feet a day in 2026 and rising toward 114 in 2027 — much of it near-costless 'associated' gas that comes out of oil wells regardless of the gas price. Storage sits about 6% above its five-year average (a surplus), and shale is highly price-elastic: a backlog of drilled-but-uncompleted wells can be turned on within weeks, so every rally invites a supply flood. Seasonality is strong and tradable (winter heating, summer cooling), but the underlying balance is loose.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Record production, much of it near-costless associated gas.",
+          "detailedExplanation": "US dry-gas output is at a record ~111 billion cubic feet a day in 2026 and forecast to rise toward 114 in 2027 (EIA). A lot of it is 'associated' gas produced as a byproduct of Permian oil wells, so it keeps flowing regardless of the gas price. Record, rising supply is a persistent headwind for prices.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Storage is about 6% above the five-year average.",
+          "detailedExplanation": "US gas in storage sits roughly 6% above its five-year average after larger-than-expected injections, and the EIA expects inventories to stay above average through 2026. A storage surplus is bearish — it means there is a comfortable cushion of gas, which weighs on prices, especially heading into a mild season.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Real structural growth from LNG exports and AI data centers.",
+          "detailedExplanation": "Two durable, multi-year demand drivers are genuinely new: LNG exports rising from ~17.2 to 18.6 billion cubic feet a day as terminals ramp, and AI data centers adding electricity demand (gas is ~40% of US power). This is the strongest part of the gas case and the main reason the market could tighten over time.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "A huge, fast shale cushion caps every rally.",
+          "detailedExplanation": "Natural gas supply is highly price-elastic: shale wells drill and complete in weeks, and a backlog of drilled-but-uncompleted wells can be switched on quickly when prices rise. Near-costless associated gas adds more. This 'shale cushion' means rallies are quickly met with new supply, capping the upside.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Strong, tradable seasonal pattern.",
+          "detailedExplanation": "Gas has a powerful seasonal rhythm: winter heating spikes demand (a polar vortex can double prices in days), summer cooling adds a secondary peak, and the storage cycle (inject April-October, withdraw November-March) drives trading. Used carefully, this seasonality is a genuine, exploitable feature.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "On value gas looks good: near $3.20 it is in the lower third of its range, historically cheap in real terms, comfortably above its ~$2.00 cost floor, very cheap per unit of energy versus oil, and about 78% below its all-time high. Value is the strongest pillar.",
+      "overallAnalysisDetails": "Judged on price, gas is inexpensive. At about $3.20 it sits in the lower third of its five-year range and is historically cheap in real terms — the 2005 peak of ~$14.49 would be well over $22 in today's dollars, and the shale revolution structurally lowered real prices after 2008.\n\nThere is a real cost floor: the best Appalachian dry gas breaks even around $2.00 per MMBtu, so today's $3.20 sits comfortably above it, and prices below ~$2 quickly shut in supply. Gas is also very cheap per unit of energy versus oil (roughly 3.5x cheaper than the historical parity), and it competes with coal in power generation. It is about 78% below its all-time high, leaving huge theoretical headroom. The value case is clearly supportive — the problem, as the risk section shows, is not the price level but the volatility around it.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Lower third of its five-year range.",
+          "detailedExplanation": "At about $3.20, gas sits in the lower third of its five-year range (roughly $1.50-$9 over 2020-2025) and near the middle-low of its 52-week range ($2.48-$7.83). It is not cheap versus the last two years' floors, but it is far from frothy — a reasonable valuation entry zone.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Historically cheap in real terms.",
+          "detailedExplanation": "After adjusting for inflation, gas is cheap. The 2005 peak of ~$14.49 would be over $22 per MMBtu in today's dollars, and the shale revolution structurally lowered real prices after 2008. Today's low-$3s are a fraction of pre-shale real prices, so buyers are not paying an inflated real price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Comfortably above the ~$2.00 breakeven.",
+          "detailedExplanation": "The best Appalachian dry gas breaks even around $2.00 per MMBtu, and wells go uneconomic below that, which tends to shut in supply and support the price. At about $3.20, gas sits comfortably above that floor — enough margin to cushion the downside without being expensive.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Very cheap per unit of energy versus oil.",
+          "detailedExplanation": "At ~$65 oil and ~$3.20 gas, oil costs roughly 3.5x more per unit of energy than the historical 6:1 parity, so gas is very cheap per BTU. Gas also competes with coal in power generation. This wide value gap versus substitutes underwrites the LNG and gas-to-power demand story.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 78% below the 2005 record of ~$14.49.",
+          "detailedExplanation": "Gas near $3.20 is about 78% below its ~$14.49 all-time high (December 2005) and ~64% below the 2022 peak. That leaves enormous theoretical headroom rather than record-high risk, though gas's history shows it can stay cheap for years between weather- or supply-driven spikes.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "This is where gas fails hardest: the highest volatility of any major commodity (179% in early 2022), routine 80-90% crashes, extreme weather and hurricane exposure, and a poor inflation-hedge record (it crashed during the 2022 inflation spike). The one plus is low sensitivity to the US dollar. Four of five factors fail.",
+      "overallAnalysisDetails": "Natural gas is the riskiest of the major commodities. Its 30-day historical volatility averaged 124% in early 2022 and hit 179% in February 2022 — a 20-year high — and even 'normal' annualized volatility runs 50-80%+. Crashes of 80-90% are routine, not tail events: from ~$14 in 2005 to ~$2 in 2012, from ~$10 in 2022 to ~$2 in 2023, and a 64% fall in just three months in early 2026.\n\nThe core risk is weather. Cold snaps spike heating demand and cause 'freeze-offs' that physically shut in wells just as demand peaks, while Gulf hurricanes threaten both production and LNG export terminals (the 2022 Freeport LNG outage moved global prices for months). Gas is also a poor inflation hedge — it crashed about 80% during the highest inflation in 40 years in 2022-23 — and has low correlation to stocks, so its diversification value is undercut by its crash risk. The one bright spot is that gas is still largely a domestic market with limited US-dollar sensitivity. Overall, this is a high-risk commodity best sized small.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "The highest volatility of any major commodity.",
+          "detailedExplanation": "Gas volatility hit 179% in February 2022 (a 20-year high) and normally runs 50-80%+ a year — far above oil, metals or stocks. This is why it is called 'the widowmaker.' Such extreme volatility makes it dangerous to hold, especially with leverage.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "80-90% crashes are routine, not rare.",
+          "detailedExplanation": "Gas regularly loses 80-90% of its value: ~$14 (2005) to ~$2 (2012), ~$10 (2022) to ~$2 (2023), and a 64% fall in three months in early 2026. These are not tail events — they are a normal feature of the market — so downside risk is severe.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Extreme weather and hurricane exposure.",
+          "detailedExplanation": "Gas is intensely weather-driven: polar vortex cold snaps spike demand and freeze wells ('freeze-offs'), while Gulf hurricanes threaten production and LNG export terminals (the 2022 Freeport outage moved prices for months). European and Russian supply geopolitics now feed in via LNG. This unpredictability is a major risk.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Low dollar sensitivity — a domestic market.",
+          "detailedExplanation": "Unlike oil, gas is still largely a domestic US market where local supply, demand and storage set the price, so its sensitivity to the US dollar is weak. That relative insulation from currency swings is a modest positive — the one bright spot in an otherwise high-risk profile — though the LNG boom is slowly globalizing it.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "A poor inflation hedge that crashed during 2022 inflation.",
+          "detailedExplanation": "Gas has low correlation to stocks, but it is a poor inflation hedge: it crashed about 80% in 2022-23, during the highest inflation in 40 years, because its price is set by weather and storage, not the macro cycle. So it cannot be relied on for portfolio inflation protection, and its low stock correlation is offset by its crash risk.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The forward balance is modestly tightening as LNG and data-center demand grow, but record production offsets much of it, the EIA sees only ~$3.34-$3.46 (and recently cut its 2027 view), bank targets are widely dispersed with bearish 2028 tails, and the bull case is matched by an equally live glut case. Only the tightening balance passes.",
+      "overallAnalysisDetails": "The forward setup is a genuine tug-of-war. On the bullish side, LNG export capacity (+~1.4 billion cubic feet a day) and AI data-center power demand are set to tighten the balance into 2027 — a real, structural demand-growth thesis. On the bearish side, record production (+~2.6 billion cubic feet a day from 2026 to 2027) and rising associated gas from oil wells offset much of that growth, so the market tightens only modestly.\n\nForecasts are muted. The EIA's June 2026 outlook sees Henry Hub averaging about $3.34 in the second half of 2026 and $3.46 in 2027 — flat-to-slightly-up — and it actually cut its 2027 view by more than $1 versus January, citing more associated-gas supply. Bank targets are widely dispersed: Goldman around $4.15 for 2026-27 but ~$2.70 for 2028-29, Morgan Stanley up to $5 if a winter deficit emerges, S&P around $3.75. The bull case (LNG + data centers lift the floor, a cold winter drains storage to $5+) is matched by an equally credible bear case (shale floods the market, mild weather leaves a glut, prices sink toward $2 with 60-90% drawdowns). Watchable catalysts are clear, but the risk-reward is balanced at best.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Modestly tightening on LNG and data-center demand.",
+          "detailedExplanation": "The forward balance tightens into 2027 as LNG export capacity and AI data-center power demand grow — a genuine, structural demand story. Record production and rising associated gas offset much of it, so the market tightens modestly rather than sharply, but the direction of the balance is the one clear positive in the outlook.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "EIA sees only ~$3.34-$3.46 and recently cut 2027.",
+          "detailedExplanation": "The EIA's June 2026 outlook sees Henry Hub averaging about $3.34 in the second half of 2026 and $3.46 in 2027 — barely above today's ~$3.20 — and it cut its 2027 forecast by more than $1 versus January on higher associated-gas supply. A flat, recently-downgraded official view is not a supportive signal.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Widely dispersed targets with bearish 2028 tails.",
+          "detailedExplanation": "Bank targets range widely: Goldman around $4.15 for 2026-27 but ~$2.70 for 2028-29, Morgan Stanley up to $5 in a winter-deficit scenario, S&P around $3.75. The wide dispersion and bearish longer-tail forecasts reflect low conviction rather than a clear upside signal.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Credible bull case, but an equally live glut case.",
+          "detailedExplanation": "The bull case is LNG plus data centers lifting the demand floor and a cold winter draining storage to $5+. The bear case — shale and associated gas flooding the market, mild weather leaving a glut, prices sinking toward the ~$2 breakeven with 60-90% drawdowns — is equally credible. With no margin of safety on the risk, the scenario balance does not favor a long holder.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Clear catalysts, but they cut both ways.",
+          "detailedExplanation": "Watch weather forecasts (the #1 short-term driver), the weekly EIA storage report, LNG terminal startups and outages, data-center power deals, and oil prices (which drive associated gas). These are clear and monitorable, but in a loose, oversupplied market they are as likely to trigger a sell-off as a rally, so they are not a dependable tailwind.",
+          "result": "Fail"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/palladium.json
+++ b/insights-ui/src/commodity-data/reports/palladium.json
@@ -1,0 +1,202 @@
+{
+  "slug": "palladium",
+  "name": "Palladium",
+  "commodityGroup": "Metals",
+  "priceSymbol": "PA=F",
+  "exchange": "NYMEX",
+  "unit": "troy ounce",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on palladium: about $1,280/oz in mid-2026, still ~62% below its 2022 record. Nearly all its demand comes from gasoline cars, which electric vehicles are slowly replacing — a structural decline. It looks cheap, but cheap for a reason. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Cautious / Negative — cheap, but for a reason.\n\nPalladium is almost a one-trick metal: roughly 80-90% of its demand comes from catalytic converters in gasoline cars. That single dependence is the whole story. In early July 2026 palladium trades around $1,280 an ounce — still about 62% below its March 2022 record of ~$3,440, a crash it has never recovered from. It bounced ~30% over the past year, but that was a cyclical rebound, not a turnaround.\n\nThe problem is structural, not temporary. Two forces are permanently shrinking palladium's demand: battery electric cars (which need no catalytic converter) are slowly replacing gasoline cars, and carmakers have already swapped more than a million ounces a year of palladium for cheaper platinum. Meanwhile a decade-long supply shortfall is now flipping into surplus, and recycling of old converters is rising fast. Palladium does look cheap — it trades near the cost of mining it and below platinum — and short-term supply shocks (especially from Russia, which mines ~40% of it) could spark sharp rallies. But most analysts see it drifting flat-to-lower. Best understood as a high-risk, contrarian/cyclical trade rather than a long-term hold.",
+  "keyFacts": {
+    "keyFacts": "Palladium is a 'platinum-group metal' whose fortunes are tied almost entirely to one use: catalytic converters that clean the exhaust of gasoline-powered cars, which make up roughly 80-90% of its demand. Small amounts also go into electronics, dentistry and jewelry. This narrow dependence makes palladium unusually exposed to what happens in the car industry.\n\nIn early July 2026 palladium is around $1,280 an ounce. To understand it, you have to know its recent history: it soared to a record ~$3,440 in March 2022 (partly on fears about Russian supply after the invasion of Ukraine), then collapsed and has stayed roughly 62% below that peak. For a beginner, the key point is that palladium faces a genuine long-term decline in demand — electric cars and a permanent shift to cheaper platinum are eating away at its only major market — even though its low price and concentrated Russian supply can produce violent short-term rallies.",
+    "greenFlags": [
+      {
+        "flag": "Trades near the cost of mining it",
+        "explanation": "At ~$1,280, palladium sits close to the all-in cost of its highest-cost producers (the only primary US mine, Stillwater, has costs near ~$1,290 and was partly shut down). When a metal trades near the cost of production, high-cost supply gets cut — as is already happening — which puts a rough floor under the price.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Cheap versus platinum, with short-term supply risk",
+        "explanation": "Palladium now trades at a discount to platinum, reversing years when it was 2-3x more expensive. That cheapness could slow or even reverse the switch to platinum. And with ~40% of supply coming from Russia (facing sanctions and a US anti-dumping case), a supply shock could spark a sharp, if temporary, rally.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Electric cars are shrinking its only real market",
+        "explanation": "Roughly 80-90% of palladium demand is gasoline-car catalytic converters. Battery electric vehicles use none. As EVs slowly replace combustion engines, palladium's core demand faces a structural, long-term decline — the central reason to be cautious.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Deficit flipping to surplus, recycling rising",
+        "explanation": "After more than a decade of supply shortfalls, the market is tipping into surplus (Johnson Matthey projects a small surplus in 2026, the first since 2012). On top of that, recycling of old catalytic converters is growing at double-digit rates, adding supply just as demand weakens.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Autocatalysts (gasoline vehicle emissions control)", "Electronics", "Dentistry", "Jewelry (minor)"],
+    "topProducers": [
+      { "country": "Russia", "share": "~40%" },
+      { "country": "South Africa", "share": "~38%" },
+      { "country": "Canada", "share": "~9%" },
+      { "country": "United States", "share": "~5%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "PALL", "note": "Physically-backed spot palladium ETF" },
+      { "type": "Futures", "name": "PA=F", "note": "NYMEX front-month contract" },
+      { "type": "Physical", "name": "Bars / coins", "note": "Direct ownership; a thin, illiquid retail market" },
+      { "type": "Equities", "name": "PGM miners (e.g. Sibanye-Stillwater)", "note": "Leveraged, operational exposure; many are cutting palladium output" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "This is palladium's weak spot. Its one big market — gasoline-car converters — is in structural decline from electric cars and platinum substitution, while a decade-long deficit is flipping to surplus and recycling is rising fast. Only falling mine supply offers any support.",
+      "overallAnalysisDetails": "Palladium's supply and demand are moving in the wrong direction for holders. On the demand side, roughly 80-90% of palladium goes into gasoline-car catalytic converters, and that market faces a double squeeze: battery electric vehicles use no converter, and carmakers have permanently swapped more than a million ounces a year of palladium for cheaper platinum. Johnson Matthey forecasts total demand falling about 9% in 2026, with auto demand shrinking as gasoline-car production declines. Hybrids (which use slightly more palladium than pure gasoline cars) and a temporary slowdown in EV adoption cushion the fall, but the long-term direction is down.\n\nOn the supply side, mine output is falling — Russian production has dropped to its lowest in two decades and the main US mine has been partly curtailed — which is the one genuinely supportive factor. But recycling of old converters is growing fast, and after more than a decade of shortfalls the overall market is now tipping into surplus (Johnson Matthey sees a small surplus in 2026, the first since 2012). A market moving from deficit to surplus, with a shrinking core demand, is a bearish setup.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Mine supply is falling — the one supportive factor.",
+          "detailedExplanation": "Palladium mine output is dropping: Russian production is at a 20-year low and the only primary US mine (Stillwater) has been partly shut down at low prices. Falling supply is the single genuinely price-supportive part of the palladium story, so this factor passes even as the demand side deteriorates.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "The market is flipping from deficit to surplus.",
+          "detailedExplanation": "After more than a decade of shortfalls, palladium is tipping into surplus — Johnson Matthey projects the first small surplus since 2012 in 2026. A market that is building rather than drawing down its stockpiles is a bearish signal for price, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Its one big market is in structural decline.",
+          "detailedExplanation": "Roughly 80-90% of demand is gasoline-car converters — a pillar being eroded by both battery EVs and the permanent switch to platinum. Total demand is forecast to fall ~9% in 2026. When a metal's single dominant demand source is in secular decline, that is a core red flag, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Recycling is a fast-growing new source of supply.",
+          "detailedExplanation": "Even though mining is falling, recycling of old catalytic converters is rising at double-digit rates and adds a large, growing stream of secondary supply. That recycled metal helps cap any rally and pushes the market toward surplus, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "No meaningful seasonal pattern.",
+          "detailedExplanation": "Palladium has no reliable seasonal edge. Its price is driven by global car production, Russian supply and sanctions news, and its price relationship to platinum — not by the calendar.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "On pure price measures palladium looks cheap — near the cost of mining it, below platinum, and far off its record. But this is a classic value trap: it is cheap because its demand is permanently shrinking, so the low price may be justified rather than a bargain.",
+      "overallAnalysisDetails": "Palladium screens as inexpensive, and that is genuine as far as it goes. At ~$1,280 it sits in the lower part of its own recent range (it averaged ~$2,400 five years ago), near the all-in cost of its highest-cost producers, and at a discount to platinum after years of trading at a large premium. Its cost floor is real: the main US mine's costs are around ~$1,290, and it has already been partly shut down — the classic sign that low prices are forcing high-cost supply offline, which limits how much further the price can fall.\n\nThe crucial caveat is why it is cheap. Palladium has crashed ~62% from its 2022 peak because its only major market is in structural decline. So the low price is not necessarily a discount to fair value — it may simply reflect a business (gasoline-car exhaust) that is slowly disappearing. The distance from its old high is not a reliable springboard here, because the demand that drove that high is not coming back. Cheap, in palladium's case, is cheap for a reason.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "In the lower part of its own multi-year range.",
+          "detailedExplanation": "At ~$1,280, palladium is well below its five-year average (~$2,400) and sits in the lower portion of its range since 2016 (~$615 low, ~$3,440 high). On this narrow measure it is relatively cheap, so the factor passes — with the caveat that cheapness reflects a weakening demand story.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Below its recent-decade real average.",
+          "detailedExplanation": "In inflation-adjusted terms palladium has round-tripped an entire boom — from ~$615 in 2016 up to ~$3,440 in 2022 and back to ~$1,280. Today's real price is well below its 2020-2022 average, so on this measure it is not stretched, and the factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Trading near the cost of its marginal producers.",
+          "detailedExplanation": "Palladium sits close to the ~$1,290 all-in cost of its highest-cost supply, and the only primary US mine has already been partly curtailed. Because the price is near the point where high-cost supply shuts down, the downside is somewhat limited — a genuine cost floor — so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Now cheaper than platinum.",
+          "detailedExplanation": "Palladium trades at a discount to platinum (~$1,280 versus ~$1,640), reversing years when it was far more expensive. Being the cheaper of the two could slow the switch to platinum and even prompt some carmakers to swing back to palladium — a mildly favorable relative-value point, so the factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "~62% below its 2022 record — but the demand is gone.",
+          "detailedExplanation": "Palladium is roughly 62% below its ~$3,440 record from March 2022. Normally that headroom would be bullish, but the demand that drove that spike (a Russian-supply scare plus peak gasoline-car production) is not returning, so the gap reflects a permanent re-rating rather than a recovery runway. This factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Palladium is one of the most volatile precious metals — it lost ~75% from its 2022 peak and has not recovered. Its supply is dangerously concentrated in Russia, and it is a pro-cyclical car-industry bet, not a portfolio hedge. High risk on almost every axis.",
+      "overallAnalysisDetails": "Palladium is a high-risk asset by nearly every measure. Its volatility is extreme — even more than platinum and far more than gold or the stock market — with a roughly 92% swing within 2025 alone. Its worst drawdown is brutal and unhealed: from ~$3,440 in March 2022 it fell around 75% to its lows and remains ~62% down, with no recovery.\n\nThe risks are concentrated and structural. About 40% of supply comes from Russia (mainly one company, Norilsk Nickel), which brings sanctions and trade-action risk — a US anti-dumping case on Russian palladium is active — and another ~38% comes from South Africa with its power and labor problems, so roughly 80% of supply sits in two politically sensitive countries. And because palladium is tied to car production, it is pro-cyclical: it tends to fall in economic slowdowns rather than protect a portfolio, and it is a poor inflation hedge. It offers little of the diversification value that gold provides.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "Among the most volatile precious metals.",
+          "detailedExplanation": "Palladium's price swings are extreme — even sharper than platinum's and far beyond gold's or the stock market's, with roughly a 92% range within 2025. Volatility this high, in a thin market, is hard to size and hard to stomach, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Down ~75% from 2022, with no recovery.",
+          "detailedExplanation": "From its ~$3,440 peak in March 2022, palladium fell roughly 75% and has not recovered, still sitting ~62% below the high. A drawdown this deep and this persistent — tied to a permanent demand shift — is a serious risk, so the factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "~80% of supply is in Russia and South Africa.",
+          "detailedExplanation": "About 40% of palladium comes from Russia (sanctions and anti-dumping risk) and ~38% from South Africa (power and labor problems), so roughly 80% of supply is in two fragile jurisdictions. This is extreme concentration; a supply shock can spike the price, but the standing risk is high, so the factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Driven by cars, not the dollar.",
+          "detailedExplanation": "Palladium's price is set far more by global car production than by the US dollar or interest rates, so the strong-dollar, high-rate backdrop is not its main headwind. On this narrow measure the dollar is not the binding constraint, so the factor passes — its real problems lie elsewhere.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Pro-cyclical — not a diversifier.",
+          "detailedExplanation": "Palladium moves with the industrial and car-production cycle, so it tends to fall in slowdowns alongside risk assets rather than hedge them, and it is a weak inflation hedge. It does not provide the portfolio diversification investors seek from precious metals, so this factor fails.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The base case is a structural decline: demand falling ~9% in 2026, the market flipping to surplus, and most bank targets flat-to-lower versus today's ~$1,280. Short-term supply shocks are the main upside wildcard, but the long-term direction is down.",
+      "overallAnalysisDetails": "The forward view is the weakest of the metals covered here. Johnson Matthey projects total demand falling about 9% in 2026 and the market moving into its first surplus since 2012, as auto demand shrinks with gasoline-car production and recycling climbs. That is the opposite of the tightening story that supports platinum and silver.\n\nBank forecasts reflect the caution: a Reuters analyst poll put 2026 around $1,262 (roughly today's level), J.P. Morgan near $1,150, and while some houses are more constructive (Bank of America ~$1,725), the consensus clusters flat-to-lower. The bull case is real but mostly short-term and cyclical: a lingering near-term deficit, falling Russian and US mine supply, a price near the cost floor, cheapness versus platinum, and the wildcard of Russian sanctions or tariffs sparking a supply scare. The bear case — the base case — is structural: EVs and platinum substitution permanently erode the ~80-90% of demand from gasoline cars. Watch Russian sanctions/anti-dumping developments, the pace of EV versus hybrid adoption, further mine curtailments, and the platinum-palladium spread.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Flipping from deficit to surplus.",
+          "detailedExplanation": "The multi-year deficit is closing and turning into a small surplus in 2026, with demand forecast down ~9% and recycling rising. A market loosening from deficit to surplus is a bearish forward balance, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "Johnson Matthey sees demand falling and a surplus forming.",
+          "detailedExplanation": "Johnson Matthey's 2026 report projects total demand down ~9%, auto demand shrinking with gasoline-car output, and the first surplus since 2012. The authoritative view points to weakness, not strength, so this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Consensus is flat-to-lower versus spot.",
+          "detailedExplanation": "A Reuters poll averaged ~$1,262 for 2026 (about today's ~$1,280), with J.P. Morgan near $1,150; only a minority (e.g. Bank of America ~$1,725) are meaningfully bullish. Because the consensus does not point clearly above spot, this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Structural bear case is the base case.",
+          "detailedExplanation": "The bull case (near-term deficit, falling supply, cheap versus platinum, a possible sanctions-driven spike) is real but mostly short-term. The bear case — EVs and platinum substitution permanently shrinking demand — is more likely and more damaging over time, so the skew is to the downside and this factor fails.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Russian sanctions are the big, watchable wildcard.",
+          "detailedExplanation": "There are genuinely actionable catalysts: Russian sanctions or US anti-dumping duties could remove ~40% of supply and spark a sharp rally, and further mine curtailments could tighten the near-term market. These watchable, potentially supportive events earn a pass even within a bearish structural story.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/platinum.json
+++ b/insights-ui/src/commodity-data/reports/platinum.json
@@ -1,0 +1,216 @@
+{
+  "slug": "platinum",
+  "name": "Platinum",
+  "commodityGroup": "Metals",
+  "priceSymbol": "PL=F",
+  "exchange": "NYMEX",
+  "unit": "troy ounce",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on platinum: about $1,640/oz in mid-2026 after a big 2025 rally, deep in a four-year supply deficit, cheap versus gold, but heavily dependent on South Africa and exposed to electric cars. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Positive, with real structural risks.\n\nPlatinum is mostly an industrial metal that also has a precious-metal side. Its biggest job is inside catalytic converters, the part that cleans up car exhaust — about 40% of demand. It also goes into glass-making, chemicals, jewelry, and, increasingly, investment bars. In early July 2026 platinum trades around $1,640 an ounce after a powerful 2025 rally (it briefly topped $2,300 in January 2026), yet it still sits about 28% below its 2008 record and, strikingly, at roughly 40% of the price of gold.\n\nThe bullish case is a genuine supply squeeze: the market has been short of platinum for four years running, above-ground stocks are down to under three months of demand, and more than 80% of mine supply comes from a single troubled country — South Africa — where output is falling. Platinum is also cheap versus gold and still below its inflation-adjusted record. The risks are equally real: the long-term shift to battery electric cars (which use no catalytic converter) threatens the core auto demand, and that heavy reliance on South Africa is a constant supply hazard. Best suited to investors who want a deficit-driven, contrarian precious-metal play and can stomach an industrial metal's swings.",
+  "keyFacts": {
+    "keyFacts": "Platinum is a 'platinum-group metal' (PGM) that is both an industrial workhorse and a precious metal. Its single biggest use — around 40% of demand — is in catalytic converters that scrub pollution from car and truck exhaust. It is also used in glass manufacturing, chemical processing, jewelry, and as an investment, and it is an emerging ingredient in hydrogen fuel cells and electrolyzers.\n\nIn early July 2026 platinum is around $1,640 an ounce. That is up strongly over the past year after a big 2025 rally, but still about 28% below its 2008 record of ~$2,290. The number that catches most investors' eyes is its relationship to gold: platinum is rarer than gold but trades at roughly 40% of gold's price, a historic discount (platinum used to trade at a premium to gold). For a beginner, the story is a tug-of-war: a tight, deficit-driven supply picture concentrated in South Africa, versus a long-term threat from electric cars eroding its main demand.",
+    "greenFlags": [
+      {
+        "flag": "Four straight years of supply deficits",
+        "explanation": "The world has used more platinum than it produced for four years running: shortfalls of ~1,071 (2023), ~995 (2024) and ~692 thousand ounces (2025), with another ~297 thousand ounces forecast for 2026. Above-ground stocks have been drawn down to under three months of demand — a genuinely tight market.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Cheap versus gold and below its real record",
+        "explanation": "Platinum trades at roughly 40% of gold's price (gold is ~2.5x platinum), a historic discount for a metal that is actually rarer than gold and once traded at a premium to it. It also remains well below its inflation-adjusted 2008 high, so on long-run value measures it looks inexpensive.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Substitution tailwind from palladium",
+        "explanation": "When palladium became far more expensive, carmakers switched to using cheaper platinum in gasoline catalytic converters. That substitution added over a million ounces a year of platinum demand and helped drive the deficit — a real, ongoing support for demand.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Electric cars threaten the core demand",
+        "explanation": "About 40% of platinum demand comes from catalytic converters, which battery electric vehicles do not have. As EV adoption grows over the coming decade, this core demand pillar faces a slow structural decline — the central long-term risk to platinum.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Over 80% of supply comes from South Africa",
+        "explanation": "More than 80% of mined platinum comes from South Africa, where chronic power shortages (load-shedding), labor disputes and cost pressures repeatedly disrupt output (African production fell ~6% in 2025). Add Russia as a top producer, and the supply chain is dangerously concentrated in a few fragile places.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": [
+      "Autocatalysts (vehicle emissions control)",
+      "Industrial (glass, chemicals, electrical)",
+      "Jewelry",
+      "Investment (bars, coins, ETFs) and emerging hydrogen fuel cells"
+    ],
+    "topProducers": [
+      { "country": "South Africa", "share": "~72%" },
+      { "country": "Russia", "share": "~10%" },
+      { "country": "Zimbabwe", "share": "~8%" },
+      { "country": "North America", "share": "~5%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "PPLT", "note": "Physically-backed spot platinum ETF" },
+      { "type": "Futures", "name": "PL=F", "note": "NYMEX front-month contract" },
+      { "type": "Physical", "name": "Bars / coins", "note": "Direct ownership, storage costs apply" },
+      {
+        "type": "Equities",
+        "name": "PGM miners (e.g. Sibanye-Stillwater, Anglo American Platinum)",
+        "note": "Leveraged, operational exposure — dominated by South African risk"
+      }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Platinum is in its fourth straight supply deficit, with stocks drawn down to under three months of demand. Mine supply is flat-to-falling and concentrated in South Africa, while substitution and industrial use support demand. The balance favors demand — but electric cars are a long-term threat.",
+      "overallAnalysisDetails": "Platinum supply is both constrained and dangerously concentrated. More than 80% of mined platinum comes from South Africa, where power cuts, labor issues and high costs keep pushing output down — African production fell about 6% in 2025. Miners have chosen to pay dividends rather than invest in new mines, so little new supply is coming. Recycling old catalytic converters adds a growing but partial offset (~1.6 million ounces in 2025). The result is a market that has been short of platinum for four straight years, drawing above-ground stocks down to under three months of demand cover.\n\nOn demand, the picture is a balance of forces. Autocatalysts (~40% of demand) are supported in the near term by carmakers swapping in platinum for pricier palladium, and industrial and investment demand are firm. But the elephant in the room is the shift to battery electric vehicles, which use no catalytic converter — a slow, structural erosion of platinum's biggest demand source over the coming decade. Emerging hydrogen fuel-cell demand could help fill that gap, but it is not material yet.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Mine supply is flat-to-falling; South African output fell ~6% in 2025.",
+          "detailedExplanation": "Platinum production is stuck or shrinking, dragged down by South Africa's power and cost problems, and miners are not investing in new capacity. Constrained supply meeting a market already in deficit is supportive for the price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Four years of deficits cut stocks to under three months of demand.",
+          "detailedExplanation": "Persistent shortfalls have drained above-ground stocks to under three months of cover by the end of 2026 — a tight buffer. When the cushion of stored metal shrinks like this, the market is more sensitive to any supply shock, which supports prices.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Substitution and industrial use hold demand up near-term; EVs threaten it long-term.",
+          "detailedExplanation": "Near term, demand is resilient: carmakers substituting platinum for palladium add over a million ounces a year, industrial use is up ~9%, and investment bar-and-coin demand is strong. The long-term worry is that battery EVs erode the ~40% auto-catalyst pillar. For now the demand base holds, but the EV risk is real and flagged.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "Almost no new supply coming; miners chose payouts over projects.",
+          "detailedExplanation": "Despite the price rally, platinum miners have favored returning cash to shareholders over building new mines, and South African output keeps slipping. With a thin project pipeline, there is little spare capacity to cap a rally in the next few years.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "No strong, reliable seasonal pattern.",
+          "detailedExplanation": "Platinum has no dependable seasonal edge for investors. Its price is driven by the auto/industrial cycle, South African supply news, the platinum-gold and platinum-palladium ratios, and investment flows — not the calendar.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Platinum looks genuinely cheap on long-run measures: below its inflation-adjusted 2008 record, at a historic ~40% of gold's price, and with a cost floor not far below the current price. The one caveat is that it has become pricier than palladium, which could slow the substitution tailwind.",
+      "overallAnalysisDetails": "Platinum is one of the better value stories in the metals complex, though it has run up sharply. At ~$1,640 it is high versus its own recent decade (it traded $800-$1,200 for years), which tempers the pure range picture. But on the measures that matter for a rarer precious metal, it looks cheap: it remains well below its inflation-adjusted 2008 high, it trades at roughly 40% of gold's price (a historic discount for a metal scarcer than gold), and the cost to mine it is not far below the current price. South African producers' all-in cost is around $1,000 an ounce, and a large slice of the industry was losing money at 2022-2023 prices — so the marginal cost floor sits closer beneath platinum than it does beneath gold or silver, giving more real downside support.\n\nThe subtle negative is relative to its closest cousin, palladium. Platinum used to trade far below palladium; now it trades above it. That reversal removes the incentive for carmakers to keep swapping platinum in and could even prompt a partial swing back to palladium — a headwind to watch.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "High versus its own 5- and 10-year range after the 2025 rally.",
+          "detailedExplanation": "Platinum traded between roughly $800 and $1,200 for much of the past decade, so at ~$1,640 it sits in the upper part of its own multi-year range. On this narrow measure it is not cheap, which is why this factor fails even though longer-run value looks better.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Still well below its inflation-adjusted 2008 high.",
+          "detailedExplanation": "Platinum's 2008 record of ~$2,290 is worth far more in today's money, so at ~$1,640 the metal is well below its real all-time high. Unlike gold, platinum has not made a new inflation-adjusted record, so on this long-run yardstick it is not stretched.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Mining cost sits relatively close beneath the price.",
+          "detailedExplanation": "South African all-in sustaining cost is around $1,000 an ounce, and much of the industry was unprofitable at 2022-2023 prices. Because high-cost South African mines sit not far below today's ~$1,640, the cost floor offers more genuine downside support for platinum than it does for gold or silver.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Now pricier than palladium, which can slow substitution.",
+          "detailedExplanation": "Platinum's closest substitute is palladium, and platinum now trades at a premium to it (about $1,640 versus ~$1,280). That reversal removes carmakers' incentive to keep switching from palladium to platinum, and could prompt some reverse-substitution — a mild headwind to platinum demand, so this factor fails despite platinum's cheapness versus gold.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 28% below its 2008 record.",
+          "detailedExplanation": "Platinum trades near $1,640 versus its ~$2,290 record from March 2008, which it has never reclaimed — roughly 28% below. With a four-year supply deficit supporting the market, that gap represents real headroom rather than fresh-record risk.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Platinum is more volatile than gold — it is a small, thinly-traded, industrially-driven market. Its two defining risks are its heavy reliance on South Africa and the long-term threat from electric cars. It has never recovered its 2008 high, but it diversifies a stock portfolio reasonably well.",
+      "overallAnalysisDetails": "Platinum trades in a small, thin market, so its price can move sharply — intraday ranges late in 2025 were several times the year's average. That volatility is higher than gold's, though it is understood and normal for a minor industrial-precious metal.\n\nThe risks that matter most are structural. First is geography: more than 80% of mine supply comes from South Africa, whose power grid (Eskom load-shedding), labor and cost problems repeatedly disrupt production, with Russia adding sanctions risk on top — the supply chain is a hostage to a few fragile places. Second is technology: the shift to battery electric cars slowly eats into the ~40% of demand that comes from catalytic converters. On the plus side, platinum's price is driven more by the auto and industrial cycle than by the dollar or interest rates, and it has a low correlation to stocks, so it still offers some portfolio diversification. Its deepest scar is that it fell more than 60% after 2008 and, even at January 2026's peak, never fully reclaimed that old high.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "More volatile than gold, but normal for a small PGM market.",
+          "detailedExplanation": "Platinum is a thin, industrially-driven market, so it swings more than gold — but that level of volatility is understood and typical for a platinum-group metal. It is manageable with sensible position sizing, so this factor passes even though the ride is bumpier than gold's.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Fell 60%+ after 2008 and never fully recovered.",
+          "detailedExplanation": "After its 2008 peak, platinum collapsed more than 60% and then ground sideways for a decade, never reclaiming that high even at January 2026's rally peak. A drawdown this deep and this slow to recover is a genuine mark against the metal.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Dangerously dependent on South Africa.",
+          "detailedExplanation": "More than 80% of supply comes from South Africa, where power cuts, labor disputes and weather regularly hit output, with Russia adding sanctions risk. This is textbook single-source supply concentration — a real hazard — so the factor fails even though supply shocks can spike the price as well as sink demand.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Less rate-driven than gold; dollar is a secondary factor.",
+          "detailedExplanation": "Platinum is priced in dollars but is driven far more by the auto and industrial cycle than by interest rates, so the high-real-yield, firm-dollar backdrop that pressures gold is a less binding headwind here. The dollar matters, but it is not platinum's main driver.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Low correlation to stocks gives some diversification.",
+          "detailedExplanation": "Despite being pro-cyclical, platinum has historically shown a low correlation to stocks and bonds, so it can add diversification to a portfolio. It is not a pure safe haven like gold, but it does not simply move in lockstep with equities either.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The near-term outlook is constructive: a fourth straight deficit, depleted stocks, and bank targets ($2,400+) well above today's ~$1,640. The long-term question mark is electric cars. The market may move toward balance by 2027 as investment demand cools.",
+      "overallAnalysisDetails": "For the next couple of years, the supply/demand setup is tight. The World Platinum Investment Council forecasts a fourth straight deficit in 2026 (~297 thousand ounces), with above-ground stocks near record lows, though the shortfall is narrowing each year and the market could move closer to balance in 2027 as 2025's surge in investment demand fades.\n\nBank forecasts are bullish: Bank of America set a 2026 target of $2,450 an ounce, and a Reuters analyst poll averaged $2,400 — both well above the current ~$1,640. The bull case rests on the deficit, depleted stocks, flat South African supply, palladium-to-platinum substitution, and the emerging hydrogen economy. The bear case is the slow erosion of auto demand from electric cars, falling jewelry demand, and the risk that 2025's investment inflows do not repeat. Key things to watch: South African supply shocks, the pace of EV versus hybrid adoption, investment flows, and the hydrogen/fuel-cell ramp toward 2030.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "A fourth straight deficit is forecast for 2026.",
+          "detailedExplanation": "The market is projected to stay in deficit in 2026 (~297 thousand ounces) with stocks near record lows, though the gap is narrowing and 2027 could approach balance. The forward balance still leans tight and supportive, even if less dramatically than in prior years.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "WPIC's structural-deficit thesis is intact.",
+          "detailedExplanation": "The World Platinum Investment Council maintains that platinum is in a genuine multi-year deficit, with supply constrained by flat mine output and depleted stocks. Even a more balanced 2026-2027 'won't fix the fundamental long-term tightness,' per WPIC — a constructive official view.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Bank targets ($2,400+) sit well above spot.",
+          "detailedExplanation": "Bank of America targets $2,450 for 2026 and a Reuters analyst poll averages $2,400 — both far above the ~$1,640 price, implying meaningful upside if the deficit thesis holds. The consensus clearly points higher, so this factor passes.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Near-term deficit skews up; electric cars are the long-term risk.",
+          "detailedExplanation": "Bull case: four straight deficits, depleted stocks, constrained South African supply, palladium substitution and emerging hydrogen demand, with bank targets well above spot. Bear case: EVs slowly erode auto demand and 2025's investment surge may not repeat. Near-term the skew favors the upside; the long-term risk is real and worth sizing for.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "South African supply, EV adoption, investment flows, and hydrogen.",
+          "detailedExplanation": "The clearest catalysts are South African supply shocks (a supportive risk), the pace of battery-EV versus hybrid adoption, investment and China bar-and-coin flows, and the ramp of hydrogen/fuel-cell demand toward 2030. On balance the calendar is watchable and leans supportive.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/silver.json
+++ b/insights-ui/src/commodity-data/reports/silver.json
@@ -1,0 +1,207 @@
+{
+  "slug": "silver",
+  "name": "Silver",
+  "commodityGroup": "Metals",
+  "priceSymbol": "SI=F",
+  "exchange": "COMEX",
+  "unit": "troy ounce",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on silver: about $62/oz in mid-2026 after a record ~$121 in January and a ~40% crash. Half precious metal, half industrial metal — it has a six-year supply deficit but is far more volatile than gold. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Positive, but high-risk and volatile.\n\nSilver is a hybrid: part precious metal (a store of value like gold) and part industrial metal (about 60% of demand goes into electronics, solar panels and other manufacturing). That split is the key to understanding it. In early July 2026 silver trades around $62 per ounce, roughly 49% below the record ~$121.62 it hit on 29 January 2026 before a violent crash — including one single-day drop of about 32%. Even so, it is up sharply over the past year.\n\nThe bullish case is real: the silver market has run a supply shortfall (deficit) for five straight years and 2026 looks set to be a sixth, because a lot of new silver comes out of the ground only as a by-product of mining other metals, so supply can't easily grow to meet demand. Bank price targets ($81-$100) sit well above today's price. The catch is risk: silver swings about twice as hard as gold, its crashes are deep and slow to recover, and it tends to fall alongside the stock market in a panic rather than protect you. Best suited to investors who understand it is a high-volatility way to play both precious-metal demand and the green-energy build-out — not a safe hiding place.",
+  "keyFacts": {
+    "keyFacts": "Silver is bought for two very different reasons, and that is what makes it unusual. About 60% of demand is industrial — it is the best conductor of electricity of any metal, so it goes into solar panels, phones, electric cars, and electronics. The rest is bought as jewelry, silverware, and as an investment (coins, bars and funds), where it behaves like a cheaper, more energetic cousin of gold.\n\nIn early July 2026 silver is around $62 per ounce. That follows a wild stretch: it set an all-time high of roughly $121.62 on 29 January 2026, then crashed about 40-49% in the following months. For a beginner, the two things to remember are (1) silver is a genuine supply-deficit story — the world has used more silver than it has produced for five years running — and (2) it is extremely volatile, moving far more than gold in both directions. It also tends to follow gold's lead but exaggerate the move.",
+    "greenFlags": [
+      {
+        "flag": "Six years of supply deficits",
+        "explanation": "The world has consumed more silver than it produced for five straight years (2021-2025), and 2026 is forecast to be a sixth. The 2025 shortfall was about 118 million ounces. Because roughly 72% of silver is dug up only as a by-product of mining gold, copper, lead and zinc, miners can't simply produce more silver when the price rises — which keeps the market tight.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Growing industrial demand from the green transition",
+        "explanation": "Industrial use hit a record ~680 million ounces in 2024 and kept climbing in 2025, led by electronics and solar power. Silver is a core material for the electrification of the economy, giving it a structural demand tailwind that pure precious metals like gold do not have.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Still below its inflation-adjusted record",
+        "explanation": "Silver's 1980 peak of ~$50 is worth roughly $150-$170 in today's money. So even at January 2026's nominal record of ~$121 — and far more so at ~$62 now — silver is well below its real (inflation-adjusted) high. Unlike gold, it has not made a new real record, leaving room to run.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "Extreme volatility and deep crashes",
+        "explanation": "Silver's yearly price swings run about 26-36%, roughly double gold's and far above the stock market's. It just fell about 40% in under four months from its January 2026 high, including a single-day drop near 32%. After its 2011 peak it lost more than 70% and took over a decade to recover. This is not a calm asset.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Falls with stocks in a panic, and solar demand is softening",
+        "explanation": "Because most silver demand is industrial, it often drops alongside the stock market in a risk-off sell-off instead of protecting a portfolio the way gold does. On top of that, solar-panel makers are using less silver per panel ('thrifting'), and that demand is forecast to fall about 19% in 2026.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Industrial (electronics, solar panels, EVs)", "Jewelry and silverware", "Investment (coins, bars, ETFs)", "Photography and other (minor)"],
+    "topProducers": [
+      { "country": "Mexico", "share": "~23%" },
+      { "country": "China", "share": "~13%" },
+      { "country": "Peru", "share": "~12%" },
+      { "country": "Chile", "share": "~6%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "SLV / SIVR", "note": "Physically-backed spot silver ETFs" },
+      { "type": "Futures", "name": "SI=F", "note": "COMEX front-month contract" },
+      { "type": "Physical", "name": "Coins / bars", "note": "Direct ownership; bulkier and pricier to store than gold" },
+      { "type": "Equities", "name": "Silver miners (e.g. SIL)", "note": "Leveraged, operational exposure to the price" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Silver has run a supply deficit for five straight years, with a sixth expected in 2026, because most silver is a by-product of other mining and can't ramp up on demand. Industrial demand is at records. The balance clearly favors demand.",
+      "overallAnalysisDetails": "The single most important fact about silver supply is that roughly 72% of it comes out of the ground as a by-product of mining gold, copper, lead and zinc. That means silver production is tied to the economics of those other metals, not to silver's own price. Even a record silver price only nudged 2025 mine output up about 2% to ~844 million ounces. Recycling adds another ~16% of supply. Because supply is so hard to grow, the market has been short of silver for five consecutive years (2021-2025), drawing down the above-ground stockpiles that fill the gap.\n\nOn the demand side, industrial use is the engine and it is growing: a record ~680 million ounces in 2024, driven by electronics, electric vehicles and solar power. Investment demand (coins, bars and ETFs) adds a swingy, sentiment-driven layer on top, and jewelry is steady. The one soft spot is solar: panel makers are using less silver per panel, so that slice of demand is expected to shrink in 2026. Overall, though, flat, inelastic supply meeting record industrial demand keeps the balance tight.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Mine output only crept up ~2% to ~844 Moz in 2025.",
+          "detailedExplanation": "Even at record prices, silver production barely rose, because ~72% of it is a by-product of mining other metals and can't be dialed up on demand. Top producers are Mexico (~23%), China (~13%) and Peru (~12%). Supply that can't respond to price, meeting a market already in deficit, is supportive for holders.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Five years of deficits are draining above-ground stocks.",
+          "detailedExplanation": "The market has used more silver than it produced every year since 2021 (a ~118 million ounce shortfall in 2025), which steadily eats into the exchange and vault stockpiles that cover the gap. Investment ETF holdings are near record levels and tightly held. Drawing inventories are a classic bullish signal.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Record industrial demand plus investment; solar is the soft spot.",
+          "detailedExplanation": "About 60% of demand is industrial and it hit a record ~680 Moz in 2024, led by electronics and the green transition. Investment demand adds cyclical upside. The one weak area is solar, where makers use less silver per panel and demand is forecast to fall ~19% in 2026 — but the overall demand picture is still growing and diversified.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "By-product supply can't ramp up to cap a rally.",
+          "detailedExplanation": "Because most silver is mined as a by-product, there is little spare capacity or wave of new primary silver mines waiting to come online when prices rise. That inelastic supply means a demand-driven rally is hard to cap in the short run.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "No strong, reliable seasonal pattern.",
+          "detailedExplanation": "Silver has some links to jewelry and industrial buying cycles, but no dependable seasonal edge that an investor can lean on. The price is driven far more by macro forces (real interest rates, the dollar, gold's direction) and the industrial cycle than by the calendar.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "Silver is expensive versus its recent range and mining cost, but — unusually — it is still below its 1980 inflation-adjusted record and looks cheap-to-fair versus gold. After a ~49% crash from January's high, there is real headroom to the old peak.",
+      "overallAnalysisDetails": "Judging silver's value pulls in two directions. On one hand, at ~$62 it is far above where it traded five years ago (~$25) and ten years ago (~$15-17), and it sits well above its mining cost (industry all-in cost is around $15 an ounce, though that figure is muddied by by-product accounting). By those measures it is not cheap.\n\nOn the other hand, silver is one of the few commodities still trading below its inflation-adjusted all-time high: the 1980 peak is worth roughly $150-$170 in today's dollars, so even January 2026's ~$121 record — and certainly today's ~$62 — is well under it. Against gold, the gold-to-silver ratio is about 60, a little below its long-run 65-70 average, meaning silver is modestly cheap relative to gold. And after crashing ~49% from January's high, there is now meaningful room back up to that record.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Still high versus its 5- and 10-year range.",
+          "detailedExplanation": "At ~$62, silver is well above its five-year (~$25) and ten-year (~$15-17) levels, sitting in the upper part of its multi-year range even after the recent crash. On this measure it is expensive, leaving less room to rise on valuation alone.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Still below its 1980 real (inflation-adjusted) high.",
+          "detailedExplanation": "Silver's 1980 peak of ~$50 equals roughly $150-$170 in today's money. At ~$62, silver trades far below that real record — a rare case of a metal that has NOT made a new inflation-adjusted high. On this long-run yardstick, silver is not stretched, which supports the value case.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Price sits well above the ~$15/oz mining cost.",
+          "detailedExplanation": "The industry's all-in sustaining cost is roughly $15 an ounce (flattered by credits from the other metals mined alongside silver), far below the ~$62 price. That means the cost 'floor' offers little downside protection at today's levels, though primary silver miners have higher standalone costs.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Modestly cheap versus gold.",
+          "detailedExplanation": "The gold-to-silver ratio is about 60, a bit below its long-run 65-70 average, so silver is fair-to-slightly-cheap relative to gold. Investors who want precious-metal exposure are not being pushed away from silver on relative price, which is a mild positive.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 49% below the January 2026 record.",
+          "detailedExplanation": "Silver trades near $62 versus its ~$121.62 record set on 29 January 2026 — roughly 49% below. With a six-year supply deficit and industrial demand still growing, that gap to the old high represents real headroom rather than fresh-record risk, even though silver is volatile.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "This is silver's weak spot. It is about twice as volatile as gold, its crashes are deep and slow to recover, and it often falls WITH the stock market in a panic rather than protecting you. Supply-concentration risk is moderate.",
+      "overallAnalysisDetails": "Silver is one of the wildest mainstream assets an ordinary investor can buy. Its yearly volatility runs about 26-36%, roughly double gold's and well above the stock market's. That cuts both ways — big rallies, but also brutal drops. It just fell about 40% in under four months from its January 2026 record, including a single session down around 32%, and after its 2011 peak it lost more than 70% and took over a decade to climb back.\n\nThe deeper risk is that silver is not a reliable safe haven. Because roughly 60% of its demand is industrial, in a genuine market panic it tends to fall alongside stocks (it needs a healthy economy to consume all that industrial silver), exactly when you would want a hedge to hold up. Its supply is concentrated in Mexico, China and Peru, but as a durable, non-perishable metal it faces little of the weather or single-region disruption risk that hits energy and food. The dominant risks are macro (a strong dollar, high real interest rates) and the industrial cycle.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "About twice as volatile as gold.",
+          "detailedExplanation": "Silver's annualized volatility of ~26-36% is roughly double gold's and far above the S&P 500's. For a beginner, that means position sizes should be smaller and swings of 5-10% in a day are normal. The return on offer can be large, but so is the risk, so this factor fails on a risk-adjusted basis.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "Deep crashes that take years to recover.",
+          "detailedExplanation": "Silver fell ~40% in months in early 2026 and, after its 2011 high, lost more than 70% and needed over a decade to recover. These drawdowns are far deeper and slower to heal than gold's, so a poorly-timed entry can hurt for a long time.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Moderate supply concentration, low disruption risk.",
+          "detailedExplanation": "Production is concentrated in Mexico, China and Peru (together about half of mine supply), but silver is durable and largely a by-product, so it faces little of the weather or single-region shock risk that hits crops and energy. The exposure is understood and roughly symmetric.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "High real yields and a firm dollar are a headwind.",
+          "detailedExplanation": "Like gold, silver is priced in dollars and tends to weaken when the dollar strengthens and real interest rates rise. With real 10-year yields high (~2.25%), holding a metal that pays no income has a real opportunity cost, which is a persistent headwind.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Falls with stocks in a panic; diversification is weaker than gold's.",
+          "detailedExplanation": "Because ~60% of demand is industrial, silver often drops alongside equities in a risk-off sell-off, unlike gold which tends to hold up. It is a decent inflation hedge in high-inflation periods, but its tendency to fall exactly when a portfolio is under stress weakens its diversification case.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The forward setup is constructive: a sixth straight supply deficit is expected, and bank targets ($81-$100) sit well above today's ~$62. The upside is real, but so is the risk of another sharp pullback.",
+      "overallAnalysisDetails": "Looking ahead, the supply/demand math stays tight: inelastic by-product supply meeting resilient industrial demand points to a sixth consecutive deficit in 2026, and the Silver Institute continues to flag industrial fabrication as the demand engine. That structural shortfall is the backbone of the bull case.\n\nBank forecasts are notably bullish and sit well above the current price — J.P. Morgan around $81 for 2026, UBS and ING in the mid-$80s, and Goldman Sachs and Commerzbank in the $85-$100 range. The bull case is the deficit, the green-transition demand, silver's discount to its real 1980 high, and a weaker dollar. The bear case is silver's own violence — it just crashed ~40%, solar demand is softening, and after a huge 2025 rally a deeper mean-reversion is always possible. Watch the Fed, the dollar, gold's direction (silver tends to follow and amplify it), and the industrial cycle.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "A sixth straight deficit is expected in 2026.",
+          "detailedExplanation": "With supply stuck (by-product economics) and industrial demand resilient, the market is forecast to stay in deficit for a sixth consecutive year. Softening solar demand is a moderating factor, but the overall balance still leans tight and supportive.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "Silver Institute confirms the ongoing deficit.",
+          "detailedExplanation": "The Silver Institute and Metals Focus confirm a fifth structural deficit for 2025 and project a sixth for 2026, with industrial demand carrying the load. The authoritative view is constructive rather than warning of a glut.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Bank targets ($81-$100) sit well above spot.",
+          "detailedExplanation": "Major banks see silver meaningfully higher over 6-24 months: J.P. Morgan ~$81 (2026 average), UBS/ING in the mid-$80s, and Goldman Sachs/Commerzbank in the $85-$100 range — all well above the ~$62 price. The consensus points clearly upward.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Upside skew from the deficit, but high crash risk.",
+          "detailedExplanation": "Bull case: a sixth-year deficit, green-transition demand, a discount to the 1980 real high, and a weaker dollar drive silver toward bank targets. Bear case: extreme volatility, softening solar demand, and mean reversion after 2025's surge. With targets well above spot the skew leans up, but the ride will be rough.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Fed policy, the dollar, gold's direction, and the industrial cycle.",
+          "detailedExplanation": "The clearest catalysts are the Federal Reserve's rate path, the US dollar trend, gold's direction (silver usually follows and exaggerates it), the manufacturing/industrial cycle, and the solar demand trajectory. These are watchable and, on balance, lean supportive.",
+          "result": "Pass"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/commodity-data/reports/wti-crude-oil.json
+++ b/insights-ui/src/commodity-data/reports/wti-crude-oil.json
@@ -1,0 +1,207 @@
+{
+  "slug": "wti-crude-oil",
+  "name": "Crude Oil (WTI)",
+  "commodityGroup": "Energy",
+  "priceSymbol": "CL=F",
+  "exchange": "NYMEX",
+  "unit": "barrel",
+  "currency": "USD",
+  "metaDescription": "A plain-English investor read on WTI crude oil: near $69 a barrel in mid-2026 after a Middle East spike to $119, but cheap versus history and facing a looming 2027 oversupply. Covers supply and demand, value, risk, and the outlook.",
+  "updatedAt": "2026-07-07",
+  "summary": "Overall stance: Cautious. Cheap price, but the fundamentals point down.\n\nWTI is the main US oil benchmark, priced in dollars per barrel and set at Cushing, Oklahoma. In early July 2026 it trades near $69, roughly halfway down a wild 52-week range of about $55 to $119 that was driven by a Strait of Hormuz crisis earlier in the year. It sits about 53% below its 2008 record of $147.\n\nOn value, oil looks fair-to-cheap: it is low in its multi-year range, cheap in inflation-adjusted terms, and sitting right on top of the roughly $65 cost to drill a new US shale well, which limits how far it can fall. But almost every forward-looking signal is negative. US output is at a record ~13.7 million barrels a day, OPEC+ is adding barrels back, and the group holds about 5 million barrels a day of spare capacity that caps rallies. Global demand is actually shrinking slightly, and both the US Energy Information Administration and major banks expect prices to drift into the low $60s (some see the $50s) by 2027. The main thing holding prices up — Middle East conflict — is exactly what forecasters expect to fade. Oil is also very volatile (~36% a year) with a history of brutal crashes, including going negative in 2020. Best treated as a tactical, high-risk position rather than a buy-and-hold.",
+  "keyFacts": {
+    "keyFacts": "West Texas Intermediate (WTI) is a light, low-sulfur ('sweet') crude oil that is easy to refine into gasoline and diesel. It is the benchmark for US oil, priced per 42-gallon barrel in US dollars, with the NYMEX front-month future (CL=F) setting the reference price. In early July 2026 that price is about $69 a barrel.\n\nFor a beginner, the key is that oil is a global, politically-charged commodity. Its price is a tug-of-war between OPEC+ (a group led by Saudi Arabia and Russia that manages output), booming US shale production, the health of the world economy (which sets demand), and geopolitics. 2026 has been extreme: a Strait of Hormuz crisis — the waterway that carries about a fifth of the world's oil — spiked WTI to about $119 in March before it fell back toward $69 by July as tankers started moving again. Unlike gold, oil is consumed, storable, and cyclical, so its price swings hard with the economy and with events in the Middle East.",
+    "greenFlags": [
+      {
+        "flag": "Cheap versus its own history",
+        "explanation": "At about $69, WTI is low in its 5- and 10-year range and, adjusted for inflation, far below the 2008 peak (worth over $200 in today's dollars) and the $100+ era of 2011-2014. On a pure value basis, oil is not expensive.",
+        "result": "Pass"
+      },
+      {
+        "flag": "A real cost floor under the price",
+        "explanation": "New US shale wells need roughly $65 a barrel to be profitable (Dallas Fed 2026 survey), and Saudi Arabia needs a high-$60s price to balance its budget. With WTI near $69, prices are sitting right on that cost floor, which historically slows or stops further falls.",
+        "result": "Pass"
+      },
+      {
+        "flag": "Inventories are currently tight",
+        "explanation": "Developed-world (OECD) commercial oil stocks are below their five-year average, and the US Strategic Petroleum Reserve is at its lowest since 1983 after big drawdowns. Low inventories give the current price near-term support even as a future surplus looms.",
+        "result": "Pass"
+      }
+    ],
+    "redFlags": [
+      {
+        "flag": "A large surplus is expected in 2027",
+        "explanation": "Record US supply, OPEC+ adding barrels back, and new production from Brazil and Guyana are set to outrun weak demand. The IEA and EIA both expect the market to swing into oversupply into 2027, and bank forecasts see WTI drifting to the low $60s or even $50s.",
+        "result": "Fail"
+      },
+      {
+        "flag": "Extreme volatility and crash history",
+        "explanation": "Oil's price swings about 36% a year, roughly twice the stock market. Its history includes a 77% crash in 2008 and a famous plunge to minus $37 a barrel in April 2020. This is a high-risk asset that can move violently on a single OPEC meeting or geopolitical headline.",
+        "result": "Fail"
+      }
+    ],
+    "mainUses": ["Transportation fuels (gasoline, diesel, jet fuel)", "Petrochemicals and plastics", "Heating oil", "Lubricants and asphalt"],
+    "topProducers": [
+      { "country": "United States", "share": "~16%" },
+      { "country": "Russia", "share": "~11%" },
+      { "country": "Saudi Arabia", "share": "~11%" },
+      { "country": "Canada", "share": "~6%" }
+    ],
+    "waysToInvest": [
+      { "type": "ETF", "name": "USO", "note": "Tracks WTI futures; suffers roll/contango decay over long holds" },
+      { "type": "Futures", "name": "CL=F / MCL", "note": "NYMEX WTI (1,000 bbl) and Micro WTI; leveraged, high-risk" },
+      { "type": "Equities", "name": "XLE / XOP", "note": "Energy and E&P stock ETFs; indirect, pay dividends, less roll risk" },
+      { "type": "Equities", "name": "Majors (XOM, CVX)", "note": "Integrated oil companies with company-specific exposure" }
+    ]
+  },
+  "categories": [
+    {
+      "categoryKey": "SupplyAndDemand",
+      "summary": "Supply is abundant and growing — record US output, OPEC+ adding barrels, and about 5 million barrels a day of idle spare capacity — while global demand is actually shrinking slightly in 2026. Only tight current inventories and summer seasonality lean supportive. On balance, bearish.",
+      "overallAnalysisDetails": "The supply side is heavy. US crude production is at a record of about 13.7 million barrels a day in 2026 (EIA), OPEC+ is unwinding its earlier cuts at roughly 180,000-190,000 barrels a day each month, and new non-OPEC supply from Brazil, Guyana and Canada keeps growing. On top of that, OPEC+ holds around 5 million barrels a day of spare capacity — the most since 2009 — which acts like a lid on prices: any rally invites those idle barrels back into the market.\n\nDemand, unusually, is not helping. The IEA sees global oil demand around 104 million barrels a day but actually contracting slightly in 2026, as high prices, the 2026 conflict's hit to jet and petrochemical use, and the steady grind of EVs and efficiency all bite. The two positives are near-term: OECD inventories are below their five-year average right now, and we are in the peak summer driving and hurricane season. But those are short-term supports against a structurally well-supplied backdrop.",
+      "factors": [
+        {
+          "factorKey": "production_output_trend",
+          "oneLineExplanation": "Record US output plus OPEC+ adding barrels back.",
+          "detailedExplanation": "US crude production is at a record ~13.7 million barrels a day in 2026 (EIA), and OPEC+ is unwinding its 2.2-million-barrel voluntary cut at about 180,000-190,000 barrels a day per month. Brazil, Guyana and Canada add more non-OPEC supply. Rising, record-level supply is a headwind for prices, not a support.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "global_inventories_stockpiles",
+          "oneLineExplanation": "Inventories are tight and drawing right now.",
+          "detailedExplanation": "Developed-world (OECD) commercial oil stocks sit below their five-year average, and the US Strategic Petroleum Reserve is near its lowest since 1983. The EIA expects OECD stocks to fall to their lowest since 2003 by late 2026. Low, drawing inventories give the current price genuine near-term support, even though a surplus is expected to build later.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "demand_drivers",
+          "oneLineExplanation": "Global demand is shrinking slightly in 2026.",
+          "detailedExplanation": "The IEA sees world oil demand near 104 million barrels a day but contracting modestly in 2026, hurt by high prices, weaker jet and petrochemical use, and slower Chinese growth. Longer term, EVs and efficiency steadily erode gasoline demand. A commodity whose demand is flat-to-falling has a weak fundamental base.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "spare_capacity_new_supply",
+          "oneLineExplanation": "About 5 million barrels a day of idle supply caps rallies.",
+          "detailedExplanation": "OPEC+ holds roughly 5 million barrels a day of spare capacity — the most since 2009 — with Saudi Arabia alone able to add about 3 million. US shale can also respond within 6-12 months. This large cushion of ready supply acts as a ceiling: every price rally tends to bring idle barrels back, limiting the upside.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "seasonality",
+          "oneLineExplanation": "Peak summer driving and hurricane season is supportive.",
+          "detailedExplanation": "June to August is the peak driving season, lifting gasoline demand, and the Atlantic hurricane season (June-November) can knock out Gulf of Mexico production and refining, causing bullish spikes. In early July, this seasonal backdrop is a modest positive for the price, though it is easily overwhelmed by OPEC and macro news.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "PriceAndValue",
+      "summary": "On value, oil looks attractive: near $69 it is low in its multi-year range, cheap in inflation-adjusted terms, sitting on its ~$65 shale cost floor, at a normal discount to Brent, and about 53% below its all-time high. Value is the one clearly positive pillar.",
+      "overallAnalysisDetails": "Judged purely on price, WTI is not expensive. At about $69 it sits in the lower-middle of its 5- and 10-year range and is far below its inflation-adjusted highs — the 2008 peak of $147 would be worth over $200 in today's money. That means the downside from 'overvaluation' is limited.\n\nThe most important support is the cost of production. New US shale wells need roughly $65 a barrel to be profitable, and Saudi Arabia needs a high-$60s price to balance its budget. With WTI hovering right at that level, producers start to slow drilling if prices fall much further, which historically puts a floor under the market. WTI also trades at its normal ~$3 discount to Brent (no unusual dislocation), and it is about 53% below its record. The catch: 'cheap' does not mean 'going up' — a well-supplied commodity can sit near its cost floor for a long time.",
+      "factors": [
+        {
+          "factorKey": "price_vs_range",
+          "oneLineExplanation": "Low-to-mid in its 5- and 10-year range.",
+          "detailedExplanation": "At about $69, WTI sits in the lower-middle of its recent range (roughly $55-$120 over the past year) and well below the $100+ levels of 2011-2014. It is not stretched or frothy, so there is limited valuation risk to the downside and room to rise if demand or geopolitics surprise.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "inflation_adjusted_price",
+          "oneLineExplanation": "Historically cheap after adjusting for inflation.",
+          "detailedExplanation": "In today's dollars, the 2008 peak of $147 would be worth over $200 a barrel, and the 2011-2014 era well over $120. At about $69, WTI is cheap in real terms versus its own history. Oil is not a case of buying at an inflated real price.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "cost_of_production_floor",
+          "oneLineExplanation": "Sitting right on the ~$65 shale cost floor.",
+          "detailedExplanation": "New US shale wells need roughly $65 a barrel to be profitable (Dallas Fed 2026), and Saudi Arabia's budget needs a high-$60s price. With WTI near $69, prices are at that marginal cost, which historically slows drilling and supports the market on dips. It is a genuine floor, even if it leaves little margin above cost.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "price_vs_substitute",
+          "oneLineExplanation": "Normal ~$3 discount to Brent, no distortion.",
+          "detailedExplanation": "WTI trades about $3 a barrel below Brent, its usual structural discount (WTI is landlocked at Cushing; Brent is the global waterborne benchmark). There is no unusual gap that would push buyers to switch. Versus natural gas, oil remains expensive per unit of energy, but the WTI-Brent relationship looks normal and fair.",
+          "result": "Pass"
+        },
+        {
+          "factorKey": "distance_from_all_time_high",
+          "oneLineExplanation": "About 53% below the 2008 record of $147.",
+          "detailedExplanation": "WTI trades near $69 versus its all-time high of $147.27 in July 2008, so there is a lot of theoretical headroom rather than fresh-record risk. For a mean-reverting, cyclical commodity this is normal, but it does mean the price is nowhere near a valuation ceiling.",
+          "result": "Pass"
+        }
+      ]
+    },
+    {
+      "categoryKey": "VolatilityAndRisk",
+      "summary": "Oil is high-risk on every measure: about 36% annual volatility (roughly twice stocks), a history of catastrophic crashes including going negative in 2020, extreme geopolitical exposure through the Strait of Hormuz, an inverse link to the dollar, and pro-cyclical behavior that offers little diversification. All five risk factors fail.",
+      "overallAnalysisDetails": "Crude oil is one of the riskier assets an investor can hold. Its annualized volatility is about 36% — roughly double the S&P 500 — and 2026 has been a vivid example, swinging from the $50s to $119 and back to $69 within months. Its drawdown history is severe: a 77% collapse in 2008, another deep slide in 2014-2016, and the historic first-ever negative price of minus $37 in April 2020 when storage ran out.\n\nThe biggest single risk is geopolitics. Oil is priced globally and moves violently on Middle East events; the 2026 Strait of Hormuz crisis, through which about a fifth of the world's oil flows, is the current example. Oil is also priced in dollars (so a strong dollar is a headwind) and is pro-cyclical — it tends to fall exactly when the economy and stocks fall, so it is a poor diversifier and its inflation-hedge value is undercut by the risk of demand destruction. This is a commodity for investors who can stomach large, fast losses.",
+      "factors": [
+        {
+          "factorKey": "historical_volatility",
+          "oneLineExplanation": "About 36% a year — roughly twice the stock market.",
+          "detailedExplanation": "WTI's annualized volatility is around 36%, about double the S&P 500's. 2026 proved it, swinging from the mid-$50s to $119 and back to $69 within a few months. High volatility means positions can move against you fast, which makes oil hard to hold comfortably for a beginner.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "worst_drawdowns",
+          "oneLineExplanation": "History of -77% crashes, and even negative prices in 2020.",
+          "detailedExplanation": "Oil's deepest falls are brutal: about -77% in 2008 ($147 to $34), a long slide in 2014-2016, and a historic first when the front-month future went to minus $37.63 on 20 April 2020 as storage overflowed. Unlike gold, oil's crashes can be sudden and severe, so downside risk is a real concern.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "geopolitical_weather_risk",
+          "oneLineExplanation": "Extreme exposure to Middle East and the Strait of Hormuz.",
+          "detailedExplanation": "Oil is intensely geopolitical. About a fifth of the world's oil passes through the Strait of Hormuz, and the 2026 crisis there sent WTI to $119 before it fell back. Russia sanctions, Middle East conflict and Gulf hurricanes all add uncertainty. This risk can spike the price up, but it is a source of instability, not a dependable support.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "us_dollar_sensitivity",
+          "oneLineExplanation": "Priced in dollars, so a strong dollar is a headwind.",
+          "detailedExplanation": "Oil is bought and sold in US dollars and tends to move inversely to the dollar: when the dollar strengthens, oil gets more expensive for foreign buyers and demand softens. With no clear dollar tailwind today, this standard inverse relationship is a background risk rather than a help.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "correlation_to_inflation_and_stocks",
+          "oneLineExplanation": "Pro-cyclical — falls when the economy and stocks fall.",
+          "detailedExplanation": "Oil is pro-cyclical: it rises with economic growth and tends to fall when a recession hits, which is exactly when stocks fall too. So it offers little diversification against an equity portfolio. It is a direct inflation input, but its hedge value is undercut because an oil spike can trigger the demand destruction and rate hikes that then crash the price.",
+          "result": "Fail"
+        }
+      ]
+    },
+    {
+      "categoryKey": "FutureOutlook",
+      "summary": "The forward view is bearish. The IEA and EIA both expect a surplus building into 2027, the EIA sees WTI averaging around $61 in 2027, and banks (Goldman, JPMorgan) forecast prices at or below today's level. The one prop — Middle East conflict — is what forecasters expect to fade. All five outlook factors fail.",
+      "overallAnalysisDetails": "The forward setup is the weakest part of the oil story. Both the IEA and EIA expect the market to move into oversupply into 2027 as Hormuz flows normalize, OPEC+ keeps adding barrels, and US and non-OPEC supply grows into flat-to-falling demand. The EIA's June 2026 outlook sees Brent averaging about $95 in 2026 (conflict-inflated) but falling to about $79 in 2027, with WTI around $61.\n\nBank targets tell the same story. After the mid-2026 truce, Goldman Sachs and JPMorgan cut their forecasts to roughly $70-$80 Brent for late 2026 and the mid-$60s for 2027, with some analysts warning of the $30s in a full glut. In other words, the consensus points flat-to-lower from today's $69. The bull case — renewed Middle East disruption, OPEC+ discipline, a demand surprise — is real but rests largely on geopolitics that agencies expect to resolve. On balance, the forward-looking evidence leans clearly bearish.",
+      "factors": [
+        {
+          "factorKey": "forward_supply_demand_balance",
+          "oneLineExplanation": "Surplus expected to build into 2027.",
+          "detailedExplanation": "Before the 2026 conflict, the IEA saw a large 2026 surplus; the crisis flipped it to a temporary deficit, but both the IEA and EIA expect the market to swing back into oversupply into 2027 as flows normalize and OPEC+/shale add barrels into weak demand. A structural surplus is a clear negative for future prices.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "official_agency_forecast",
+          "oneLineExplanation": "EIA sees WTI falling to around $61 in 2027.",
+          "detailedExplanation": "The EIA's June 2026 outlook expects Brent to fall from a conflict-inflated ~$95 average in 2026 to about $79 in 2027, with WTI around $61 — below today's ~$69. The official agency view is explicitly for lower prices ahead, which is a headwind for a long position.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "analyst_price_targets",
+          "oneLineExplanation": "Bank targets sit at or below today's price.",
+          "detailedExplanation": "After the mid-2026 truce, Goldman Sachs and JPMorgan cut targets to roughly $70-$80 Brent for late 2026 and the mid-$60s for 2027, and some see the $30s in a glut. With WTI near $69, the consensus implies flat-to-down, not upside. Analyst views lean bearish.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "bull_vs_bear_scenario",
+          "oneLineExplanation": "Bear case is the consensus; bull case rests on geopolitics.",
+          "detailedExplanation": "The bull case is renewed Hormuz escalation, OPEC+ discipline and a demand surprise pushing oil to $90-$110. The bear case — resolved conflict, OPEC+ and shale flooding the market, weak demand — has more institutional backing and points to the $50s-$60s. The balance of evidence favors the bears, so the skew is unfavorable.",
+          "result": "Fail"
+        },
+        {
+          "factorKey": "key_catalysts_to_watch",
+          "oneLineExplanation": "Catalysts are two-sided but lean bearish.",
+          "detailedExplanation": "Watch the monthly OPEC+ meetings (output policy), the weekly EIA inventory report, Strait of Hormuz and Iran developments, China demand data, and hurricanes. These make oil highly tradable, but the base case — normalizing supply into soft demand — means most catalysts point toward lower prices rather than higher.",
+          "result": "Fail"
+        }
+      ]
+    }
+  ]
+}

--- a/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
+++ b/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
@@ -1,5 +1,9 @@
 import { CommodityReportJson } from '@/types/commodity/commodity-analysis-types';
 import gold from '@/commodity-data/reports/gold.json';
+import silver from '@/commodity-data/reports/silver.json';
+import platinum from '@/commodity-data/reports/platinum.json';
+import palladium from '@/commodity-data/reports/palladium.json';
+import copper from '@/commodity-data/reports/copper.json';
 
 /**
  * Registry of authored commodity reports, keyed by slug.
@@ -16,4 +20,8 @@ import gold from '@/commodity-data/reports/gold.json';
  */
 export const COMMODITY_REPORTS: Record<string, CommodityReportJson> = {
   gold: gold as unknown as CommodityReportJson,
+  silver: silver as unknown as CommodityReportJson,
+  platinum: platinum as unknown as CommodityReportJson,
+  palladium: palladium as unknown as CommodityReportJson,
+  copper: copper as unknown as CommodityReportJson,
 };

--- a/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
+++ b/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
@@ -7,6 +7,11 @@ import copper from '@/commodity-data/reports/copper.json';
 import liveCattle from '@/commodity-data/reports/live-cattle.json';
 import leanHogs from '@/commodity-data/reports/lean-hogs.json';
 import feederCattle from '@/commodity-data/reports/feeder-cattle.json';
+import wtiCrudeOil from '@/commodity-data/reports/wti-crude-oil.json';
+import brentCrudeOil from '@/commodity-data/reports/brent-crude-oil.json';
+import naturalGas from '@/commodity-data/reports/natural-gas.json';
+import gasolineRbob from '@/commodity-data/reports/gasoline-rbob.json';
+import heatingOil from '@/commodity-data/reports/heating-oil.json';
 
 /**
  * Registry of authored commodity reports, keyed by slug.
@@ -30,4 +35,9 @@ export const COMMODITY_REPORTS: Record<string, CommodityReportJson> = {
   'live-cattle': liveCattle as unknown as CommodityReportJson,
   'lean-hogs': leanHogs as unknown as CommodityReportJson,
   'feeder-cattle': feederCattle as unknown as CommodityReportJson,
+  'wti-crude-oil': wtiCrudeOil as unknown as CommodityReportJson,
+  'brent-crude-oil': brentCrudeOil as unknown as CommodityReportJson,
+  'natural-gas': naturalGas as unknown as CommodityReportJson,
+  'gasoline-rbob': gasolineRbob as unknown as CommodityReportJson,
+  'heating-oil': heatingOil as unknown as CommodityReportJson,
 };

--- a/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
+++ b/insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts
@@ -4,6 +4,9 @@ import silver from '@/commodity-data/reports/silver.json';
 import platinum from '@/commodity-data/reports/platinum.json';
 import palladium from '@/commodity-data/reports/palladium.json';
 import copper from '@/commodity-data/reports/copper.json';
+import liveCattle from '@/commodity-data/reports/live-cattle.json';
+import leanHogs from '@/commodity-data/reports/lean-hogs.json';
+import feederCattle from '@/commodity-data/reports/feeder-cattle.json';
 
 /**
  * Registry of authored commodity reports, keyed by slug.
@@ -24,4 +27,7 @@ export const COMMODITY_REPORTS: Record<string, CommodityReportJson> = {
   platinum: platinum as unknown as CommodityReportJson,
   palladium: palladium as unknown as CommodityReportJson,
   copper: copper as unknown as CommodityReportJson,
+  'live-cattle': liveCattle as unknown as CommodityReportJson,
+  'lean-hogs': leanHogs as unknown as CommodityReportJson,
+  'feeder-cattle': feederCattle as unknown as CommodityReportJson,
 };


### PR DESCRIPTION
Adds real, internet-researched, beginner-friendly commodity report JSON for **13 commodities** across three groups, rendered by the existing static-JSON commodity report system (no DB, no LLM generation). Each report follows the exact \`CommodityReportJson\` schema and factor keys, uses current (mid-2026) sourced figures, and gives honest, differentiated Pass/Fail verdicts — not sugar-coated.

## Metals (5)
| Commodity | Score |
|---|---|
| Gold | 15/20 |
| Platinum | 15/20 |
| Silver | 13/20 |
| Copper | 13/20 |
| Palladium | 7/20 |

## Livestock (3)
| Commodity | Score |
|---|---|
| Live Cattle | 13/20 |
| Feeder Cattle | 11/20 |
| Lean Hogs | 8/20 |

## Energy (5) — new in this round
| Commodity | Score | Read |
|---|---|---|
| Heating Oil / Diesel (HO=F) | 14/20 | Strongest cut of the barrel — record-low distillate stocks, wide crack spreads, Russia refinery disruption; offset by high volatility and declining heating-oil end-use |
| RBOB Gasoline (RB=F) | 11/20 | Tight refining (US capacity closures, low stocks) vs. a structural EV-driven demand decline — a tactical/crack-spread trade, not a hold |
| Natural Gas (NG=F) | 9/20 | Cheap with a real LNG + AI-data-center demand story, but the most volatile major commodity ('the widowmaker') |
| Crude Oil Brent (BZ=F) | 8/20 | Cheap vs history but a 2027 surplus looms; a tactical geopolitical trade |
| Crude Oil WTI (CL=F) | 7/20 | Record US supply, ~5 mb/d OPEC+ spare capacity, shrinking demand; forecasts point to the low $60s by 2027 |

Energy figures reflect a volatile mid-2026 shaped by a Strait of Hormuz crisis (crude spiked then normalized), the US LNG export boom, AI-data-center power demand, and Ukrainian strikes on Russian refineries tightening global diesel.

### Files (this round)
- \`insights-ui/src/commodity-data/reports/{wti-crude-oil,brent-crude-oil,natural-gas,gasoline-rbob,heating-oil}.json\` (new)
- \`insights-ui/src/utils/commodity-analysis-reports/commodity-reports-registry.ts\` (register 5 energy slugs)

### Notes
- Reports are data-only JSON cast to \`unknown\`, so \`tsc\`/\`yarn compile\` is unaffected by report content; prettier formatting verified.
- Figures are point-in-time (mid-2026) and will need periodic refreshing.