### PR TITLE
Add app-config UI and LLM provider/model defaults management

### DIFF
--- a/docs/insights-ui/app-settings.md
+++ b/docs/insights-ui/app-settings.md
@@ -23,6 +23,30 @@ For every managed key, the effective value is resolved in this order:
 The admin screen shows each setting's current value and a badge for where it came
 from (**SSM** / **Env var** / **Default**). SSM reads are cached in-process for 60s.
 
+## Secrets
+
+A setting marked `secret: true` in the registry (e.g. API keys, OAuth tokens) is
+handled so it is never exposed — important because this is a **public repo**:
+
+- **Encrypted at rest:** stored as an SSM `SecureString` (KMS-encrypted), not plain
+  `String`.
+- **Never sent to the browser:** the admin action redacts secret values — it returns
+  only a set / not-set flag, never the value. The admin field is **write-only**
+  (starts empty; saving replaces the stored value).
+- **Admin-gated:** the read/write server actions require an `Admin` session.
+- **No committed defaults:** secrets must not appear in `appConfigDefaults.json`.
+  `appConfig.ts` enforces this at load — it strips and logs any secret default — so a
+  secret value can never live in the repo. Secrets resolve from **SSM or env only**.
+- **Server-only reads:** `getAppConfigValue` returns the real value only in server
+  code (the config module is never bundled to the client, and non-`NEXT_PUBLIC_` env
+  vars are never inlined into client JS).
+
+KMS note: `SecureString` uses the AWS-managed key `alias/aws/ssm` by default, whose
+key policy already lets the account's principals decrypt/encrypt *via SSM* — so the
+existing `ssm:GetParametersByPath` / `GetParameter` / `PutParameter` grant is enough,
+no extra `kms:*` policy needed. Only a **customer-managed** KMS key would require
+adding `kms:Decrypt` (reads) and `kms:GenerateDataKey` (writes).
+
 ## Code layout
 
 All under `insights-ui/src/lib/appConfig/`:

--- a/docs/insights-ui/app-settings.md
+++ b/docs/insights-ui/app-settings.md
@@ -23,6 +23,14 @@ For every managed key, the effective value is resolved in this order:
 The admin screen shows each setting's current value and a badge for where it came
 from (**SSM** / **Env var** / **Default**). SSM reads are cached in-process for 60s.
 
+A setting can be a boolean (toggle), a free-text string, or a fixed set of `options`
+(rendered as a dropdown and validated on write). Example: the default LLM
+provider/model — `LLM_DEFAULT_PROVIDER`, `LLM_DEFAULT_GEMINI_MODEL`,
+`LLM_DEFAULT_CLAUDE_MODEL` — are option-typed. These are only the **fallback** default;
+an explicit per-run selection in the report UI always wins. Server code reads them via
+`src/util/llm-default-config.ts` (server-only), which validates against the model enums
+and falls back to the code constant in `llmConstants.ts` if a value is unset or invalid.
+
 ## Secrets
 
 A setting marked `secret: true` in the registry (e.g. API keys, OAuth tokens) is

--- a/insights-ui/.env.example
+++ b/insights-ui/.env.example
@@ -34,9 +34,13 @@ PPT_GENERATION_AWS_REGION=
 PPT_GENERATION_AWS_ACCESS_KEY_ID=
 PPT_GENERATION_AWS_SECRET_ACCESS_KEY=
 PPT_GENERATION_S3_BUCKET_NAME=
-## LLM provider/model are no longer read from env — they are chosen per run in the
-## report-generation UI and default in code to Gemini + gemini-2.5-pro (claude-opus-4-7
-## for the Claude provider). See src/types/llmConstants.ts.
+## LLM provider/model are chosen per run in the report-generation UI. The FALLBACK
+## default (when a run specifies none) is managed in the admin App Settings screen
+## (LLM_DEFAULT_PROVIDER / LLM_DEFAULT_GEMINI_MODEL / LLM_DEFAULT_CLAUDE_MODEL, resolved
+## SSM -> these env vars -> code default). See src/util/llm-default-config.ts.
+LLM_DEFAULT_PROVIDER=
+LLM_DEFAULT_GEMINI_MODEL=
+LLM_DEFAULT_CLAUDE_MODEL=
 ## Tariff generation (optional): "true" runs each section synchronously (the old behavior); unset/false runs it in the background (returns fast, no 504) — the default.
 GENERATE_TARIFF_SECTIONS_SYNCHRONOUSLY=
 ## Stock report generation: "true" runs the LLM call in-process in the background on this server (Lightsail); unset/false offloads to the AWS Lambda (old behavior).

--- a/insights-ui/src/app/admin-v1/app-settings/page.tsx
+++ b/insights-ui/src/app/admin-v1/app-settings/page.tsx
@@ -16,17 +16,26 @@ const SOURCE_LABELS: Record<ResolvedAppSetting['source'], { text: string; classN
   default: { text: 'Default', className: 'border-gray-600/50 bg-gray-700/40 text-gray-300' },
 };
 
-function SourceBadge({ source }: { source: ResolvedAppSetting['source'] }): JSX.Element {
-  const { text, className } = SOURCE_LABELS[source];
+function Badge({ text, className }: { text: string; className: string }): JSX.Element {
   return <span className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}>{text}</span>;
+}
+
+function SecretBadge({ isSet }: { isSet: boolean }): JSX.Element {
+  return isSet ? (
+    <Badge text="Secret · set" className="border-emerald-700/40 bg-emerald-900/30 text-emerald-200" />
+  ) : (
+    <Badge text="Secret · not set" className="border-gray-600/50 bg-gray-700/40 text-gray-300" />
+  );
 }
 
 function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved: (saved: ResolvedAppSetting) => void }): JSX.Element {
   const { showNotification } = useNotificationContext();
-  const [draft, setDraft] = useState<string>(setting.value);
+  const isSecret = setting.secret === true;
+  // Secrets are write-only: the field always starts empty and saving replaces the stored value.
+  const [draft, setDraft] = useState<string>(isSecret ? '' : setting.value);
   const [saving, setSaving] = useState<boolean>(false);
 
-  const dirty = draft !== setting.value;
+  const dirty = isSecret ? draft !== '' : draft !== setting.value;
 
   const handleSave = async (): Promise<void> => {
     setSaving(true);
@@ -34,7 +43,12 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
       const res = await updateAppSetting(setting.key, draft);
       if (res.success) {
         showNotification({ type: 'success', message: res.message });
-        onSaved({ ...setting, value: draft, source: 'ssm' });
+        if (isSecret) {
+          setDraft('');
+          onSaved({ ...setting, value: '', isSet: true, source: 'ssm' });
+        } else {
+          onSaved({ ...setting, value: draft, isSet: draft.trim() !== '', source: 'ssm' });
+        }
       } else {
         showNotification({ type: 'error', message: res.message });
       }
@@ -46,6 +60,8 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
     }
   };
 
