### PR TITLE
feat(insights-ui): commodities — home-page showcase, sitemap, navbar link

### DIFF
--- a/insights-ui/public/sitemap_index.xml
+++ b/insights-ui/public/sitemap_index.xml
@@ -46,6 +46,9 @@
     <loc>https://koalagains.com/stock-scenarios/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://koalagains.com/commodities/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://koalagains.com/etfs/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/insights-ui/src/app/api/[spaceId]/commodities-v1/listing/route.ts
+++ b/insights-ui/src/app/api/[spaceId]/commodities-v1/listing/route.ts
@@ -1,34 +1,20 @@
-import {
-  computeCommodityFinalScore,
-  getAllCommodityBasicInfo,
-  getCommodityReportJson,
-} from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
+import { CommodityListItem, getCommodityListingItems } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
 import { withErrorHandlingV2 } from '@dodao/web-core/api/helpers/middlewares/withErrorHandling';
 import { NextRequest } from 'next/server';
 
-/** One row in the public commodities listing (grouped by `commodityGroup`). */
-export interface CommodityListItem {
-  id: string;
-  slug: string;
-  name: string;
-  commodityGroup: string;
-  finalScore: number | null;
-}
+// Re-exported so existing importers (`@/app/api/.../listing/route`) keep working;
+// the type + mapping now live in `get-commodity-report-data-utils` and are shared
+// with the home-page showcase.
+export type { CommodityListItem } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
 
 /**
  * Public listing of every commodity, ordered by group then name, with each
  * commodity's final score. Backs the `/commodities` index page so it fetches
- * through the API — data now comes from the static `commodity-data` JSON instead
+ * through the API — data comes from the static `commodity-data` JSON instead
  * of the database. `finalScore` is null until a report JSON is published.
  */
 async function getHandler(_req: NextRequest): Promise<CommodityListItem[]> {
-  return getAllCommodityBasicInfo().map((c) => ({
-    id: c.slug,
-    slug: c.slug,
-    name: c.name,
-    commodityGroup: c.commodityGroup,
-    finalScore: computeCommodityFinalScore(getCommodityReportJson(c.slug)),
-  }));
+  return getCommodityListingItems();
 }
 
 export const GET = withErrorHandlingV2<CommodityListItem[]>(getHandler);

--- a/insights-ui/src/app/commodities/sitemap.xml/route.ts
+++ b/insights-ui/src/app/commodities/sitemap.xml/route.ts
@@ -4,7 +4,12 @@ import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { COMMODITIES_LISTING_TAG } from '@/utils/commodity-analysis-reports/commodity-cache-utils';
 import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
+import { COMMODITY_CATEGORY_TO_PATH } from '@/types/commodity/commodity-analysis-types';
 import type { CommodityListItem } from '@/app/api/[spaceId]/commodities-v1/listing/route';
+
+// The four per-commodity category sub-report pages (supply-and-demand, price-and-value,
+// volatility-and-risk, future-outlook) — kept in sync with the route folders via the shared map.
+const COMMODITY_CATEGORY_PATHS: string[] = Object.values(COMMODITY_CATEGORY_TO_PATH);
 
 export const dynamic = 'force-dynamic';
 
@@ -43,7 +48,7 @@ async function generateCommodityUrls(): Promise<SiteMapUrl[]> {
     priority: 0.8,
   });
 
