### PR TITLE
feat(insights-ui): raise auto-gen weekly usage caps (day6 80%, day7 95%)

### DIFF
--- a/insights-ui/src/utils/auto-generation/auto-gen-config.ts
+++ b/insights-ui/src/utils/auto-generation/auto-gen-config.ts
@@ -24,7 +24,7 @@ export const WEEKLY_CAP_DAY_KEYS: (keyof WeeklyCapByDay)[] = ['day1', 'day2', 'd
  */
 export const AUTO_GEN_USAGE_CAPS: AutoGenUsageCaps = {
   maxFiveHourUtilizationPct: 90,
-  weeklyCapByDayPct: { day1: 20, day2: 30, day3: 40, day4: 50, day5: 60, day6: 70, day7: 80 },
+  weeklyCapByDayPct: { day1: 20, day2: 30, day3: 40, day4: 50, day5: 60, day6: 80, day7: 95 },
 };
 
 /**


### PR DESCRIPTION
## What

Raises the tail of the Claude weekly-usage day-curve in `AUTO_GEN_USAGE_CAPS` (`insights-ui/src/utils/auto-generation/auto-gen-config.ts`):

| Day | Before | After |
|-----|--------|-------|
| day1–5 | 20 / 30 / 40 / 50 / 60 | unchanged |
| day6 | 70% | **80%** |
| day7 | 80% | **95%** |

The 5-hour ceiling (90%) is untouched.

## Why

These are the safety caps that gate `enqueueAutoStockGenerationBatch` / `enqueueAutoEtfGenerationBatch` (via `evaluateAutoGenGates`). The nightly heartbeat was correctly reading all App Settings and passing every gate except this one — it returned `weekly-over-day-cap-80` because weekly Claude usage was at 84% on day 7 (old cap 80%). Raising day7 to 95% gives headroom near the weekly reset so batches can run.

## Note

These caps are code constants (not App Settings / SSM), so this change requires a deploy to take effect. Loosening them lets auto-generation spend closer to the Claude weekly subscription limit — intended here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)