### PR TITLE
ci(insights-ui): fix always-timing-out deploy wait + cache docker layers

### DIFF
--- a/.github/workflows/insights-ui-deploy-aws.yml
+++ b/.github/workflows/insights-ui-deploy-aws.yml
@@ -60,19 +60,26 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
-      # ECR repo + S3 bucket are Terraform resources — create them first so `docker push` and
-      # the static upload have targets. app_secrets defaults to {} so the targeted apply runs.
-      - name: Terraform init + ensure ECR repo and S3 bucket
+      # ECR repos + S3 bucket are Terraform resources — create them first so `docker push`, the
+      # BuildKit registry cache, and the static upload have targets. app_secrets defaults to {}
+      # so the targeted apply runs.
+      - name: Terraform init + ensure ECR repos and S3 bucket
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform init -input=false
           terraform apply -input=false -auto-approve \
-            -target=aws_ecr_repository.app -target=aws_s3_bucket.assets \
+            -target=aws_ecr_repository.app -target=aws_ecr_repository.buildcache \
+            -target=aws_s3_bucket.assets \
             -var "image_tag=$(git rev-parse --short HEAD)"
 
       - name: Login to Amazon ECR
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      # Required for `--cache-to/--cache-from type=registry`: the default docker driver cannot
+      # export a registry cache, only the docker-container driver buildx sets up here.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build & push image
         id: build
@@ -86,6 +93,9 @@ jobs:
         run: |
           TAG="$(git rev-parse --short HEAD)"
           IMAGE="$REGISTRY/$ECR_REPOSITORY:$TAG"
+          # Rewritten every run, so it lives in the MUTABLE -buildcache repo (the app repo is
+          # IMMUTABLE and would reject the second push). See container.tf.
+          CACHE="$REGISTRY/$ECR_REPOSITORY-buildcache:cache"
           # Load /_next/static/* through CloudFront (edge-cached + gzip/brotli) rather than the raw
           # S3 URL (uncompressed, no CDN). koalagains.com is the CloudFront alias and routes
           # /_next/static/* to the S3 asset origin (see deployments/insights-ui/cloudfront.tf).
@@ -93,12 +103,21 @@ jobs:
           ASSET_PREFIX="https://koalagains.com"
           # Build context = repo root (workspace dependency @dodao/web-core).
           # Phase A: base URL is the direct host; static assets are served from S3 via CloudFront.
-          docker build \
+          #
+          # `--load` (not `--push`) puts the image in the local daemon so the next step's
+          # `docker create` can extract static assets without re-pulling ~1GB from ECR; the
+          # explicit `docker push` then ships it. `image-manifest/oci-mediatypes` are REQUIRED
+          # for a registry cache on ECR — it rejects BuildKit's default cache manifest type.
+          # A cold cache (first run, or after the 7-day expiry) just builds everything, as before.
+          docker buildx build \
             -f deployments/insights-ui/Dockerfile \
             --build-arg NEXT_PUBLIC_VERCEL_URL="$DIRECT_HOST" \
             --build-arg NEXT_PUBLIC_VERCEL_ENV="production" \
             --build-arg NEXT_PUBLIC_ASSET_PREFIX="$ASSET_PREFIX" \
             --secret id=database_url,env=DATABASE_URL \
+            --cache-from "type=registry,ref=$CACHE" \
+            --cache-to "type=registry,ref=$CACHE,mode=max,image-manifest=true,oci-mediatypes=true" \
+            --load \
             -t "$IMAGE" .
           docker push "$IMAGE"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -142,20 +161,46 @@ jobs:
 
       # Wait for the new deployment version to roll to ACTIVE before smoke-testing, otherwise we
       # hit the old version (or a still-deploying container).
+      #
+      # Poll the DEPLOYMENT, not the container service: a service's state is RUNNING/UPDATING/…
+      # and is NEVER "ACTIVE" (that is a deployment state), so the previous check here could not
+      # match and always burned its full timeout (~10 min) on every deploy before falling
+      # through WITHOUT failing. Combined with a smoke check that the OLD version answers just
+      # as happily, a failed rollout reported success. We now assert the ACTIVE deployment is
+      # running the image tag this run built, and fail on FAILED or on timeout.
       - name: Wait for Lightsail deployment to be ACTIVE
+        env:
+          TAG: ${{ steps.build.outputs.tag }}
         run: |
-          for i in $(seq 1 40); do
-            state=$(aws lightsail get-container-services --service-name "$ECR_REPOSITORY" \
-              --query 'containerServices[0].state' --output text)
-            echo "Lightsail state: $state"
-            [ "$state" = "ACTIVE" ] && break
-            sleep 15
+          for i in $(seq 1 60); do
+            read -r state image <<<"$(aws lightsail get-container-service-deployments \
+              --service-name "$ECR_REPOSITORY" \
+              --query 'deployments[0].[state,containers.app.image]' --output text)"
+            echo "deployment: state=$state image=$image"
+            case "$state" in
+              ACTIVE)
+                case "$image" in
+                  *":$TAG") echo "Deployment ACTIVE on $TAG."; exit 0 ;;
+                  *) echo "ACTIVE but still the previous image; waiting for $TAG..." ;;
+                esac
+                ;;
+              FAILED)
+                echo "::error::Lightsail deployment FAILED for $TAG"
+                exit 1
+                ;;
+            esac
+            sleep 10
           done
