### PR TITLE
Revert lazy-load of LogRocket + Clarity analytics SDKs (#1670)

### DIFF
--- a/insights-ui/src/app/ClarityComponent.tsx
+++ b/insights-ui/src/app/ClarityComponent.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-// NOTE: `@microsoft/clarity` is intentionally NOT imported statically — that would
-// pull the SDK into the shared client bundle that loads on every page. It's
-// dynamically imported inside `init` (which runs on idle, after load), so the SDK
-// chunk is fetched on demand instead of up front.
+import Clarity from '@microsoft/clarity';
 import { PROD_HOST } from './LogRocketComponent';
 
 const CLARITY_PROJECT_ID = 'u82d3rnsxw';
@@ -25,14 +22,11 @@ export default function ClarityComponent(): null {
 
     const init = (): void => {
       if (cancelled) return;
-      // Load the SDK on demand (keeps it out of the initial/shared bundle).
-      import('@microsoft/clarity')
-        .then((m) => {
-          if (!cancelled) m.default.init(CLARITY_PROJECT_ID);
-        })
-        .catch(() => {
-          /* swallow — analytics must not break the app */
-        });
+      try {
+        Clarity.init(CLARITY_PROJECT_ID);
+      } catch {
+        /* swallow — analytics must not break the app */
+      }
     };
 
     const scheduleIdle = (): void => {

--- a/insights-ui/src/app/LogRocketComponent.tsx
+++ b/insights-ui/src/app/LogRocketComponent.tsx
@@ -2,10 +2,7 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-// NOTE: `logrocket` is intentionally NOT imported statically — a top-level import
-// pulls the SDK into the shared client bundle that loads on every page. It's
-// dynamically imported inside `connectAndIdentify` (which only runs after the
-// user is engaged), so the SDK chunk is fetched on demand, not up front.
+import LogRocket from 'logrocket';
 
 const PROJECT_ID = 'm3ahri/koalagains';
 const MIN_CLICKS = 2; // Require at least 2 clicks in the current session
@@ -148,10 +145,7 @@ function hasMinSessionClicks(): boolean {
 
 /* ----------------- LogRocket connect/identify ----------------- */
 
-async function connectAndIdentify(country: string | null): Promise<void> {
-  // Load the SDK on demand (keeps it out of the initial/shared bundle).
-  const LogRocket = (await import('logrocket')).default;
-
+function connectAndIdentify(country: string | null): void {
   // init once per session (StrictMode-safe)
   if (!window.__LR_INIT__ && ssOnce(SS.inited)) {
     LogRocket.init(PROJECT_ID);
@@ -181,7 +175,7 @@ async function connectAndIdentify(country: string | null): Promise<void> {
  */
 function gateConnectionOnSessionClicks(country: string | null): () => void {
   if (hasMinSessionClicks()) {
-    void connectAndIdentify(country);
+    connectAndIdentify(country);
     return () => {};
   }
 
@@ -191,7 +185,7 @@ function gateConnectionOnSessionClicks(country: string | null): () => void {
 
     const { session } = incrementSessionClickCount();
     if (session >= MIN_CLICKS) {
-      void connectAndIdentify(country);
+      connectAndIdentify(country);
       document.removeEventListener('click', onClick, { capture: true } as AddEventListenerOptions);
     }
   };


### PR DESCRIPTION
Reverts #1670, restoring the previous static-import behavior for the LogRocket and Clarity analytics integrations.

## What changed
- `ClarityComponent.tsx`: restores the top-level `import Clarity from '@microsoft/clarity'` and the synchronous `Clarity.init(...)` inside the idle `init` callback (dropping the dynamic `import('@microsoft/clarity')`).
- `LogRocketComponent.tsx`: restores the top-level `import LogRocket from 'logrocket'`; `connectAndIdentify` is synchronous again (no `async`/`await import('logrocket')`), and call sites drop the `void` wrapper.

Both SDKs are again bundled into the shared client chunk as before #1670. Gating/deferral semantics are unchanged.

Quality checks: `yarn lint`, `yarn prettier-check`, and `yarn compile` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)