+  const { text, className } = SOURCE_LABELS[setting.source];
+
   return (
     <div className="rounded-lg border border-gray-700/50 bg-gray-900/40 p-4 space-y-3">
       <div className="flex items-start justify-between gap-4">
@@ -53,7 +69,10 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
           <p className="font-medium text-white">{setting.label}</p>
           <p className="font-mono text-xs text-gray-400 mt-0.5">{setting.key}</p>
         </div>
-        <SourceBadge source={setting.source} />
+        <div className="flex flex-wrap items-center gap-2">
+          {isSecret && <SecretBadge isSet={setting.isSet} />}
+          {setting.isSet && <Badge text={text} className={className} />}
+        </div>
       </div>
 
       <p className="text-sm text-gray-300">{setting.description}</p>
@@ -61,7 +80,13 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
       {setting.type === 'boolean' ? (
         <ToggleWithIcon label={setting.label} enabled={draft === 'true'} setEnabled={(v) => setDraft(v ? 'true' : 'false')} />
       ) : (
-        <Input modelValue={draft} onUpdate={(v) => setDraft(v === undefined ? '' : String(v))} required={false} />
+        <Input
+          modelValue={draft}
+          onUpdate={(v) => setDraft(v === undefined ? '' : String(v))}
+          required={false}
+          password={isSecret}
+          placeholder={isSecret ? (setting.isSet ? 'Enter a new value to replace the current secret' : 'Enter a value') : undefined}
+        />
       )}
 
       <div className="flex justify-end">

--- a/insights-ui/src/app/admin-v1/app-settings/page.tsx
+++ b/insights-ui/src/app/admin-v1/app-settings/page.tsx
@@ -79,6 +79,18 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
 
       {setting.type === 'boolean' ? (
         <ToggleWithIcon label={setting.label} enabled={draft === 'true'} setEnabled={(v) => setDraft(v ? 'true' : 'false')} />
+      ) : setting.options ? (
+        <select
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          className="w-full max-w-md rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-indigo-500 focus:outline-none"
+        >
+          {setting.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
       ) : (
         <Input
           modelValue={draft}

--- a/insights-ui/src/lib/appConfig/appConfig.ts
+++ b/insights-ui/src/lib/appConfig/appConfig.ts
@@ -111,6 +111,9 @@ export async function setAppConfigValue(key: string, value: string): Promise<Upd
     // SSM rejects empty values, and an empty secret would silently wipe a live key.
     return { success: false, message: 'Value cannot be empty.' };
   }
+  if (def.options && !def.options.some((o) => o.value === value)) {
+    return { success: false, message: `Invalid value for ${key}. Allowed: ${def.options.map((o) => o.value).join(', ')}` };
+  }
   if (!isSsmConfigured()) {
     return {
       success: false,

--- a/insights-ui/src/lib/appConfig/appConfig.ts
+++ b/insights-ui/src/lib/appConfig/appConfig.ts
@@ -16,6 +16,19 @@ import { fetchAllSsmParameters, isSsmConfigured, putSsmParameter } from './ssmPa
 const CACHE_TTL_MS = 60_000;
 const defaults = bundledDefaults as Record<string, string>;
 
+// Public-repo safeguard: a secret must NEVER carry a committed default value —
+// `appConfigDefaults.json` is checked into a public repo, so a default there would
+// leak the secret. Strip any that slip in and warn loudly. Secrets resolve from
+// SSM or env only.
+for (const def of APP_CONFIG_DEFINITIONS) {
+  if (def.secret && def.key in defaults) {
+    console.error(
+      `[appConfig] SECURITY: secret "${def.key}" has a bundled default in appConfigDefaults.json — ignoring it. Remove that value from the committed file.`
+    );
+    delete defaults[def.key];
+  }
+}
+
 let ssmCache: { values: Record<string, string>; expiresAt: number } | null = null;
 
 async function getSsmValues(): Promise<Record<string, string>> {
@@ -49,7 +62,10 @@ export async function getAppConfigBoolean(key: string): Promise<boolean> {
 export type AppConfigSource = 'ssm' | 'env' | 'default';
 
 export interface ResolvedAppSetting extends AppConfigDefinition {
+  /** Effective value. Always empty for secrets — their value is never sent to the client. */
   value: string;
+  /** Whether a non-empty value is currently configured (used to show set/not-set for secrets). */
+  isSet: boolean;
   /** Where the effective value came from. */
   source: AppConfigSource;
 }
@@ -60,13 +76,23 @@ export interface AppSettingsForAdmin {
   settings: ResolvedAppSetting[];
 }
 
-/** Every managed setting with its resolved value and where that value came from. */
+function resolveRaw(key: string, ssm: Record<string, string>): { value: string; source: AppConfigSource } {
+  if (ssm[key] !== undefined) return { value: ssm[key], source: 'ssm' };
+  if (process.env[key] !== undefined) return { value: process.env[key] as string, source: 'env' };
+  return { value: defaults[key] ?? '', source: 'default' };
+}
+
+/**
+ * Every managed setting with its resolved value and where that value came from.
+ * Admin-facing: secret values are redacted (never leave the server) — only their
+ * set/not-set state is reported.
+ */
 export async function getResolvedAppSettings(): Promise<ResolvedAppSetting[]> {
   const ssm = await getSsmValues();
   return APP_CONFIG_DEFINITIONS.map((def) => {
-    if (ssm[def.key] !== undefined) return { ...def, value: ssm[def.key], source: 'ssm' };
-    if (process.env[def.key] !== undefined) return { ...def, value: process.env[def.key] as string, source: 'env' };
-    return { ...def, value: defaults[def.key] ?? '', source: 'default' };
+    const { value, source } = resolveRaw(def.key, ssm);
+    const isSet = value.trim() !== '';
+    return { ...def, value: def.secret ? '' : value, isSet, source };
   });
 }
 
@@ -77,8 +103,13 @@ export interface UpdateAppSettingResult {
 
 /** Persist a managed value to SSM. Requires SSM to be configured. */
 export async function setAppConfigValue(key: string, value: string): Promise<UpdateAppSettingResult> {
-  if (!APP_CONFIG_DEFINITIONS.some((d) => d.key === key)) {
+  const def = APP_CONFIG_DEFINITIONS.find((d) => d.key === key);
+  if (!def) {
     return { success: false, message: `Unknown setting: ${key}` };
+  }
+  if (value === '') {
+    // SSM rejects empty values, and an empty secret would silently wipe a live key.
+    return { success: false, message: 'Value cannot be empty.' };
   }
   if (!isSsmConfigured()) {
     return {
@@ -88,7 +119,7 @@ export async function setAppConfigValue(key: string, value: string): Promise<Upd
     };
   }
   try {
-    await putSsmParameter(key, value);
+    await putSsmParameter(key, value, def.secret ?? false);
     ssmCache = null; // force a fresh read on next access
     return { success: true, message: `Saved ${key}` };
   } catch (err) {

--- a/insights-ui/src/lib/appConfig/appConfigDefaults.json
+++ b/insights-ui/src/lib/appConfig/appConfigDefaults.json
@@ -1,4 +1,8 @@
 {
   "USE_LAMBDA_FOR_LLM_RESPONSE": "false",
-  "GENERATE_TARIFF_SECTIONS_SYNCHRONOUSLY": "false"
+  "GENERATE_TARIFF_SECTIONS_SYNCHRONOUSLY": "false",
+  "LAMBDA_URL_LLM_CALL_WITH_CALLBACK": "",
+  "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+  "ANTHROPIC_OAUTH_TOKEN_URL": "https://platform.claude.com/v1/oauth/token",
+  "CLAUDE_CODE_VERSION": "2.1.80"
 }

--- a/insights-ui/src/lib/appConfig/appConfigDefaults.json
+++ b/insights-ui/src/lib/appConfig/appConfigDefaults.json
@@ -4,5 +4,8 @@
   "LAMBDA_URL_LLM_CALL_WITH_CALLBACK": "",
   "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
   "ANTHROPIC_OAUTH_TOKEN_URL": "https://platform.claude.com/v1/oauth/token",
-  "CLAUDE_CODE_VERSION": "2.1.80"
+  "CLAUDE_CODE_VERSION": "2.1.80",
+  "LLM_DEFAULT_PROVIDER": "gemini",
+  "LLM_DEFAULT_GEMINI_MODEL": "gemini-2.5-pro",
+  "LLM_DEFAULT_CLAUDE_MODEL": "claude-opus-4-7"
 }

--- a/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
+++ b/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
@@ -8,6 +8,11 @@
  * To manage a new value: add its key + metadata here, add a default in
  * `appConfigDefaults.json`, then read it in code via `getAppConfigValue` /
  * `getAppConfigBoolean` instead of `process.env`.
+ *
+ * SECRETS: set `secret: true`. Secret values are stored as SSM `SecureString`,
+ * redacted from the admin UI (write-only), and MUST NOT have a default in
+ * `appConfigDefaults.json` — that file is committed to a public repo. Secrets
+ * resolve from SSM or env only.
  */
 export type AppConfigValueType = 'boolean' | 'string';
 
@@ -19,6 +24,12 @@ export interface AppConfigDefinition {
   /** What the setting does and the effect of each value. */
   description: string;
   type: AppConfigValueType;
+  /**
+   * When true the value is a secret: stored as an SSM `SecureString` and never
+   * returned to the admin UI (shown as set/not-set, edited write-only). Reads on
+   * the server still get the real decrypted value.
+   */
+  secret?: boolean;
 }
 
 export const APP_CONFIG_DEFINITIONS: AppConfigDefinition[] = [
@@ -59,6 +70,27 @@ export const APP_CONFIG_DEFINITIONS: AppConfigDefinition[] = [
     label: 'Claude Code version header',
     description: 'Value sent as the claude-cli user-agent version on Claude subscription OAuth calls.',
     type: 'string',
+  },
+  {
+    key: 'GOOGLE_API_KEY',
+    label: 'Google / Gemini API key',
+    description: 'API key for the Gemini provider — report generation and grounded (Google Search) responses.',
+    type: 'string',
+    secret: true,
+  },
+  {
+    key: 'ANTHROPIC_OAUTH_REFRESH_TOKEN',
+    label: 'Claude OAuth refresh token',
+    description: 'Long-lived Claude subscription refresh token (sk-ant-ort…). Exchanged on demand for short-lived access tokens; rotations persist to S3.',
+    type: 'string',
+    secret: true,
+  },
+  {
+    key: 'ANTHROPIC_OAUTH_TOKEN',
+    label: 'Claude OAuth static access token (fallback)',
+    description: 'Static Claude access token (sk-ant-oat…) used only if the refresh flow fails. Short-lived — for bootstrap / dev.',
+    type: 'string',
+    secret: true,
   },
 ];
 

--- a/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
+++ b/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
@@ -14,7 +14,15 @@
  * `appConfigDefaults.json` — that file is committed to a public repo. Secrets
  * resolve from SSM or env only.
  */
+import { ClaudeModel, GeminiModel, LLMProvider } from '@/types/llmConstants';
+
 export type AppConfigValueType = 'boolean' | 'string';
+
+/** One choice for a setting that has a fixed set of allowed values (rendered as a dropdown). */
+export interface AppConfigOption {
+  value: string;
+  label: string;
+}
 
 export interface AppConfigDefinition {
   /** Env-var-style key. Also the SSM parameter name (under the configured prefix). */
@@ -30,6 +38,8 @@ export interface AppConfigDefinition {
    * the server still get the real decrypted value.
    */
   secret?: boolean;
+  /** Fixed set of allowed values. When present the admin UI shows a dropdown and writes are validated against it. */
+  options?: AppConfigOption[];
 }
 
 export const APP_CONFIG_DEFINITIONS: AppConfigDefinition[] = [
@@ -70,6 +80,39 @@ export const APP_CONFIG_DEFINITIONS: AppConfigDefinition[] = [
     label: 'Claude Code version header',
     description: 'Value sent as the claude-cli user-agent version on Claude subscription OAuth calls.',
     type: 'string',
+  },
+  {
+    key: 'LLM_DEFAULT_PROVIDER',
+    label: 'Default LLM provider',
+    description: 'Fallback provider for report generation when a request does not specify one. A per-run selection in the report UI always overrides this.',
+    type: 'string',
+    options: [
+      { value: LLMProvider.GEMINI, label: 'Gemini' },
+      { value: LLMProvider.GEMINI_WITH_GROUNDING, label: 'Gemini (with grounding)' },
+      { value: LLMProvider.CLAUDE, label: 'Claude' },
+    ],
+  },
+  {
+    key: 'LLM_DEFAULT_GEMINI_MODEL',
+    label: 'Default Gemini model',
+    description: 'Fallback Gemini model for report generation when none is specified. A per-run model selection overrides this.',
+    type: 'string',
+    options: [
+      { value: GeminiModel.GEMINI_2_5_PRO, label: 'gemini-2.5-pro' },
+      { value: GeminiModel.GEMINI_3_1_PRO_PREVIEW, label: 'gemini-3.1-pro-preview' },
+    ],
+  },
+  {
+    key: 'LLM_DEFAULT_CLAUDE_MODEL',
+    label: 'Default Claude model',
+    description: 'Fallback Claude model used when the Claude provider runs without an explicit model. A per-run model selection overrides this.',
+    type: 'string',
+    options: [
+      { value: ClaudeModel.CLAUDE_OPUS_4_8, label: 'Claude Opus 4.8' },
+      { value: ClaudeModel.CLAUDE_OPUS_4_7, label: 'Claude Opus 4.7' },
+      { value: ClaudeModel.CLAUDE_SONNET_4_6, label: 'Claude Sonnet 4.6' },
+      { value: ClaudeModel.CLAUDE_HAIKU_4_5, label: 'Claude Haiku 4.5' },
+    ],
   },
   {
     key: 'GOOGLE_API_KEY',

--- a/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
+++ b/insights-ui/src/lib/appConfig/appConfigDefinitions.ts
@@ -36,6 +36,30 @@ export const APP_CONFIG_DEFINITIONS: AppConfigDefinition[] = [
       'OFF (default): generate each tariff section in the background and return immediately. ON: the request waits for the full LLM generation (old synchronous behavior).',
     type: 'boolean',
   },
+  {
+    key: 'LAMBDA_URL_LLM_CALL_WITH_CALLBACK',
+    label: 'LLM-call Lambda URL (callback path)',
+    description: 'Base URL of the AWS Lambda that runs an LLM call and posts the result back via callback. Used only when the Lambda path is enabled.',
+    type: 'string',
+  },
+  {
+    key: 'ANTHROPIC_BASE_URL',
+    label: 'Anthropic API base URL',
+    description: 'Base URL for the Claude Messages / usage API (Claude provider). Defaults to the real Anthropic API; override only to point at a proxy.',
+    type: 'string',
+  },
+  {
+    key: 'ANTHROPIC_OAUTH_TOKEN_URL',
+    label: 'Anthropic OAuth token endpoint',
+    description: 'Endpoint used to exchange the Claude subscription refresh token for a short-lived access token. Change only if the OAuth host moves.',
+    type: 'string',
+  },
+  {
+    key: 'CLAUDE_CODE_VERSION',
+    label: 'Claude Code version header',
+    description: 'Value sent as the claude-cli user-agent version on Claude subscription OAuth calls.',
+    type: 'string',
+  },
 ];
 
 export const APP_CONFIG_KEYS: string[] = APP_CONFIG_DEFINITIONS.map((d) => d.key);

--- a/insights-ui/src/lib/appConfig/ssmParameterStore.ts
+++ b/insights-ui/src/lib/appConfig/ssmParameterStore.ts
@@ -52,8 +52,8 @@ export async function fetchAllSsmParameters(): Promise<Record<string, string>> {
   return values;
 }
 
-/** Write (or overwrite) a single parameter under the prefix. */
-export async function putSsmParameter(key: string, value: string): Promise<void> {
+/** Write (or overwrite) a single parameter under the prefix. Secrets are stored encrypted (SecureString). */
+export async function putSsmParameter(key: string, value: string, secret: boolean = false): Promise<void> {
   const ssm = getClient();
-  await ssm.send(new PutParameterCommand({ Name: `${getSsmPrefix()}${key}`, Value: value, Type: 'String', Overwrite: true }));
+  await ssm.send(new PutParameterCommand({ Name: `${getSsmPrefix()}${key}`, Value: value, Type: secret ? 'SecureString' : 'String', Overwrite: true }));
 }

--- a/insights-ui/src/util/claude/claude-oauth-client.ts
+++ b/insights-ui/src/util/claude/claude-oauth-client.ts
@@ -17,6 +17,7 @@
  * be tested in isolation before being wired into any workflow.
  */
 
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { getClaudeAccessToken, invalidateClaudeAccessToken } from '@/util/claude/claude-token-provider';
 
 /** Anthropic rejects OAuth requests unless this is the first system block. */
@@ -138,8 +139,8 @@ export async function callClaudeWithOAuth(options: CallClaudeOAuthOptions): Prom
   }
 
   const model = options.model ?? DEFAULT_MODEL;
-  const baseUrl = (options.baseUrl ?? process.env.ANTHROPIC_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
-  const ccVersion = process.env.CLAUDE_CODE_VERSION ?? DEFAULT_CC_VERSION;
+  const baseUrl = (options.baseUrl ?? (await getAppConfigValue('ANTHROPIC_BASE_URL')) ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const ccVersion = (await getAppConfigValue('CLAUDE_CODE_VERSION')) ?? DEFAULT_CC_VERSION;
 
   // Identity block MUST come first; any caller-supplied system prompt follows it.
   const system: AnthropicTextBlock[] = [{ type: 'text', text: CLAUDE_CODE_IDENTITY }];

--- a/insights-ui/src/util/claude/claude-token-provider.ts
+++ b/insights-ui/src/util/claude/claude-token-provider.ts
@@ -159,7 +159,7 @@ async function candidateRefreshTokens(): Promise<string[]> {
 
   add(currentRefreshToken);
   add(await loadPersistedRefreshToken());
-  add(process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN);
+  add(await getAppConfigValue('ANTHROPIC_OAUTH_REFRESH_TOKEN'));
 
   return candidates;
 }
@@ -257,7 +257,7 @@ export async function getClaudeAccessToken(forceRefresh = false): Promise<string
   } catch (err) {
     // No usable refresh token — fall back to a static access token if one is
     // configured (local dev / bootstrap), otherwise surface the refresh failure.
-    const staticToken = process.env.ANTHROPIC_OAUTH_TOKEN?.trim();
+    const staticToken = (await getAppConfigValue('ANTHROPIC_OAUTH_TOKEN'))?.trim();
     if (staticToken) {
       console.warn('[claude-token-provider] refresh failed; falling back to the static ANTHROPIC_OAUTH_TOKEN.', err);
       return staticToken;

--- a/insights-ui/src/util/claude/claude-token-provider.ts
+++ b/insights-ui/src/util/claude/claude-token-provider.ts
@@ -28,6 +28,7 @@
  * point. If this is ever scaled out, move the cache to a shared store.
  */
 
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 
@@ -37,9 +38,10 @@ const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 /**
  * Claude Code OAuth token endpoint — note this is the platform host, NOT
  * api.anthropic.com (which serves the Messages API) and NOT
- * console.anthropic.com (which 404s). Overridable for tests via env.
+ * console.anthropic.com (which 404s). Overridable via the `ANTHROPIC_OAUTH_TOKEN_URL`
+ * app-config setting (App Settings screen); this is the fallback default.
  */
-const TOKEN_ENDPOINT = process.env.ANTHROPIC_OAUTH_TOKEN_URL ?? 'https://platform.claude.com/v1/oauth/token';
+const DEFAULT_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
 
 /** Refresh a bit BEFORE the real expiry so an in-flight request never races the cutover. */
 const EXPIRY_SKEW_MS = 5 * 60 * 1000;
@@ -164,7 +166,8 @@ async function candidateRefreshTokens(): Promise<string[]> {
 
 /** One exchange attempt. Caches the access token and persists any rotation on success. */
 async function exchangeRefreshToken(refreshToken: string): Promise<string> {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const tokenEndpoint = (await getAppConfigValue('ANTHROPIC_OAUTH_TOKEN_URL')) ?? DEFAULT_TOKEN_ENDPOINT;
+  const response = await fetch(tokenEndpoint, {
     method: 'POST',
     headers: { 'content-type': 'application/json', accept: 'application/json' },
     body: JSON.stringify({

--- a/insights-ui/src/util/claude/claude-usage.ts
+++ b/insights-ui/src/util/claude/claude-usage.ts
@@ -1,3 +1,4 @@
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { ANTHROPIC_BETA, DEFAULT_BASE_URL, DEFAULT_CC_VERSION } from '@/util/claude/claude-oauth-client';
 import { getClaudeAccessToken, invalidateClaudeAccessToken } from '@/util/claude/claude-token-provider';
 
@@ -95,8 +96,8 @@ export interface GetClaudeUsageOptions {
  * configured or the endpoint returns a non-2xx response.
  */
 export async function getClaudeSubscriptionUsage(options: GetClaudeUsageOptions = {}): Promise<ClaudeSubscriptionUsage> {
-  const baseUrl = (options.baseUrl ?? process.env.ANTHROPIC_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
-  const ccVersion = process.env.CLAUDE_CODE_VERSION ?? DEFAULT_CC_VERSION;
+  const baseUrl = (options.baseUrl ?? (await getAppConfigValue('ANTHROPIC_BASE_URL')) ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const ccVersion = (await getAppConfigValue('CLAUDE_CODE_VERSION')) ?? DEFAULT_CC_VERSION;
 
   const sendWithToken = (token: string): Promise<Response> =>
     fetch(`${baseUrl}${USAGE_PATH}`, {

--- a/insights-ui/src/util/claude/get-claude-structured-response.ts
+++ b/insights-ui/src/util/claude/get-claude-structured-response.ts
@@ -1,5 +1,5 @@
-import { getDefaultClaudeModel } from '@/types/llmConstants';
 import { callClaudeWithOAuth } from '@/util/claude/claude-oauth-client';
+import { getConfiguredDefaultClaudeModel } from '@/util/llm-default-config';
 
 /**
  * Claude structured-output helper used by `getLLMResponse` when
@@ -26,7 +26,7 @@ import { callClaudeWithOAuth } from '@/util/claude/claude-oauth-client';
 const REPORT_MAX_TOKENS = 32000;
 
 export interface ClaudeStructuredResultOptions {
-  /** Override the Claude model. Defaults to `getDefaultClaudeModel()` (LLM_MODEL / claude-opus-4-7). */
+  /** Override the Claude model. Defaults to the App Settings `LLM_DEFAULT_CLAUDE_MODEL` (else claude-opus-4-7). */
   model?: string;
   /** Override the output token cap. Defaults to 32000. */
   maxTokens?: number;
@@ -55,7 +55,7 @@ function extractJson(text: string): string {
  * a failed API call or unparseable JSON — the caller's retry loop handles it.
  */
 export async function getClaudeStructuredResult<Output>(prompt: string, outputSchema: object, options: ClaudeStructuredResultOptions = {}): Promise<Output> {
-  const model = options.model ?? getDefaultClaudeModel();
+  const model = options.model ?? (await getConfiguredDefaultClaudeModel());
 
   // Note: usage-limit pacing for auto-generated reports lives in the stock
   // generation processor (see `auto-stock-generation-utils.ts`), not here. This

--- a/insights-ui/src/util/get-llm-response.ts
+++ b/insights-ui/src/util/get-llm-response.ts
@@ -1,7 +1,8 @@
 import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { GeminiModel, LLMProvider, getDefaultLLMProvider, getDefaultModelForProvider } from '@/types/llmConstants';
+import { GeminiModel, LLMProvider } from '@/types/llmConstants';
+import { getConfiguredDefaultModelForProvider, getConfiguredDefaultProvider } from '@/util/llm-default-config';
 import { getClaudeStructuredResult } from '@/util/claude/get-claude-structured-response';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
@@ -231,15 +232,17 @@ export function compileTemplate(template: string, inputData: Record<string, unkn
  */
 export async function getLLMResponse<Output>({
   invocationId,
-  llmProvider = getDefaultLLMProvider(),
+  llmProvider: providedProvider,
   modelName,
   prompt,
   outputSchema,
   maxRetries = 1,
   isTestInvocation,
 }: LLMResponseOptions): Promise<{ result: Output; sourceLinks?: Array<{ uri: string; title?: string }> }> {
-  // Resolve the model provider-aware so a claude provider never falls back to a Gemini id.
-  const resolvedModel = modelName || getDefaultModelForProvider(llmProvider);
+  // Per-run selection wins; otherwise use the App Settings default. Resolve the model
+  // provider-aware so a claude provider never falls back to a Gemini id.
+  const llmProvider = providedProvider ?? (await getConfiguredDefaultProvider());
+  const resolvedModel = modelName || (await getConfiguredDefaultModelForProvider(llmProvider));
   let lastResult: unknown | null = null;
   let sourceLinks: Array<{ uri: string; title?: string }> | undefined;
 
@@ -358,9 +361,11 @@ export async function getLLMResponse<Output>({
 export async function getLLMResponseForPromptViaInvocation<Input, Output>(
   params: LLMResponseViaInvocationRequest<Input>
 ): Promise<LLMResponseObject<Input, Output>> {
-  const { promptKey, llmProvider = getDefaultLLMProvider(), spaceId, inputJson, bodyToAppend, requestFrom } = params;
-  // Resolve the model provider-aware so a claude provider never falls back to a Gemini id.
-  const model = params.model || getDefaultModelForProvider(llmProvider);
+  const { promptKey, llmProvider: providedProvider, spaceId, inputJson, bodyToAppend, requestFrom } = params;
+  // Per-run selection wins; otherwise use the App Settings default. Resolve the model
+  // provider-aware so a claude provider never falls back to a Gemini id.
+  const llmProvider = providedProvider ?? (await getConfiguredDefaultProvider());
+  const model = params.model || (await getConfiguredDefaultModelForProvider(llmProvider));
 
   // Validate required fields
   if (!promptKey) {
@@ -482,9 +487,11 @@ export async function getLLMResponseForPromptViaTestInvocation<Output>(
   params: LLMResponseViaTestInvocationRequest
 ): Promise<TestPromptInvocationResponse<Output>> {
   console.log('getLLMResponseForPromptViaTestInvocation', JSON.stringify(params, null, 2));
-  const { promptId, promptTemplate, llmProvider = getDefaultLLMProvider(), spaceId, bodyToAppend, inputJsonString } = params;
-  // Resolve the model provider-aware so a claude provider never falls back to a Gemini id.
-  const model = params.model || getDefaultModelForProvider(llmProvider);
+  const { promptId, promptTemplate, llmProvider: providedProvider, spaceId, bodyToAppend, inputJsonString } = params;
+  // Per-run selection wins; otherwise use the App Settings default. Resolve the model
+  // provider-aware so a claude provider never falls back to a Gemini id.
+  const llmProvider = providedProvider ?? (await getConfiguredDefaultProvider());
+  const model = params.model || (await getConfiguredDefaultModelForProvider(llmProvider));
 
   // Validate required fields
   if (!promptId || !promptTemplate) {

--- a/insights-ui/src/util/get-llm-response.ts
+++ b/insights-ui/src/util/get-llm-response.ts
@@ -1,3 +1,4 @@
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { GeminiModel, LLMProvider, getDefaultLLMProvider, getDefaultModelForProvider } from '@/types/llmConstants';
@@ -86,7 +87,7 @@ export function validateData(schema: object, data: unknown): ValidationResult {
 /**
  * Initializes an LLM model based on provider and model name
  */
-function initializeLLM(provider: LLMProvider, modelName: GeminiModel): BaseChatModel {
+async function initializeLLM(provider: LLMProvider, modelName: GeminiModel): Promise<BaseChatModel> {
   if (provider !== LLMProvider.OPENAI && provider !== LLMProvider.GEMINI && provider !== LLMProvider.GEMINI_WITH_GROUNDING) {
     throw new Error(`Unsupported LLM provider: ${provider}`);
   }
@@ -98,7 +99,7 @@ function initializeLLM(provider: LLMProvider, modelName: GeminiModel): BaseChatM
   } else if (provider === LLMProvider.GEMINI || provider === LLMProvider.GEMINI_WITH_GROUNDING) {
     return new ChatGoogleGenerativeAI({
       model: modelName,
-      apiKey: process.env.GOOGLE_API_KEY,
+      apiKey: await getAppConfigValue('GOOGLE_API_KEY'),
       temperature: 1,
     });
   } else {
@@ -304,7 +305,7 @@ export async function getLLMResponse<Output>({
         result = singleCallGroundedResult;
       } else {
         // Initialize LLM for structured output
-        const llm = initializeLLM(llmProvider === LLMProvider.GEMINI_WITH_GROUNDING ? LLMProvider.GEMINI : llmProvider, resolvedModel as GeminiModel);
+        const llm = await initializeLLM(llmProvider === LLMProvider.GEMINI_WITH_GROUNDING ? LLMProvider.GEMINI : llmProvider, resolvedModel as GeminiModel);
         const structured = llm.withStructuredOutput(outputSchema);
 
         // Get response from LLM

--- a/insights-ui/src/util/llm-default-config.ts
+++ b/insights-ui/src/util/llm-default-config.ts
@@ -1,0 +1,40 @@
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
+import { ClaudeModel, GeminiModel, LLMProvider, getDefaultClaudeModel, getDefaultGeminiModel, getDefaultLLMProvider } from '@/types/llmConstants';
+
+/**
+ * Server-only resolvers for the DEFAULT LLM provider / model, layered over the code
+ * constants in `llmConstants.ts`.
+ *
+ * An explicit per-run selection ALWAYS wins — these apply only when a generation
+ * request carries no provider/model. Values come from the App Settings KV
+ * (`LLM_DEFAULT_PROVIDER` / `LLM_DEFAULT_GEMINI_MODEL` / `LLM_DEFAULT_CLAUDE_MODEL`)
+ * and fall back to the code constant when unset or invalid, so a bad value can never
+ * break generation.
+ *
+ * Keep this OUT of client bundles — it reads server-only config. Client dropdowns use
+ * the plain constants / select-items in `llmConstants.ts` instead.
+ */
+
+const PROVIDERS = new Set<string>(Object.values(LLMProvider));
+const GEMINI_MODELS = new Set<string>(Object.values(GeminiModel));
+const CLAUDE_MODELS = new Set<string>(Object.values(ClaudeModel));
+
+export async function getConfiguredDefaultProvider(): Promise<LLMProvider> {
+  const value = await getAppConfigValue('LLM_DEFAULT_PROVIDER');
+  return value && PROVIDERS.has(value) ? (value as LLMProvider) : getDefaultLLMProvider();
+}
+
+export async function getConfiguredDefaultGeminiModel(): Promise<string> {
+  const value = await getAppConfigValue('LLM_DEFAULT_GEMINI_MODEL');
+  return value && GEMINI_MODELS.has(value) ? value : getDefaultGeminiModel();
+}
+
+export async function getConfiguredDefaultClaudeModel(): Promise<string> {
+  const value = await getAppConfigValue('LLM_DEFAULT_CLAUDE_MODEL');
+  return value && CLAUDE_MODELS.has(value) ? value : getDefaultClaudeModel();
+}
+
+/** Provider-aware default model: Claude default for the Claude provider, Gemini default otherwise. */
+export async function getConfiguredDefaultModelForProvider(provider: LLMProvider): Promise<string> {
+  return provider === LLMProvider.CLAUDE ? getConfiguredDefaultClaudeModel() : getConfiguredDefaultGeminiModel();
+}

--- a/insights-ui/src/util/llm-grounding-utils.ts
+++ b/insights-ui/src/util/llm-grounding-utils.ts
@@ -1,13 +1,14 @@
 import { GoogleGenAI } from '@google/genai';
+import { getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { GeminiModel, getDefaultGeminiModel } from '@/types/llmConstants';
 
 // Lazily construct the client. Constructing GoogleGenAI at module load throws when
 // GOOGLE_API_KEY is unset, which breaks `next build` (page-data collection imports this module
 // without runtime secrets). The key is only needed when a function below actually runs.
 let _geminiWithSearchModel: GoogleGenAI | undefined;
-function geminiWithSearchModel(): GoogleGenAI {
+async function geminiWithSearchModel(): Promise<GoogleGenAI> {
   if (!_geminiWithSearchModel) {
-    _geminiWithSearchModel = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+    _geminiWithSearchModel = new GoogleGenAI({ apiKey: await getAppConfigValue('GOOGLE_API_KEY') });
   }
   return _geminiWithSearchModel;
 }
@@ -64,7 +65,9 @@ export async function getGroundedStructuredResponse<Output>(
   modelName: GeminiModel = getDefaultGeminiModel(),
   outputJsonSchema: object
 ): Promise<GroundedStructuredResponse<Output>> {
-  const resp: any = await geminiWithSearchModel().models.generateContent({
+  const resp: any = await (
+    await geminiWithSearchModel()
+  ).models.generateContent({
     model: modelName,
     contents: [
       {
@@ -113,7 +116,9 @@ export async function getGroundedResponse(prompt: string, modelName: GeminiModel
     tools: [groundingTool],
   };
 
-  const searchResponse: any = await geminiWithSearchModel().models.generateContent({
+  const searchResponse: any = await (
+    await geminiWithSearchModel()
+  ).models.generateContent({
     model: modelName,
     contents: [
       {

--- a/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
@@ -1,4 +1,4 @@
-import { getAppConfigBoolean } from '@/lib/appConfig/appConfig';
+import { getAppConfigBoolean, getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { LLMProvider, getDefaultLLMProvider, getDefaultModelForProvider } from '@/types/llmConstants';
@@ -50,9 +50,9 @@ async function updateLastInvocationTime(generationRequestId: string, reportType:
  * Core function to get LLM response
  */
 export async function callLambdaForLLMResponseViaCallback<Input>(request: LLMResponseViaLambdaRequest<Input>): Promise<void> {
-  const baseUrl = process.env.LAMBDA_URL_LLM_CALL_WITH_CALLBACK || '';
+  const baseUrl = (await getAppConfigValue('LAMBDA_URL_LLM_CALL_WITH_CALLBACK')) || '';
   if (!baseUrl) {
-    throw new Error('LAMBDA_URL_LLM_CALL_WITH_CALLBACK environment variable is not set');
+    throw new Error('LAMBDA_URL_LLM_CALL_WITH_CALLBACK is not set (App Settings / env)');
   }
 
   try {

--- a/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
+++ b/insights-ui/src/utils/analysis-reports/llm-callback-lambda-utils.ts
@@ -1,7 +1,8 @@
 import { getAppConfigBoolean, getAppConfigValue } from '@/lib/appConfig/appConfig';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
-import { LLMProvider, getDefaultLLMProvider, getDefaultModelForProvider } from '@/types/llmConstants';
+import { LLMProvider } from '@/types/llmConstants';
+import { getConfiguredDefaultModelForProvider, getConfiguredDefaultProvider } from '@/util/llm-default-config';
 import { ReportType } from '@/types/ticker-typesv1';
 import {
   compileTemplate,
@@ -108,9 +109,9 @@ export async function getLLMResponseForPromptViaInvocationViaLambda<Input>(args:
   const { symbol, exchange, generationRequestId, params, reportType, moverType } = args;
   const { promptKey, llmProvider: providedLlmProvider, model: providedModel, spaceId, inputJson, bodyToAppend, requestFrom } = params;
 
-  // Use provided values or provider-aware defaults
-  const llmProvider = providedLlmProvider || getDefaultLLMProvider();
-  const model = providedModel || getDefaultModelForProvider(llmProvider);
+  // Use provided values or provider-aware defaults (per-run selection wins; defaults come from App Settings)
+  const llmProvider = providedLlmProvider || (await getConfiguredDefaultProvider());
+  const model = providedModel || (await getConfiguredDefaultModelForProvider(llmProvider));
 
   // Validate required fields
   if (!promptKey) {

--- a/insights-ui/src/utils/etf-analysis-reports/etf-llm-lambda-utils.ts
+++ b/insights-ui/src/utils/etf-analysis-reports/etf-llm-lambda-utils.ts
@@ -2,7 +2,8 @@ import { getAppConfigBoolean } from '@/lib/appConfig/appConfig';
 import { prisma } from '@/prisma';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfReportType } from '@/types/etf/etf-analysis-types';
-import { getDefaultLLMProvider, getDefaultModelForProvider, LLMProvider } from '@/types/llmConstants';
+import { LLMProvider } from '@/types/llmConstants';
+import { getConfiguredDefaultModelForProvider, getConfiguredDefaultProvider } from '@/util/llm-default-config';
 import { compileTemplate, createPromptInvocation, loadSchema, updateInvocationStatus, validateData } from '@/util/get-llm-response';
 import { callLambdaForLLMResponseViaCallback, LLMResponseViaLambdaRequest } from '@/utils/analysis-reports/llm-callback-lambda-utils';
 import { processEtfReportLLMResponseInBackground } from '@/utils/etf-analysis-reports/background-etf-llm-generation-utils';
@@ -56,10 +57,10 @@ async function updateEtfLastInvocationTime(generationRequestId: string, reportTy
 export async function callEtfLambdaForLLMResponse(args: EtfLLMRequest): Promise<void> {
   const { symbol, exchange, generationRequestId, inputJson, promptKey, spaceId, reportType } = args;
 
-  // Use the provider/model chosen in the UI when present; otherwise keep the
-  // previous behavior and fall back to the LLM_PROVIDER / LLM_MODEL env defaults.
-  const llmProvider = args.llmProvider ?? getDefaultLLMProvider();
-  const model = args.model ?? getDefaultModelForProvider(llmProvider);
+  // Use the provider/model chosen in the UI when present; otherwise fall back to
+  // the App Settings defaults (LLM_DEFAULT_PROVIDER / LLM_DEFAULT_*_MODEL).
+  const llmProvider = args.llmProvider ?? (await getConfiguredDefaultProvider());
+  const model = args.model ?? (await getConfiguredDefaultModelForProvider(llmProvider));
 
   const prompt = await prisma.prompt.findFirstOrThrow({
     where: {


### PR DESCRIPTION
## Summary

Adds a comprehensive app-config management system to the admin UI, enabling runtime configuration of LLM providers, models, API endpoints, and secrets without code changes or redeployment. Introduces support for:

- **Dropdown-based settings** with fixed allowed values (e.g., LLM provider/model selection)
- **Secret management** (API keys, OAuth tokens) stored as encrypted SSM `SecureString` parameters, never exposed to the browser
- **LLM provider/model defaults** configurable per-environment, with per-run UI selections always taking precedence
- **Validation** on write (options, non-empty values) and at load (secrets never committed to the repo)

## Changes

### Core Config System (`appConfig/`)

- **`appConfigDefinitions.ts`**: Extended `AppConfigDefinition` interface with `secret` and `options` fields; added 10 new settings (LLM defaults, API endpoints, OAuth tokens, API keys)
- **`appConfig.ts`**: 
  - Added security safeguard: strips any secret defaults from bundled `appConfigDefaults.json` at load and logs a warning
  - Extended `ResolvedAppSetting` with `isSet` flag (for secrets, only set/not-set is reported to the client)
  - Redacts secret values in `getResolvedAppSettings()` (returns empty string, never the real value)
  - Added validation in `setAppConfigValue()` for empty values and option constraints
- **`ssmParameterStore.ts`**: Updated `putSsmParameter()` to store secrets as SSM `SecureString` (KMS-encrypted) instead of plain `String`
- **`appConfigDefaults.json`**: Added defaults for new settings (no secrets included, per security policy)

### Admin UI (`admin-v1/app-settings/`)

- **`page.tsx`**:
  - Refactored badge rendering (generic `Badge` component + `SecretBadge` for set/not-set state)
  - Added dropdown support for option-typed settings
  - Secrets are write-only: field starts empty, saving replaces the stored value, no value is ever displayed
  - Added `password` input type and placeholder text for secrets
  - Updated state management to handle dirty-state correctly for secrets vs. regular values

### LLM Defaults Resolution (`util/llm-default-config.ts` — new file)

Server-only module (never bundled to client) that resolves LLM provider/model defaults from app-config with fallback to code constants:
- `getConfiguredDefaultProvider()` → `LLM_DEFAULT_PROVIDER` setting or code default
- `getConfiguredDefaultGeminiModel()` → `LLM_DEFAULT_GEMINI_MODEL` setting or code default
- `getConfiguredDefaultClaudeModel()` → `LLM_DEFAULT_CLAUDE_MODEL` setting or code default
- `getConfiguredDefaultModelForProvider()` → provider-aware model selection

All functions validate against enums and gracefully fall back to code constants if a value is unset or invalid, ensuring a bad config value can never break generation.

### LLM Integration Updates

Updated all LLM call sites to use app-config defaults instead of code constants:
- **`get-llm-response.ts`**: Uses `getConfiguredDefaultProvider()` and `getConfiguredDefaultModelForProvider()` when no per-run selection is provided
- **`llm-callback-lambda-utils.ts`**: Reads `LAMBDA_URL_LLM_CALL_WITH_CALLBACK` from app-config
- **`llm-grounding-utils.ts`**: Reads `GOOGLE_API_KEY` from app-config
- **`claude-token-provider.ts`**: Reads `ANTHROPIC_OAUTH_REFRESH_TOKEN` and `ANTHROPIC_OAUTH_TOKEN_URL` from app-config
- **`claude-oauth-client.ts`**: Reads `ANTHROPIC_BASE_URL` and `CLAUDE_CODE_VERSION` from app-config
- **`claude-usage.ts`**: Reads `ANTHROPIC_BASE_URL` from app-config

https://claude.ai/code/session_015cS8EDfwX1o3hg8KYAugDS