### PR TITLE
feat(insights-ui): self-refreshing Claude OAuth token via refresh token

### DIFF
--- a/deployments/insights-ui/variables.tf
+++ b/deployments/insights-ui/variables.tf
@@ -164,9 +164,17 @@ variable "app_env" {
     GENERATE_TARIFF_SECTIONS_SYNCHRONOUSLY = "false"
     # LLM provider/model are no longer read from env. They are chosen per run in the
     # report-generation UI and default in code to Gemini + gemini-2.5-pro (claude-opus-4-7
-    # for the Claude provider). The Claude provider still needs the ANTHROPIC_OAUTH_TOKEN
-    # secret (in app_secrets / Secrets Manager) plus the background path
-    # (USE_LAMBDA_FOR_LLM_RESPONSE = "false"). See src/types/llmConstants.ts.
+    # for the Claude provider). The Claude provider authenticates with a Claude subscription
+    # OAuth token via the token provider (src/util/claude/claude-token-provider.ts):
+    #   - PREFERRED: ANTHROPIC_OAUTH_REFRESH_TOKEN (sk-ant-ort..., long-lived) in app_secrets /
+    #     Secrets Manager. The app exchanges it for short-lived access tokens on demand, so the
+    #     deployment is self-sustaining. Rotated refresh tokens are persisted to a PRIVATE S3
+    #     object (s3://<S3_BUCKET_NAME>/internal/claude-oauth/refresh-token.json) so they
+    #     survive restarts — the app user needs s3:GetObject/PutObject on that key.
+    #   - FALLBACK: ANTHROPIC_OAUTH_TOKEN (sk-ant-oat..., a static access token) — works but
+    #     expires in hours and cannot self-refresh; only for local dev / bootstrap.
+    # Also needs the background path (USE_LAMBDA_FOR_LLM_RESPONSE = "false"). See
+    # src/types/llmConstants.ts.
   }
 }
 

--- a/insights-ui/.env.example
+++ b/insights-ui/.env.example
@@ -41,7 +41,10 @@ PPT_GENERATION_S3_BUCKET_NAME=
 GENERATE_TARIFF_SECTIONS_SYNCHRONOUSLY=
 ## Stock report generation: "true" runs the LLM call in-process in the background on this server (Lightsail); unset/false offloads to the AWS Lambda (old behavior).
 USE_LAMBDA_FOR_LLM_RESPONSE=
-## Claude subscription OAuth token (sk-ant-oat01-...). Required when generating via the Claude provider (selected in the report-generation UI) on the background path (USE_LAMBDA_FOR_LLM_RESPONSE=false).
+## Claude subscription OAuth for the Claude provider (selected in the report-generation UI) on the background path (USE_LAMBDA_FOR_LLM_RESPONSE=false).
+## PREFERRED: a long-lived refresh token (sk-ant-ort01-...). The app exchanges it for short-lived access tokens on demand and persists rotations to S3, so it is self-sustaining.
+ANTHROPIC_OAUTH_REFRESH_TOKEN=
+## FALLBACK: a static access token (sk-ant-oat01-...). Works but expires in hours and cannot self-refresh — local dev / bootstrap only.
 ANTHROPIC_OAUTH_TOKEN=
 ## fetching information lambdas:
 STOCK_ANALYZER_LAMBDA_URL=

--- a/insights-ui/src/components/login/login-popup-auto-prompt.tsx
+++ b/insights-ui/src/components/login/login-popup-auto-prompt.tsx
@@ -15,16 +15,7 @@ const LAST_PATH_KEY = 'loginPopupLastPath';
 const SHOWN_KEY = 'loginPopupShown';
 const DISMISSED_AT_KEY = 'loginPopupDismissedAt';
 
-const EXCLUDED_PATH_PREFIXES: readonly string[] = [
-  '/login',
-  '/auth',
-  '/admin-v1',
-  '/prompts',
-  '/invocations',
-  '/generate-ppt',
-  '/api',
-  '/blogs',
-];
+const EXCLUDED_PATH_PREFIXES: readonly string[] = ['/login', '/auth', '/admin-v1', '/prompts', '/invocations', '/generate-ppt', '/api', '/blogs'];
 
 function isExcludedPath(pathname: string): boolean {
   if (EXCLUDED_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))) return true;

