### PR TITLE
feat(insights-ui): competition on Opus 4.8 + one-shot retry for failed report sections

### DIFF
--- a/insights-ui/prisma/migrations/20260719000000_add_generation_request_retried_steps/migration.sql
+++ b/insights-ui/prisma/migrations/20260719000000_add_generation_request_retried_steps/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ticker_v1_generation_requests" ADD COLUMN     "retried_steps" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/insights-ui/prisma/schema.prisma
+++ b/insights-ui/prisma/schema.prisma
@@ -850,6 +850,9 @@ model TickerV1GenerationRequest {
   inProgressStep String?  @map("in_progress_step")
   completedSteps String[] @default([]) @map("completed_steps")
   failedSteps    String[] @default([]) @map("failed_steps")
+  // Failed steps that were already given their single retry. A step present in
+  // BOTH failedSteps and retriedSteps has failed twice and is terminal.
+  retriedSteps   String[] @default([]) @map("retried_steps")
 
   // Timestamps for tracking
   createdAt          DateTime  @default(now()) @map("created_at")

--- a/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/generation-report-utils.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { GeminiModel, LLMProvider } from '@/types/llmConstants';
+import { ClaudeModel, GeminiModel, LLMProvider } from '@/types/llmConstants';
 import { GenerationRequestStatus, ReportType, TickerAnalysisCategory, TickerV1WithIndustryAndSubIndustry } from '@/types/ticker-typesv1';
 import {
   fetchAnalysisFactors,
@@ -445,7 +445,12 @@ export async function triggerGenerationOfAReportSimplified(symbol: string, excha
   await markAsInProgress(generationRequest, nextStep);
 
   if (nextStep === ReportType.COMPETITION) {
-    await generateCompetitionAnalysis(spaceId, tickerRecord, generationRequest.id, selection);
+    // Competition always runs on Claude Opus 4.8, regardless of the
+    // request-level provider/model (which still applies to every other section).
+    await generateCompetitionAnalysis(spaceId, tickerRecord, generationRequest.id, {
+      llmProvider: LLMProvider.CLAUDE,
+      model: ClaudeModel.CLAUDE_OPUS_4_8,
+    });
     return;
   }
 

--- a/insights-ui/src/utils/analysis-reports/report-status-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/report-status-utils.ts
@@ -95,6 +95,27 @@ export async function markAsInProgress(generationRequest: TickerV1GenerationRequ
 }
 
 export async function markAsCompleted(generationRequest: TickerV1GenerationRequest): Promise<void> {
+  // Before finalizing, give each failed step exactly ONE retry: move steps that
+  // haven't been retried yet out of failedSteps (recording them in retriedSteps)
+  // so calculatePendingSteps picks them up again, and keep the request open.
+  // A step that fails again after its retry stays in failedSteps and is terminal.
+  const stepsToRetry = generationRequest.failedSteps.filter((step) => !generationRequest.retriedSteps.includes(step));
+  if (stepsToRetry.length > 0) {
+    console.log('Retrying failed steps once for generation request', generationRequest.id, ':', stepsToRetry);
+    await prisma.tickerV1GenerationRequest.update({
+      where: {
+        id: generationRequest.id,
+      },
+      data: {
+        failedSteps: generationRequest.failedSteps.filter((step) => generationRequest.retriedSteps.includes(step)),
+        retriedSteps: [...generationRequest.retriedSteps, ...stepsToRetry],
+        inProgressStep: null,
+        updatedAt: new Date(),
+      },
+    });
+    return;
+  }
+
   const hasFailed = generationRequest.failedSteps.length > 0;
 
   await prisma.tickerV1GenerationRequest.update({


### PR DESCRIPTION
- Competition report always generates with Claude Opus 4.8, regardless of
  the request-level provider/model (other sections keep the request's choice).
- Failed sections now get exactly one retry: when a generation request has
  no pending steps left, markAsCompleted moves not-yet-retried failed steps
  from failedSteps to the new retriedSteps column so they become pending
  again once. A step that fails after its retry is terminal and the request
  is marked Failed as before.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0138KV5qtUvBeihCgAqqz2aN