### PR TITLE
docs(insights-ui): add Claude integration follow-up tasks

### DIFF
--- a/docs/insights-ui/tasks/todo-tasks.md
+++ b/docs/insights-ui/tasks/todo-tasks.md
@@ -104,6 +104,27 @@ Single source of truth for active KoalaGains work. Completed items live in
 
 ---
 
+## Claude integration
+
+> Provider-level infra shared by stock, ETF, and tariff report generation. The Claude
+> subscription OAuth path (`LLMProvider.CLAUDE`) and the provider/model selection UI
+> (`llmConstants.ts`, `ClaudeModel`) have landed; these are the follow-ups on top of them.
+> Do not add `LLM_PROVIDER`/`LLM_MODEL` env reads back in — defaults are fixed constants
+> in `llmConstants.ts` and UI selections flow through explicitly.
+
+### Surface Anthropic usage / rate-limit headers from the OAuth path
+
+- [ ] **Capture the response headers** in `src/util/claude/claude-oauth-client.ts` — `callClaudeWithOAuth` returns the body-level token `usage` but never reads `response.headers`, so Anthropic's `anthropic-ratelimit-*` headers are discarded. Add a `rateLimit` field to `CallClaudeOAuthResult` (parsed from the headers) without changing the existing `text`/`usage`/`model` callers.
+- [ ] **Confirm the real header names** before building any numeric gauge on top — this is the open blocker for usage pacing. Log the full raw header set from one live OAuth call and record the exact keys (unified vs input/output token buckets, reset timestamps, remaining-percent vs remaining-count) in `docs/insights-ui/` so downstream work isn't guessing.
+- [ ] **Thread the values through** `getClaudeStructuredResult` and `getLLMResponse` so a generation run can read remaining budget after each call, without coupling the thin structured-output helper to bookkeeping.
+
+### Usage-gated off-hours auto-generation
+
+- [ ] **Pace nightly Claude generation against remaining subscription budget** — a scheduled enqueue endpoint (separate from the synchronous per-report path) that reads the surfaced rate-limit headers, stops enqueuing when remaining budget drops below a floor, and resumes after the reset window. Ties together the existing off-hours refresh tasks under Stocks and the ETF Claude-Code pipeline; blocked on the header work above.
+- [ ] Open: per-model vs account-wide budget accounting when a run mixes Opus/Sonnet/Haiku; floor as absolute remaining vs percent; back-off strategy when a `429` is hit despite pacing.
+
+---
+
 ## Trends page
 
 > Decide once: shared `Trend` model linked to both stock and ETF join tables, or parallel


### PR DESCRIPTION
## What

Adds a new `## Claude integration` section to the KoalaGains open-task list (`docs/insights-ui/tasks/todo-tasks.md`), capturing the provider-infra follow-ups that sit on top of the recently-landed Claude subscription OAuth path (PR #1687) and provider/model selection UI (PRs #1689/#1690).

## Tasks added

**Surface Anthropic usage / rate-limit headers from the OAuth path**
- `callClaudeWithOAuth` (`src/util/claude/claude-oauth-client.ts`) reads the body-level token `usage` but never touches `response.headers`, so Anthropic's `anthropic-ratelimit-*` headers are discarded. Task: add a `rateLimit` field to `CallClaudeOAuthResult` without disturbing existing callers.
- Confirm the real header names (the open blocker) and record them under `docs/insights-ui/`.
- Thread the values through `getClaudeStructuredResult` / `getLLMResponse`.

**Usage-gated off-hours auto-generation**
- A scheduled enqueue endpoint that paces nightly Claude generation against remaining subscription budget; ties together the existing off-hours stock refresh + ETF Claude-Code pipeline tasks. Blocked on the header work above.

## Notes

Docs-only change — no source files touched, so `yarn lint`/`compile` have nothing to act on. Task wording was verified against the current `claude-oauth-client.ts` and `llmConstants.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)