### PR TITLE
Refactor pagination: extract SectionPagination component and use tabs UI

### DIFF
--- a/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
+++ b/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
@@ -208,6 +208,17 @@ export default function EtfGenerationRequestsPage(): JSX.Element {
   const [secondsLeft, setSecondsLeft] = useState(REFRESH_SECONDS);
   const [isPaused, setIsPaused] = useState(false);
 
+  // A background refresh can drain a bucket below the page the user is on, leaving them on an
+  // out-of-range (empty) page with no way back. Snap each section's page into range when data lands.
+  useEffect(() => {
+    if (!data) return;
+    const clampToRange = (count: number) => (page: number) => Math.min(page, Math.max(1, Math.ceil(count / PAGE_SIZE)));
+    setInProgressPage(clampToRange(data.counts.inProgress));
+    setNotStartedPage(clampToRange(data.counts.notStarted));
+    setFailedPage(clampToRange(data.counts.failed));
+    setCompletedPage(clampToRange(data.counts.completed));
+  }, [data]);
+
   function handleManualRefresh() {
     setInProgressPage(1);
     setFailedPage(1);

--- a/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
+++ b/insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import SectionPagination from '@/app/admin-v1/generation-requests/SectionPagination';
 import { useDebouncedValue } from '@/app/admin-v1/etf-reports/useDebouncedValue';
 import { EtfGenerationRequestsResponse, EtfGenerationRequestWithEtf } from '@/app/api/[spaceId]/etfs-v1/generation-requests/route';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { KoalaGainsSpaceId } from '@/types/koalaGainsConstants';
 import { EtfGenerationRequestStatus, EtfReportType } from '@/types/etf/etf-analysis-types';
 import Button from '@dodao/web-core/components/core/buttons/Button';
 import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
-import { ArrowPathIcon, ChevronLeftIcon, ChevronRightIcon, PauseIcon, PlayIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, PauseIcon, PlayIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -61,52 +63,6 @@ function StatusDot({ isEnabled, stepName, completedSteps, failedSteps, inProgres
 
 const REFRESH_SECONDS = 30;
 const PAGE_SIZE = 50;
-
-interface SectionPaginationProps {
-  currentPage: number;
-  totalCount: number;
-  rowsOnPage: number;
-  onPageChange: (page: number) => void;
-}
-
-function SectionPagination({ currentPage, totalCount, rowsOnPage, onPageChange }: SectionPaginationProps): JSX.Element | null {
-  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
-  if (totalPages <= 1) return null;
-
-  const rangeStart = (currentPage - 1) * PAGE_SIZE + 1;
-  const rangeEnd = (currentPage - 1) * PAGE_SIZE + rowsOnPage;
-
-  return (
-    <div className="flex items-center justify-between px-2 py-3 mt-3 border-t border-gray-700/60">
-      <span className="text-sm text-gray-400">
-        Showing {rangeStart}
-        {'–'}
-        {rangeEnd} of {totalCount}
-      </span>
-      <div className="flex items-center space-x-2">
-        <button
-          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
-          disabled={currentPage === 1}
-          className="p-2 rounded-md text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          title="Previous page"
-        >
-          <ChevronLeftIcon className="h-5 w-5" />
-        </button>
-        <span className="text-sm text-gray-300">
-          Page {currentPage} of {totalPages}
-        </span>
-        <button
-          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
-          disabled={currentPage === totalPages}
-          className="p-2 rounded-md text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          title="Next page"
-        >
-          <ChevronRightIcon className="h-5 w-5" />
-        </button>
-      </div>
-    </div>
-  );
-}
 
 function SectionHeader({ title, totalCount }: { title: string; totalCount: number }): JSX.Element {
   return (
@@ -288,40 +244,67 @@ export default function EtfGenerationRequestsPage(): JSX.Element {
     return () => clearInterval(timerId);
   }, [hasActive, isPaused, reFetchData]);
 
-  const sections = [
-    {
-      title: 'In Progress',
-      rows: data?.inProgress ?? [],
-      border: 'border-blue-500',
-      count: data?.counts?.inProgress ?? 0,
-      currentPage: inProgressPage,
-      setPage: setInProgressPage,
-    },
-    {
-      title: 'Not Started',
-      rows: data?.notStarted ?? [],
-      border: 'border-gray-500',
-      count: data?.counts?.notStarted ?? 0,
-      currentPage: notStartedPage,
-      setPage: setNotStartedPage,
-    },
-    {
-      title: 'Failed',
-      rows: data?.failed ?? [],
-      border: 'border-red-500',
-      count: data?.counts?.failed ?? 0,
-      currentPage: failedPage,
-      setPage: setFailedPage,
-    },
-    {
-      title: 'Completed',
-      rows: data?.completed ?? [],
-      border: 'border-green-500',
-      count: data?.counts?.completed ?? 0,
-      currentPage: completedPage,
-      setPage: setCompletedPage,
-    },
-  ];
+  interface Section {
+    title: string;
+    rows: EtfGenerationRequestWithEtf[];
+    border: string;
+    count: number;
+    currentPage: number;
+    setPage: (page: number) => void;
+  }
+
+  const inProgressSection: Section = {
+    title: 'In Progress',
+    rows: data?.inProgress ?? [],
+    border: 'border-blue-500',
+    count: data?.counts?.inProgress ?? 0,
+    currentPage: inProgressPage,
+    setPage: setInProgressPage,
+  };
+  const notStartedSection: Section = {
+    title: 'Not Started',
+    rows: data?.notStarted ?? [],
+    border: 'border-gray-500',
+    count: data?.counts?.notStarted ?? 0,
+    currentPage: notStartedPage,
+    setPage: setNotStartedPage,
+  };
+  const failedSection: Section = {
+    title: 'Failed',
+    rows: data?.failed ?? [],
+    border: 'border-red-500',
+    count: data?.counts?.failed ?? 0,
+    currentPage: failedPage,
+    setPage: setFailedPage,
+  };
+  const completedSection: Section = {
+    title: 'Completed',
+    rows: data?.completed ?? [],
+    border: 'border-green-500',
+    count: data?.counts?.completed ?? 0,
+    currentPage: completedPage,
+    setPage: setCompletedPage,
+  };
+
+  const activeCount: number = (data?.counts?.inProgress ?? 0) + (data?.counts?.notStarted ?? 0);
+
+  function renderSection({ title, rows, border, count, currentPage, setPage }: Section): JSX.Element {
+    return (
+      <div className={`bg-gray-800 border ${border} rounded-lg p-4`}>
+        <SectionHeader title={`${title} Requests`} totalCount={count} />
+        {loading && rows.length === 0 ? (
+          <div className="py-8">Loading...</div>
+        ) : rows.length === 0 ? (
+          <div className="py-4">No {title.toLowerCase()} requests.</div>
+        ) : (
+          <>
+            <EtfRequestsTable rows={rows} onReloadRequest={handleReloadRequest} />
+            <SectionPagination currentPage={currentPage} totalCount={count} rowsOnPage={rows.length} pageSize={PAGE_SIZE} onPageChange={setPage} />
+          </>
+        )}
+      </div>
+    );
+  }
 
   return (
     <>
@@ -397,23 +380,22 @@ export default function EtfGenerationRequestsPage(): JSX.Element {
         </div>
       </div>
 
-      {sections.map(({ title, rows, border, count, currentPage, setPage }) => (
-        <div key={title} className="mb-6">
-          <div className={`bg-gray-800 border ${border} rounded-lg p-4`}>
-            <SectionHeader title={`${title} Requests`} totalCount={count} />
-            {loading && rows.length === 0 ? (
-              <div className="py-8">Loading...</div>
-            ) : rows.length === 0 ? (
-              <div className="py-4">No {title.toLowerCase()} requests.</div>
-            ) : (
-              <>
-                <EtfRequestsTable rows={rows} onReloadRequest={handleReloadRequest} />
-                <SectionPagination currentPage={currentPage} totalCount={count} rowsOnPage={rows.length} onPageChange={setPage} />
-              </>
-            )}
-          </div>
-        </div>
-      ))}
+      <Tabs defaultValue="active">
+        <TabsList className="mb-4">
+          <TabsTrigger value="active">In Progress &amp; Not Started ({activeCount})</TabsTrigger>
+          <TabsTrigger value="failed">Failed ({data?.counts?.failed ?? 0})</TabsTrigger>
+          <TabsTrigger value="completed">Completed ({data?.counts?.completed ?? 0})</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="active" className="flex flex-col gap-6">
+          {renderSection(inProgressSection)}
+          {renderSection(notStartedSection)}
+        </TabsContent>
+
+        <TabsContent value="failed">{renderSection(failedSection)}</TabsContent>
+
+        <TabsContent value="completed">{renderSection(completedSection)}</TabsContent>
+      </Tabs>
     </>
   );
 }

--- a/insights-ui/src/app/admin-v1/generation-requests/RequestsSection.tsx
+++ b/insights-ui/src/app/admin-v1/generation-requests/RequestsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import GenerationRequestsTable, { GenerationRequestWithFlags } from '@/app/admin-v1/generation-requests/GenerationRequestsTable';
-import Button from '@dodao/web-core/components/core/buttons/Button';
+import SectionPagination from '@/app/admin-v1/generation-requests/SectionPagination';
 import React from 'react';
 
 type BorderTone = 'blue' | 'gray' | 'red' | 'green';
@@ -19,27 +19,31 @@ interface RequestsSectionProps {
   rows: GenerationRequestWithFlags[];
   totalCount: number;
   loading: boolean;
-  onShowMore: () => void;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
   onReloadRequest: (request: GenerationRequestWithFlags) => void;
 }
 
-/** One status bucket: bordered card + count header + table / loading / empty state. */
-export default function RequestsSection({ title, tone, rows, totalCount, loading, onShowMore, onReloadRequest }: RequestsSectionProps): JSX.Element {
-  const hasMore: boolean = rows.length < totalCount;
+/** One status bucket: bordered card + count header + table / loading / empty state + page-number pager. */
+export default function RequestsSection({
+  title,
+  tone,
+  rows,
+  totalCount,
+  loading,
+  currentPage,
+  pageSize,
+  onPageChange,
+  onReloadRequest,
+}: RequestsSectionProps): JSX.Element {
   return (
     <div className={`bg-gray-800 border ${BORDER_CLASS[tone]} rounded-lg p-3`}>
       <div className="flex items-baseline justify-between mb-2">
         <h3 className="text-lg font-semibold">{title}</h3>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-gray-400">
-            Showing {rows.length} of {totalCount} total item{totalCount === 1 ? '' : 's'}
-          </span>
-          {hasMore && (
-            <Button onClick={onShowMore} variant="text" className="text-blue-400 hover:text-blue-300">
-              Show More
-            </Button>
-          )}
-        </div>
+        <span className="text-sm text-gray-400">
+          {totalCount} total item{totalCount === 1 ? '' : 's'}
+        </span>
       </div>
 
       {loading && rows.length === 0 ? (
@@ -47,7 +51,10 @@ export default function RequestsSection({ title, tone, rows, totalCount, loading
       ) : rows.length === 0 ? (
         <div className="py-3 text-gray-400">No {title.toLowerCase()}.</div>
       ) : (
-        <GenerationRequestsTable rows={rows} onReloadRequest={onReloadRequest} />
+        <>
+          <GenerationRequestsTable rows={rows} onReloadRequest={onReloadRequest} />
+          <SectionPagination currentPage={currentPage} totalCount={totalCount} rowsOnPage={rows.length} pageSize={pageSize} onPageChange={onPageChange} />
+        </>
       )}
     </div>
   );

--- a/insights-ui/src/app/admin-v1/generation-requests/SectionPagination.tsx
+++ b/insights-ui/src/app/admin-v1/generation-requests/SectionPagination.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+interface SectionPaginationProps {
+  currentPage: number;
+  totalCount: number;
+  rowsOnPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}
+
+/** Page-number pager for a single status bucket. Shared by the stock and ETF generation-request pages. */
+export default function SectionPagination({ currentPage, totalCount, rowsOnPage, pageSize, onPageChange }: SectionPaginationProps): JSX.Element | null {
+  const totalPages: number = Math.max(1, Math.ceil(totalCount / pageSize));
+  if (totalPages <= 1) return null;
+
+  const rangeStart: number = (currentPage - 1) * pageSize + 1;
+  const rangeEnd: number = (currentPage - 1) * pageSize + rowsOnPage;
+
+  return (
+    <div className="flex items-center justify-between px-2 py-3 mt-3 border-t border-gray-700/60">
+      <span className="text-sm text-gray-400">
+        Showing {rangeStart}
+        {'–'}
+        {rangeEnd} of {totalCount}
+      </span>
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+          disabled={currentPage === 1}
+          className="p-2 rounded-md text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          title="Previous page"
+        >
+          <ChevronLeftIcon className="h-5 w-5" />
+        </button>
+        <span className="text-sm text-gray-300">
+          Page {currentPage} of {totalPages}
+        </span>
+        <button
+          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage === totalPages}
+          className="p-2 rounded-md text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          title="Next page"
+        >
+          <ChevronRightIcon className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/insights-ui/src/app/admin-v1/generation-requests/page.tsx
+++ b/insights-ui/src/app/admin-v1/generation-requests/page.tsx
@@ -13,56 +13,34 @@ import Button from '@dodao/web-core/components/core/buttons/Button';
 import { useFetchData } from '@dodao/web-core/ui/hooks/fetch/useFetchData';
 import getBaseUrl from '@dodao/web-core/utils/api/getBaseURL';
 import { ArrowPathIcon, PauseIcon, PlayIcon } from '@heroicons/react/24/outline';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 const REFRESH_SECONDS: number = 30;
 const PAGE_SIZE: number = 15;
 
-type Pagination = { skip: number; take: number };
-const INITIAL_PAGINATION: Pagination = { skip: 0, take: PAGE_SIZE };
-
 export default function GenerationRequestsPage(): JSX.Element {
-  const [inProgressPagination, setInProgressPagination] = useState<Pagination>(INITIAL_PAGINATION);
-  const [failedPagination, setFailedPagination] = useState<Pagination>(INITIAL_PAGINATION);
-  const [notStartedPagination, setNotStartedPagination] = useState<Pagination>(INITIAL_PAGINATION);
-  const [completedPagination, setCompletedPagination] = useState<Pagination>(INITIAL_PAGINATION);
+  const [inProgressPage, setInProgressPage] = useState<number>(1);
+  const [notStartedPage, setNotStartedPage] = useState<number>(1);
+  const [failedPage, setFailedPage] = useState<number>(1);
+  const [completedPage, setCompletedPage] = useState<number>(1);
 
-  const [accumulatedInProgress, setAccumulatedInProgress] = useState<GenerationRequestWithFlags[]>([]);
-  const [accumulatedFailed, setAccumulatedFailed] = useState<GenerationRequestWithFlags[]>([]);
-  const [accumulatedNotStarted, setAccumulatedNotStarted] = useState<GenerationRequestWithFlags[]>([]);
-  const [accumulatedCompleted, setAccumulatedCompleted] = useState<GenerationRequestWithFlags[]>([]);
-
-  const baseUrl: string = `${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/generation-requests`;
-  const params = new URLSearchParams();
-  params.append('inProgressSkip', inProgressPagination.skip.toString());
-  params.append('inProgressTake', inProgressPagination.take.toString());
-  params.append('failedSkip', failedPagination.skip.toString());
-  params.append('failedTake', failedPagination.take.toString());
-  params.append('notStartedSkip', notStartedPagination.skip.toString());
-  params.append('notStartedTake', notStartedPagination.take.toString());
-  params.append('completedSkip', completedPagination.skip.toString());
-  params.append('completedTake', completedPagination.take.toString());
-  const apiUrl: string = `${baseUrl}?${params.toString()}`;
+  const apiUrl: string = useMemo(() => {
+    const params = new URLSearchParams();
+    params.append('inProgressSkip', String((inProgressPage - 1) * PAGE_SIZE));
+    params.append('inProgressTake', String(PAGE_SIZE));
+    params.append('failedSkip', String((failedPage - 1) * PAGE_SIZE));
+    params.append('failedTake', String(PAGE_SIZE));
+    params.append('notStartedSkip', String((notStartedPage - 1) * PAGE_SIZE));
+    params.append('notStartedTake', String(PAGE_SIZE));
+    params.append('completedSkip', String((completedPage - 1) * PAGE_SIZE));
+    params.append('completedTake', String(PAGE_SIZE));
+    return `${getBaseUrl()}/api/${KoalaGainsSpaceId}/tickers-v1/generation-requests?${params.toString()}`;
+  }, [inProgressPage, failedPage, notStartedPage, completedPage]);
 
   const { data, loading, reFetchData } = useFetchData<GenerationRequestsResponse>(apiUrl, {}, 'Failed to fetch generation requests');
 
-  useEffect(() => {
-    if (!data) return;
-
-    // Merge based on the skip echoed back in the response (not local pagination state, which
-    // updates before the matching fetch resolves and would re-append the previous batch).
-    const mergeRows = (prev: GenerationRequestWithFlags[], rows: GenerationRequestWithFlags[], skip: number): GenerationRequestWithFlags[] => {
-      const base: GenerationRequestWithFlags[] = skip === 0 ? [] : prev.slice(0, skip);
-      const seenIds = new Set<string>(base.map((row) => row.id));
-      return [...base, ...rows.filter((row) => !seenIds.has(row.id))];
-    };
-
-    setAccumulatedInProgress((p) => mergeRows(p, data.inProgress || [], data.pagination.inProgress.skip));
-    setAccumulatedFailed((p) => mergeRows(p, data.failed || [], data.pagination.failed.skip));
-    setAccumulatedNotStarted((p) => mergeRows(p, data.notStarted || [], data.pagination.notStarted.skip));
-    setAccumulatedCompleted((p) => mergeRows(p, data.completed || [], data.pagination.completed.skip));
-  }, [data]);
-
+  const counts = data?.counts;
+  const activeCount: number = (counts?.inProgress ?? 0) + (counts?.notStarted ?? 0);
   const hasActive: boolean = (data?.notStarted?.length ?? 0) > 0 || (data?.inProgress?.length ?? 0) > 0;
 
   const [secondsLeft, setSecondsLeft] = useState<number>(REFRESH_SECONDS);
@@ -70,19 +48,15 @@ export default function GenerationRequestsPage(): JSX.Element {
   const [selectedRequest, setSelectedRequest] = useState<GenerationRequestWithFlags | null>(null);
   const [isPaused, setIsPaused] = useState<boolean>(false);
 
-  function resetPagination(): void {
-    setInProgressPagination(INITIAL_PAGINATION);
-    setFailedPagination(INITIAL_PAGINATION);
-    setNotStartedPagination(INITIAL_PAGINATION);
-    setCompletedPagination(INITIAL_PAGINATION);
-    setAccumulatedInProgress([]);
-    setAccumulatedFailed([]);
-    setAccumulatedNotStarted([]);
-    setAccumulatedCompleted([]);
+  function resetToFirstPage(): void {
+    setInProgressPage(1);
+    setNotStartedPage(1);
+    setFailedPage(1);
+    setCompletedPage(1);
   }
 
   function handleManualRefresh(): void {
-    resetPagination();
+    resetToFirstPage();
     reFetchData();
     setSecondsLeft(REFRESH_SECONDS);
   }
@@ -90,10 +64,6 @@ export default function GenerationRequestsPage(): JSX.Element {
   function handleTogglePause(): void {
     setIsPaused((prev) => !prev);
   }
-
-  const loadMore = (setPagination: React.Dispatch<React.SetStateAction<Pagination>>) => (): void => {
-    setPagination((prev) => ({ skip: prev.skip + prev.take, take: prev.take }));
-  };
 
   function handleReloadRequest(request: GenerationRequestWithFlags): void {
     setSelectedRequest(request);
@@ -154,9 +124,6 @@ export default function GenerationRequestsPage(): JSX.Element {
     return () => clearInterval(timerId);
   }, [hasActive, isPaused, reFetchData]);
 
-  const counts = data?.counts;
-  const activeCount: number = (counts?.inProgress ?? 0) + (counts?.notStarted ?? 0);
-
   return (
     <>
       <div className="flex flex-wrap gap-3 justify-between items-center mb-4">
@@ -207,19 +174,23 @@ export default function GenerationRequestsPage(): JSX.Element {
           <RequestsSection
             title="In Progress Requests"
             tone="blue"
-            rows={accumulatedInProgress}
-            totalCount={counts?.inProgress ?? accumulatedInProgress.length}
+            rows={data?.inProgress ?? []}
+            totalCount={counts?.inProgress ?? 0}
             loading={loading}
-            onShowMore={loadMore(setInProgressPagination)}
+            currentPage={inProgressPage}
+            pageSize={PAGE_SIZE}
+            onPageChange={setInProgressPage}
             onReloadRequest={handleReloadRequest}
           />
           <RequestsSection
             title="Not Started Requests"
             tone="gray"
-            rows={accumulatedNotStarted}
-            totalCount={counts?.notStarted ?? accumulatedNotStarted.length}
+            rows={data?.notStarted ?? []}
+            totalCount={counts?.notStarted ?? 0}
             loading={loading}
-            onShowMore={loadMore(setNotStartedPagination)}
+            currentPage={notStartedPage}
+            pageSize={PAGE_SIZE}
+            onPageChange={setNotStartedPage}
             onReloadRequest={handleReloadRequest}
           />
         </TabsContent>
@@ -228,10 +199,12 @@ export default function GenerationRequestsPage(): JSX.Element {
           <RequestsSection
             title="Failed Requests"
             tone="red"
-            rows={accumulatedFailed}
-            totalCount={counts?.failed ?? accumulatedFailed.length}
+            rows={data?.failed ?? []}
+            totalCount={counts?.failed ?? 0}
             loading={loading}
-            onShowMore={loadMore(setFailedPagination)}
+            currentPage={failedPage}
+            pageSize={PAGE_SIZE}
+            onPageChange={setFailedPage}
             onReloadRequest={handleReloadRequest}
           />
         </TabsContent>
@@ -240,10 +213,12 @@ export default function GenerationRequestsPage(): JSX.Element {
           <RequestsSection
             title="Completed Requests"
             tone="green"
-            rows={accumulatedCompleted}
-            totalCount={counts?.completed ?? accumulatedCompleted.length}
+            rows={data?.completed ?? []}
+            totalCount={counts?.completed ?? 0}
             loading={loading}
-            onShowMore={loadMore(setCompletedPagination)}
+            currentPage={completedPage}
+            pageSize={PAGE_SIZE}
+            onPageChange={setCompletedPage}
             onReloadRequest={handleReloadRequest}
           />
         </TabsContent>

--- a/insights-ui/src/app/admin-v1/generation-requests/page.tsx
+++ b/insights-ui/src/app/admin-v1/generation-requests/page.tsx
@@ -41,12 +41,23 @@ export default function GenerationRequestsPage(): JSX.Element {
 
   const counts = data?.counts;
   const activeCount: number = (counts?.inProgress ?? 0) + (counts?.notStarted ?? 0);
-  const hasActive: boolean = (data?.notStarted?.length ?? 0) > 0 || (data?.inProgress?.length ?? 0) > 0;
+  const hasActive: boolean = (counts?.inProgress ?? 0) > 0 || (counts?.notStarted ?? 0) > 0;
 
   const [secondsLeft, setSecondsLeft] = useState<number>(REFRESH_SECONDS);
   const [showReloadModal, setShowReloadModal] = useState<boolean>(false);
   const [selectedRequest, setSelectedRequest] = useState<GenerationRequestWithFlags | null>(null);
   const [isPaused, setIsPaused] = useState<boolean>(false);
+
+  // A background refresh can drain a bucket below the page the user is on, leaving them on an
+  // out-of-range (empty) page with no way back. Snap each section's page into range when data lands.
+  useEffect(() => {
+    if (!data) return;
+    const clampToRange = (count: number) => (page: number) => Math.min(page, Math.max(1, Math.ceil(count / PAGE_SIZE)));
+    setInProgressPage(clampToRange(data.counts.inProgress));
+    setNotStartedPage(clampToRange(data.counts.notStarted));
+    setFailedPage(clampToRange(data.counts.failed));
+    setCompletedPage(clampToRange(data.counts.completed));
+  }, [data]);
 
   function resetToFirstPage(): void {
     setInProgressPage(1);


### PR DESCRIPTION
## Summary

This PR refactors pagination across generation request pages by:

1. **Extracting `SectionPagination` component** – Moves the shared pagination UI from `etf-generation-requests/page.tsx` into a reusable `generation-requests/SectionPagination.tsx` component used by both stock and ETF generation request pages.

2. **Simplifying pagination state management** – Replaces accumulation-based pagination (skip/take with accumulated rows) with page-number-based pagination (currentPage state). This is cleaner and more intuitive for users.

3. **Adding tabs UI to ETF page** – Introduces `Tabs` component to group ETF generation requests by status (Active, Failed, Completed), improving UX for pages with many requests.

4. **Updating RequestsSection component** – Replaces "Show More" button with integrated `SectionPagination` component for consistent pagination across both pages.

## Changes

### New Files
- `insights-ui/src/app/admin-v1/generation-requests/SectionPagination.tsx` – Shared pagination component with page-number navigation

### Modified Files
- `insights-ui/src/app/admin-v1/etf-generation-requests/page.tsx`
  - Removed inline `SectionPagination` component
  - Replaced sections array with individual section objects
  - Added `renderSection()` helper function
  - Wrapped sections in `Tabs` component for better organization
  - Changed pagination from skip/take to page numbers

- `insights-ui/src/app/admin-v1/generation-requests/page.tsx`
  - Replaced pagination state (skip/take + accumulated rows) with page-number state
  - Simplified API URL construction using `useMemo`
  - Removed accumulation logic and `resetPagination()` function
  - Updated `RequestsSection` props to use page-based pagination

- `insights-ui/src/app/admin-v1/generation-requests/RequestsSection.tsx`
  - Replaced "Show More" button with `SectionPagination` component
  - Updated props interface to accept `currentPage`, `pageSize`, and `onPageChange`
  - Simplified header to show total count instead of "Showing X of Y"

## Benefits

- **Code reuse** – Single pagination component used by both pages
- **Better UX** – Page-number navigation is more predictable than "Show More"
- **Cleaner state** – Page numbers are simpler to manage than skip/take with accumulation
- **Improved organization** – Tabs on ETF page reduce cognitive load when viewing many requests

## Testing

- Verified pagination navigation (previous/next buttons) on both pages
- Confirmed tab switching on ETF generation requests page
- Tested empty states and loading states for each section
- Verified page counts and range display are correct

https://claude.ai/code/session_01SheUAP33rMGouEEv2MkdBv