-  // Per-commodity overview pages
+  // Per-commodity overview page + its four category sub-report pages
   const commodities = await getAllCommodities();
   for (const commodity of commodities) {
     urls.push({
@@ -51,6 +56,14 @@ async function generateCommodityUrls(): Promise<SiteMapUrl[]> {
       changefreq: 'weekly',
       priority: 0.7,
     });
+
+    for (const categoryPath of COMMODITY_CATEGORY_PATHS) {
+      urls.push({
+        url: `/commodities/${commodity.slug}/${categoryPath}`,
+        changefreq: 'weekly',
+        priority: 0.6,
+      });
+    }
   }
 
   return urls;

--- a/insights-ui/src/app/commodities/sitemap.xml/route.ts
+++ b/insights-ui/src/app/commodities/sitemap.xml/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
+import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
+import { COMMODITIES_LISTING_TAG } from '@/utils/commodity-analysis-reports/commodity-cache-utils';
+import { getCanonicalUrl } from '@/utils/getBaseUrlForServerSidePages';
+import type { CommodityListItem } from '@/app/api/[spaceId]/commodities-v1/listing/route';
+
+export const dynamic = 'force-dynamic';
+
+interface SiteMapUrl {
+  url: string;
+  changefreq: string;
+  priority?: number;
+  lastmod?: string;
+}
+
+/**
+ * Every commodity for the sitemap. The listing fetch uses cache tags only (no
+ * time-based revalidation for now) so it can be purged on demand via
+ * `COMMODITIES_LISTING_TAG`.
+ */
+async function getAllCommodities(): Promise<CommodityListItem[]> {
+  try {
+    const response = await fetch(`${getBaseUrl()}/api/${KoalaGainsSpaceId}/commodities-v1/listing`, {
+      next: { tags: [COMMODITIES_LISTING_TAG] },
+    });
+    if (!response.ok) return [];
+    return (await response.json()) as CommodityListItem[];
+  } catch (error) {
+    console.error('Error fetching commodity listing for sitemap:', error);
+    return [];
+  }
+}
+
+async function generateCommodityUrls(): Promise<SiteMapUrl[]> {
+  const urls: SiteMapUrl[] = [];
+
+  // Main commodities index page
+  urls.push({
+    url: '/commodities',
+    changefreq: 'daily',
+    priority: 0.8,
+  });
+
+  // Per-commodity overview pages
+  const commodities = await getAllCommodities();
+  for (const commodity of commodities) {
+    urls.push({
+      url: `/commodities/${commodity.slug}`,
+      changefreq: 'weekly',
+      priority: 0.7,
+    });
+  }
+
+  return urls;
+}
+
+async function GET(): Promise<NextResponse<Buffer>> {
+  try {
+    const urls = await generateCommodityUrls();
+    const smStream = new SitemapStream({ hostname: getCanonicalUrl() });
+
+    for (const url of urls) {
+      smStream.write(url);
+    }
+
+    smStream.end();
+    const response: Buffer = await streamToPromise(smStream);
+
+    return new NextResponse(response as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating commodities sitemap:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
+export { GET };

--- a/insights-ui/src/app/page.tsx
+++ b/insights-ui/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Hero } from '@/components/home-page/Hero';
 import KoalagainsOfferings from '@/components/home-page/KoalagainsOfferings';
 import KoalaGainsPlatform from '@/components/home-page/KoalaGainsPlatform';
 import ServiceNavigation from '@/components/home-page/ServiceNavigation';
+import TopCommoditiesShowcase from '@/components/home-page/TopCommoditiesShowcase';
 import TopEtfAssetClassesShowcase from '@/components/home-page/TopEtfAssetClassesShowcase';
 import type { EtfAssetClassesIndexResponse } from '@/app/api/[spaceId]/etfs-v1/listings/asset-classes-index/route';
 import { IndustryWithTopTickers } from '@/types/api/ticker-industries';
@@ -13,6 +14,8 @@ import { getPostsData } from '@/util/blog-utils';
 import { themeColors } from '@/util/theme-colors';
 import { SupportedCountries } from '@/utils/countryExchangeUtils';
 import { getEtfAssetClassesIndexTag } from '@/utils/etf-cache-utils';
+import { COMMODITIES_LISTING_TAG } from '@/utils/commodity-analysis-reports/commodity-cache-utils';
+import { getCommodityListingItems } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
 import { getTopEtfAssetClasses } from '@/utils/home-page/top-etf-asset-classes';
 import { getTopIndustriesWithTickers } from '@/utils/home-page/top-industries';
 import { getStocksPageTag, getHomePagePostsTag } from '@/utils/ticker-v1-cache-utils';
@@ -157,13 +160,27 @@ const getEtfAssetClassesCached = unstable_cache(async () => fetchTopEtfAssetClas
   tags: [getEtfAssetClassesIndexTag(SupportedCountries.US)],
 });
 
+// Commodities read straight from bundled static JSON (no DB / no HTTP self-fetch), so this is
+// build-safe for the static export of "/". Cached + tagged like the industries/ETF data above so
+// the page is generated once at build time and revalidating the commodities listing refreshes it.
+const getCommoditiesCached = unstable_cache(async () => getCommodityListingItems(), ['home-page-commodities'], {
+  revalidate: WEEK,
+  tags: [COMMODITIES_LISTING_TAG],
+});
+
 export default async function Home() {
-  const [industries, posts, etfAssetClasses] = await Promise.all([getIndustriesCached(), getPostsCached(), getEtfAssetClassesCached()]);
+  const [industries, posts, etfAssetClasses, commodities] = await Promise.all([
+    getIndustriesCached(),
+    getPostsCached(),
+    getEtfAssetClassesCached(),
+    getCommoditiesCached(),
+  ]);
 
   return (
     <div style={{ ...themeColors }}>
       <Hero industries={industries} />
       <TopEtfAssetClassesShowcase country={SupportedCountries.US} data={etfAssetClasses} />
+      <TopCommoditiesShowcase commodities={commodities} />
       <ServiceNavigation />
       <KoalagainsOfferings />
       <KoalaGainsPlatform />

--- a/insights-ui/src/components/commodity-reports/CommodityGroupCard.tsx
+++ b/insights-ui/src/components/commodity-reports/CommodityGroupCard.tsx
@@ -38,7 +38,7 @@ export default function CommodityGroupCard({
         {countLabel}
       </div>
 
-      <ul className="divide-y divide-color flex-1">
+      <ul className="flex-1">
         {displayed.map((commodity) => {
           const hasScore = commodity.finalScore !== null;
           const { textColorClass, bgColorClass } = getScoreColorClasses(commodity.finalScore ?? 0);

--- a/insights-ui/src/components/commodity-reports/CommodityGroupCard.tsx
+++ b/insights-ui/src/components/commodity-reports/CommodityGroupCard.tsx
@@ -11,8 +11,21 @@ const COMMODITY_MAX_SCORE = 20;
  * is the header (with a count pill) and each commodity is a scored row, reusing
  * the same score-badge colors as stocks for a consistent look.
  */
-export default function CommodityGroupCard({ group, commodities }: { group: string; commodities: CommodityListItem[] }): JSX.Element {
+export default function CommodityGroupCard({
+  group,
+  commodities,
+  limit,
+}: {
+  group: string;
+  commodities: CommodityListItem[];
+  /** When set (home-page showcase), show only the highest-scored `limit` rows so every group card lines up. Omit on the listing page to show the full group. */
+  limit?: number;
+}): JSX.Element {
   const countLabel = `${commodities.length.toLocaleString()} ${commodities.length === 1 ? 'commodity' : 'commodities'}`;
+
+  // Home page passes a limit → show the top-scored few so all group cards are equal height; the
+  // listing page passes none → keep the full alphabetical group exactly as provided.
+  const displayed = limit != null ? [...commodities].sort((a, b) => (b.finalScore ?? 0) - (a.finalScore ?? 0)).slice(0, limit) : commodities;
 
   return (
     <div className="relative bg-block-bg-color rounded-lg border border-color overflow-hidden flex flex-col">
@@ -26,7 +39,7 @@ export default function CommodityGroupCard({ group, commodities }: { group: stri
       </div>
 
       <ul className="divide-y divide-color flex-1">
-        {commodities.map((commodity) => {
+        {displayed.map((commodity) => {
           const hasScore = commodity.finalScore !== null;
           const { textColorClass, bgColorClass } = getScoreColorClasses(commodity.finalScore ?? 0);
 

--- a/insights-ui/src/components/core/TopNav/TopNav.tsx
+++ b/insights-ui/src/components/core/TopNav/TopNav.tsx
@@ -32,6 +32,7 @@ const reportsDropdown: ReportItem[] = [
   { name: 'Crowdfunding Reports', href: '/crowd-funding', description: 'Detailed crowdfunding analysis', isNew: false },
   { name: 'Stock Reports', href: '/stocks', description: 'Value investing insights', isNew: true },
   { name: 'ETF Reports', href: '/etfs', description: 'ETF investment analysis by asset class', isNew: true },
+  { name: 'Commodities', href: '/commodities', description: 'Energy, metals, agriculture & livestock analysis', isNew: true },
   { name: 'Stock Scenarios', href: '/stock-scenarios', description: 'Stocks that win or lose per scenario', isNew: true },
   { name: 'Tariff Reports', href: '/tariff-reports', description: 'Trade tariff impact analysis', isNew: false },
   { name: 'Daily Top Gainers', href: '/daily-top-movers/top-gainers/country/US', description: 'Top performing stocks today', isNew: true },

--- a/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
+++ b/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
@@ -1,0 +1,47 @@
+import CommodityGroupCard from '@/components/commodity-reports/CommodityGroupCard';
+import type { CommodityListItem } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
+import React from 'react';
+
+export interface TopCommoditiesShowcaseProps {
+  commodities: CommodityListItem[];
+}
+
+/**
+ * Home-page showcase of commodities grouped by `commodityGroup` — the commodity
+ * twin of the ETF `TopEtfAssetClassesShowcase` and stock `TopIndustriesShowcase`.
+ * Reuses the `/commodities` listing `CommodityGroupCard` so the home page and
+ * listing page stay visually consistent. There are four groups (Energy, Metals,
+ * Agriculture, Livestock), so the grid rounds out to one row of four cards.
+ * Renders nothing when no commodities exist.
+ */
+export default function TopCommoditiesShowcase({ commodities }: TopCommoditiesShowcaseProps): React.JSX.Element | null {
+  if (commodities.length === 0) {
+    return null;
+  }
+
+  const groups = Array.from(new Set(commodities.map((c) => c.commodityGroup)));
+
+  return (
+    <section className="bg-gray-800">
+      <div className="w-full mx-auto max-w-7xl sm:px-2 lg:px-8 px-6 py-8 sm:py-12">
+        <div className="mb-6 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            Explore <span className="text-indigo-400">Commodities</span> by Group
+          </h2>
+          <p className="mt-3 text-base sm:text-lg leading-7 text-gray-300 max-w-2xl mx-auto">
+            AI-generated analysis and scoring across Energy, Metals, Agriculture &amp; Livestock.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start">
+          {groups.map((group) => (
+            <CommodityGroupCard key={group} group={group} commodities={commodities.filter((c) => c.commodityGroup === group)} />
+          ))}
+        </div>
+      </div>
+
+      {/* Separator matching the ETF section above so the home-page rhythm stays consistent */}
+      <div className="border-b border-gray-600"></div>
+    </section>
+  );
+}

--- a/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
+++ b/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
@@ -1,10 +1,15 @@
 import CommodityGroupCard from '@/components/commodity-reports/CommodityGroupCard';
 import type { CommodityListItem } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
+import Link from 'next/link';
 import React from 'react';
 
 export interface TopCommoditiesShowcaseProps {
   commodities: CommodityListItem[];
 }
+
+// Show the top few (highest-scored) commodities per group on the home page — same idea as the
+// top-3 tickers per industry — so all four group cards are the same height and the row stays tidy.
+const TOP_PER_GROUP = 3;
 
 /**
  * Home-page showcase of commodities grouped by `commodityGroup` — the commodity
@@ -33,14 +38,21 @@ export default function TopCommoditiesShowcase({ commodities }: TopCommoditiesSh
           </p>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 items-start">
           {groups.map((group) => (
-            <CommodityGroupCard key={group} group={group} commodities={commodities.filter((c) => c.commodityGroup === group)} />
+            <CommodityGroupCard key={group} group={group} commodities={commodities.filter((c) => c.commodityGroup === group)} limit={TOP_PER_GROUP} />
           ))}
+        </div>
+
+        <div className="mt-8 flex justify-center">
+          <Link href="/commodities" className="text-indigo-400 hover:text-indigo-300 font-semibold transition-colors">
+            View all commodities <span aria-hidden>→</span>
+          </Link>
         </div>
       </div>
 
-      {/* Separator matching the ETF section above so the home-page rhythm stays consistent */}
+      {/* Single divider below the ETF + Commodities block (the ETF section drops its own bottom
+          border so Commodities has no "top" line and matches the ETF section's clean look). */}
       <div className="border-b border-gray-600"></div>
     </section>
   );

--- a/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
+++ b/insights-ui/src/components/home-page/TopCommoditiesShowcase.tsx
@@ -1,6 +1,5 @@
 import CommodityGroupCard from '@/components/commodity-reports/CommodityGroupCard';
 import type { CommodityListItem } from '@/utils/commodity-analysis-reports/get-commodity-report-data-utils';
-import Link from 'next/link';
 import React from 'react';
 
 export interface TopCommoditiesShowcaseProps {
@@ -42,12 +41,6 @@ export default function TopCommoditiesShowcase({ commodities }: TopCommoditiesSh
           {groups.map((group) => (
             <CommodityGroupCard key={group} group={group} commodities={commodities.filter((c) => c.commodityGroup === group)} limit={TOP_PER_GROUP} />
           ))}
-        </div>
-
-        <div className="mt-8 flex justify-center">
-          <Link href="/commodities" className="text-indigo-400 hover:text-indigo-300 font-semibold transition-colors">
-            View all commodities <span aria-hidden>→</span>
-          </Link>
         </div>
       </div>
 

--- a/insights-ui/src/components/home-page/TopEtfAssetClassesShowcase.tsx
+++ b/insights-ui/src/components/home-page/TopEtfAssetClassesShowcase.tsx
@@ -72,8 +72,8 @@ export default function TopEtfAssetClassesShowcase({ country, data }: TopEtfAsse
         <EtfGroupingCardGrid columns={3} items={items} />
       </div>
 
-      {/* Separator between the ETF section and "Explore Our Insights" */}
-      <div className="border-b border-gray-600"></div>
+      {/* No bottom divider here: the Commodities showcase renders directly below and owns the single
+          separator for the combined ETF + Commodities block, so Commodities has no "top" border. */}
     </section>
   );
 }

--- a/insights-ui/src/utils/commodity-analysis-reports/get-commodity-report-data-utils.ts
+++ b/insights-ui/src/utils/commodity-analysis-reports/get-commodity-report-data-utils.ts
@@ -62,6 +62,30 @@ export function getCommodityBasicInfo(slug: string): CommodityBasicInfo | null {
   return ALL_COMMODITIES.find((c) => c.slug === slug) ?? null;
 }
 
+/** One row in the public commodities listing (grouped by `commodityGroup`). */
+export interface CommodityListItem {
+  id: string;
+  slug: string;
+  name: string;
+  commodityGroup: string;
+  finalScore: number | null;
+}
+
+/**
+ * Every commodity with its final score, ordered by group then name. Backs both
+ * the `/commodities` listing API and the home-page commodities showcase (which
+ * reads it directly, no HTTP self-fetch, so the static export of "/" is safe).
+ */
+export function getCommodityListingItems(): CommodityListItem[] {
+  return getAllCommodityBasicInfo().map((c) => ({
+    id: c.slug,
+    slug: c.slug,
+    name: c.name,
+    commodityGroup: c.commodityGroup,
+    finalScore: computeCommodityFinalScore(getCommodityReportJson(c.slug)),
+  }));
+}
+
 /** The authored report JSON for a slug, or null when none has been published. */
 export function getCommodityReportJson(slug: string): CommodityReportJson | null {
   return COMMODITY_REPORTS[slug] ?? null;


### PR DESCRIPTION
## What

All commodities front-end work on `add-commodities-task`. **Supersedes #1693** — contains every change from that PR plus a home-page commodities section, so #1693 can be closed.

## Commits

1. **feat: commodities sitemap** *(from #1693)* — new `src/app/commodities/sitemap.xml/route.ts` (index page + each `/commodities/<slug>`), registered in `public/sitemap_index.xml`. Listing fetched via `COMMODITIES_LISTING_TAG` (cache-tag only, no time-based revalidation).
2. **feat: Commodities navbar link** *(from #1693)* — adds Commodities to the Reports dropdown in `TopNav.tsx`.
3. **feat: home-page commodities showcase** *(new)* — see below.

## Home-page commodities section

Adds a `TopCommoditiesShowcase` after the ETF showcase on `/` (`src/app/page.tsx`), mirroring the ETF `TopEtfAssetClassesShowcase` and stock `TopIndustriesShowcase` for a consistent look: a centered "Explore Commodities by Group" heading followed by the four commodity-group cards (Energy, Metals, Agriculture, Livestock) in a responsive grid that rounds out to one row of four. Reuses the existing `CommodityGroupCard` from the `/commodities` listing page so the home page and listing stay visually identical.

### Home page stays statically generated

The commodities data is read exactly like the stocks/ETF data: a build-safe direct read (bundled static JSON — no DB, no HTTP self-fetch) wrapped in `unstable_cache` (`home-page-commodities`, 1-week revalidate, tagged `COMMODITIES_LISTING_TAG`) and awaited inside the existing `Promise.all`. So `/` continues to be generated once at build time (fast first paint), and revalidating the commodities listing refreshes the showcase.

### Shared listing helper (reuse, not duplication)

Extracted the listing type + mapping into `getCommodityListingItems()` / `CommodityListItem` in `get-commodity-report-data-utils.ts`. The `/api/[spaceId]/commodities-v1/listing` route now calls it (and re-exports the type for existing importers), and the home page reads it directly.

## Quality checks

`yarn lint`, `yarn prettier-check`, and `yarn compile` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
