### PR TITLE
Refine App Settings tables: fixed label width, checkmark save, tinted groups

### DIFF
--- a/insights-ui/src/app/admin-v1/app-settings/page.tsx
+++ b/insights-ui/src/app/admin-v1/app-settings/page.tsx
@@ -22,6 +22,9 @@ const SOURCE_BADGE: Record<ResolvedAppSetting['source'], { variant: StatusBadgeV
   default: { variant: 'neutral', label: 'Default' },
 };
 
+// Alternating surface tint per group table so adjacent sections are easy to tell apart.
+const TABLE_TONES = ['bg-surface', 'bg-surface-2'];
+
 function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved: (saved: ResolvedAppSetting) => void }): JSX.Element {
   const { showNotification } = useNotificationContext();
   const isSecret = setting.secret === true;
@@ -76,18 +79,13 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
             >
               <InformationCircleIcon className="h-4 w-4" />
             </button>
-            <div>
-              <Text as="div" size="sm" weight="medium" tone="body">
-                {setting.label}
-              </Text>
-              <Text as="div" size="xs" tone="muted" className="font-mono">
-                {setting.key}
-              </Text>
-            </div>
+            <Text as="div" size="sm" weight="medium" tone="body">
+              {setting.label}
+            </Text>
           </div>
         </td>
 
-        <td className="w-[22rem] py-2 pr-3">
+        <td className="py-2 pr-3">
           {setting.type === 'boolean' ? (
             <ToggleWithIcon label={setting.label} enabled={draft === 'true'} setEnabled={(v) => setDraft(v ? 'true' : 'false')} />
           ) : setting.options ? (
@@ -124,9 +122,9 @@ function SettingRow({ setting, onSaved }: { setting: ResolvedAppSetting; onSaved
 
         <td className="py-2 text-right">
           <IconButton
-            iconName={IconTypes.ArrowDownTrayIcon}
+            iconName={IconTypes.Checkmark}
             tooltip={dirty ? 'Save' : 'No changes to save'}
-            primary
+            primary={dirty}
             removeBorder
             disabled={!dirty || saving}
             loading={saving}
@@ -220,19 +218,25 @@ export default function AppSettingsPage(): JSX.Element {
       )}
 
       {data &&
-        APP_CONFIG_GROUPS.map((group) => {
+        APP_CONFIG_GROUPS.map((group, index) => {
           const groupSettings = data.settings.filter((s) => s.group === group.id);
           if (groupSettings.length === 0) return null;
           return (
-            <section key={group.id}>
+            <section key={group.id} className={`rounded-lg border border-border p-3 sm:p-4 ${TABLE_TONES[index % TABLE_TONES.length]}`}>
               <Heading as="h2" size="md" weight="semibold" tone="white">
                 {group.label}
               </Heading>
-              <Text as="p" size="xs" tone="muted" className="mb-2 mt-0.5">
+              <Text as="p" size="xs" tone="muted" className="mb-3 mt-0.5">
                 {group.description}
               </Text>
               <div className="overflow-x-auto">
-                <table className="w-full text-left">
+                <table className="w-full table-fixed text-left">
+                  <colgroup>
+                    <col className="w-2/5 lg:w-[30%]" />
+                    <col />
+                    <col className="w-36" />
+                    <col className="w-14" />
+                  </colgroup>
                   <tbody>
                     {groupSettings.map((setting) => (
                       <SettingRow key={setting.key} setting={setting} onSaved={handleSaved} />

--- a/shared/web-core/src/components/core/buttons/IconButton.tsx
+++ b/shared/web-core/src/components/core/buttons/IconButton.tsx
@@ -9,7 +9,7 @@ import RobotIconSolid from '@dodao/web-core/components/core/icons/RobotIconSolid
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import { DocumentPlusIcon, ArrowPathIcon } from '@heroicons/react/24/solid';
 import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/20/solid';
-import { PencilSquareIcon, PlusIcon, TrashIcon, ArrowsPointingOutIcon } from '@heroicons/react/20/solid';
+import { PencilSquareIcon, PlusIcon, TrashIcon, ArrowsPointingOutIcon, CheckIcon } from '@heroicons/react/20/solid';
 import styles from './IconButton.module.scss';
 import { ClipboardIcon } from '@heroicons/react/24/outline';
 
@@ -78,6 +78,8 @@ const IconButton: React.FC<IconButtonProps> = ({
         return <ArrowPathIcon width={width} height={height} />;
       case IconTypes.Clipboard:
         return <ClipboardIcon width={width} height={height} />;
+      case IconTypes.Checkmark:
+        return <CheckIcon width={width} height={height} />;
       case IconTypes.Reading:
         return <ReadingIcon />;
       case IconTypes.Summary:

--- a/shared/web-core/src/components/core/icons/IconTypes.ts
+++ b/shared/web-core/src/components/core/icons/IconTypes.ts
@@ -14,4 +14,5 @@ export enum IconTypes {
   FullScreenIcon = 'FullScreenIcon',
   ArrowsPointingOutIcon = 'ArrowsPointingOutIcon',
   Clipboard = 'Clipboard',
+  Checkmark = 'Checkmark',
 }


### PR DESCRIPTION
## Summary

Refines the admin **App Settings** screen (`/admin-v1/app-settings`) per review feedback:

- **Fixed label column width** — each setting's label column is now a fixed width (40% on smaller screens, 30% on large) via a `table-fixed` colgroup, so labels line up and left-aligned values are easy to scan across rows.
- **Removed the raw config key** from each row — the human-readable label is enough; the key (e.g. `ANTHROPIC_OAUTH_TOKEN`) only added noise.
- **Checkmark save button** — the per-row save control is now a checkmark `IconButton` that is **primary (colored) when the value is dirty** and **non-primary / disabled** otherwise, replacing the previous download-tray icon.
- **Tinted group tables** — each group's table gets an alternating surface shade (`bg-surface` / `bg-surface-2`) so adjacent sections are easy to tell apart.

Shared change: adds a reusable `Checkmark` icon to the web-core `IconButton` (additive enum value + case).

Descriptions stay behind the per-row "i" info toggle, and dropdown option notes still show inline while selecting — the compact-by-default behavior is unchanged.

### Code Review
- [x] I have carefully reviewed my code and believe it is final from my side.
- [x] I have ensured there is no hardcoded color in my changes. Colors are the semantic theme tokens (`bg-surface`, `bg-surface-2`, `border-border`, `text-muted`, `text-body`) plus the existing `StatusBadge` tones; no raw hex/`gray-*`.

### Theme Compatibility
- [ ] Surfaces/tokens used are theme-defined, but I have not visually verified light theme in a browser.

### Device Compatibility
- [ ] Layout uses responsive widths (`w-2/5 lg:w-[30%]`) and an `overflow-x-auto` wrapper, but not manually verified on each breakpoint.

### Functional Testing
- [x] `yarn compile` (tsc) passes — only pre-existing, unrelated `@/images/*` type errors remain.
- [x] `yarn lint` and `yarn prettier-check` pass clean.

### Testing Documentation
- Type-checked and linted the changes; the save button's enabled/disabled state is driven by the existing `dirty` computation, and the icon swap + `primary={dirty}` is a presentational change over already-working save logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013a9C8RsX9Jht4W5RX3rMtw)_