--- a/insights-ui/src/util/claude/claude-oauth-client.ts
+++ b/insights-ui/src/util/claude/claude-oauth-client.ts
@@ -17,6 +17,8 @@
  * be tested in isolation before being wired into any workflow.
  */
 
+import { getClaudeAccessToken, invalidateClaudeAccessToken } from '@/util/claude/claude-token-provider';
+
 /** Anthropic rejects OAuth requests unless this is the first system block. */
 export const CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude.";
 
@@ -41,7 +43,10 @@ export interface CallClaudeOAuthOptions {
   model?: string;
   /** Response length cap. Defaults to 1024. */
   maxTokens?: number;
-  /** OAuth token. Defaults to the `ANTHROPIC_OAUTH_TOKEN` env var. */
+  /**
+   * Explicit OAuth access token. When omitted, the token provider supplies one —
+   * refreshing a long-lived refresh token as needed (see claude-token-provider).
+   */
   oauthToken?: string;
   /** API base URL. Defaults to `ANTHROPIC_BASE_URL` env, else the real API. */
   baseUrl?: string;
@@ -127,11 +132,6 @@ interface AnthropicMessageResponse {
  * upstream error body included.
  */
 export async function callClaudeWithOAuth(options: CallClaudeOAuthOptions): Promise<CallClaudeOAuthResult> {
-  const oauthToken = options.oauthToken ?? process.env.ANTHROPIC_OAUTH_TOKEN;
-  if (!oauthToken) {
-    throw new Error('ANTHROPIC_OAUTH_TOKEN is not set. Export your Claude subscription OAuth token (sk-ant-oat...) before calling.');
-  }
-
   const prompt = options.prompt?.trim();
   if (!prompt) {
     throw new Error('callClaudeWithOAuth requires a non-empty prompt.');
@@ -160,19 +160,31 @@ export async function callClaudeWithOAuth(options: CallClaudeOAuthOptions): Prom
     body.output_config = { effort: options.effort };
   }
 
-  const response = await fetch(`${baseUrl}/v1/messages`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'anthropic-version': '2023-06-01',
-      'anthropic-beta': ANTHROPIC_BETA,
-      authorization: `Bearer ${oauthToken}`,
-      'x-app': 'cli',
-      'user-agent': `claude-cli/${ccVersion} (external, cli)`,
-      'x-anthropic-billing-header': `cc_version=${ccVersion}.${model}; cc_entrypoint=cli;`,
-    },
-    body: JSON.stringify(body),
-  });
+  const sendWithToken = (token: string): Promise<Response> =>
+    fetch(`${baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': ANTHROPIC_BETA,
+        authorization: `Bearer ${token}`,
+        'x-app': 'cli',
+        'user-agent': `claude-cli/${ccVersion} (external, cli)`,
+        'x-anthropic-billing-header': `cc_version=${ccVersion}.${model}; cc_entrypoint=cli;`,
+      },
+      body: JSON.stringify(body),
+    });
+
+  // When the caller supplies an explicit token we use it verbatim (no refresh).
+  // Otherwise the provider hands us a fresh access token and can re-mint one on a 401.
+  const usingProvider = !options.oauthToken;
+  let response = await sendWithToken(options.oauthToken ?? (await getClaudeAccessToken()));
+
+  // A managed access token can expire between mint and use; force one refresh + retry on 401.
+  if (response.status === 401 && usingProvider) {
+    invalidateClaudeAccessToken();
+    response = await sendWithToken(await getClaudeAccessToken(true));
+  }
 
   const responseText = await response.text();
   const rateLimit = parseRateLimitHeaders(response.headers);

--- a/insights-ui/src/util/claude/claude-token-provider.ts
+++ b/insights-ui/src/util/claude/claude-token-provider.ts
@@ -137,27 +137,33 @@ async function persistRefreshToken(refreshToken: string): Promise<void> {
   }
 }
 
-/** Resolves the refresh token to use: in-memory rotated value → persisted S3 copy → env bootstrap. */
-async function resolveRefreshToken(): Promise<string | null> {
-  if (currentRefreshToken) return currentRefreshToken;
+/**
+ * Candidate refresh tokens to try, in priority order:
+ *   1. in-memory rotated value (this process's newest),
+ *   2. the persisted S3 copy (newest across restarts),
+ *   3. the `ANTHROPIC_OAUTH_REFRESH_TOKEN` env bootstrap.
+ *
+ * We return a LIST rather than a single token because rotation can happen
+ * out-of-band — an operator re-seeding Secrets Manager, or a redeploy injecting
+ * a newer bootstrap than what S3 holds. A single stale candidate must not take
+ * Claude down when a working one is sitting right behind it.
+ */
+async function candidateRefreshTokens(): Promise<string[]> {
+  const candidates: string[] = [];
+  const add = (token: string | null | undefined): void => {
+    const trimmed = token?.trim();
+    if (trimmed && !candidates.includes(trimmed)) candidates.push(trimmed);
+  };
 
-  const persisted = await loadPersistedRefreshToken();
-  if (persisted) {
-    currentRefreshToken = persisted;
-    return persisted;
-  }
+  add(currentRefreshToken);
+  add(await loadPersistedRefreshToken());
+  add(process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN);
 
-  const envToken = process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN?.trim();
-  if (envToken) {
-    currentRefreshToken = envToken;
-    return envToken;
-  }
-
-  return null;
+  return candidates;
 }
 
-/** Exchanges the refresh token for a fresh access token, caches it, and persists any rotation. */
-async function refreshAccessToken(refreshToken: string): Promise<string> {
+/** One exchange attempt. Caches the access token and persists any rotation on success. */
+async function exchangeRefreshToken(refreshToken: string): Promise<string> {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', accept: 'application/json' },
@@ -182,14 +188,41 @@ async function refreshAccessToken(refreshToken: string): Promise<string> {
   const expiresInMs = (json.expires_in ?? 3600) * 1000;
   cachedAccessToken = { token: accessToken, expiresAtMs: Date.now() + expiresInMs - EXPIRY_SKEW_MS };
 
-  // Rotation: if a new refresh token came back, adopt and persist it. The old one is now invalid.
+  // Rotation: the endpoint hands back a NEW refresh token and invalidates the one
+  // we just used. Adopt + persist it, or the next restart replays a dead token.
   const rotated = json.refresh_token?.trim();
   if (rotated && rotated !== refreshToken) {
     currentRefreshToken = rotated;
     await persistRefreshToken(rotated);
+  } else {
+    currentRefreshToken = refreshToken;
   }
 
   return accessToken;
+}
+
+/** Tries each candidate refresh token until one succeeds. Throws the last error if all fail. */
+async function refreshAccessToken(): Promise<string> {
+  const candidates = await candidateRefreshTokens();
+  if (candidates.length === 0) {
+    throw new Error('No Claude refresh token available.');
+  }
+
+  let lastError: unknown;
+  for (const [index, candidate] of candidates.entries()) {
+    try {
+      return await exchangeRefreshToken(candidate);
+    } catch (err) {
+      lastError = err;
+      // This candidate is stale (most likely rotated out-of-band). Drop it from
+      // memory so it isn't retried first next time, and fall through to the next.
+      if (currentRefreshToken === candidate) currentRefreshToken = null;
+      if (index < candidates.length - 1) {
+        console.warn(`[claude-token-provider] refresh candidate ${index + 1}/${candidates.length} rejected; trying the next source.`);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 /**
@@ -203,28 +236,31 @@ export async function getClaudeAccessToken(forceRefresh = false): Promise<string
     return cachedAccessToken.token;
   }
 
-  const refreshToken = await resolveRefreshToken();
-
-  if (!refreshToken) {
-    // No refresh token anywhere — fall back to a static access token (local dev / tests).
-    const staticToken = process.env.ANTHROPIC_OAUTH_TOKEN?.trim();
-    if (staticToken) return staticToken;
-    throw new Error(
-      'No Claude OAuth credentials found. Set ANTHROPIC_OAUTH_REFRESH_TOKEN (preferred, self-refreshing) ' + 'or a static ANTHROPIC_OAUTH_TOKEN access token.'
-    );
-  }
-
   if (forceRefresh) {
     cachedAccessToken = null;
   }
 
-  // Collapse concurrent refreshes into one exchange.
+  // Collapse concurrent refreshes into one exchange — a burst of report requests
+  // after expiry must not fire N competing rotations (they would invalidate
+  // each other, since each exchange rotates the refresh token).
   if (!inFlightRefresh) {
-    inFlightRefresh = refreshAccessToken(refreshToken).finally(() => {
+    inFlightRefresh = refreshAccessToken().finally(() => {
       inFlightRefresh = null;
     });
   }
-  return inFlightRefresh;
+
+  try {
+    return await inFlightRefresh;
+  } catch (err) {
+    // No usable refresh token — fall back to a static access token if one is
+    // configured (local dev / bootstrap), otherwise surface the refresh failure.
+    const staticToken = process.env.ANTHROPIC_OAUTH_TOKEN?.trim();
+    if (staticToken) {
+      console.warn('[claude-token-provider] refresh failed; falling back to the static ANTHROPIC_OAUTH_TOKEN.', err);
+      return staticToken;
+    }
+    throw err;
+  }
 }
 
 /** Clears the cached access token so the next call re-exchanges. Call this on a 401. */

--- a/insights-ui/src/util/claude/claude-token-provider.ts
+++ b/insights-ui/src/util/claude/claude-token-provider.ts
@@ -34,8 +34,12 @@ import { Readable } from 'stream';
 /** Public OAuth client id the Claude Code CLI uses; required on the token exchange. */
 const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
-/** Claude Code OAuth token endpoint. Overridable for tests via env. */
-const TOKEN_ENDPOINT = process.env.ANTHROPIC_OAUTH_TOKEN_URL ?? 'https://console.anthropic.com/v1/oauth/token';
+/**
+ * Claude Code OAuth token endpoint — note this is the platform host, NOT
+ * api.anthropic.com (which serves the Messages API) and NOT
+ * console.anthropic.com (which 404s). Overridable for tests via env.
+ */
+const TOKEN_ENDPOINT = process.env.ANTHROPIC_OAUTH_TOKEN_URL ?? 'https://platform.claude.com/v1/oauth/token';
 
 /** Refresh a bit BEFORE the real expiry so an in-flight request never races the cutover. */
 const EXPIRY_SKEW_MS = 5 * 60 * 1000;

--- a/insights-ui/src/util/claude/claude-token-provider.ts
+++ b/insights-ui/src/util/claude/claude-token-provider.ts
@@ -1,0 +1,229 @@
+/**
+ * Supplies a valid Claude **subscription OAuth access token** to the Claude
+ * callers (`callClaudeWithOAuth`, `getClaudeSubscriptionUsage`).
+ *
+ * Access tokens (`sk-ant-oat...`) are short-lived (~a few hours). Baking a static
+ * one into the deployment means Claude stops working the moment it expires. This
+ * provider instead holds the long-lived **refresh token** (`sk-ant-ort...`) and
+ * exchanges it for a fresh access token on demand — the same thing the Claude
+ * Code CLI does — so the server is self-sustaining.
+ *
+ * Token sources, in priority order (first one that yields a token wins):
+ *   1. In-memory cached access token, if still valid (no network call).
+ *   2. Refresh flow: exchange a refresh token at the OAuth token endpoint. The
+ *      refresh token itself is resolved from (a) the in-memory rotated value,
+ *      (b) the persisted S3 copy, then (c) the `ANTHROPIC_OAUTH_REFRESH_TOKEN`
+ *      env var (the bootstrap value injected from Secrets Manager).
+ *   3. Fallback: a static `ANTHROPIC_OAUTH_TOKEN` access token env var (local
+ *      dev / tests / backward compatibility). Returned as-is, unmanaged.
+ *
+ * Refresh-token ROTATION: the token endpoint returns a NEW refresh token on each
+ * exchange and invalidates the old one. We therefore persist the rotated token
+ * to a PRIVATE S3 object so it survives container restarts/redeploys (the env
+ * bootstrap is only good for the very first exchange after a fresh rotation
+ * lineage). The bucket has no public bucket policy and we write with a private
+ * ACL, so the credential is not anonymously readable.
+ *
+ * Single-node only (service_scale = 1): the in-memory cache is the coherence
+ * point. If this is ever scaled out, move the cache to a shared store.
+ */
+
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+
+/** Public OAuth client id the Claude Code CLI uses; required on the token exchange. */
+const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+/** Claude Code OAuth token endpoint. Overridable for tests via env. */
+const TOKEN_ENDPOINT = process.env.ANTHROPIC_OAUTH_TOKEN_URL ?? 'https://console.anthropic.com/v1/oauth/token';
+
+/** Refresh a bit BEFORE the real expiry so an in-flight request never races the cutover. */
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+
+/** S3 location of the rotated refresh token (private object). */
+const REFRESH_TOKEN_S3_BUCKET = process.env.S3_BUCKET_NAME || 'dodao-ai-insights-agent';
+const REFRESH_TOKEN_S3_KEY = process.env.CLAUDE_OAUTH_REFRESH_S3_KEY || 'internal/claude-oauth/refresh-token.json';
+const S3_REGION = process.env.AWS_DEFAULT_REGION || process.env.AWS_REGION || 'us-east-1';
+
+interface CachedAccessToken {
+  token: string;
+  /** Epoch ms after which the token must be re-fetched (already includes the skew). */
+  expiresAtMs: number;
+}
+
+interface PersistedRefreshToken {
+  refreshToken: string;
+  updatedAt: string;
+}
+
+interface TokenEndpointResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+// ---- Module state (single-node coherence point) -----------------------------
+let cachedAccessToken: CachedAccessToken | null = null;
+/** Most recent refresh token this process has seen (after any rotation). */
+let currentRefreshToken: string | null = null;
+/** De-dupes concurrent refreshes so a burst of requests triggers a single exchange. */
+let inFlightRefresh: Promise<string> | null = null;
+
+let s3Client: S3Client | null = null;
+function getS3Client(): S3Client | null {
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) return null;
+  if (!s3Client) {
+    s3Client = new S3Client({ region: S3_REGION, credentials: { accessKeyId, secretAccessKey } });
+  }
+  return s3Client;
+}
+
+async function streamToString(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/** Best-effort read of the persisted (rotated) refresh token from S3. Returns null if absent/unavailable. */
+async function loadPersistedRefreshToken(): Promise<string | null> {
+  const client = getS3Client();
+  if (!client) return null;
+  try {
+    const res = await client.send(new GetObjectCommand({ Bucket: REFRESH_TOKEN_S3_BUCKET, Key: REFRESH_TOKEN_S3_KEY }));
+    const body = await streamToString(res.Body as Readable);
+    const parsed = JSON.parse(body) as PersistedRefreshToken;
+    return parsed.refreshToken?.trim() || null;
+  } catch (err: unknown) {
+    const name = (err as { name?: string })?.name;
+    if (name !== 'NoSuchKey' && name !== 'NotFound') {
+      console.warn('[claude-token-provider] could not read persisted refresh token from S3:', name ?? err);
+    }
+    return null;
+  }
+}
+
+/** Best-effort write of the rotated refresh token to a PRIVATE S3 object so it survives restarts. */
+async function persistRefreshToken(refreshToken: string): Promise<void> {
+  const client = getS3Client();
+  if (!client) {
+    console.warn('[claude-token-provider] no AWS creds; rotated refresh token kept in memory only (will not survive a restart).');
+    return;
+  }
+  try {
+    const payload: PersistedRefreshToken = { refreshToken, updatedAt: new Date().toISOString() };
+    await client.send(
+      new PutObjectCommand({
+        Bucket: REFRESH_TOKEN_S3_BUCKET,
+        Key: REFRESH_TOKEN_S3_KEY,
+        Body: JSON.stringify(payload),
+        ContentType: 'application/json',
+        // Explicitly private + encrypted — this is a credential, never public-read.
+        ACL: 'private',
+        ServerSideEncryption: 'AES256',
+      })
+    );
+  } catch (err) {
+    // Non-fatal: the token still works in-memory for this process's lifetime.
+    console.error('[claude-token-provider] failed to persist rotated refresh token to S3:', err);
+  }
+}
+
+/** Resolves the refresh token to use: in-memory rotated value → persisted S3 copy → env bootstrap. */
+async function resolveRefreshToken(): Promise<string | null> {
+  if (currentRefreshToken) return currentRefreshToken;
+
+  const persisted = await loadPersistedRefreshToken();
+  if (persisted) {
+    currentRefreshToken = persisted;
+    return persisted;
+  }
+
+  const envToken = process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN?.trim();
+  if (envToken) {
+    currentRefreshToken = envToken;
+    return envToken;
+  }
+
+  return null;
+}
+
+/** Exchanges the refresh token for a fresh access token, caches it, and persists any rotation. */
+async function refreshAccessToken(refreshToken: string): Promise<string> {
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CLAUDE_OAUTH_CLIENT_ID,
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Claude OAuth token refresh failed: ${response.status} ${response.statusText}: ${text}`);
+  }
+
+  const json = JSON.parse(text) as TokenEndpointResponse;
+  const accessToken = json.access_token?.trim();
+  if (!accessToken) {
+    throw new Error('Claude OAuth token refresh returned no access_token.');
+  }
+
+  const expiresInMs = (json.expires_in ?? 3600) * 1000;
+  cachedAccessToken = { token: accessToken, expiresAtMs: Date.now() + expiresInMs - EXPIRY_SKEW_MS };
+
+  // Rotation: if a new refresh token came back, adopt and persist it. The old one is now invalid.
+  const rotated = json.refresh_token?.trim();
+  if (rotated && rotated !== refreshToken) {
+    currentRefreshToken = rotated;
+    await persistRefreshToken(rotated);
+  }
+
+  return accessToken;
+}
+
+/**
+ * Returns a valid Claude access token, refreshing (and rotating) as needed.
+ *
+ * @param forceRefresh Skip the in-memory cache and force a new exchange — used to
+ *   recover from a 401 where the cached token was rejected mid-flight.
+ */
+export async function getClaudeAccessToken(forceRefresh = false): Promise<string> {
+  if (!forceRefresh && cachedAccessToken && cachedAccessToken.expiresAtMs > Date.now()) {
+    return cachedAccessToken.token;
+  }
+
+  const refreshToken = await resolveRefreshToken();
+
+  if (!refreshToken) {
+    // No refresh token anywhere — fall back to a static access token (local dev / tests).
+    const staticToken = process.env.ANTHROPIC_OAUTH_TOKEN?.trim();
+    if (staticToken) return staticToken;
+    throw new Error(
+      'No Claude OAuth credentials found. Set ANTHROPIC_OAUTH_REFRESH_TOKEN (preferred, self-refreshing) ' + 'or a static ANTHROPIC_OAUTH_TOKEN access token.'
+    );
+  }
+
+  if (forceRefresh) {
+    cachedAccessToken = null;
+  }
+
+  // Collapse concurrent refreshes into one exchange.
+  if (!inFlightRefresh) {
+    inFlightRefresh = refreshAccessToken(refreshToken).finally(() => {
+      inFlightRefresh = null;
+    });
+  }
+  return inFlightRefresh;
+}
+
+/** Clears the cached access token so the next call re-exchanges. Call this on a 401. */
+export function invalidateClaudeAccessToken(): void {
+  cachedAccessToken = null;
+}