+          echo "::error::Timed out waiting for Lightsail deployment $TAG to become ACTIVE"
+          exit 1
 
+      # Belt-and-braces: the wait above already proves the new version is serving, but this
+      # catches an app that rolls out ACTIVE yet 500s on a real request through the public host.
       - name: Smoke check (direct host)
         run: |
           for i in $(seq 1 10); do
             curl -fsS "https://$DIRECT_HOST/api/health" && exit 0
             echo "health not ready, retrying..."; sleep 15
           done
+          echo "::error::Smoke check failed against https://$DIRECT_HOST/api/health"
           exit 1

--- a/deployments/insights-ui/container.tf
+++ b/deployments/insights-ui/container.tf
@@ -22,6 +22,35 @@ resource "aws_ecr_lifecycle_policy" "app" {
   })
 }
 
+# BuildKit layer cache for the CI docker build (`--cache-to/--cache-from type=registry`).
+# Kept in its OWN repo, deliberately MUTABLE: the cache lives under a single rewritten tag,
+# which the app repo's IMMUTABLE policy would reject on the second push. Keeping app images
+# immutable matters (a git-SHA tag must always mean the same bits) — so the cache goes here
+# instead of relaxing that guarantee. Nothing deploys from this repo; it is CI scratch space.
+resource "aws_ecr_repository" "buildcache" {
+  name                 = "${var.ecr_repository_name}-buildcache"
+  image_tag_mutability = "MUTABLE"
+
+  # Cache blobs are rewritten every build and never deployed — scanning them is pure cost.
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+# BuildKit replaces the cache tag each run, orphaning the previous blobs. Without this they
+# accumulate forever (the cache is GBs per build).
+resource "aws_ecr_lifecycle_policy" "buildcache" {
+  repository = aws_ecr_repository.buildcache.name
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Expire untagged cache blobs after 7 days"
+      selection    = { tagStatus = "untagged", countType = "sinceImagePushed", countUnit = "days", countNumber = 7 }
+      action       = { type = "expire" }
+    }]
+  })
+}
+
 resource "aws_lightsail_container_service" "app" {
   name        = var.name_prefix
   power       = var.service_power


### PR DESCRIPTION
Measured the last full deploy (43m05s wall) before changing anything:

| Phase | Time | Verdict |
|---|---|---|
| Queue (runner availability) | 21m18s | Incidental — a later run started in 3s |
| Build & push image | 7m16s | Improvable (no layer cache) |
| Terraform apply | 3m10s | Fine |
| **Wait for ACTIVE** | **10m36s** | **Pure waste — a bug** |

## 1. The wait step was broken (correctness, not just speed)

It polled `containerServices[0].state` and broke on `"ACTIVE"`. But service states are `PENDING/READY/RUNNING/UPDATING/…` — **`ACTIVE` is a *deployment* state**, so the condition never matched. Every deploy burned the full `40 × 15s` timeout (~10 min — exactly the observed 636s), then **fell through without failing**.

Combined with a smoke check that only curls `/api/health` — which the **old** version answers happily — **a failed rollout could report success.**

Observed live while writing this: deployment v74 went ACTIVE on the merge commit while its CI run sat "in_progress" for another ~10 min.

Now: polls the *deployment*, asserts the ACTIVE deployment runs the tag this run built, fails on `FAILED` and on timeout. Verified against the live API — matching tag exits immediately, wrong tag waits then exits 1.

## 2. No docker layer cache

On a fresh runner `docker build` starts cold, and the Dockerfile's `--mount=type=cache` pnpm store **does not persist between runs** — so every deploy re-ran `pnpm install` from zero.

Now builds with buildx + a registry cache. Notes on the choices:
- **Separate `-buildcache` ECR repo, MUTABLE.** The cache is a single rewritten tag; the app repo is `IMMUTABLE` and would reject the second push. Keeping app images immutable is worth preserving (a git-SHA tag must always mean the same bits).
- **`image-manifest=true,oci-mediatypes=true`** — ECR rejects BuildKit's default cache manifest type.
- **`--load` rather than `--push`** so the static-asset extraction step (`docker create`) doesn't re-pull ~1GB from ECR.
- Lifecycle policy expires untagged cache blobs after 7 days (they'd accumulate at GBs/build).
- Cold cache (first run, or post-expiry) simply builds everything as before.
- Not `type=gha`: that cache is 10GB/repo shared across every workflow in this monorepo and would thrash.

`next build` still re-runs on any code change (`COPY . .` invalidates), so this targets the install/deps layers, not the whole build.

## Expected

~22 min of work → ~10–12 min, and the deploy now fails when it actually fails.

Validated: `terraform validate` + `fmt` clean, workflow YAML parses, wait-loop logic exercised against the live AWS API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)