### PR TITLE
fix(academy-ui): stop /api/spaces throwing on unknown tidbitshub subdomain

### DIFF
--- a/academy-ui/src/app/api/spaces/route.ts
+++ b/academy-ui/src/app/api/spaces/route.ts
@@ -30,12 +30,15 @@ async function getHandler(req: NextRequest): Promise<NextResponse<SpaceWithInteg
 
   if (domain?.includes('.tidbitshub.org') || domain?.includes('.tidbitshub-localhost.org')) {
     const idFromDomain = domain.split('.')[0];
-    const space = await prisma.space.findFirstOrThrow({
+    // Reserved subdomains (e.g. `sitemap`) have no matching space. Use findFirst so an unknown
+    // subdomain returns an empty list (caller resolves it to "no space") instead of throwing a
+    // Prisma "record not found" error that floods the server logs on every crawler request.
+    const space = await prisma.space.findFirst({
       where: {
         id: idFromDomain,
       },
     });
-    return NextResponse.json([await getWithIntegrations(space)]);
+    return space ? NextResponse.json([await getWithIntegrations(space)]) : NextResponse.json([]);
   }
 
   if (domain === 'dodao-ui-robinnagpal.vercel.app' || domain === 'localhost' || domain?.includes('.vercel.app')) {


### PR DESCRIPTION
## Problem

`GET /api/spaces?domain=<host>` runs on essentially every academy-ui page render (via `getSpaceServerSide`). For a reserved subdomain like `sitemap.tidbitshub.org`, no `Space` matches the literal domain, so the `.tidbitshub.org` branch takes the first subdomain label as a space id (`"sitemap"`) and calls `prisma.space.findFirstOrThrow({ where: { id: "sitemap" } })`. There is no space with that id, so it throws `PrismaClientKnownRequestError` (P2025). The error middleware logs it and posts to Discord for **every** such request — crawlers hit the sitemap host constantly, so this is a high-frequency log flood (returns HTTP 500).

## Fix (minimal, scoped to the tidbitshub branch)

Swap `findFirstOrThrow` → `findFirst` and return an empty list when no space matches:

```ts
const space = await prisma.space.findFirst({ where: { id: idFromDomain } });
return space ? NextResponse.json([await getWithIntegrations(space)]) : NextResponse.json([]);
```

- **Real spaces are unaffected:** `alchemix.tidbitshub.org` → space id `alchemix` exists → returned exactly as before.
- **Unknown subdomains** (e.g. `sitemap`) → `[]` (HTTP 200). The caller (`getSpaceBasedOnHostHeader`) reads `data?.[0]`, so an empty list resolves to "no space" — the same effective outcome as the old 500 path, but with **no thrown exception, no error log, and no Discord spam**.

No error-middleware changes; behavior for valid domains is unchanged.

## Files
- `academy-ui/src/app/api/spaces/route.ts`

## Checks
`yarn lint` (warnings only, none in this file), `yarn prettier-check`, and `yarn compile` all pass for academy-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)