--- a/insights-ui/src/util/claude/claude-usage.ts
+++ b/insights-ui/src/util/claude/claude-usage.ts
@@ -1,4 +1,5 @@
 import { ANTHROPIC_BETA, DEFAULT_BASE_URL, DEFAULT_CC_VERSION } from '@/util/claude/claude-oauth-client';
+import { getClaudeAccessToken, invalidateClaudeAccessToken } from '@/util/claude/claude-token-provider';
 
 /**
  * Reads the Claude **subscription** usage from Anthropic's OAuth usage endpoint
@@ -80,36 +81,44 @@ function toScopedWeekly(window: UsageWindowJson | null | undefined, limit: Usage
 }
 
 export interface GetClaudeUsageOptions {
-  /** OAuth token override; defaults to `ANTHROPIC_OAUTH_TOKEN`. */
+  /**
+   * Explicit OAuth access token. When omitted, the token provider supplies one —
+   * refreshing a long-lived refresh token as needed (see claude-token-provider).
+   */
   oauthToken?: string;
   /** API base URL; defaults to `ANTHROPIC_BASE_URL` env, else the real API. */
   baseUrl?: string;
 }
 
 /**
- * Fetches the current subscription usage. Throws if the OAuth token is missing
- * or the endpoint returns a non-2xx response.
+ * Fetches the current subscription usage. Throws if no OAuth credentials are
+ * configured or the endpoint returns a non-2xx response.
  */
 export async function getClaudeSubscriptionUsage(options: GetClaudeUsageOptions = {}): Promise<ClaudeSubscriptionUsage> {
-  const oauthToken = options.oauthToken ?? process.env.ANTHROPIC_OAUTH_TOKEN;
-  if (!oauthToken) {
-    throw new Error('ANTHROPIC_OAUTH_TOKEN is not set. Export your Claude subscription OAuth token (sk-ant-oat...) before reading usage.');
-  }
-
   const baseUrl = (options.baseUrl ?? process.env.ANTHROPIC_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
   const ccVersion = process.env.CLAUDE_CODE_VERSION ?? DEFAULT_CC_VERSION;
 
-  const response = await fetch(`${baseUrl}${USAGE_PATH}`, {
-    method: 'GET',
-    headers: {
-      accept: 'application/json',
-      'anthropic-version': '2023-06-01',
-      'anthropic-beta': ANTHROPIC_BETA,
-      authorization: `Bearer ${oauthToken}`,
-      'x-app': 'cli',
-      'user-agent': `claude-cli/${ccVersion} (external, cli)`,
-    },
-  });
+  const sendWithToken = (token: string): Promise<Response> =>
+    fetch(`${baseUrl}${USAGE_PATH}`, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': ANTHROPIC_BETA,
+        authorization: `Bearer ${token}`,
+        'x-app': 'cli',
+        'user-agent': `claude-cli/${ccVersion} (external, cli)`,
+      },
+    });
+
+  const usingProvider = !options.oauthToken;
+  let response = await sendWithToken(options.oauthToken ?? (await getClaudeAccessToken()));
+
+  // A managed access token can expire between mint and use; force one refresh + retry on 401.
+  if (response.status === 401 && usingProvider) {
+    invalidateClaudeAccessToken();
+    response = await sendWithToken(await getClaudeAccessToken(true));
+  }
 
   const responseText = await response.text();
   if (!response.ok) {


### PR DESCRIPTION
## What & why

The Claude subscription OAuth path baked a **static access token** (`ANTHROPIC_OAUTH_TOKEN`, `sk-ant-oat...`) into the deployment. Access tokens expire in a few hours, so Claude report generation and the nightly usage-gated auto-stock cron (`enqueue-auto-stock-generation`) would stop working within a day.

This adds a **token provider** that holds the **long-lived refresh token** (`ANTHROPIC_OAUTH_REFRESH_TOKEN`, `sk-ant-ort...`) and exchanges it for short-lived access tokens on demand — the same flow the Claude Code CLI uses — so the deployment is self-sustaining.

## Changes

- **`src/util/claude/claude-token-provider.ts`** (new)
  - In-memory access-token cache with a 5-min expiry skew (single node, `scale=1`).
  - Concurrent refreshes collapse into one exchange.
  - **Refresh-token rotation** persisted to a **private, AES256-encrypted S3 object** (`s3://$S3_BUCKET_NAME/internal/claude-oauth/refresh-token.json`) so it survives restarts/redeploys.
  - Token resolution order: in-memory rotated → persisted S3 → `ANTHROPIC_OAUTH_REFRESH_TOKEN` env → static `ANTHROPIC_OAUTH_TOKEN` fallback.
- **`claude-oauth-client.ts` / `claude-usage.ts`** — source tokens from the provider; retry once on a `401` with a forced refresh.
- **`variables.tf` / `.env.example`** — document the preferred refresh-token env var.

## Deployment notes

- Set `ANTHROPIC_OAUTH_REFRESH_TOKEN` in Secrets Manager (`insights-ui/app-env`) — bootstrap value; the app persists rotations to S3 thereafter.
- The app runtime IAM user (`insights-ui-vercel-project`) already has S3 access to the bucket.
- Static `ANTHROPIC_OAUTH_TOKEN` remains valid as a fallback during the bridge.

## Caveat

Refresh tokens rotate on use and are shared with the interactive Claude Code login they were minted from; once the server refreshes, a local CLI session using the same credential will need to re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)