### PR TITLE
feat(insights-ui): add commodities sitemap

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -46,6 +46,9 @@
     <loc>https://koalagains.com/stock-scenarios/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://koalagains.com/commodities/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://koalagains.com/etfs/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/insights-ui/src/app/commodities/sitemap.xml/route.ts
+++ b/insights-ui/src/app/commodities/sitemap.xml/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { COMMODITIES_LISTING_TAG } from '@/utils/commodity-analysis-reports/commodity-cache-utils';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
+import type { CommodityListItem } from '@/app/api/[spaceId]/commodities-v1/listing/route';
+
+export const dynamic = 'force-dynamic';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+/**
+ * Every commodity for the sitemap. The listing fetch uses cache tags only (no
+ * time-based revalidation for now) so it can be purged on demand via
+ * `COMMODITIES_LISTING_TAG`.
+ */
+async function getAllCommodities(): Promise<CommodityListItem[]> {
+  try {
+    const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/commodities-v1/listing`, {
+      next: { tags: [COMMODITIES_LISTING_TAG] },
+    });
+    if (!response.ok) return [];
+    return (await response.json()) as CommodityListItem[];
+  } catch (error) {
+    console.error('Error fetching commodity listing for sitemap:', error);
+    return [];
+  }
+}
+
+async function generateCommodityUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  // Main commodities index page
+  urls.push({
+    url: '/commodities',
+    changefreq: 'daily',
+    priority: 0.8,
+  });
+
+  // Per-commodity overview pages
+  const commodities = await getAllCommodities();
+  for (const commodity of commodities) {
+    urls.push({
+      url: `/commodities/${commodity.slug}`,
+      changefreq: 'weekly',
+      priority: 0.7,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(): Promise<NextResponse<Buffer>> {
+  try {
+    const urls = await generateCommodityUrls();
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating commodities sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -32,6 +32,7 @@ const reportsDropdown: ReportItem[] = [
   { name: 'Crowdfunding Reports', href: '/crowd-funding', description: 'Detailed crowdfunding analysis', isNew: false },
   { name: 'Stock Reports', href: '/stocks', description: 'Value investing insights', isNew: true },
   { name: 'ETF Reports', href: '/etfs', description: 'ETF investment analysis by asset class', isNew: true },
+  { name: 'Commodities', href: '/commodities', description: 'Energy, metals, agriculture & livestock analysis', isNew: true },
   { name: 'Stock Scenarios', href: '/stock-scenarios', description: 'Stocks that win or lose per scenario', isNew: true },
   { name: 'Tariff Reports', href: '/tariff-reports', description: 'Trade tariff impact analysis', isNew: false },
   { name: 'Daily Top Gainers', href: '/daily-top-movers/top-gainers/country/US', description: 'Top performing stocks today', isNew: true },


### PR DESCRIPTION
## Summary

Adds a dedicated sitemap for the commodities section and registers it in the sitemap index.

- New route `src/app/commodities/sitemap.xml/route.ts` emitting:
  - the `/commodities` index page
  - each per-commodity overview page `/commodities/<slug>`
- The listing is fetched from `/api/<spaceId>/commodities-v1/listing` using **cache tags only** (`COMMODITIES_LISTING_TAG`) with **no time-based revalidation** for now.
- Registers `/commodities/sitemap.xml` in `public/sitemap_index.xml`.

Follows the existing sitemap pattern (`stock-scenarios`, `daily-top-movers`).

Note: CloudFront routing for this sitemap is intentionally **not** included here — that will be handled separately later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)